### PR TITLE
Add route prefetching for faster navigation

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { VersionDisplay } from "@/components/VersionDisplay";
+import { prefetchRoute } from "@/lib/prefetch";
 
 export function LandingPage() {
   const navigate = useNavigate();
@@ -152,6 +153,8 @@ export function LandingPage() {
             <div className="flex items-center space-x-2 sm:space-x-4">
               <Button
                 variant="ghost"
+                onMouseEnter={() => prefetchRoute("/login")}
+                onFocus={() => prefetchRoute("/login")}
                 onClick={() => navigate("/login")}
                 aria-label="Sign in to your account"
                 className="text-sm text-linear-text-secondary hover:text-linear-text hidden sm:block"
@@ -159,6 +162,8 @@ export function LandingPage() {
                 Log in
               </Button>
               <Button
+                onMouseEnter={() => prefetchRoute("/login")}
+                onFocus={() => prefetchRoute("/login")}
                 onClick={() => navigate("/login")}
                 aria-label="Start your 3-day free trial"
                 className="bg-linear-text text-linear-bg text-sm font-medium px-4 sm:px-5 py-2 rounded-lg hover:bg-linear-text-secondary transition-colors"
@@ -193,6 +198,8 @@ export function LandingPage() {
               <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
                 <Button
                   className="bg-linear-text text-linear-bg px-6 py-3 text-sm font-medium rounded-lg hover:bg-linear-text-secondary transition-colors w-full sm:w-auto"
+                  onMouseEnter={() => prefetchRoute("/login")}
+                  onFocus={() => prefetchRoute("/login")}
                   onClick={() => navigate("/login")}
                 >
                   Try free for 3 days
@@ -544,6 +551,8 @@ export function LandingPage() {
                 </ul>
                 <Button
                   className="w-full bg-linear-text text-linear-bg hover:bg-linear-text-secondary focus:ring-2 focus:ring-linear-purple/50 transition-colors"
+                  onMouseEnter={() => prefetchRoute("/login")}
+                  onFocus={() => prefetchRoute("/login")}
                   onClick={() => navigate("/login")}
                   aria-describedby="trial-terms"
                 >
@@ -574,6 +583,8 @@ export function LandingPage() {
             <div className="flex justify-center gap-4">
               <Button
                 className="bg-linear-text text-linear-bg px-8 py-4 text-base font-medium rounded-lg hover:bg-linear-text-secondary transition-colors"
+                onMouseEnter={() => prefetchRoute("/login")}
+                onFocus={() => prefetchRoute("/login")}
                 onClick={() => navigate("/login")}
               >
                 Try free for 3 days
@@ -581,6 +592,8 @@ export function LandingPage() {
               <Button
                 variant="ghost"
                 className="border border-linear-border text-linear-text-secondary hover:bg-linear-border/50 hover:text-linear-text px-8 py-4 text-base rounded-lg transition-all"
+                onMouseEnter={() => prefetchRoute("/login")}
+                onFocus={() => prefetchRoute("/login")}
                 onClick={() => navigate("/login")}
               >
                 View demo
@@ -606,13 +619,31 @@ export function LandingPage() {
             </p>
           </div>
           <div className="mb-8 flex flex-wrap justify-center gap-2 sm:gap-4 md:gap-8">
-            <Button variant="ghost" onClick={() => navigate("/privacy")} className="text-linear-text-secondary hover:text-linear-text text-sm">
+            <Button
+              variant="ghost"
+              onMouseEnter={() => prefetchRoute("/privacy")}
+              onFocus={() => prefetchRoute("/privacy")}
+              onClick={() => navigate("/privacy")}
+              className="text-linear-text-secondary hover:text-linear-text text-sm"
+            >
               Privacy Policy
             </Button>
-            <Button variant="ghost" onClick={() => navigate("/terms")} className="text-linear-text-secondary hover:text-linear-text text-sm">
+            <Button
+              variant="ghost"
+              onMouseEnter={() => prefetchRoute("/terms")}
+              onFocus={() => prefetchRoute("/terms")}
+              onClick={() => navigate("/terms")}
+              className="text-linear-text-secondary hover:text-linear-text text-sm"
+            >
               Terms of Service
             </Button>
-            <Button variant="ghost" onClick={() => navigate("/changelog")} className="text-linear-text-secondary hover:text-linear-text text-sm">
+            <Button
+              variant="ghost"
+              onMouseEnter={() => prefetchRoute("/changelog")}
+              onFocus={() => prefetchRoute("/changelog")}
+              onClick={() => navigate("/changelog")}
+              className="text-linear-text-secondary hover:text-linear-text text-sm"
+            >
               Changelog
             </Button>
             <Button

--- a/src/lib/prefetch.ts
+++ b/src/lib/prefetch.ts
@@ -1,0 +1,18 @@
+const routeImports: Record<string, () => Promise<any>> = {
+  "/login": () => import("../pages/Login"),
+  "/dashboard": () => import("../pages/Dashboard"),
+  "/settings": () => import("../pages/Settings"),
+  "/subscription": () => import("../pages/Subscription"),
+  "/terms": () => import("../pages/Terms"),
+  "/privacy": () => import("../pages/Privacy"),
+  "/changelog": () => import("../pages/Changelog"),
+  "/splash": () => import("../pages/Splash"),
+  "/": () => import("../pages/Index"),
+};
+
+export function prefetchRoute(path: string): void {
+  const importer = routeImports[path];
+  if (importer) {
+    importer();
+  }
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import { WeightPrompt } from "@/components/WeightPrompt";
 import { TrialGuard } from "@/components/TrialGuard";
 import { VersionDisplay } from "@/components/VersionDisplay";
 import { EmailConfirmationBanner } from "@/components/EmailConfirmationBanner";
+import { prefetchRoute } from "@/lib/prefetch";
 import { isSupabaseConfigured } from "@/lib/supabase";
 
 // Helper function to calculate age from birthday
@@ -262,6 +263,8 @@ const Dashboard = () => {
               <Button
                 size="icon"
                 variant="ghost"
+                onMouseEnter={() => prefetchRoute("/healthkit-test")}
+                onFocus={() => prefetchRoute("/healthkit-test")}
                 onClick={() => navigate("/healthkit-test")}
                 className="text-linear-text-secondary hover:text-linear-text hover:bg-linear-border/50 transition-colors"
                 title="HealthKit Testing (Development)"
@@ -286,6 +289,8 @@ const Dashboard = () => {
             <Button
               size="icon"
               variant="ghost"
+              onMouseEnter={() => prefetchRoute("/settings")}
+              onFocus={() => prefetchRoute("/settings")}
               onClick={() => navigate("/settings")}
               className="h-10 w-10 text-linear-text-secondary hover:text-linear-text hover:bg-linear-border/50 transition-colors"
             >
@@ -349,6 +354,8 @@ const Dashboard = () => {
               <Button
                 size="icon"
                 variant="ghost"
+                onMouseEnter={() => prefetchRoute("/settings")}
+                onFocus={() => prefetchRoute("/settings")}
                 onClick={() => navigate("/settings")}
                 className="h-10 w-10 bg-linear-bg/80 text-linear-text-secondary shadow-lg backdrop-blur-sm hover:bg-linear-card hover:text-linear-text transition-colors"
               >

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,7 @@ import { useResponsive } from "@/hooks/use-responsive";
 import { useAuth } from "@/contexts/AuthContext";
 import { Capacitor } from "@capacitor/core";
 import { useSwipeNavigation } from "@/hooks/use-swipe-navigation";
+import { prefetchRoute } from "@/lib/prefetch";
 
 const Index = () => {
   const { isMobile } = useResponsive();
@@ -12,6 +13,11 @@ const Index = () => {
   const navigate = useNavigate();
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [forceRedirect, setForceRedirect] = useState(false);
+
+  // Prefetch login page to speed up navigation
+  useEffect(() => {
+    prefetchRoute("/login");
+  }, []);
 
   // Add swipe navigation to go to login
   useSwipeNavigation({

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -15,6 +15,7 @@ import {
 import { useAppleSignIn } from "@/hooks/use-apple-signin";
 import { useSwipeNavigation } from "@/hooks/use-swipe-navigation";
 import { VersionDisplay } from "@/components/VersionDisplay";
+import { prefetchRoute } from "@/lib/prefetch";
 
 const Login = () => {
   const navigate = useNavigate();
@@ -231,6 +232,8 @@ const Login = () => {
       <div className="flex items-center justify-between p-6">
         <Button
           variant="ghost"
+          onMouseEnter={() => prefetchRoute("/")}
+          onFocus={() => prefetchRoute("/")}
           onClick={() => navigate("/")}
           className="text-linear-text-secondary hover:text-linear-text"
         >
@@ -447,6 +450,8 @@ const Login = () => {
         <p className="text-sm text-linear-text-tertiary">
           By continuing, you agree to our{" "}
           <button
+            onMouseEnter={() => prefetchRoute("/terms")}
+            onFocus={() => prefetchRoute("/terms")}
             onClick={() => navigate("/terms")}
             className="text-linear-purple hover:underline"
           >
@@ -454,6 +459,8 @@ const Login = () => {
           </button>{" "}
           and{" "}
           <button
+            onMouseEnter={() => prefetchRoute("/privacy")}
+            onFocus={() => prefetchRoute("/privacy")}
             onClick={() => navigate("/privacy")}
             className="text-linear-purple hover:underline"
           >
@@ -462,6 +469,8 @@ const Login = () => {
         </p>
         <div className="mt-4 flex justify-center gap-4">
           <button
+            onMouseEnter={() => prefetchRoute("/changelog")}
+            onFocus={() => prefetchRoute("/changelog")}
             onClick={() => navigate("/changelog")}
             className="text-sm text-linear-text-tertiary transition-colors hover:text-linear-text"
           >

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -31,6 +31,7 @@ import { useSupabaseBodyMetrics } from "@/hooks/use-supabase-body-metrics";
 import { useSupabaseSubscription } from "@/hooks/use-supabase-subscription";
 import { useSwipeNavigation } from "@/hooks/use-swipe-navigation";
 import { LogOut } from "lucide-react";
+import { prefetchRoute } from "@/lib/prefetch";
 
 const Settings = () => {
   const navigate = useNavigate();
@@ -210,6 +211,8 @@ const Settings = () => {
           <Button
             size="icon"
             variant="ghost"
+            onMouseEnter={() => prefetchRoute("/dashboard")}
+            onFocus={() => prefetchRoute("/dashboard")}
             onClick={() => navigate("/dashboard")}
             className="h-10 w-10 text-linear-text-secondary hover:text-linear-text hover:bg-linear-border/50 transition-colors"
           >
@@ -344,6 +347,8 @@ const Settings = () => {
                   </div>
                   <ArrowLeft
                     className="h-4 w-4 rotate-180 cursor-pointer text-muted-foreground"
+                    onMouseEnter={() => prefetchRoute("/subscription")}
+                    onFocus={() => prefetchRoute("/subscription")}
                     onClick={() => navigate("/subscription")}
                   />
                 </div>

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from "react-router-dom";
 import { useSubscription } from "@/hooks/use-subscription";
 import { Paywall } from "@/components/Paywall";
 import { useSwipeNavigation } from "@/hooks/use-swipe-navigation";
+import { prefetchRoute } from "@/lib/prefetch";
 
 const Subscription = () => {
   const navigate = useNavigate();
@@ -65,6 +66,8 @@ const Subscription = () => {
         <Button
           size="icon"
           variant="outline"
+          onMouseEnter={() => prefetchRoute("/settings")}
+          onFocus={() => prefetchRoute("/settings")}
           onClick={() => navigate("/settings")}
           className="h-10 w-10 border-border bg-secondary text-foreground hover:bg-muted"
         >


### PR DESCRIPTION
## Summary
- add small prefetch utility for pages
- prefetch login on homepage mount
- prefetch routes on hover/focus for nav buttons

## Testing
- `npm run typecheck`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d08acf0188327b149367b25dc4918