### PR TITLE
Add onboarding flow test and fix step calculation

### DIFF
--- a/src/components/onboarding/OnboardingFlow.test.tsx
+++ b/src/components/onboarding/OnboardingFlow.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => {
+  const supabaseMock = {
+    from: vi.fn(() => supabaseMock),
+    upsert: vi.fn(() => Promise.resolve({ error: null })),
+  };
+  return { supabase: supabaseMock };
+});
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    getPlatform: vi.fn(() => "web"),
+    isNativePlatform: vi.fn(() => false),
+  },
+  registerPlugin: vi.fn(() => ({})),
+}));
+
+vi.mock("@capacitor/haptics", () => ({
+  Haptics: { impact: vi.fn(), notification: vi.fn() },
+  ImpactStyle: { Light: "light" },
+}));
+
+import { useAuth } from "@/contexts/AuthContext";
+import { OnboardingFlow } from "./OnboardingFlow";
+
+describe("OnboardingFlow", () => {
+  const mockUser = {
+    id: "1",
+    email: "test@example.com",
+    user_metadata: {},
+  } as any;
+  const onComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useAuth as any).mockReturnValue({ user: mockUser });
+  });
+
+  it("shows gender step after completing name", async () => {
+    render(<OnboardingFlow onComplete={onComplete} />);
+
+    expect(screen.getByText("What's your name?"));
+    const input = screen.getByPlaceholderText("Enter your full name");
+    const user = userEvent.setup();
+    await user.type(input, "John Doe");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await screen.findByText("What's your gender?");
+  });
+
+  it("skips name step when provided and continues correctly", async () => {
+    (useAuth as any).mockReturnValue({
+      user: {
+        ...mockUser,
+        user_metadata: { name: "Jane" },
+      },
+    });
+
+    render(<OnboardingFlow onComplete={onComplete} />);
+
+    expect(screen.getByText("What's your gender?"));
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Male" }));
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await screen.findByText("When were you born?");
+  });
+});

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { AnimatePresence } from "framer-motion";
 import { OnboardingName } from "./OnboardingName";
 import { OnboardingGender } from "./OnboardingGender";
@@ -45,18 +45,22 @@ export function OnboardingFlow({
     height: healthKitData?.height,
   });
 
-  // Determine which steps to show based on existing data
-  const steps = [
-    { id: "name", show: !data.name },
-    { id: "gender", show: !data.gender },
-    { id: "birthday", show: !data.birthday },
-    { id: "units", show: true }, // Always show units preference
-    { id: "height", show: !data.height },
-    { id: "healthkit", show: isNativeiOS() }, // Show HealthKit step on iOS
-  ].filter((step) => step.show);
+  // Determine which steps to show based on initial data only
+  const [steps] = useState(() => {
+    const initialSteps = [
+      { id: "name" as const, show: !data.name },
+      { id: "gender" as const, show: !data.gender },
+      { id: "birthday" as const, show: !data.birthday },
+      { id: "units" as const, show: true }, // Always show units preference
+      { id: "height" as const, show: !data.height },
+      { id: "healthkit" as const, show: isNativeiOS() }, // Show HealthKit step on iOS
+    ];
+
+    return initialSteps.filter((step) => step.show).map((s) => s.id);
+  });
 
   const totalSteps = steps.length;
-  const currentStepData = steps[currentStep];
+  const currentStepId = steps[currentStep];
 
   const handleNext = () => {
     if (currentStep < steps.length - 1) {
@@ -133,7 +137,7 @@ export function OnboardingFlow({
 
   return (
     <AnimatePresence mode="wait">
-      {currentStepData?.id === "name" && (
+      {currentStepId === "name" && (
         <OnboardingName
           key="name"
           onComplete={(name) => {
@@ -147,7 +151,7 @@ export function OnboardingFlow({
         />
       )}
 
-      {currentStepData?.id === "gender" && (
+      {currentStepId === "gender" && (
         <OnboardingGender
           key="gender"
           onComplete={(gender) => {
@@ -161,7 +165,7 @@ export function OnboardingFlow({
         />
       )}
 
-      {currentStepData?.id === "birthday" && (
+      {currentStepId === "birthday" && (
         <OnboardingBirthday
           key="birthday"
           onComplete={(birthday) => {
@@ -175,7 +179,7 @@ export function OnboardingFlow({
         />
       )}
 
-      {currentStepData?.id === "units" && (
+      {currentStepId === "units" && (
         <OnboardingUnits
           key="units"
           onComplete={(units) => {
@@ -189,7 +193,7 @@ export function OnboardingFlow({
         />
       )}
 
-      {currentStepData?.id === "height" && (
+      {currentStepId === "height" && (
         <OnboardingHeight
           key="height"
           onComplete={(height) => {
@@ -204,7 +208,7 @@ export function OnboardingFlow({
         />
       )}
 
-      {currentStepData?.id === "healthkit" && (
+      {currentStepId === "healthkit" && (
         <OnboardingHealthKit
           key="healthkit"
           onComplete={(enabled) => {


### PR DESCRIPTION
## Summary
- fix onboarding step calculation so steps are based on initial data
- add new unit tests for the onboarding flow

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df8549ae48327ab58cc6342d510db