### PR TITLE
Add landing page timeline demo

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { VersionDisplay } from "@/components/VersionDisplay";
+import LandingTimelineDemo from "@/components/LandingTimelineDemo";
 
 export function LandingPage() {
   const navigate = useNavigate();
@@ -383,49 +384,8 @@ export function LandingPage() {
                   {/* Background gradient */}
                   <div className="absolute inset-0 bg-gradient-to-br from-linear-purple/20 via-transparent to-transparent blur-3xl" />
                   
-                  {/* Mock timeline interface */}
-                  <div className="relative rounded-2xl border border-linear-border bg-linear-card p-8">
-                    <div className="mb-6 text-center">
-                      <div className="inline-flex items-center gap-2 rounded-full bg-linear-purple/10 px-4 py-2">
-                        <Calendar className="h-4 w-4 text-linear-purple" />
-                        <span className="text-sm font-medium text-linear-purple">March 15, 2024</span>
-                      </div>
-                    </div>
-                    
-                    <div className="grid gap-4 text-center mb-8">
-                      <div>
-                        <div className="text-3xl font-bold text-linear-text">14.5%</div>
-                        <div className="text-sm text-linear-text-tertiary">Body Fat</div>
-                      </div>
-                      <div className="grid grid-cols-2 gap-4">
-                        <div>
-                          <div className="text-2xl font-semibold text-linear-text">165 lbs</div>
-                          <div className="text-sm text-linear-text-tertiary">Weight</div>
-                        </div>
-                        <div>
-                          <div className="text-2xl font-semibold text-linear-text">23.1</div>
-                          <div className="text-sm text-linear-text-tertiary">FFMI</div>
-                        </div>
-                      </div>
-                    </div>
-                    
-                    {/* Timeline slider */}
-                    <div className="relative">
-                      <div className="mb-2 flex items-center justify-between text-xs text-linear-text-tertiary">
-                        <span>Jan 2024</span>
-                        <span>Today</span>
-                      </div>
-                      <div className="relative h-3 rounded-full bg-linear-border">
-                        <div className="absolute left-0 h-full w-3/4 rounded-full bg-gradient-to-r from-linear-purple/60 to-linear-purple" />
-                        <div className="absolute left-3/4 top-1/2 h-6 w-6 -translate-y-1/2 rounded-full border-2 border-linear-bg bg-linear-purple shadow-lg" />
-                      </div>
-                      <div className="mt-4 text-center">
-                        <p className="text-sm text-linear-text-secondary">
-                          ← Swipe to travel through time →
-                        </p>
-                      </div>
-                    </div>
-                  </div>
+                  {/* Interactive timeline demo */}
+                  <LandingTimelineDemo />
                 </div>
               </div>
             </div>

--- a/src/components/LandingTimelineDemo.tsx
+++ b/src/components/LandingTimelineDemo.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import { Slider } from "@/components/ui/slider";
+import { Calendar } from "lucide-react";
+
+interface DemoEntry {
+  date: string; // ISO string
+  bodyFat: number;
+  weight: number; // in lbs
+  ffmi: number;
+}
+
+const demoData: DemoEntry[] = [
+  { date: "2024-01-01", bodyFat: 21, weight: 180, ffmi: 22.0 },
+  { date: "2024-01-15", bodyFat: 19, weight: 176, ffmi: 22.1 },
+  { date: "2024-02-01", bodyFat: 17, weight: 172, ffmi: 22.3 },
+  { date: "2024-02-15", bodyFat: 15, weight: 169, ffmi: 22.4 },
+  { date: "2024-03-05", bodyFat: 13, weight: 166, ffmi: 22.6 },
+  { date: "2024-03-25", bodyFat: 12, weight: 164, ffmi: 22.7 },
+];
+
+function formatDate(dateStr: string, opts?: Intl.DateTimeFormatOptions) {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString("en-US", opts);
+}
+
+export function LandingTimelineDemo() {
+  const [index, setIndex] = useState(demoData.length - 1);
+  const entry = demoData[index];
+
+  const startLabel = formatDate(demoData[0].date, { month: "short", year: "numeric" });
+  const endLabel = formatDate(demoData[demoData.length - 1].date, { month: "short", year: "numeric" });
+
+  return (
+    <div className="relative rounded-2xl border border-linear-border bg-linear-card p-8">
+      <div className="mb-6 text-center">
+        <div className="inline-flex items-center gap-2 rounded-full bg-linear-purple/10 px-4 py-2">
+          <Calendar className="h-4 w-4 text-linear-purple" />
+          <span className="text-sm font-medium text-linear-purple">
+            {formatDate(entry.date, { month: "long", day: "numeric", year: "numeric" })}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid gap-4 text-center mb-8">
+        <div>
+          <div className="text-3xl font-bold text-linear-text">{entry.bodyFat}%</div>
+          <div className="text-sm text-linear-text-tertiary">Body Fat</div>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <div className="text-2xl font-semibold text-linear-text">{entry.weight} lbs</div>
+            <div className="text-sm text-linear-text-tertiary">Weight</div>
+          </div>
+          <div>
+            <div className="text-2xl font-semibold text-linear-text">{entry.ffmi}</div>
+            <div className="text-sm text-linear-text-tertiary">FFMI</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="relative">
+        <div className="mb-2 flex items-center justify-between text-xs text-linear-text-tertiary">
+          <span>{startLabel}</span>
+          <span>{endLabel}</span>
+        </div>
+        <Slider
+          value={[index]}
+          min={0}
+          max={demoData.length - 1}
+          step={1}
+          onValueChange={(v) => setIndex(v[0])}
+        />
+        <div className="mt-4 text-center">
+          <p className="text-sm text-linear-text-secondary">Drag to travel through time</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default LandingTimelineDemo;


### PR DESCRIPTION
## Summary
- add new interactive timeline demo component
- hook the component into the landing page

## Testing
- `npm test` *(fails: Failed to resolve imports and timed out tests)*

------
https://chatgpt.com/codex/tasks/task_e_684d1161b1088327a5cef0a51ed3211f