### PR TITLE
Fix RevenueCat env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
 
 # RevenueCat Configuration
+VITE_REVENUECAT_IOS_KEY=your_ios_revenuecat_key
+VITE_REVENUECAT_WEB_KEY=your_web_revenuecat_key
+# Legacy (optional)
 VITE_REVENUECAT_PUBLIC_KEY=your_revenuecat_public_key
 
 # Stripe Product IDs (for RevenueCat configuration)

--- a/.env.production
+++ b/.env.production
@@ -6,5 +6,8 @@ VITE_SUPABASE_URL=https://przjeunffnkjzxpykvjn.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InByempldW5mZm5ranp4cHlrdmpuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk0MTI1NDYsImV4cCI6MjA2NDk4ODU0Nn0.jZyohfzoydZKaSH_q0Tu4VqEbyFDdf-8i0kSm-YzB8w
 
 # RevenueCat Configuration (production)
-# Public key from: RevenueCat Dashboard > Apps > [Your App] > API Keys > Public key
+# Platform-specific public keys from RevenueCat Dashboard
+VITE_REVENUECAT_IOS_KEY=appl_dJsnXzyTgEAsntJQjOxeOvOnoXP
+VITE_REVENUECAT_WEB_KEY=strp_kPUxxTPVLFHFRUapUTafrHwSMAE
+# Legacy (optional)
 VITE_REVENUECAT_PUBLIC_KEY=appl_dJsnXzyTgEAsntJQjOxeOvOnoXP

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ A modern body composition tracking application built with React and TypeScript. 
    SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
 
    # RevenueCat Configuration
+   VITE_REVENUECAT_IOS_KEY=your_ios_public_key
+   VITE_REVENUECAT_WEB_KEY=your_web_public_key
+   # Legacy (optional)
    VITE_REVENUECAT_PUBLIC_KEY=your_revenuecat_public_key
 
    # Stripe Product IDs (for RevenueCat configuration)

--- a/REVENUECAT_IMPORT_GUIDE.md
+++ b/REVENUECAT_IMPORT_GUIDE.md
@@ -90,9 +90,12 @@
 ## Step 7: Get API Keys
 
 1. Go to **Project Settings** → **API Keys**
-2. Copy the **Public API Key** for Web
+2. Copy the **Public API Key** for Web and iOS
 3. Update your `.env` file:
    ```env
+   VITE_REVENUECAT_WEB_KEY=your_web_public_key
+   VITE_REVENUECAT_IOS_KEY=your_ios_public_key
+   # Legacy (optional)
    VITE_REVENUECAT_PUBLIC_KEY=your_copied_public_key
    ```
 

--- a/REVENUECAT_SETUP.md
+++ b/REVENUECAT_SETUP.md
@@ -21,7 +21,10 @@
 2. Copy the "Public Key" for Web platform
    - ⚠️ **IMPORTANT**: Use the PUBLIC key (starts with `public_` or `appl_`), NOT the secret key (starts with `sk_`)
    - The secret key is for server-side use only and will cause "Invalid API Key" errors on client
-3. Add to your environment variables as `VITE_REVENUECAT_PUBLIC_KEY`
+3. Add to your environment variables:
+   - `VITE_REVENUECAT_WEB_KEY` (for web/Stripe)
+   - `VITE_REVENUECAT_IOS_KEY` (for iOS apps)
+   - Optionally, `VITE_REVENUECAT_PUBLIC_KEY` for legacy support
 
 ## 3. Connect Stripe Products to RevenueCat
 

--- a/cypress/e2e/revenuecat-integration.cy.ts
+++ b/cypress/e2e/revenuecat-integration.cy.ts
@@ -18,7 +18,7 @@ describe("RevenueCat Integration", () => {
   });
 
   describe("RevenueCat Debug Card", () => {
-    it('should show "Ready" status when VITE_REVENUECAT_PUBLIC_KEY is properly configured', () => {
+    it('should show "Ready" status when RevenueCat API keys are properly configured', () => {
       // Visit settings page where RevenueCat debug card should be displayed
       cy.visit("/settings");
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "supabase:generate-types": "npx supabase gen types typescript --local > src/types/supabase.ts",
     "render:avatars": "node ./scripts/svg-avatar-renderer.cjs",
     "render:avatars:full": "tsc --project ./scripts/tsconfig.json && node ./scripts/dist/render-avatars.js && rimraf ./scripts/dist ./scripts/__tmp",
-    "revenuecat:validate": "node -e \"console.log('RevenueCat configuration:', {configured: !!process.env.VITE_REVENUECAT_PUBLIC_KEY, key: process.env.VITE_REVENUECAT_PUBLIC_KEY?.slice(0,20) + '...'})\"",
+    "revenuecat:validate": "node -e \"const ios=process.env.VITE_REVENUECAT_IOS_KEY; const web=process.env.VITE_REVENUECAT_WEB_KEY; const legacy=process.env.VITE_REVENUECAT_PUBLIC_KEY; console.log('RevenueCat configuration:', { ios: !!ios, web: !!web, legacy: !!legacy });\"",
     "revenuecat:test": "echo 'Testing RevenueCat integration...' && npm run dev",
     "vercel:dev": "vercel dev",
     "vercel:build": "vercel build",

--- a/src/components/RevenueCatDebug.tsx
+++ b/src/components/RevenueCatDebug.tsx
@@ -135,9 +135,7 @@ export function RevenueCatDebug() {
             <div>
               <span className="font-medium">Will Renew:</span>
               <Badge
-                variant={
-                  subscriptionStatus.willRenew ? "default" : "secondary"
-                }
+                variant={subscriptionStatus.willRenew ? "default" : "secondary"}
               >
                 {subscriptionStatus.willRenew ? "Yes" : "No"}
               </Badge>
@@ -237,12 +235,33 @@ export function RevenueCatDebug() {
           <div>
             Public Key:{" "}
             {(() => {
-              const key = import.meta.env.VITE_REVENUECAT_PUBLIC_KEY;
-              if (!key) return "✗ Missing";
-              if (key.startsWith("sk_"))
+              const isIOS =
+                Capacitor.isNativePlatform() &&
+                Capacitor.getPlatform() === "ios";
+              const key = isIOS
+                ? import.meta.env.VITE_REVENUECAT_IOS_KEY
+                : import.meta.env.VITE_REVENUECAT_WEB_KEY;
+              const legacy = import.meta.env.VITE_REVENUECAT_PUBLIC_KEY;
+
+              if (!key && !legacy) return "✗ Missing";
+
+              const activeKey = key || legacy;
+
+              if (activeKey.startsWith("sk_"))
                 return "✗ Secret key (should be public)";
-              if (key === "your_revenuecat_public_key")
+
+              const validIOS = isIOS && activeKey.startsWith("appl_");
+              const validWeb =
+                !isIOS &&
+                (activeKey.startsWith("strp_") ||
+                  activeKey.startsWith("public_"));
+
+              if (isIOS && !validIOS) return "✗ Invalid iOS key";
+              if (!isIOS && !validWeb) return "✗ Invalid Web key";
+
+              if (activeKey === "your_revenuecat_public_key")
                 return "✗ Not configured";
+
               return "✓ Configured";
             })()}
           </div>

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -6,6 +6,8 @@ Object.defineProperty(globalThis, "import", {
   value: {
     meta: {
       env: {
+        VITE_REVENUECAT_IOS_KEY: "appl_test_key_123",
+        VITE_REVENUECAT_WEB_KEY: "strp_test_key_456",
         VITE_REVENUECAT_PUBLIC_KEY: "appl_test_key_123",
         VITE_SUPABASE_URL: "https://test.supabase.co",
         VITE_SUPABASE_ANON_KEY: "test-anon-key",

--- a/vercel-local.json
+++ b/vercel-local.json
@@ -2,6 +2,8 @@
   "env": {
     "VITE_SUPABASE_URL": "https://przjeunffnkjzxpykvjn.supabase.co",
     "VITE_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InByempldW5mZm5ranp4cHlrdmpuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk0MTI1NDYsImV4cCI6MjA2NDk4ODU0Nn0.jZyohfzoydZKaSH_q0Tu4VqEbyFDdf-8i0kSm-YzB8w",
+    "VITE_REVENUECAT_IOS_KEY": "appl_dJsnXzyTgEAsntJQjOxeOvOnoXP",
+    "VITE_REVENUECAT_WEB_KEY": "strp_kPUxxTPVLFHFRUapUTafrHwSMAE",
     "VITE_REVENUECAT_PUBLIC_KEY": "appl_dJsnXzyTgEAsntJQjOxeOvOnoXP"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -51,6 +51,8 @@
     "env": {
       "VITE_SUPABASE_URL": "https://przjeunffnkjzxpykvjn.supabase.co",
       "VITE_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InByempldW5mZm5ranp4cHlrdmpuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk0MTI1NDYsImV4cCI6MjA2NDk4ODU0Nn0.jZyohfzoydZKaSH_q0Tu4VqEbyFDdf-8i0kSm-YzB8w",
+      "VITE_REVENUECAT_IOS_KEY": "appl_dJsnXzyTgEAsntJQjOxeOvOnoXP",
+      "VITE_REVENUECAT_WEB_KEY": "strp_kPUxxTPVLFHFRUapUTafrHwSMAE",
       "VITE_REVENUECAT_PUBLIC_KEY": "appl_dJsnXzyTgEAsntJQjOxeOvOnoXP"
     }
   }


### PR DESCRIPTION
## Summary
- document platform-specific RevenueCat keys
- update environment examples and docs
- validate RevenueCat config using new keys
- handle both iOS and web keys in debug component

## Testing
- `npm run format.fix`
- `npm test` *(fails: expected '#9CA0A8' to be '#CCCCCC')*

------
https://chatgpt.com/codex/tasks/task_e_684d08794f4c8327ad4074be5181f1b8