### PR TITLE
Improve phone input UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logyourbody",
-  "version": "2025.06.16",
+  "version": "2025.06.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logyourbody",
-      "version": "2025.06.16",
+      "version": "2025.06.53",
       "license": "MIT",
       "dependencies": {
         "@capacitor-community/apple-sign-in": "^7.0.1",
@@ -68,6 +68,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
+        "react-phone-number-input": "^3.4.12",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
         "recharts": "^2.12.7",
@@ -8409,6 +8410,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -9039,6 +9046,12 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/country-flag-icons": {
+      "version": "1.5.19",
+      "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.5.19.tgz",
+      "integrity": "sha512-D/ZkRyj+ywJC6b2IrAN3/tpbReMUqmuRLlcKFoY/o0+EPQN9Ev/e8tV+D3+9scvu/tarxwLErNwS73C3yzxs/g==",
       "license": "MIT"
     },
     "node_modules/create-require": {
@@ -11232,6 +11245,27 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/input-format": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/input-format/-/input-format-0.3.14.tgz",
+      "integrity": "sha512-gHMrgrbCgmT4uK5Um5eVDUohuV9lcs95ZUUN9Px2Y0VIfjTzT2wF8Q3Z4fwLFm7c5Z2OXCm53FHoovj6SlOKdg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.1.0",
+        "react-dom": ">=18.1.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/input-otp": {
@@ -13878,6 +13912,23 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
+    },
+    "node_modules/react-phone-number-input": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/react-phone-number-input/-/react-phone-number-input-3.4.12.tgz",
+      "integrity": "sha512-Raob77KdtLGm49iC6nuOX9qy6Mg16idkgC7Y1mHmvG2WBYoauHpzxYNlfmFskQKeiztrJIwPhPzBhjFwjenNCA==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.5.1",
+        "country-flag-icons": "^1.5.17",
+        "input-format": "^0.3.10",
+        "libphonenumber-js": "^1.11.20",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/react-reconciler": {
       "version": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-phone-number-input": "^3.4.12",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",

--- a/src/components/SMSLogin.tsx
+++ b/src/components/SMSLogin.tsx
@@ -1,11 +1,15 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { PhoneNumberInput } from "@/components/ui/phone-input";
 import { Label } from "@/components/ui/label";
 import { ArrowLeft, MessageSquare, Shield, Smartphone } from "lucide-react";
 import { useSMSAuth } from "@/hooks/use-sms-auth";
 import { cn } from "@/lib/utils";
-import { AsYouType, parsePhoneNumberFromString } from "libphonenumber-js";
+import {
+  isValidPhoneNumber,
+  formatPhoneNumberIntl,
+} from "react-phone-number-input";
 
 interface SMSLoginProps {
   onBack: () => void;
@@ -33,7 +37,7 @@ export const SMSLogin = React.memo(function SMSLogin({
 
   const [resendCountdown, setResendCountdown] = useState(0);
   const codeInputRefs = useRef<(HTMLInputElement | null)[]>([]);
-  const isPhoneValid = !!parsePhoneNumberFromString(phoneNumber, "US")?.isValid();
+  const isPhoneValid = phoneNumber ? isValidPhoneNumber(phoneNumber) : false;
 
   // Auto-paste functionality for verification codes
   useEffect(() => {
@@ -64,9 +68,8 @@ export const SMSLogin = React.memo(function SMSLogin({
   }, [resendCountdown]);
 
   const formatPhoneDisplay = (phone: string) => {
-    const parsed = parsePhoneNumberFromString(phone, "US");
-    if (parsed) {
-      return parsed.formatInternational();
+    if (phone && isValidPhoneNumber(phone)) {
+      return formatPhoneNumberIntl(phone);
     }
     return phone;
   };
@@ -124,12 +127,7 @@ export const SMSLogin = React.memo(function SMSLogin({
   return (
     <div className={cn("mx-auto w-full max-w-md", className)}>
       {/* Back button */}
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={onBack}
-        className="-ml-2 mb-6"
-      >
+      <Button variant="ghost" size="sm" onClick={onBack} className="-ml-2 mb-6">
         <ArrowLeft className="mr-2 h-4 w-4" />
         Back
       </Button>
@@ -155,17 +153,12 @@ export const SMSLogin = React.memo(function SMSLogin({
               <Label htmlFor="phone" className="text-sm font-medium">
                 Phone Number
               </Label>
-              <Input
+              <PhoneNumberInput
                 id="phone"
-                type="tel"
-                placeholder="+1 555 123 4567"
                 value={phoneNumber}
-                onChange={(e) =>
-                  setPhoneNumber(new AsYouType("US").input(e.target.value))
-                }
-                className="h-12 text-base"
-                autoComplete="tel"
-                autoFocus
+                onChange={(val) => setPhoneNumber(val || "")}
+                defaultCountry="US"
+                className="text-base"
               />
             </div>
 

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import PhoneInput from "react-phone-number-input";
+import en from "react-phone-number-input/locale/en.json";
+import { cn } from "@/lib/utils";
+
+export interface PhoneNumberInputProps {
+  value?: string;
+  onChange: (value?: string) => void;
+  defaultCountry?: string;
+  className?: string;
+  countrySelectClassName?: string;
+  inputClassName?: string;
+}
+
+export const PhoneNumberInput = React.forwardRef<
+  HTMLInputElement,
+  PhoneNumberInputProps
+>(
+  (
+    {
+      value,
+      onChange,
+      defaultCountry = "US",
+      className,
+      countrySelectClassName,
+      inputClassName,
+      ...rest
+    },
+    ref,
+  ) => {
+    return (
+      <PhoneInput
+        {...rest}
+        ref={ref}
+        international
+        defaultCountry={defaultCountry}
+        value={value}
+        onChange={onChange}
+        labels={en}
+        className={cn(
+          "flex h-12 w-full items-center rounded-lg border border-linear-border bg-linear-card focus-within:border-linear-purple",
+          className,
+        )}
+        countrySelectProps={{
+          className: cn(
+            "mr-2 rounded-l-lg bg-transparent pl-3 pr-1 py-2 text-sm outline-none",
+            countrySelectClassName,
+          ),
+        }}
+        numberInputProps={{
+          className: cn(
+            "PhoneInputInput flex-1 rounded-r-lg bg-transparent px-2 py-2 text-base text-linear-text placeholder:text-linear-text-tertiary focus:outline-none",
+            inputClassName,
+          ),
+          autoComplete: "tel",
+        }}
+      />
+    );
+  },
+);
+PhoneNumberInput.displayName = "PhoneNumberInput";

--- a/src/hooks/use-sms-auth.tsx
+++ b/src/hooks/use-sms-auth.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
 import { toast } from "sonner";
-import { parsePhoneNumberFromString } from "libphonenumber-js";
+import { isValidPhoneNumber } from "react-phone-number-input";
 
 interface UseSMSAuthReturn {
   isLoading: boolean;
@@ -27,11 +27,10 @@ export function useSMSAuth(): UseSMSAuthReturn {
   const [error, setError] = useState<string | null>(null);
 
   const formatPhoneNumber = useCallback((phone: string): string | null => {
-    const parsed = parsePhoneNumberFromString(phone, "US");
-    if (!parsed || !parsed.isValid()) {
+    if (!phone || !isValidPhoneNumber(phone)) {
       return null;
     }
-    return parsed.number; // E.164 format
+    return phone; // Already in E.164 format from the input component
   }, []);
 
   const sendSMSCode = useCallback(async (): Promise<boolean> => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import "react-phone-number-input/style.css";
 import {
   setupBrowserExtensionErrorHandler,
   logBrowserEnvironment,


### PR DESCRIPTION
## Summary
- add `react-phone-number-input` dependency
- style a new `PhoneNumberInput` component
- integrate new phone input in the SMS login page
- validate phone numbers using the new helper
- load library styles globally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f0342fb7c83278b995eaffbc90d01