### PR TITLE
Fix settings timeout redirect

### DIFF
--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -102,6 +102,14 @@ export function RouteGuard({
     };
   }, [location.pathname, navigate, redirectTimeout, fallbackRoute, isProtectedOrProblematicRoute]);
 
+  // Clear the timeout once the page has finished loading
+  useEffect(() => {
+    if (!isLoading && timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, [isLoading]);
+
   // Detect potential redirect loops - but only on protected routes
   useEffect(() => {
     // Skip redirect loop detection for public routes


### PR DESCRIPTION
## Summary
- clear route timeout when settings finish loading

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfefd750883278765a29683212359