### PR TITLE
Refactor data display components

### DIFF
--- a/src/components/DataStat.tsx
+++ b/src/components/DataStat.tsx
@@ -1,0 +1,19 @@
+import { cn } from '@/lib/utils'
+import { ReactNode } from 'react'
+
+interface DataStatProps {
+  icon?: ReactNode
+  value: ReactNode
+  label: string
+  className?: string
+}
+
+export function DataStat({ icon, value, label, className }: DataStatProps) {
+  return (
+    <div className={cn('rounded-lg bg-linear-border/20 p-4 text-center', className)}>
+      {icon && <div className="mb-2 flex justify-center">{icon}</div>}
+      <div className="text-2xl font-bold text-linear-text">{value}</div>
+      <div className="text-xs text-linear-text-tertiary">{label}</div>
+    </div>
+  )
+}

--- a/src/components/LandingTimelineDemo.tsx
+++ b/src/components/LandingTimelineDemo.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Slider } from "./ui/slider";
 import { Calendar } from "lucide-react";
+import { DataStat } from "./DataStat";
 
 interface DemoEntry {
   date: string; // ISO string
@@ -42,19 +43,10 @@ export function LandingTimelineDemo() {
       </div>
 
       <div className="grid gap-4 text-center mb-8">
-        <div>
-          <div className="text-3xl font-bold text-linear-text">{entry.bodyFat}%</div>
-          <div className="text-sm text-linear-text-tertiary">Body Fat</div>
-        </div>
+        <DataStat value={`${entry.bodyFat}%`} label="Body Fat" />
         <div className="grid grid-cols-2 gap-4">
-          <div>
-            <div className="text-2xl font-semibold text-linear-text">{entry.weight} lbs</div>
-            <div className="text-sm text-linear-text-tertiary">Weight</div>
-          </div>
-          <div>
-            <div className="text-2xl font-semibold text-linear-text">{entry.ffmi}</div>
-            <div className="text-sm text-linear-text-tertiary">FFMI</div>
-          </div>
+          <DataStat value={`${entry.weight} lbs`} label="Weight" />
+          <DataStat value={entry.ffmi} label="FFMI" />
         </div>
       </div>
 

--- a/src/components/StepTrackerModule.tsx
+++ b/src/components/StepTrackerModule.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Footprints, TrendingUp, Zap, Activity } from "lucide-react";
+import { DataStat } from "./DataStat";
 
 export function StepTrackerSection() {
   const [currentStep, setCurrentStep] = useState(7234);
@@ -201,35 +202,38 @@ export function StepTrackerSection() {
                   whileInView={{ opacity: 1, scale: 1 }}
                   viewport={{ once: true }}
                   transition={{ delay: 0.6 }}
-                  className="rounded-lg bg-linear-border/20 p-4 text-center"
                 >
-                  <Zap className="mx-auto mb-2 h-5 w-5 text-yellow-500" />
-                  <div className="text-2xl font-bold text-linear-text">1,247</div>
-                  <div className="text-xs text-linear-text-tertiary">Calories burned</div>
+                  <DataStat
+                    icon={<Zap className="h-5 w-5 text-yellow-500" />}
+                    value="1,247"
+                    label="Calories burned"
+                  />
                 </motion.div>
-                
+
                 <motion.div
                   initial={{ opacity: 0, scale: 0.95 }}
                   whileInView={{ opacity: 1, scale: 1 }}
                   viewport={{ once: true }}
                   transition={{ delay: 0.7 }}
-                  className="rounded-lg bg-linear-border/20 p-4 text-center"
                 >
-                  <Activity className="mx-auto mb-2 h-5 w-5 text-green-500" />
-                  <div className="text-2xl font-bold text-linear-text">5.2</div>
-                  <div className="text-xs text-linear-text-tertiary">Miles walked</div>
+                  <DataStat
+                    icon={<Activity className="h-5 w-5 text-green-500" />}
+                    value="5.2"
+                    label="Miles walked"
+                  />
                 </motion.div>
-                
+
                 <motion.div
                   initial={{ opacity: 0, scale: 0.95 }}
                   whileInView={{ opacity: 1, scale: 1 }}
                   viewport={{ once: true }}
                   transition={{ delay: 0.8 }}
-                  className="rounded-lg bg-linear-border/20 p-4 text-center"
                 >
-                  <TrendingUp className="mx-auto mb-2 h-5 w-5 text-blue-500" />
-                  <div className="text-2xl font-bold text-linear-text">87%</div>
-                  <div className="text-xs text-linear-text-tertiary">Goal completion</div>
+                  <DataStat
+                    icon={<TrendingUp className="h-5 w-5 text-blue-500" />}
+                    value="87%"
+                    label="Goal completion"
+                  />
                 </motion.div>
               </div>
             </div>

--- a/src/components/__tests__/DataStat.test.tsx
+++ b/src/components/__tests__/DataStat.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import { DataStat } from '../DataStat'
+import { Zap } from 'lucide-react'
+
+describe('DataStat', () => {
+  it('renders value and label', () => {
+    render(<DataStat value="123" label="Test" />)
+    expect(screen.getByText('123')).toBeInTheDocument()
+    expect(screen.getByText('Test')).toBeInTheDocument()
+  })
+
+  it('renders icon when provided', () => {
+    render(<DataStat icon={<Zap data-testid="icon" />} value="5" label="Zap" />)
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- extract `DataStat` component for uniform data display
- refactor `StepTrackerModule` and `LandingTimelineDemo` to use it
- add unit test for `DataStat`

## Testing
- `npx eslint src/components/DataStat.tsx src/components/StepTrackerModule.tsx src/components/LandingTimelineDemo.tsx`
- `npx jest src/components/__tests__/DataStat.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_685657d4af24832794fbaf9055e8db4a