### PR TITLE
Fix WebAuthn credential id parsing

### DIFF
--- a/src/hooks/use-webauthn.tsx
+++ b/src/hooks/use-webauthn.tsx
@@ -241,7 +241,7 @@ export function useWebAuthn(): WebAuthnState & WebAuthnActions {
     try {
       const challenge = generateChallenge();
       const allowCredentials = state.credentials.map((cred) => ({
-        id: new TextEncoder().encode(cred.id),
+        id: base64urlToBuffer(cred.id),
         type: "public-key" as const,
       }));
 


### PR DESCRIPTION
## Summary
- use `base64urlToBuffer` in `authenticateWithBiometric`

## Testing
- `npm test` *(fails: Test timed out in 5000ms)*

------
https://chatgpt.com/codex/tasks/task_e_684cf058decc83278057836393aa56bc