### PR TITLE
Fix iOS dashboard refresh loop

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import {
   setupBrowserExtensionErrorHandler,
   logBrowserEnvironment,
 } from "./lib/browser-compat";
+import { Capacitor } from "@capacitor/core";
 
 // Setup browser extension error handling - defer to avoid blocking
 setTimeout(() => {
@@ -16,8 +17,8 @@ setTimeout(() => {
   }
 }, 0);
 
-// Register service worker for PWA functionality - defer to avoid blocking
-if ("serviceWorker" in navigator) {
+// Register service worker for PWA functionality on web only - defer to avoid blocking
+if ("serviceWorker" in navigator && !Capacitor.isNativePlatform()) {
   // Use requestIdleCallback to defer SW registration
   const registerSW = () => {
     navigator.serviceWorker


### PR DESCRIPTION
## Summary
- prevent service worker registration on native iOS builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df892197c83278b132a4b9e9b981d