### PR TITLE
Improve email input experience

### DIFF
--- a/src/app/login/__tests__/login.test.tsx
+++ b/src/app/login/__tests__/login.test.tsx
@@ -189,4 +189,16 @@ describe('LoginPage', () => {
     // Check that it has minLength attribute
     expect(passwordInput).toHaveAttribute('minLength', '6')
   })
+
+  it('shows domain suggestions as the user types an email', async () => {
+    const user = userEvent.setup()
+    render(<LoginPage />)
+
+    const emailInput = screen.getByLabelText('Email')
+
+    await user.type(emailInput, 'user@gm')
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(screen.getByText('user@gmail.com')).toBeInTheDocument()
+  })
 })

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { EmailInput } from '@/components/ui/email-input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -89,12 +90,11 @@ export default function LoginPage() {
                   <Label htmlFor="signin-email">Email</Label>
                   <div className="relative">
                     <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                    <Input
+                    <EmailInput
                       id="signin-email"
-                      type="email"
                       placeholder="you@example.com"
                       value={email}
-                      onChange={(e) => setEmail(e.target.value)}
+                      onChange={(e) => setEmail((e.target as HTMLInputElement).value)}
                       className="pl-10"
                       required
                       disabled={loading}
@@ -145,12 +145,11 @@ export default function LoginPage() {
                   <Label htmlFor="signup-email">Email</Label>
                   <div className="relative">
                     <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                    <Input
+                    <EmailInput
                       id="signup-email"
-                      type="email"
                       placeholder="you@example.com"
                       value={email}
-                      onChange={(e) => setEmail(e.target.value)}
+                      onChange={(e) => setEmail((e.target as HTMLInputElement).value)}
                       className="pl-10"
                       required
                       disabled={loading}

--- a/src/components/ui/email-input.tsx
+++ b/src/components/ui/email-input.tsx
@@ -1,0 +1,125 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { Input } from "./input"
+
+export interface EmailInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  suggestions?: string[]
+  warnDisposable?: boolean
+}
+
+const defaultSuggestions = [
+  "gmail.com",
+  "outlook.com",
+  "yahoo.com",
+  "icloud.com",
+  "hotmail.com",
+]
+const disposableDomains = ["mailinator.com", "tempmail.com", "10minutemail.com"]
+
+const EmailInput = React.forwardRef<HTMLInputElement, EmailInputProps>(
+  ({ className, suggestions = defaultSuggestions, warnDisposable = true, ...props }, ref) => {
+    const [value, setValue] = React.useState(props.value?.toString() ?? "")
+    const [showList, setShowList] = React.useState(false)
+    const [error, setError] = React.useState<string | null>(null)
+
+    const updateValue = (val: string) => {
+      setValue(val)
+      if (props.onChange) {
+        // create synthetic event for external handler
+        const event = {
+          ...new Event("input", { bubbles: true }),
+          target: { value: val }
+        } as unknown as React.ChangeEvent<HTMLInputElement>
+        props.onChange(event)
+      }
+    }
+
+    const validate = (email: string) => {
+      if (!email.includes("@")) return "Looks like you’re missing the ‘@’ symbol"
+      const domain = email.split("@")[1] || ""
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u
+      if (!emailRegex.test(email)) return "Invalid email address"
+      if (warnDisposable && disposableDomains.includes(domain)) {
+        return "Disposable email addresses are not allowed"
+      }
+      return null
+    }
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = e.target.value
+      updateValue(val)
+      setError(validate(val))
+      setShowList(true)
+    }
+
+    const applySuggestion = (domain: string) => {
+      const local = value.split("@")[0]
+      const val = `${local}@${domain}`
+      updateValue(val)
+      setError(validate(val))
+      setShowList(false)
+    }
+
+    const suggestionMatches = React.useMemo(() => {
+      const domainPart = value.split("@")[1] ?? ""
+      return suggestions.filter((d) => d.startsWith(domainPart))
+    }, [value, suggestions])
+
+    const localPart = value.split("@")[0]
+    const domainPart = value.includes("@") ? value.split("@")[1] : ""
+
+    return (
+      <div className="relative">
+        <div className="pointer-events-none absolute inset-0 flex items-center px-3 py-2 text-sm">
+          <span className="text-blue-600">{localPart}</span>
+          {value.includes("@") && <span className="text-gray-400">@</span>}
+          <span className="text-green-600">{domainPart}</span>
+        </div>
+        <Input
+          {...props}
+          ref={ref}
+          type="text"
+          role="textbox"
+          aria-label="Email"
+          aria-invalid={error ? "true" : "false"}
+          value={value}
+          onChange={handleChange}
+          onFocus={() => setShowList(true)}
+          onBlur={(e) => {
+            setShowList(false)
+            props.onBlur?.(e)
+          }}
+          className={cn("text-transparent caret-current", className)}
+          autoComplete="email"
+        />
+        {showList && suggestionMatches.length > 0 && (
+          <ul
+            role="listbox"
+            className="absolute z-10 mt-1 w-full overflow-hidden rounded-md border bg-white text-sm shadow-md"
+          >
+            {suggestionMatches.map((s) => (
+              <li
+                key={s}
+                role="option"
+                className="cursor-pointer px-3 py-1 hover:bg-gray-100"
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  applySuggestion(s)
+                }}
+              >
+                {localPart}@{s}
+              </li>
+            ))}
+          </ul>
+        )}
+        {error && (
+          <p className="mt-1 text-sm text-red-600" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    )
+  }
+)
+EmailInput.displayName = "EmailInput"
+export { EmailInput }


### PR DESCRIPTION
## Summary
- add `EmailInput` component with syntax highlighting, domain suggestions, and inline validation
- use `EmailInput` on login screen
- test domain autocomplete

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f45ab9ab083278cd8b753671f9b68