### PR TITLE
Enable SMS authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,10 @@ STRIPE_ANNUAL_PRICE_ID=price_1RY9YJRCO021kiwCBzaxnVEU
 STRIPE_MONTHLY_PRODUCT_ID=prod_ST5iisIAa5WOlT
 STRIPE_ANNUAL_PRODUCT_ID=prod_ST5jCsCdmToZ1d
 
+# SMS Authentication (Twilio)
+SUPABASE_AUTH_SMS_TWILIO_ACCOUNT_SID=your_twilio_account_sid
+SUPABASE_AUTH_SMS_TWILIO_MESSAGE_SERVICE_SID=your_message_service_sid
+SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN=your_twilio_auth_token
+
 # Optional: OpenAI API for Supabase AI features
 OPENAI_API_KEY=your_openai_api_key

--- a/README.md
+++ b/README.md
@@ -103,7 +103,15 @@ A modern body composition tracking application built with React and TypeScript. 
    STRIPE_ANNUAL_PRICE_ID=price_1RY9YJRCO021kiwCBzaxnVEU
    STRIPE_MONTHLY_PRODUCT_ID=prod_ST5iisIAa5WOlT
    STRIPE_ANNUAL_PRODUCT_ID=prod_ST5jCsCdmToZ1d
+
+   # SMS Authentication (Twilio)
+   SUPABASE_AUTH_SMS_TWILIO_ACCOUNT_SID=your_twilio_account_sid
+   SUPABASE_AUTH_SMS_TWILIO_MESSAGE_SERVICE_SID=your_message_service_sid
+   SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN=your_twilio_auth_token
    ```
+
+   Make sure SMS sign-ups are enabled in `supabase/config.toml` by setting
+   `enable_signup = true` under `[auth.sms]` and enabling the Twilio provider.
 
 4. **Database Setup**
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -183,7 +183,7 @@ otp_expiry = 3600
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.
-enable_signup = false
+enable_signup = true
 # If enabled, users need to confirm their phone number before signing in.
 enable_confirmations = false
 # Template for sending OTP to users
@@ -208,10 +208,11 @@ max_frequency = "5s"
 # uri = "pg-functions://<database>/<schema>/<hook_name>"
 
 # Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+# Configure Twilio as the SMS provider
 [auth.sms.twilio]
-enabled = false
-account_sid = ""
-message_service_sid = ""
+enabled = true
+account_sid = "env(SUPABASE_AUTH_SMS_TWILIO_ACCOUNT_SID)"
+message_service_sid = "env(SUPABASE_AUTH_SMS_TWILIO_MESSAGE_SERVICE_SID)"
 # DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
 auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
 


### PR DESCRIPTION
## Summary
- enable SMS signups in Supabase config
- activate Twilio provider through env variables
- document SMS env vars in README and `.env.example`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf0937f5c832785090d5bc234364e