### PR TITLE
Improve weight logging UX

### DIFF
--- a/src/components/weight-logging-v2/WeightLoggingFlowV2.tsx
+++ b/src/components/weight-logging-v2/WeightLoggingFlowV2.tsx
@@ -39,6 +39,10 @@ interface WeightLoggingFlowV2Props {
     bodyFat?: BodyFatData;
     method?: MethodData;
   };
+  /**
+   * Default units if no initial weight is provided
+   */
+  units?: "imperial" | "metric";
 }
 
 interface WeightLoggingFlowContentProps extends WeightLoggingFlowV2Props {
@@ -243,8 +247,9 @@ function WeightLoggingFlowContent({
 
 export function WeightLoggingFlowV2(props: WeightLoggingFlowV2Props) {
   // Store form data at the top level
+  const defaultUnit = props.units === "metric" ? "kg" : "lbs";
   const [weightData, setWeightData] = useState<WeightData>(
-    props.initialData?.weight || { value: 0, unit: "lbs" },
+    props.initialData?.weight || { value: 0, unit: defaultUnit },
   );
   const [bodyFatData, setBodyFatData] = useState<BodyFatData>(
     props.initialData?.bodyFat || { value: 15 },

--- a/src/components/weight-logging-v2/WeightLoggingWrapper.tsx
+++ b/src/components/weight-logging-v2/WeightLoggingWrapper.tsx
@@ -84,6 +84,7 @@ export function WeightLoggingWrapper({
             onComplete={handleComplete}
             onCancel={onClose}
             initialData={initialData}
+            units={units}
           />
         </motion.div>
       )}

--- a/src/components/weight-logging-v2/WeightStep.tsx
+++ b/src/components/weight-logging-v2/WeightStep.tsx
@@ -21,7 +21,7 @@ interface WeightStepProps {
 }
 
 export function WeightStep({ value, onChange }: WeightStepProps) {
-  const { setCanGoNext } = useStepper();
+  const { setCanGoNext, goNext, canGoNext } = useStepper();
   const [inputValue, setInputValue] = useState(
     value.value > 0 ? value.value.toString() : "",
   );
@@ -218,6 +218,9 @@ export function WeightStep({ value, onChange }: WeightStepProps) {
           interaction_type: "keyboard",
           value: `${numValue} ${unit}`,
         });
+        if (canGoNext) {
+          goNext();
+        }
       }
     }
   };
@@ -294,7 +297,7 @@ export function WeightStep({ value, onChange }: WeightStepProps) {
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.2, duration: 0.25 }}
       >
-        <div className="flex rounded-xl bg-linear-card border border-linear-border p-1">
+        <div className="flex rounded-xl border border-linear-border bg-linear-card p-1">
           <button
             onClick={handleUnitToggle}
             className={cn(


### PR DESCRIPTION
## Summary
- set default weight unit based on user settings
- pass unit preference from wrapper to flow
- allow pressing Enter to advance in weight step

## Testing
- `npm test`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684df84c1e3c83279f465519214b492d