### PR TITLE
Add Face ID app lock for iOS

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -43,7 +43,9 @@
 	<true/>
 	<key>NSHealthShareUsageDescription</key>
 	<string>LogYourBody needs access to read your health data including weight, height, and body composition metrics to track your progress and provide personalized insights.</string>
-	<key>NSHealthUpdateUsageDescription</key>
-	<string>LogYourBody needs access to write body composition data to your Health app to keep your metrics in sync across all your health apps.</string>
+        <key>NSHealthUpdateUsageDescription</key>
+        <string>LogYourBody needs access to write body composition data to your Health app to keep your metrics in sync across all your health apps.</string>
+        <key>NSFaceIDUsageDescription</key>
+        <string>Face ID is used to protect your private progress data.</string>
 </dict>
 </plist>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import { SplashScreen } from "@capacitor/splash-screen";
 import { serviceWorkerManager } from "@/lib/service-worker-manager";
 import { RouteGuard } from "@/components/RouteGuard";
 import { AuthDebugger } from "@/components/AuthDebugger";
+import { FaceIDGate } from "@/components/FaceIDGate";
 
 // Lazy load pages for better code splitting
 const Index = React.lazy(() => import("./pages/Index"));
@@ -241,13 +242,15 @@ const App = () => {
   }, []); // Empty deps - runs once
 
   return (
-    <AppProviders>
-      <BrowserRouter>
-        <SEOHead />
-        <AppRoutes />
-        <AuthDebugger />
-      </BrowserRouter>
-    </AppProviders>
+    <FaceIDGate>
+      <AppProviders>
+        <BrowserRouter>
+          <SEOHead />
+          <AppRoutes />
+          <AuthDebugger />
+        </BrowserRouter>
+      </AppProviders>
+    </FaceIDGate>
   );
 };
 

--- a/src/components/FaceIDGate.tsx
+++ b/src/components/FaceIDGate.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from "react";
+import { isNativeiOS } from "@/lib/platform";
+
+interface FaceIDGateProps {
+  children: React.ReactNode;
+}
+
+export function FaceIDGate({ children }: FaceIDGateProps) {
+  const [authenticated, setAuthenticated] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const authenticate = async () => {
+      if (!isNativeiOS()) {
+        setAuthenticated(true);
+        return;
+      }
+
+      const enabled = localStorage.getItem("faceid_lock_enabled") === "true";
+      if (!enabled) {
+        setAuthenticated(true);
+        return;
+      }
+
+      try {
+        const { BiometricAuth } = (window as any).Capacitor?.Plugins || {};
+        if (BiometricAuth) {
+          const result = await BiometricAuth.authenticate({
+            reason: "Unlock LogYourBody with Face ID",
+            title: "Face ID Required",
+            subtitle: "Unlock LogYourBody",
+            description: "Authenticate to access your data",
+          });
+          if (result?.isAuthenticated) {
+            setAuthenticated(true);
+          } else {
+            setError("Face ID authentication failed");
+          }
+        } else {
+          // No plugin - allow access
+          setAuthenticated(true);
+        }
+      } catch (err) {
+        console.warn("Face ID authentication error", err);
+        setError("Authentication failed");
+      }
+    };
+
+    authenticate();
+  }, []);
+
+  if (!authenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent"></div>
+          {error && <p className="text-destructive text-sm">{error}</p>}
+        </div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -26,6 +26,7 @@ import { RevenueCatDebug } from "@/components/RevenueCatDebug";
 import { HealthKitSyncButton } from "@/components/HealthKitSyncButton";
 import { HealthKitDebug } from "@/components/HealthKitDebug";
 import { AuthGuard } from "@/components/AuthGuard";
+import { isNativeiOS } from "@/lib/platform";
 import { useAuth } from "@/contexts/AuthContext";
 import { useSupabaseBodyMetrics } from "@/hooks/use-supabase-body-metrics";
 import { useSupabaseSubscription } from "@/hooks/use-supabase-subscription";
@@ -63,6 +64,9 @@ const Settings = () => {
   const [editEmail, setEditEmail] = useState(user?.email || "");
   const [editPassword, setEditPassword] = useState("");
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
+  const [faceIdLock, setFaceIdLock] = useState(
+    localStorage.getItem("faceid_lock_enabled") === "true",
+  );
 
   // Update form states when user data loads
   useEffect(() => {
@@ -106,6 +110,15 @@ const Settings = () => {
       }
     } else {
       setNotificationsEnabled(false);
+    }
+  };
+
+  const handleFaceIdLockToggle = (checked: boolean) => {
+    setFaceIdLock(checked);
+    if (checked) {
+      localStorage.setItem("faceid_lock_enabled", "true");
+    } else {
+      localStorage.removeItem("faceid_lock_enabled");
     }
   };
 
@@ -486,6 +499,17 @@ const Settings = () => {
                 Security
               </h2>
               <BiometricSetup />
+              {isNativeiOS() && (
+                <div className="-mx-2 mt-4 flex items-center justify-between rounded px-2 py-4 hover:bg-secondary/20">
+                  <div className="text-base font-medium text-foreground">
+                    Require Face ID on Launch
+                  </div>
+                  <Switch
+                    checked={faceIdLock}
+                    onCheckedChange={handleFaceIdLockToggle}
+                  />
+                </div>
+              )}
             </div>
 
             {/* Database Status Section */}


### PR DESCRIPTION
## Summary
- add FaceIDGate component to require Face ID when opening the app
- wire FaceIDGate into `App.tsx`
- allow iOS users to toggle Face ID lock in Settings
- update iOS Info.plist with Face ID usage description

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d0792d3b0832786027bd4ff434f02