### PR TITLE
Improve test coverage

### DIFF
--- a/src/components/SEOHead.test.tsx
+++ b/src/components/SEOHead.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { SEOHead } from "./SEOHead";
+
+
+describe("SEOHead", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    document.title = "";
+  });
+
+  it("updates document title and meta tags", () => {
+    render(
+      <MemoryRouter initialEntries={["/test"]}>
+        <SEOHead
+          title="Test Title"
+          description="Desc"
+          keywords="one,two"
+          image="/img.png"
+          url="https://example.com/test"
+          type="article"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(document.title).toBe("Test Title");
+    const desc = document.querySelector("meta[name='description']");
+    expect(desc?.getAttribute("content")).toBe("Desc");
+    const ogTitle = document.querySelector("meta[property='og:title']");
+    expect(ogTitle?.getAttribute("content")).toBe("Test Title");
+    const canonical = document.querySelector("link[rel='canonical']");
+    expect(canonical?.getAttribute("href")).toBe("https://example.com/test");
+  });
+});

--- a/src/components/VersionDisplay.test.tsx
+++ b/src/components/VersionDisplay.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { VersionDisplay } from "./VersionDisplay";
+
+
+describe("VersionDisplay", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: { getRegistration: vi.fn().mockResolvedValue({ update: vi.fn() }) },
+      configurable: true,
+    });
+  });
+
+  it("shows version badge", () => {
+    render(<VersionDisplay />);
+    expect(screen.getByText("v1.0.0")).toBeInTheDocument();
+  });
+
+  it("checks for updates when button clicked", async () => {
+    const update = vi.fn();
+    const getReg = vi.fn().mockResolvedValue({ update });
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: { getRegistration: getReg },
+      configurable: true,
+    });
+    const user = userEvent.setup();
+    render(<VersionDisplay showBuildInfo={true} />);
+    await user.click(screen.getByRole("button", { name: /check updates/i }));
+    expect(getReg).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(update).toHaveBeenCalled();
+      expect(screen.getByText(/last checked/i)).toBeInTheDocument();
+    });
+  });
+
+  it("updates online status on offline event", () => {
+    render(<VersionDisplay showBuildInfo={true} />);
+    expect(screen.getByText(/online/i)).toBeInTheDocument();
+    act(() => {
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(screen.getByText(/offline/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/onboarding/OnboardingName.test.tsx
+++ b/src/components/onboarding/OnboardingName.test.tsx
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type MockedFunction } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { OnboardingName } from "./OnboardingName";
+import { Capacitor } from "@capacitor/core";
+import { Haptics } from "@capacitor/haptics";
 
 // Mock Capacitor modules
 vi.mock("@capacitor/core", () => ({
@@ -315,5 +317,19 @@ describe("OnboardingName", () => {
         screen.queryByText("Please enter at least 2 characters"),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("auto focuses input and triggers haptic feedback on native", () => {
+    vi.useFakeTimers();
+    const isNativeMock = Capacitor.isNativePlatform as unknown as MockedFunction<typeof Capacitor.isNativePlatform>;
+    isNativeMock.mockReturnValue(true);
+    render(
+      <OnboardingName onComplete={mockOnComplete} currentStep={1} totalSteps={5} />,
+    );
+    vi.advanceTimersByTime(400);
+    const input = screen.getByPlaceholderText("Enter your full name");
+    expect(document.activeElement).toBe(input);
+    expect(Haptics.impact).toHaveBeenCalledWith({ style: "light" });
+    vi.useRealTimers();
   });
 });

--- a/src/components/profile/__tests__/StatsGrid.test.tsx
+++ b/src/components/profile/__tests__/StatsGrid.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, renderHook } from "@testing-library/react";
 import React from "react";
-import { StatsGrid } from "../StatsGrid";
+import { StatsGrid, useStatsAnnouncement } from "../StatsGrid";
 import { DashboardMetrics } from "@/types/bodymetrics";
 
 // Mock framer-motion
@@ -218,5 +218,17 @@ describe("StatsGrid", () => {
     // Should have responsive classes for mobile/desktop layouts
     const gridElement = container.firstChild;
     expect(gridElement).toHaveClass("md:flex-col");
+  });
+
+  it("announces stat updates via live region", () => {
+    vi.useFakeTimers();
+    renderHook(() => useStatsAnnouncement(mockMetrics, "176 lbs"));
+    const liveRegion = document.querySelector('div[aria-live="polite"]');
+    expect(liveRegion).toBeInTheDocument();
+    vi.advanceTimersByTime(150);
+    expect(liveRegion?.textContent).toContain("Stats updated");
+    vi.advanceTimersByTime(1000);
+    expect(document.querySelector('div[aria-live="polite"]')).not.toBeInTheDocument();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- add tests for SEOHead meta updates
- add tests for VersionDisplay component
- check haptic autofocus on native onboarding flow
- verify StatsGrid live region announcements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df82bbf2883279e6d4ccc38ff7a6e