### PR TITLE
Fix runtime issues in hooks and service worker

### DIFF
--- a/src/hooks/use-sms-auth.tsx
+++ b/src/hooks/use-sms-auth.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import { supabase, isSupabaseConfigured } from "@/lib/supabase";
 import { toast } from "sonner";
 
 interface UseSMSAuthReturn {
@@ -42,6 +42,11 @@ export function useSMSAuth(): UseSMSAuthReturn {
       return false;
     }
 
+    if (!isSupabaseConfigured || !supabase) {
+      setError("Authentication service not available");
+      return false;
+    }
+
     setIsLoading(true);
     setError(null);
 
@@ -76,6 +81,11 @@ export function useSMSAuth(): UseSMSAuthReturn {
   const verifySMSCode = useCallback(async (): Promise<boolean> => {
     if (!verificationCode.trim() || verificationCode.length !== 6) {
       setError("Please enter a valid 6-digit verification code");
+      return false;
+    }
+
+    if (!isSupabaseConfigured || !supabase) {
+      setError("Authentication service not available");
       return false;
     }
 

--- a/src/hooks/use-supabase-body-metrics.tsx
+++ b/src/hooks/use-supabase-body-metrics.tsx
@@ -92,14 +92,18 @@ export function useSupabaseBodyMetrics() {
       .eq("user_id", user.id)
       .single();
 
-    if (error && error.code !== "PGRST116") {
-      // Return default settings if none exist
-      return {
-        userId: user.id,
-        units: "imperial",
-        healthKitSyncEnabled: false,
-        googleFitSyncEnabled: false,
-      };
+    if (error) {
+      if (error.code === "PGRST116") {
+        // Return default settings if none exist
+        return {
+          userId: user.id,
+          units: "imperial",
+          healthKitSyncEnabled: false,
+          googleFitSyncEnabled: false,
+        };
+      }
+
+      throw new Error(`Failed to fetch settings: ${error.message}`);
     }
 
     return data;

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -176,7 +176,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,

--- a/src/hooks/use-webauthn.tsx
+++ b/src/hooks/use-webauthn.tsx
@@ -183,9 +183,14 @@ export function useWebAuthn(): WebAuthnState & WebAuthnActions {
       }
 
       const response = credential.response as AuthenticatorAttestationResponse;
+      const publicKeyBytes =
+        typeof (response as any).getPublicKey === "function"
+          ? (response as any).getPublicKey()
+          : response.attestationObject;
+
       const newCredential: WebAuthnCredential = {
         id: credential.id,
-        publicKey: bufferToBase64url(response.getPublicKey()!),
+        publicKey: bufferToBase64url(publicKeyBytes),
         counter: 0,
         deviceType: getDeviceType(),
         createdAt: new Date().toISOString(),

--- a/src/lib/service-worker-manager.ts
+++ b/src/lib/service-worker-manager.ts
@@ -225,14 +225,18 @@ class ServiceWorkerManager {
       if (registration?.waiting) {
         registration.waiting.postMessage({ type: "SKIP_WAITING" });
 
-        // Listen for the new SW to take control
-        navigator.serviceWorker.addEventListener("controllerchange", () => {
+        // Listen once for the new SW to take control
+        const onControllerChange = () => {
           console.log("New service worker activated");
-          // Notify user instead of automatic reload
           toast.success("App updated", {
             description: "A new version is ready. Please refresh when convenient.",
           });
-        });
+        };
+        navigator.serviceWorker.addEventListener(
+          "controllerchange",
+          onControllerChange,
+          { once: true },
+        );
       }
     } catch (error) {
       console.error("Error skipping waiting service worker:", error);


### PR DESCRIPTION
## Summary
- handle missing Supabase client in SMS auth hook
- correct error handling in Supabase body metrics hook
- make WebAuthn registration portable by avoiding `getPublicKey`
- ensure service worker update listener only fires once
- avoid repeated effect subscriptions in `useToast`

## Testing
- `npm install`
- `npm test` *(fails: Failed to resolve imports and timeout errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d0d1240608327b9fd35a67819ebb4