### PR TITLE
Improve onboarding signup validation and session handling

### DIFF
--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -353,9 +353,34 @@ final class OnboardingFlowViewModel: ObservableObject {
         return trimmed.range(of: pattern, options: .regularExpression) != nil
     }
 
+    private var trimmedAccountPassword: String {
+        accountPassword.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var accountPasswordMeetsLengthRequirement: Bool {
+        trimmedAccountPassword.count >= 8
+    }
+
+    var accountPasswordHasUpperAndLower: Bool {
+        let hasUpper = trimmedAccountPassword.rangeOfCharacter(from: .uppercaseLetters) != nil
+        let hasLower = trimmedAccountPassword.rangeOfCharacter(from: .lowercaseLetters) != nil
+        return hasUpper && hasLower
+    }
+
+    var accountPasswordHasNumberOrSymbol: Bool {
+        let hasNumber = trimmedAccountPassword.rangeOfCharacter(from: .decimalDigits) != nil
+        let hasSymbol = trimmedAccountPassword.rangeOfCharacter(from: CharacterSet.alphanumerics.inverted) != nil
+        return hasNumber || hasSymbol
+    }
+
+    var isAccountPasswordValid: Bool {
+        accountPasswordMeetsLengthRequirement
+            && accountPasswordHasUpperAndLower
+            && accountPasswordHasNumberOrSymbol
+    }
+
     var canContinueAccountCreation: Bool {
-        let password = accountPassword.trimmingCharacters(in: .whitespacesAndNewlines)
-        return canContinueEmailCapture && password.count >= 8
+        canContinueEmailCapture && isAccountPasswordValid
     }
 
     func updateSex(_ sex: BiologicalSex) {
@@ -439,6 +464,8 @@ final class OnboardingFlowViewModel: ObservableObject {
 
     func createAccount(authManager: AuthManager) async {
         guard canContinueAccountCreation else { return }
+        let email = emailAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+        let password = trimmedAccountPassword
         await MainActor.run {
             isCreatingAccount = true
             accountCreationError = nil
@@ -450,9 +477,9 @@ final class OnboardingFlowViewModel: ObservableObject {
                 accountCreationStage = .creatingAccount
             }
             try await authManager.signUp(
-                email: emailAddress,
-                password: accountPassword,
-                name: ""
+                email: email,
+                password: password,
+                name: "",
             )
 
             await MainActor.run {

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreAccountCreationView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreAccountCreationView.swift
@@ -104,8 +104,18 @@ struct BodyScoreAccountCreationView: View {
 
     private var passwordRules: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ruleRow(text: "At least 8 characters", satisfied: viewModel.accountPassword.count >= 8)
-            ruleRow(text: "Mix of letters & numbers", satisfied: hasLetters && hasNumbers)
+            ruleRow(
+                text: "At least 8 characters",
+                satisfied: viewModel.accountPasswordMeetsLengthRequirement
+            )
+            ruleRow(
+                text: "Upper & lowercase letters",
+                satisfied: viewModel.accountPasswordHasUpperAndLower
+            )
+            ruleRow(
+                text: "At least one number or symbol",
+                satisfied: viewModel.accountPasswordHasNumberOrSymbol
+            )
         }
     }
 
@@ -117,14 +127,6 @@ struct BodyScoreAccountCreationView: View {
                 .font(OnboardingTypography.caption)
                 .foregroundStyle(satisfied ? Color.appText : Color.appTextSecondary)
         }
-    }
-
-    private var hasLetters: Bool {
-        viewModel.accountPassword.rangeOfCharacter(from: .letters) != nil
-    }
-
-    private var hasNumbers: Bool {
-        viewModel.accountPassword.rangeOfCharacter(from: .decimalDigits) != nil
     }
 
     private func submit() {

--- a/apps/ios/LogYourBody/Services/AuthManager.swift
+++ b/apps/ios/LogYourBody/Services/AuthManager.swift
@@ -444,6 +444,11 @@ class AuthManager: NSObject, ObservableObject {
             throw AuthError.clerkNotInitialized
         }
 
+        if clerk.session != nil {
+            // Clear any existing session so we can create a fresh account
+            await logout()
+        }
+
         do {
             // Create sign up with email and password
             // Note: If your Clerk instance requires legal acceptance,


### PR DESCRIPTION
## Summary
- enforce Clerk-aligned password rules during onboarding and pass trimmed credentials to sign up
- update onboarding password guidance to include uppercase/lowercase and number or symbol requirements
- clear any existing Clerk session before creating a new account to avoid "already signed in" errors

## Testing
- swiftlint lint --strict *(fails: command not found in container)*
- xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,name=iPhone 16' build-for-testing *(fails: command not found in container)*
- xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,name=iPhone 16' test *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fc44a30488327a2f9a041335ae9d7)