### PR TITLE
feat: move Clerk signup to email OTP and password to settings

### DIFF
--- a/apps/ios/LogYourBody/DesignSystem/Organisms/LoginForm.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/LoginForm.swift
@@ -8,21 +8,20 @@ import SwiftUI
 
 struct LoginForm: View {
     @Binding var email: String
-    @Binding var password: String
     @Binding var isLoading: Bool
 
     let onLogin: () -> Void
-    let onForgotPassword: () -> Void
     let onAppleSignIn: () -> Void
 
-    @FocusState private var focusedField: Field?
-
-    enum Field {
-        case email, password
+    private var isValidEmail: Bool {
+        let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        let pattern = "^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+        return trimmed.range(of: pattern, options: .regularExpression) != nil
     }
 
     private var isFormValid: Bool {
-        !email.isEmpty && !password.isEmpty
+        isValidEmail
     }
 
     var body: some View {
@@ -36,29 +35,14 @@ struct LoginForm: View {
                 autocapitalization: .never
             )
             .onSubmit {
-                focusedField = .password
-            }
-
-            // Password Field
-            VStack(alignment: .leading, spacing: 8) {
-                AuthFormField(
-                    label: "Password",
-                    text: $password,
-                    isSecure: true,
-                    textContentType: .password
-                )
-                .onSubmit {
-                    if isFormValid {
-                        onLogin()
-                    }
-                }
-
-                // Forgot Password Link
-                HStack {
-                    Spacer()
-                    DSAuthLink(title: "Forgot password?", action: onForgotPassword)
+                if isFormValid {
+                    onLogin()
                 }
             }
+
+            Text("We'll email you a one-time code to sign you in.")
+                .font(.system(size: 13))
+                .foregroundColor(.appTextSecondary)
 
             // Login Button
             BaseButton(
@@ -97,10 +81,8 @@ struct LoginForm: View {
 
             LoginForm(
                 email: .constant(""),
-                password: .constant(""),
                 isLoading: .constant(false),
                 onLogin: {},
-                onForgotPassword: {},
                 onAppleSignIn: {}
             )
             .padding(.horizontal, 24)

--- a/apps/ios/LogYourBody/Views/LoginView.swift
+++ b/apps/ios/LogYourBody/Views/LoginView.swift
@@ -10,7 +10,6 @@ import AuthenticationServices
 struct LoginView: View {
     @EnvironmentObject var authManager: AuthManager
     @State private var email = ""
-    @State private var password = ""
     @State private var isLoading = false
     @State private var showError = false
     @State private var errorMessage = ""
@@ -59,7 +58,7 @@ struct LoginView: View {
                 // Molecule: Auth Header
                 AuthHeader(
                     title: "LogYourBody",
-                    subtitle: "Track your fitness journey"
+                    subtitle: "Sign in with a one-time code sent to your email."
                 )
                 .padding(.top, authManager.isClerkLoaded ? 80 : 20)
                 .padding(.bottom, 24)
@@ -71,12 +70,8 @@ struct LoginView: View {
                 // Organism: Login Form
                 LoginForm(
                     email: $email,
-                    password: $password,
                     isLoading: $isLoading,
                     onLogin: login,
-                    onForgotPassword: {
-                        // Navigate to forgot password
-                    },
                     onAppleSignIn: {
                         Task {
                             await authManager.handleAppleSignIn()
@@ -248,7 +243,7 @@ struct LoginView: View {
         AnalyticsService.shared.track(
             event: "login_attempt",
             properties: [
-                "method": "password"
+                "method": "email_otp"
             ]
         )
 
@@ -256,7 +251,7 @@ struct LoginView: View {
             do {
                 try await AuthManager.shared.login(
                     email: self.email,
-                    password: self.password
+                    password: ""
                 )
                 // Reset loading state on success
                 isLoading = false
@@ -268,7 +263,7 @@ struct LoginView: View {
                 AnalyticsService.shared.track(
                     event: "login_failed",
                     properties: [
-                        "method": "password"
+                        "method": "email_otp"
                     ]
                 )
             }


### PR DESCRIPTION
Align Clerk auth so signup and sign-in are email-OTP based, with passwords managed from settings/security surfaces. Includes iOS email-OTP login flow and copy updates.