### PR TITLE
Fix onboarding safe area spacing

### DIFF
--- a/src/components/HealthKitSetup.tsx
+++ b/src/components/HealthKitSetup.tsx
@@ -168,7 +168,7 @@ export function HealthKitSetup({ onComplete, onSkip }: HealthKitSetupProps) {
       </div>
 
       {/* Fixed Action Buttons at Bottom */}
-      <div className="space-y-4 pb-safe">
+      <div className="space-y-4 pb-safe-bottom">
         <Button
           onClick={handleEnableHealthKit}
           disabled={isRequesting || loading}
@@ -200,7 +200,7 @@ export function HealthKitSetup({ onComplete, onSkip }: HealthKitSetupProps) {
       </div>
 
       {/* Fixed Action Buttons at Bottom */}
-      <div className="space-y-4 pb-safe">
+      <div className="space-y-4 pb-safe-bottom">
         <p className="text-center text-sm text-muted-foreground">
           You can always enable this later in Settings
         </p>

--- a/src/styles/onboarding-tokens.ts
+++ b/src/styles/onboarding-tokens.ts
@@ -139,7 +139,8 @@ export const onboardingTokens = {
 // Tailwind class mappings for consistent styling
 export const onboardingClasses = {
   container: "min-h-svh flex flex-col bg-background",
-  safeArea: "flex-1 flex flex-col px-6 pt-safe pb-safe",
+  // Use platform safe-area insets for proper spacing on notch devices
+  safeArea: "flex-1 flex flex-col px-6 pt-safe-top pb-safe-bottom",
 
   progress: {
     container: "flex items-center justify-center gap-3 py-4",


### PR DESCRIPTION
## Description
- ensure safe area classes use pt-safe-top/pb-safe-bottom
- adjust HealthKit setup layout to use pb-safe-bottom

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df8de306c8327a39c446b3c10b005