### PR TITLE
Optimize Vite build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev": "vite",
     "build": "vite build",
     "test": "vitest --run",
+    "test:watch": "vitest",
     "format.fix": "prettier --write .",
     "typecheck": "tsc",
     "supabase:start": "npx supabase start",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,8 +89,29 @@ export default defineConfig(({ mode }) => ({
     sourcemap: mode === "development",
     // Minification optimizations
     minify: "esbuild",
+    // Additional esbuild tweaks for smaller bundles
+    esbuild: {
+      drop: mode === "production" ? ["console", "debugger"] : [],
+    },
+    // Disable legacy modulepreload polyfill
+    modulePreload: {
+      polyfill: false,
+    },
     // Asset optimization
     assetsInlineLimit: 4096,
+  },
+  // Speed up dev server and tests by pre-bundling heavy deps
+  optimizeDeps: {
+    include: [
+      "react",
+      "react-dom",
+      "react-router-dom",
+      "@tanstack/react-query",
+      "@supabase/supabase-js",
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-dropdown-menu",
+      "@radix-ui/react-toast",
+    ],
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- tweak Vite build for smaller production bundles
- prebundle heavy deps for faster dev server
- add watch mode script for vitest

## Testing
- `npm test` *(fails: Test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684d0cf4197083279a0dc904f000dcdb