### PR TITLE
Allow null profile emails

### DIFF
--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -81,7 +81,7 @@ export function OnboardingFlow({
       // Save profile
       const { error: profileError } = await supabase.from("profiles").upsert({
         id: user.id,
-        email: user.email || "",
+        email: user.email ?? null,
         name: data.name,
         gender: data.gender,
         birthday: data.birthday,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -266,7 +266,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         // Create minimal profile that will trigger ProfileSetup
         const { error: profileError } = await supabase.from("profiles").insert({
           id: user.id,
-          email: user.email || "",
+          email: user.email ?? null,
           name: userName,
           // Don't set gender, birthday, height - let ProfileGuard show ProfileSetup
         });

--- a/supabase/migrations/20250114000000_allow_null_email.sql
+++ b/supabase/migrations/20250114000000_allow_null_email.sql
@@ -1,0 +1,5 @@
+-- Allow email to be NULL in profiles table for SMS-only signups
+ALTER TABLE profiles ALTER COLUMN email DROP NOT NULL;
+
+-- Convert empty string emails to NULL for consistency
+UPDATE profiles SET email = NULL WHERE email = '';


### PR DESCRIPTION
## Summary
- allow email to be null in the `profiles` table
- store `null` instead of empty string during profile creation and onboarding

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0e85bfa083279dd0d7b23cebb8f9