### PR TITLE
Fix login refresh loop

### DIFF
--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -58,14 +58,22 @@ export function RouteGuard({
             hideSplashScreen();
           }
 
-          toast.error("Loading timeout - redirecting", {
-            description: "Redirecting to home due to loading timeout.",
+          toast.error("Loading timeout", {
+            description: location.pathname === "/login"
+              ? "The login screen is taking a while to load."
+              : "Redirecting to home due to loading timeout.",
           });
 
-          // Force navigation to fallback route (home)
-          setTimeout(() => {
-            navigate(fallbackRoute, { replace: true });
-          }, 1000);
+          // Avoid redirect loops on the login screen
+          if (location.pathname !== "/login") {
+            setTimeout(() => {
+              navigate(fallbackRoute, { replace: true });
+            }, 1000);
+          } else {
+            console.warn(
+              "RouteGuard timeout occurred on /login - staying on page",
+            );
+          }
         });
       }
     }, redirectTimeout);


### PR DESCRIPTION
## Summary
- prevent redirect loops when the login page hits a RouteGuard timeout

## Testing
- `npx vitest --run` *(fails: Need to install the following packages: vitest@3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_684cf884203c8327902c24e319b1a83d