### PR TITLE
Add global error boundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ import { Capacitor } from "@capacitor/core";
 import { SplashScreen } from "@capacitor/splash-screen";
 import { serviceWorkerManager } from "@/lib/service-worker-manager";
 import { RouteGuard } from "@/components/RouteGuard";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { AuthDebugger } from "@/components/AuthDebugger";
 
 // Lazy load pages for better code splitting
@@ -244,7 +245,9 @@ const App = () => {
     <AppProviders>
       <BrowserRouter>
         <SEOHead />
-        <AppRoutes />
+        <ErrorBoundary>
+          <AppRoutes />
+        </ErrorBoundary>
         <AuthDebugger />
       </BrowserRouter>
     </AppProviders>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import React, { Component, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("Uncaught error:", error, errorInfo);
+  }
+
+  handleReload = () => {
+    if (typeof window !== "undefined") {
+      window.location.reload();
+    }
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen flex-col items-center justify-center p-4 text-center">
+          <h2 className="mb-2 text-xl font-semibold">Something went wrong</h2>
+          <p className="mb-4 text-muted-foreground">
+            An unexpected error occurred. Please reload the page.
+          </p>
+          <Button onClick={this.handleReload}>Reload</Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- add ErrorBoundary component
- use ErrorBoundary around routes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run typecheck`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf77a93f88327833cfec92ec8e655