### PR TITLE
Improve PWA splash flow

### DIFF
--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -24,6 +24,17 @@ export const isWebApp = (): boolean => {
   return Capacitor.getPlatform() === "web";
 };
 
+// Check if app is installed as a PWA (standalone display mode)
+export const isPWAInstalled = (): boolean => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    (window.navigator as any).standalone === true
+  );
+};
+
 // Check if running in development mode
 export const isDevelopment = (): boolean => {
   return process.env.NODE_ENV === "development";
@@ -65,6 +76,7 @@ export const getPlatformInfo = () => {
     isWeb: isWebApp(),
     isiOS: isNativeiOS(),
     isAndroid: isNativeAndroid(),
+    isPWAInstalled: isPWAInstalled(),
     shouldShowPWA: shouldShowPWAFeatures(),
     shouldShowEmailAuth: shouldShowEmailAuth(),
     shouldShowGoogleSignIn: shouldShowGoogleSignIn(),
@@ -80,6 +92,7 @@ export const logPlatformInfo = (): void => {
   console.log("Is iOS:", info.isiOS);
   console.log("Is Android:", info.isAndroid);
   console.log("Is Web:", info.isWeb);
+  console.log("PWA Installed:", info.isPWAInstalled);
   console.log("Show PWA Features:", info.shouldShowPWA);
   console.log("Show Email Auth:", info.shouldShowEmailAuth);
   console.log("Show Google Sign In:", info.shouldShowGoogleSignIn);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import { LandingPage } from "@/components/LandingPage";
 import { useResponsive } from "@/hooks/use-responsive";
 import { useAuth } from "@/contexts/AuthContext";
 import { Capacitor } from "@capacitor/core";
+import { isPWAInstalled } from "@/lib/platform";
 import { useSwipeNavigation } from "@/hooks/use-swipe-navigation";
 import { prefetchRoute } from "@/lib/prefetch";
 
@@ -69,9 +70,14 @@ const Index = () => {
   }, [user, loading, navigate, isRedirecting]);
 
   useEffect(() => {
-    // For native iOS, automatically navigate to splash after a short delay
-    if (Capacitor.isNativePlatform() && !loading && !user && !isRedirecting) {
-      console.log("Native platform detected, navigating to splash");
+    // For native apps or installed PWA, automatically navigate to splash after a short delay
+    if (
+      (Capacitor.isNativePlatform() || isPWAInstalled()) &&
+      !loading &&
+      !user &&
+      !isRedirecting
+    ) {
+      console.log("Native or installed PWA detected, navigating to splash");
       const timer = setTimeout(() => {
         navigate("/splash", { replace: true });
       }, 500);
@@ -103,8 +109,8 @@ const Index = () => {
     );
   }
 
-  // For native platforms, don't render content (will redirect to splash)
-  if (Capacitor.isNativePlatform()) {
+  // For native platforms or installed PWA, don't render content (will redirect to splash)
+  if (Capacitor.isNativePlatform() || isPWAInstalled()) {
     return (
       <div className="flex min-h-svh items-center justify-center bg-background">
         <div className="text-center">


### PR DESCRIPTION
## Summary
- detect when the app is installed as a PWA
- on installed PWA show the splash screen by default just like the native apps

## Testing
- `npm run typecheck`
- `npm test` *(fails: Failed to resolve imports and test timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_684da790f9908327b1bbac827b050d53