### PR TITLE
Add tests for remaining components

### DIFF
--- a/src/components/__tests__/FeaturesFlyout.test.tsx
+++ b/src/components/__tests__/FeaturesFlyout.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FeaturesFlyout } from '../FeaturesFlyout'
+
+describe('FeaturesFlyout', () => {
+  it('opens the panel on click', () => {
+    render(<FeaturesFlyout />)
+    fireEvent.click(screen.getByRole('button', { name: /features/i }))
+    expect(screen.getByText('Body Fat % Tracking')).toBeInTheDocument()
+  })
+
+  it('calls onFeatureClick when feature clicked', () => {
+    const onFeatureClick = jest.fn()
+    render(<FeaturesFlyout onFeatureClick={onFeatureClick} />)
+    fireEvent.click(screen.getByRole('button', { name: /features/i }))
+    fireEvent.click(screen.getByText('Body Fat % Tracking'))
+    expect(onFeatureClick).toHaveBeenCalledWith('body-fat-tracking')
+  })
+})

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import { Footer } from '../Footer'
+
+jest.mock('../VersionDisplay', () => ({
+  VersionDisplay: () => <div data-testid="version">v1.0.0</div>
+}))
+
+describe('Footer', () => {
+  it('renders cta and social links', () => {
+    render(<Footer />)
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument()
+    expect(screen.getByText('Start Free Trial')).toBeInTheDocument()
+    expect(screen.getByText('LogYourBody')).toBeInTheDocument()
+    expect(screen.getByTestId('version')).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/LandingTimelineDemo.test.tsx
+++ b/src/components/__tests__/LandingTimelineDemo.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { LandingTimelineDemo } from '../LandingTimelineDemo'
+
+jest.mock('../ui/slider', () => ({
+  Slider: ({ value, onValueChange }: any) => (
+    <input
+      data-testid="slider"
+      type="range"
+      value={value[0]}
+      onChange={e => onValueChange([Number(e.target.value)])}
+    />
+  )
+}))
+
+describe('LandingTimelineDemo', () => {
+  it('updates metrics when slider changes', () => {
+    render(<LandingTimelineDemo />)
+    expect(screen.getByText('12%')).toBeInTheDocument()
+    expect(screen.getByText('164 lbs')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByTestId('slider'), { target: { value: '0' } })
+
+    expect(screen.getByText('21%')).toBeInTheDocument()
+    expect(screen.getByText('180 lbs')).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/StepTrackerModule.test.tsx
+++ b/src/components/__tests__/StepTrackerModule.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import { StepTrackerSection } from '../StepTrackerModule'
+
+describe('StepTrackerSection', () => {
+  it('renders weekly overview', () => {
+    render(<StepTrackerSection />)
+    expect(screen.getByText('Movement matters.')).toBeInTheDocument()
+    expect(screen.getByText('We track it all.')).toBeInTheDocument()
+    expect(screen.getByText('This Week')).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/VersionDisplay.test.tsx
+++ b/src/components/__tests__/VersionDisplay.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import { VersionDisplay } from '../VersionDisplay'
+
+describe('VersionDisplay', () => {
+  it('shows version from env', () => {
+    process.env.NEXT_PUBLIC_VERSION = '9.9.9'
+    render(<VersionDisplay />)
+    expect(screen.getByText('v9.9.9')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add missing unit tests for the component library

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f137719e48327afd67c38b5158c06