### PR TITLE
Add brand page and reference in style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Design Resources
+
+- [Style Guide](docs/STYLE_GUIDE.md)
+- [Brand Page](docs/BRAND_PAGE.md)

--- a/docs/BRAND_PAGE.md
+++ b/docs/BRAND_PAGE.md
@@ -1,0 +1,27 @@
+# LogYourBody Brand Page
+
+Our brand is inspired by the timeless simplicity of [Linear](https://linear.app). This page lists the colors and fonts that define our look and feel.
+
+## Colors
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| Primary | #5E6AD2 | Buttons, active states |
+| Foreground | #F7F8F8 | Text and icons |
+| Background | #0A0B0D | Page background |
+| Muted | #6E7178 | Subtle text |
+| Border | #1F2023 | Dividers |
+| Text Primary | #F7F8F8 | Main text |
+| Text Secondary | #9CA0A8 | Secondary text |
+| Text Tertiary | #6E7178 | Tertiary text |
+
+## Fonts
+
+We use the **Inter** typeface for a crisp, modern feel. System fonts are used as fallbacks to keep rendering fast and consistent across platforms.
+
+```
+font-family: "Inter", system-ui, -apple-system, sans-serif;
+```
+
+---
+For implementation details, see the [Style Guide](STYLE_GUIDE.md).

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,0 +1,19 @@
+# LogYourBody Style Guide
+
+This guide defines the design principles and tokens used across our product. It serves as the single source of truth for our team and for any automated tools.
+
+## Design Tokens
+
+All colors, typography, spacing, and animation values are stored in `src/styles/design-tokens.ts`. These tokens power every component, ensuring consistency and accessibility.
+
+## Brand Page
+
+For the full color palette and typography details, see the [Brand Page](BRAND_PAGE.md). Use these values when creating new components or external assets so that everything aligns with our brand.
+
+## Usage
+
+- **Colors**: Reference tokens via helper functions (`getColor`, `tw` classes) rather than hard‑coding values.
+- **Typography**: Use the predefined token styles for headings, labels, and body text.
+- **Spacing**: Leverage tokenized spacing values for consistent layouts.
+
+Maintaining these guidelines ensures that our design stays cohesive as we scale.


### PR DESCRIPTION
## Summary
- add brand page with colors and fonts
- create style guide referencing design tokens
- link docs from README

## Testing
- `npm run lint` *(fails: @typescript-eslint no-unused-vars, react-hooks rules)*
- `npm run typecheck` *(fails: TS errors in codebase)*
- `npm test` *(fails: 2 test suites)*

------
https://chatgpt.com/codex/tasks/task_e_685660e26f6c83279657408c13ac198f