### PR TITLE
Fix landing page UX issues

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -252,6 +252,7 @@ export function LandingPage() {
                     <button
                       className="flex items-center justify-center gap-2 text-base text-linear-text-secondary hover:text-linear-text transition-colors group"
                       aria-label="View live demo"
+                      onClick={() => scrollToSection('timeline-feature')}
                     >
                       See it in action
                       <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden="true" />

--- a/src/components/StepTrackerModule.tsx
+++ b/src/components/StepTrackerModule.tsx
@@ -161,7 +161,7 @@ export function StepTrackerSection() {
                 
                 <div className="grid grid-cols-7 gap-2">
                   {weekData.map((day, index) => (
-                    <motion.div
+                    <motion.button
                       key={day.day}
                       initial={{ opacity: 0, y: 20 }}
                       whileInView={{ opacity: 1, y: 0 }}
@@ -173,6 +173,8 @@ export function StepTrackerSection() {
                           : "hover:bg-linear-border/30"
                       }`}
                       onClick={() => setActiveDay(index)}
+                      aria-pressed={index === activeDay}
+                      aria-label={`Show data for day ${day.day}`}
                     >
                       <div className="mb-2 text-xs font-medium text-linear-text-tertiary">{day.day}</div>
                       <div className="mb-3 h-24 relative">
@@ -189,7 +191,7 @@ export function StepTrackerSection() {
                       <div className="text-xs font-semibold text-linear-text">
                         {day.steps > 0 ? `${(day.steps / 1000).toFixed(1)}k` : "—"}
                       </div>
-                    </motion.div>
+                    </motion.button>
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- scroll to the timeline feature when the "See it in action" button is clicked
- make step tracker day buttons keyboard accessible

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1652abc483278f9988fae05003b5