### PR TITLE
Update Privacy and Terms to mention vendors

### DIFF
--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -126,7 +126,19 @@ const Privacy = () => {
           </section>
 
           <section className="space-y-4">
-            <h3 className="text-xl font-semibold">7. Your Rights</h3>
+            <h3 className="text-xl font-semibold">7. Third-Party Services</h3>
+            <p className="leading-relaxed text-muted-foreground">
+              We use trusted third-party vendors to operate LogYourBody. These
+              include Supabase for data storage and authentication, RevenueCat
+              and Stripe for subscription management and payment processing, and
+              Vercel for hosting and analytics. These providers may process your
+              information solely to provide their services to us and are
+              obligated to protect your data.
+            </p>
+          </section>
+
+          <section className="space-y-4">
+            <h3 className="text-xl font-semibold">8. Your Rights</h3>
             <p className="leading-relaxed text-muted-foreground">
               You have the right to:
             </p>
@@ -140,7 +152,7 @@ const Privacy = () => {
           </section>
 
           <section className="space-y-4">
-            <h3 className="text-xl font-semibold">8. Children's Privacy</h3>
+            <h3 className="text-xl font-semibold">9. Children's Privacy</h3>
             <p className="leading-relaxed text-muted-foreground">
               LogYourBody is not intended for use by children under the age of
               13. We do not knowingly collect personal information from children
@@ -149,7 +161,7 @@ const Privacy = () => {
           </section>
 
           <section className="space-y-4">
-            <h3 className="text-xl font-semibold">9. Changes to This Policy</h3>
+            <h3 className="text-xl font-semibold">10. Changes to This Policy</h3>
             <p className="leading-relaxed text-muted-foreground">
               We may update this privacy policy from time to time. We will
               notify you of any changes by posting the new privacy policy on
@@ -158,7 +170,7 @@ const Privacy = () => {
           </section>
 
           <section className="space-y-4">
-            <h3 className="text-xl font-semibold">10. Contact Us</h3>
+            <h3 className="text-xl font-semibold">11. Contact Us</h3>
             <p className="leading-relaxed text-muted-foreground">
               If you have any questions about this Privacy Policy, please
               contact us at:

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -115,7 +115,18 @@ const Terms = () => {
           </section>
 
           <section className="space-y-4">
-            <h3 className="text-xl font-semibold">7. Changes to Terms</h3>
+            <h3 className="text-xl font-semibold">7. Third-Party Services</h3>
+            <p className="leading-relaxed text-muted-foreground">
+              LogYourBody relies on services such as Supabase for data storage
+              and authentication, RevenueCat and Stripe for handling
+              subscriptions and payments, and Vercel for hosting and analytics.
+              Your use of the Service is also subject to these providers'
+              respective terms and policies.
+            </p>
+          </section>
+
+          <section className="space-y-4">
+            <h3 className="text-xl font-semibold">8. Changes to Terms</h3>
             <p className="leading-relaxed text-muted-foreground">
               LogYourBody may revise these terms of service at any time without
               notice. By using this application, you are agreeing to be bound by
@@ -124,7 +135,7 @@ const Terms = () => {
           </section>
 
           <section className="space-y-4">
-            <h3 className="text-xl font-semibold">8. Contact Information</h3>
+            <h3 className="text-xl font-semibold">9. Contact Information</h3>
             <p className="leading-relaxed text-muted-foreground">
               If you have any questions about these Terms of Service, please
               contact us at:


### PR DESCRIPTION
## Summary
- add third-party vendor details to the privacy page
- add a third-party services section in terms of service

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d09999af48327b039e6aa20c377d8