### PR TITLE
Implement responsive image optimization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,7 @@
         "typescript": "^5.5.3",
         "vercel": "^43.1.0",
         "vite": "^6.2.2",
+        "vite-plugin-image-presets": "^0.3.4",
         "vite-plugin-pwa": "^1.0.0",
         "vitest": "^3.1.4",
         "workbox-window": "^7.3.0"
@@ -3419,6 +3420,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@nuxt/devalue": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/devalue/-/devalue-2.0.2.tgz",
+      "integrity": "sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@perfood/capacitor-healthkit": {
       "version": "2.0.0-alpha.2",
@@ -16631,6 +16639,70 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-image-presets": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-image-presets/-/vite-plugin-image-presets-0.3.4.tgz",
+      "integrity": "sha512-jVMMY7iuzDCRNUgPKo5oMZ5QPeJA5bou6i+38SmGxW5zrqkRI3QBDGNnUqIUg/nhz7J1fQji1SagGjgiiKfW6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/devalue": "^2.0",
+        "debug": "^4.3",
+        "pathe": "^0.2",
+        "sharp": "^0.30.5"
+      }
+    },
+    "node_modules/vite-plugin-image-presets/node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-plugin-image-presets/node_modules/pathe": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-0.2.0.tgz",
+      "integrity": "sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-plugin-image-presets/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vite-plugin-image-presets/node_modules/sharp": {
+      "version": "0.30.7",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.7.tgz",
+      "integrity": "sha512-G+MY2YW33jgflKPTXXptVO28HvNOo9G3j0MybYAHeEmby+QuD2U98dT6ueht9cv/XDqZspSpIhoSW+BAKJ7Hig==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.1",
+        "node-addon-api": "^5.0.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.3.7",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^2.1.1",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/vite-plugin-pwa": {

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "vercel": "^43.1.0",
     "vite": "^6.2.2",
     "vite-plugin-pwa": "^1.0.0",
+    "vite-plugin-image-presets": "^0.3.4",
     "vitest": "^3.1.4",
     "workbox-window": "^7.3.0"
   }

--- a/src/components/AvatarSilhouette.tsx
+++ b/src/components/AvatarSilhouette.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { LazyImage } from "@/components/ui/lazy-image";
+import { buildSrcSet } from "@/utils/image-helpers";
 
 interface AvatarSilhouetteProps {
   gender: "male" | "female";
@@ -148,6 +149,8 @@ export const AvatarSilhouette = React.memo(function AvatarSilhouette({
         {showPhoto && profileImage ? (
           <LazyImage
             src={profileImage}
+            srcSet={buildSrcSet(profileImage, 400)}
+            sizes="(min-width: 768px) 400px, 100vw"
             alt="Profile"
             className="max-h-full max-w-full rounded-lg object-contain"
           />

--- a/src/components/profile/AvatarDisplay.tsx
+++ b/src/components/profile/AvatarDisplay.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { tw, getAnimation } from "@/styles/design-tokens";
 import { LazyImage } from "@/components/ui/lazy-image";
+import { buildSrcSet } from "@/utils/image-helpers";
 import {
   getAvatarUrlFromMetrics,
   getFallbackAvatarUrl,
@@ -87,6 +88,8 @@ export const AvatarDisplay = React.memo<AvatarDisplayProps>(
               >
                 <LazyImage
                   src={profileImage}
+                  srcSet={buildSrcSet(profileImage, 400)}
+                  sizes="(min-width: 768px) 400px, 100vw"
                   alt={`Profile photo showing current body composition`}
                   className="max-h-full max-w-full rounded-lg object-contain shadow-lg"
                 />
@@ -102,6 +105,8 @@ export const AvatarDisplay = React.memo<AvatarDisplayProps>(
               >
                 <LazyImage
                   src={avatarError ? fallbackUrl : avatarUrl}
+                  srcSet={buildSrcSet(avatarError ? fallbackUrl : avatarUrl, 256)}
+                  sizes="(min-width: 768px) 256px, 40vw"
                   alt={`${gender} body composition wireframe showing ${(bodyFatPercentage || 0).toFixed(1)}% body fat`}
                   className="h-full w-full object-contain"
                   onError={handleAvatarError}

--- a/src/components/ui/lazy-image.tsx
+++ b/src/components/ui/lazy-image.tsx
@@ -1,9 +1,13 @@
 import React, { useState, useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
+import placeholderSrc from "/placeholder.svg?preset=optimized&src";
+import placeholderSrcSet from "/placeholder.svg?preset=optimized&srcset";
 
 interface LazyImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   src: string;
   alt: string;
+  srcSet?: string;
+  sizes?: string;
   placeholder?: string;
   className?: string;
   fallback?: React.ReactNode;
@@ -12,7 +16,9 @@ interface LazyImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
 export const LazyImage = React.memo(function LazyImage({
   src,
   alt,
-  placeholder = "/placeholder.svg",
+  srcSet,
+  sizes,
+  placeholder = placeholderSrc,
   className,
   fallback,
   ...props
@@ -60,6 +66,7 @@ export const LazyImage = React.memo(function LazyImage({
       {!isLoaded && (
         <img
           src={placeholder}
+          srcSet={placeholderSrcSet}
           alt=""
           className={cn(
             "absolute inset-0 h-full w-full object-cover transition-opacity duration-300",
@@ -78,6 +85,8 @@ export const LazyImage = React.memo(function LazyImage({
       {isInView && (
         <img
           src={src}
+          srcSet={srcSet}
+          sizes={sizes}
           alt={alt}
           onLoad={handleLoad}
           onError={handleError}

--- a/src/utils/image-helpers.ts
+++ b/src/utils/image-helpers.ts
@@ -1,0 +1,4 @@
+export function buildSrcSet(url: string, width: number): string {
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}width=${width} 1x, ${url}${sep}width=${width * 2} 2x`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { VitePWA } from "vite-plugin-pwa";
 import { visualizer } from "rollup-plugin-visualizer";
+import imagePresets, { hdPreset } from "vite-plugin-image-presets";
 import path from "path";
 import { readFileSync } from "fs";
 
@@ -115,6 +116,15 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
+    imagePresets({
+      optimized: hdPreset({
+        widths: [320, 640, 960],
+        formats: {
+          webp: { quality: 70 },
+          png: { quality: 80 },
+        },
+      }),
+    }),
 
     // Bundle analyzer (only in analyze mode)
     ...(mode === "analyze"


### PR DESCRIPTION
## Summary
- add `vite-plugin-image-presets` for retina assets
- extend `LazyImage` with `srcSet`/`sizes` and optimized placeholder
- generate responsive URLs via new `buildSrcSet` helper
- use `srcSet` in profile components

## Testing
- `npm install --package-lock-only`
- `npm install`
- `npm test` *(fails: vitest cannot resolve modules)*

------
https://chatgpt.com/codex/tasks/task_e_684dacfe63a4832787ba6990adc55708