### PR TITLE
Fix routing version mention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ The Fusion Starter is a modern, production-ready template for building full-stac
 
 ## Routing System
 
-The routing system is powered by React Router 7:
+The routing system is powered by React Router 6:
 
 - `src/pages/Index.tsx` represents the home page.
 - Routes are defined in `src/App.tsx` using the `react-router-dom` import


### PR DESCRIPTION
## Summary
- fix mention of React Router version in CLAUDE.md

## Testing
- `npm test` *(fails: useSafeQuery and integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_684cf04e29f0832795eb91b0a7017cc9