### PR TITLE
Improve blog content rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logyourbody",
-  "version": "2025.06.16",
+  "version": "2025.06.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logyourbody",
-      "version": "2025.06.16",
+      "version": "2025.06.14",
       "license": "MIT",
       "dependencies": {
         "@capacitor-community/apple-sign-in": "^7.0.1",
@@ -57,12 +57,14 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
+        "dompurify": "^3.2.6",
         "embla-carousel-react": "^8.3.0",
         "framer-motion": "^12.17.3",
         "heic2any": "^0.0.4",
         "input-otp": "^1.2.4",
         "libphonenumber-js": "^1.12.9",
         "lucide-react": "^0.462.0",
+        "marked": "^15.0.12",
         "next-themes": "^0.3.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
@@ -6569,7 +6571,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/webxr": {
@@ -9515,6 +9517,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -12207,6 +12218,18 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,8 @@
     "embla-carousel-react": "^8.3.0",
     "framer-motion": "^12.17.3",
     "heic2any": "^0.0.4",
+    "dompurify": "^3.2.6",
+    "marked": "^15.0.12",
     "input-otp": "^1.2.4",
     "libphonenumber-js": "^1.12.9",
     "lucide-react": "^0.462.0",

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Calendar,
   Clock,
@@ -16,6 +22,8 @@ import { useNavigate, useParams } from "react-router-dom";
 import { prefetchRoute } from "@/lib/prefetch";
 import Footer from "@/components/Footer";
 import { getAllPosts, getPostBySlug, getAllTags } from "@/lib/blog";
+import { marked } from "marked";
+import DOMPurify from "dompurify";
 
 const Blog = () => {
   const navigate = useNavigate();
@@ -30,10 +38,15 @@ const Blog = () => {
 
   // Filter posts by selected tag
   const filteredPosts = selectedTag
-    ? allPosts.filter(post => post.tags.includes(selectedTag))
+    ? allPosts.filter((post) => post.tags.includes(selectedTag))
     : allPosts;
 
   const featuredPost = allPosts[0]; // Most recent post as featured
+
+  const sanitizedContent = React.useMemo(() => {
+    if (!currentPost) return "";
+    return DOMPurify.sanitize(marked.parse(currentPost.content));
+  }, [currentPost?.content]);
 
   if (currentPost) {
     // Individual post view
@@ -41,13 +54,13 @@ const Blog = () => {
       <div className="min-h-svh bg-linear-bg font-inter">
         {/* Header */}
         <header className="border-b border-linear-border" role="banner">
-          <div className="container mx-auto px-4 sm:px-6 py-4">
+          <div className="container mx-auto px-4 py-4 sm:px-6">
             <nav className="flex items-center justify-between">
               <button
                 onClick={() => navigate("/")}
                 onMouseEnter={() => prefetchRoute("/")}
                 onFocus={() => prefetchRoute("/")}
-                className="text-lg sm:text-xl font-semibold text-linear-text hover:text-linear-text-secondary transition-colors"
+                className="text-lg font-semibold text-linear-text transition-colors hover:text-linear-text-secondary sm:text-xl"
               >
                 LogYourBody
               </button>
@@ -73,7 +86,7 @@ const Blog = () => {
                   onMouseEnter={() => prefetchRoute("/login")}
                   onFocus={() => prefetchRoute("/login")}
                   onClick={() => navigate("/login")}
-                  className="bg-linear-text text-linear-bg text-sm font-medium px-4 py-2 rounded-lg hover:bg-linear-text-secondary transition-colors"
+                  className="rounded-lg bg-linear-text px-4 py-2 text-sm font-medium text-linear-bg transition-colors hover:bg-linear-text-secondary"
                 >
                   Sign up
                 </Button>
@@ -83,22 +96,22 @@ const Blog = () => {
         </header>
 
         {/* Article */}
-        <main className="container mx-auto px-4 sm:px-6 py-12">
-          <article className="max-w-4xl mx-auto">
+        <main className="container mx-auto px-4 py-12 sm:px-6">
+          <article className="mx-auto max-w-4xl">
             {/* Article header */}
             <header className="mb-12">
-              <div className="flex flex-wrap gap-2 mb-4">
+              <div className="mb-4 flex flex-wrap gap-2">
                 {currentPost.tags.map((tag) => (
                   <Badge key={tag} variant="secondary" className="text-xs">
                     {tag}
                   </Badge>
                 ))}
               </div>
-              
-              <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight text-linear-text mb-6">
+
+              <h1 className="mb-6 text-4xl font-bold tracking-tight text-linear-text sm:text-5xl md:text-6xl">
                 {currentPost.title}
               </h1>
-              
+
               <div className="flex items-center gap-6 text-sm text-linear-text-secondary">
                 <div className="flex items-center gap-2">
                   <User className="h-4 w-4" />
@@ -117,40 +130,29 @@ const Blog = () => {
 
             {/* Article content */}
             <div className="prose prose-lg max-w-none">
-              <div 
-                className="text-linear-text-secondary leading-relaxed"
-                dangerouslySetInnerHTML={{ 
-                  __html: currentPost.content
-                    .replace(/^# /gm, '<h1 class="text-3xl font-bold text-linear-text mt-8 mb-4">')
-                    .replace(/^## /gm, '<h2 class="text-2xl font-semibold text-linear-text mt-8 mb-4">')
-                    .replace(/^### /gm, '<h3 class="text-xl font-semibold text-linear-text mt-6 mb-3">')
-                    .replace(/\*\*(.*?)\*\*/g, '<strong class="font-semibold text-linear-text">$1</strong>')
-                    .replace(/\*(.*?)\*/g, '<em>$1</em>')
-                    .replace(/`([^`]+)`/g, '<code class="bg-linear-card px-2 py-1 rounded text-sm font-mono">$1</code>')
-                    .replace(/```([^```]+)```/gs, '<pre class="bg-linear-card p-4 rounded-lg overflow-x-auto"><code class="font-mono text-sm">$1</code></pre>')
-                    .replace(/^\| (.*) \|$/gm, '<div class="table-row">$1</div>')
-                    .replace(/\n\n/g, '</p><p class="mb-4">')
-                    .replace(/^(?!<[h|p|d])/gm, '<p class="mb-4">')
-                    + '</p>'
-                }}
+              <div
+                className="leading-relaxed text-linear-text-secondary"
+                dangerouslySetInnerHTML={{ __html: sanitizedContent }}
               />
             </div>
 
             {/* CTA */}
-            <div className="mt-12 p-8 bg-linear-card/30 rounded-xl border border-linear-border">
-              <h3 className="text-xl font-semibold text-linear-text mb-4">
+            <div className="mt-12 rounded-xl border border-linear-border bg-linear-card/30 p-8">
+              <h3 className="mb-4 text-xl font-semibold text-linear-text">
                 Ready to Start Tracking?
               </h3>
-              <p className="text-linear-text-secondary mb-6">
-                Join thousands of people using LogYourBody to track what really matters for their fitness journey.
+              <p className="mb-6 text-linear-text-secondary">
+                Join thousands of people using LogYourBody to track what really
+                matters for their fitness journey.
               </p>
               <Button
                 onClick={() => navigate("/login")}
                 onMouseEnter={() => prefetchRoute("/login")}
                 className="bg-linear-text text-linear-bg hover:bg-linear-text-secondary"
+                aria-label="Start Free Trial"
               >
                 Start Free Trial
-                <ArrowRight className="h-4 w-4 ml-2" />
+                <ArrowRight className="ml-2 h-4 w-4" />
               </Button>
             </div>
           </article>
@@ -166,13 +168,13 @@ const Blog = () => {
     <div className="min-h-svh bg-linear-bg font-inter">
       {/* Header */}
       <header className="border-b border-linear-border" role="banner">
-        <div className="container mx-auto px-4 sm:px-6 py-4">
+        <div className="container mx-auto px-4 py-4 sm:px-6">
           <nav className="flex items-center justify-between">
             <button
               onClick={() => navigate("/")}
               onMouseEnter={() => prefetchRoute("/")}
               onFocus={() => prefetchRoute("/")}
-              className="text-lg sm:text-xl font-semibold text-linear-text hover:text-linear-text-secondary transition-colors"
+              className="text-lg font-semibold text-linear-text transition-colors hover:text-linear-text-secondary sm:text-xl"
             >
               LogYourBody
             </button>
@@ -190,7 +192,7 @@ const Blog = () => {
                 onMouseEnter={() => prefetchRoute("/login")}
                 onFocus={() => prefetchRoute("/login")}
                 onClick={() => navigate("/login")}
-                className="bg-linear-text text-linear-bg text-sm font-medium px-4 py-2 rounded-lg hover:bg-linear-text-secondary transition-colors"
+                className="rounded-lg bg-linear-text px-4 py-2 text-sm font-medium text-linear-bg transition-colors hover:bg-linear-text-secondary"
               >
                 Sign up
               </Button>
@@ -204,38 +206,42 @@ const Blog = () => {
         <section className="py-16 md:py-24">
           <div className="container mx-auto px-4 sm:px-6">
             <div className="mx-auto max-w-4xl text-center">
-              <div className="flex items-center justify-center gap-2 mb-6">
+              <div className="mb-6 flex items-center justify-center gap-2">
                 <BookOpen className="h-8 w-8 text-linear-purple" />
-                <Badge className="bg-linear-purple/10 text-white border-linear-purple/20">
+                <Badge className="border-linear-purple/20 bg-linear-purple/10 text-white">
                   Evidence-Based Content
                 </Badge>
               </div>
-              
-              <h1 className="mb-6 text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight text-linear-text">
+
+              <h1 className="mb-6 text-4xl font-bold tracking-tight text-linear-text sm:text-5xl md:text-6xl">
                 The LogYourBody
                 <br />
                 <span className="bg-gradient-to-r from-linear-purple via-linear-text to-linear-purple bg-clip-text text-transparent">
                   Blog
                 </span>
               </h1>
-              
+
               <p className="mx-auto mb-8 max-w-2xl text-lg text-linear-text-secondary">
-                Science-based articles about body composition, fitness tracking, and building sustainable habits. 
-                No fluff, just actionable insights backed by research.
+                Science-based articles about body composition, fitness tracking,
+                and building sustainable habits. No fluff, just actionable
+                insights backed by research.
               </p>
             </div>
           </div>
         </section>
 
         {/* Tags Filter */}
-        <section className="py-8 border-y border-linear-border bg-linear-card/20">
+        <section className="border-y border-linear-border bg-linear-card/20 py-8">
           <div className="container mx-auto px-4 sm:px-6">
-            <div className="flex flex-wrap gap-2 justify-center">
+            <div className="flex flex-wrap justify-center gap-2">
               <Button
                 variant={selectedTag === null ? "default" : "outline"}
                 size="sm"
                 onClick={() => setSelectedTag(null)}
-                className={selectedTag === null ? "bg-linear-text text-linear-bg" : ""}
+                className={
+                  selectedTag === null ? "bg-linear-text text-linear-bg" : ""
+                }
+                aria-label="Show all posts"
               >
                 All Posts
               </Button>
@@ -245,9 +251,12 @@ const Blog = () => {
                   variant={selectedTag === tag ? "default" : "outline"}
                   size="sm"
                   onClick={() => setSelectedTag(tag)}
-                  className={selectedTag === tag ? "bg-linear-text text-linear-bg" : ""}
+                  className={
+                    selectedTag === tag ? "bg-linear-text text-linear-bg" : ""
+                  }
+                  aria-label={`Filter by tag ${tag}`}
                 >
-                  <Tag className="h-3 w-3 mr-1" />
+                  <Tag className="mr-1 h-3 w-3" />
                   {tag}
                 </Button>
               ))}
@@ -260,31 +269,37 @@ const Blog = () => {
           <section className="py-16">
             <div className="container mx-auto px-4 sm:px-6">
               <div className="mb-8">
-                <h2 className="text-2xl font-bold text-linear-text mb-4">Featured Article</h2>
+                <h2 className="mb-4 text-2xl font-bold text-linear-text">
+                  Featured Article
+                </h2>
               </div>
-              
-              <Card className="border-linear-border bg-linear-card/50 overflow-hidden">
+
+              <Card className="overflow-hidden border-linear-border bg-linear-card/50">
                 <div className="md:flex">
-                  <div className="md:w-1/3 bg-gradient-to-br from-linear-purple/20 to-linear-purple/5 p-8 flex items-center justify-center">
+                  <div className="flex items-center justify-center bg-gradient-to-br from-linear-purple/20 to-linear-purple/5 p-8 md:w-1/3">
                     <TrendingUp className="h-16 w-16 text-white" />
                   </div>
-                  <div className="md:w-2/3 p-8">
-                    <div className="flex flex-wrap gap-2 mb-4">
+                  <div className="p-8 md:w-2/3">
+                    <div className="mb-4 flex flex-wrap gap-2">
                       {featuredPost.tags.map((tag) => (
-                        <Badge key={tag} variant="secondary" className="text-xs">
+                        <Badge
+                          key={tag}
+                          variant="secondary"
+                          className="text-xs"
+                        >
                           {tag}
                         </Badge>
                       ))}
                     </div>
-                    
-                    <h3 className="text-2xl font-bold text-linear-text mb-4">
+
+                    <h3 className="mb-4 text-2xl font-bold text-linear-text">
                       {featuredPost.title}
                     </h3>
-                    
-                    <p className="text-linear-text-secondary mb-6">
+
+                    <p className="mb-6 text-linear-text-secondary">
                       {featuredPost.excerpt}
                     </p>
-                    
+
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-4 text-sm text-linear-text-secondary">
                         <div className="flex items-center gap-1">
@@ -296,14 +311,16 @@ const Blog = () => {
                           {featuredPost.readTime}
                         </div>
                       </div>
-                      
+
                       <Button
                         onClick={() => navigate(`/blog/${featuredPost.slug}`)}
-                        onMouseEnter={() => prefetchRoute(`/blog/${featuredPost.slug}`)}
+                        onMouseEnter={() =>
+                          prefetchRoute(`/blog/${featuredPost.slug}`)
+                        }
                         className="bg-linear-text text-linear-bg hover:bg-linear-text-secondary"
                       >
                         Read Article
-                        <ArrowRight className="h-4 w-4 ml-2" />
+                        <ArrowRight className="ml-2 h-4 w-4" />
                       </Button>
                     </div>
                   </div>
@@ -317,37 +334,47 @@ const Blog = () => {
         <section className="py-16">
           <div className="container mx-auto px-4 sm:px-6">
             <div className="mb-8">
-              <h2 className="text-2xl font-bold text-linear-text mb-4">
-                {selectedTag ? `Posts tagged \"${selectedTag}\"` : "Latest Articles"}
+              <h2 className="mb-4 text-2xl font-bold text-linear-text">
+                {selectedTag
+                  ? `Posts tagged \"${selectedTag}\"`
+                  : "Latest Articles"}
               </h2>
               <p className="text-linear-text-secondary">
-                {filteredPosts.length} article{filteredPosts.length !== 1 ? 's' : ''}
+                {filteredPosts.length} article
+                {filteredPosts.length !== 1 ? "s" : ""}
               </p>
             </div>
 
             <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
               {filteredPosts.map((post) => (
-                <Card key={post.slug} className="border-linear-border bg-linear-card group hover:shadow-lg transition-all">
+                <Card
+                  key={post.slug}
+                  className="group border-linear-border bg-linear-card transition-all hover:shadow-lg"
+                >
                   <CardHeader>
-                    <div className="flex flex-wrap gap-2 mb-3">
+                    <div className="mb-3 flex flex-wrap gap-2">
                       {post.tags.slice(0, 2).map((tag) => (
-                        <Badge key={tag} variant="secondary" className="text-xs">
+                        <Badge
+                          key={tag}
+                          variant="secondary"
+                          className="text-xs"
+                        >
                           {tag}
                         </Badge>
                       ))}
                     </div>
-                    
-                    <CardTitle className="text-lg text-linear-text group-hover:text-linear-purple transition-colors">
+
+                    <CardTitle className="text-lg text-linear-text transition-colors group-hover:text-linear-purple">
                       {post.title}
                     </CardTitle>
-                    
+
                     <CardDescription className="text-linear-text-secondary">
                       {post.excerpt}
                     </CardDescription>
                   </CardHeader>
-                  
+
                   <CardContent>
-                    <div className="flex items-center justify-between mb-4">
+                    <div className="mb-4 flex items-center justify-between">
                       <div className="flex items-center gap-3 text-sm text-linear-text-secondary">
                         <div className="flex items-center gap-1">
                           <Calendar className="h-3 w-3" />
@@ -359,10 +386,10 @@ const Blog = () => {
                         </div>
                       </div>
                     </div>
-                    
+
                     <Button
                       variant="ghost"
-                      className="w-full justify-between text-linear-text-secondary hover:text-linear-text hover:bg-linear-purple/10 transition-colors"
+                      className="w-full justify-between text-linear-text-secondary transition-colors hover:bg-linear-purple/10 hover:text-linear-text"
                       onClick={() => navigate(`/blog/${post.slug}`)}
                       onMouseEnter={() => prefetchRoute(`/blog/${post.slug}`)}
                     >
@@ -375,9 +402,11 @@ const Blog = () => {
             </div>
 
             {filteredPosts.length === 0 && (
-              <div className="text-center py-12">
-                <Search className="h-12 w-12 text-linear-text-secondary mx-auto mb-4" />
-                <h3 className="text-xl font-semibold text-linear-text mb-2">No articles found</h3>
+              <div className="py-12 text-center">
+                <Search className="mx-auto mb-4 h-12 w-12 text-linear-text-secondary" />
+                <h3 className="mb-2 text-xl font-semibold text-linear-text">
+                  No articles found
+                </h3>
                 <p className="text-linear-text-secondary">
                   Try selecting a different tag or view all posts.
                 </p>
@@ -387,14 +416,14 @@ const Blog = () => {
         </section>
 
         {/* Newsletter CTA */}
-        <section className="py-16 bg-linear-card/30">
-          <div className="container mx-auto px-4 sm:px-6 text-center">
-            <h2 className="text-3xl font-bold text-linear-text mb-4">
+        <section className="bg-linear-card/30 py-16">
+          <div className="container mx-auto px-4 text-center sm:px-6">
+            <h2 className="mb-4 text-3xl font-bold text-linear-text">
               Stay Updated
             </h2>
-            <p className="text-linear-text-secondary mb-8 max-w-2xl mx-auto">
-              Get notified when we publish new evidence-based articles about body composition, 
-              fitness tracking, and sustainable health habits.
+            <p className="mx-auto mb-8 max-w-2xl text-linear-text-secondary">
+              Get notified when we publish new evidence-based articles about
+              body composition, fitness tracking, and sustainable health habits.
             </p>
             <Button
               onClick={() => navigate("/login")}
@@ -402,7 +431,7 @@ const Blog = () => {
               className="bg-linear-text text-linear-bg hover:bg-linear-text-secondary"
             >
               Join LogYourBody
-              <ArrowRight className="h-4 w-4 ml-2" />
+              <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- parse markdown posts using `marked` and sanitize with `dompurify`
- add accessibility labels for CTA and tag filter buttons
- include `marked` and `dompurify` dependencies

## Testing
- `npm test`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684de00418b0832791a15be167e46d21