### PR TITLE
feat(ios): ship paid LogYourBody MVP

### DIFF
--- a/apps/ios/LogYourBody/ContentView.swift
+++ b/apps/ios/LogYourBody/ContentView.swift
@@ -41,11 +41,13 @@ struct ContentView: View {
             return false
         }
 
-        // Check all required fields exist
-        let hasName = profile.fullName != nil && !(profile.fullName?.isEmpty ?? true)
+        let displayName = profile.fullName ?? user.name
+        let hasName = !(displayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
         let hasDOB = profile.dateOfBirth != nil
+        let hasHeight = (profile.height ?? 0) > 0
+        let hasGender = !(profile.gender?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
 
-        return hasName && hasDOB
+        return hasName && hasDOB && hasHeight && hasGender
     }
 
     private var shouldShowOnboarding: Bool {

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/LoginForm.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/LoginForm.swift
@@ -26,6 +26,14 @@ struct LoginForm: View {
 
     var body: some View {
         VStack(spacing: 20) {
+            // Apple Sign In is the primary path for the paid iOS app.
+            SocialLoginButton(
+                provider: .apple,
+                action: onAppleSignIn
+            )
+
+            DSAuthDivider()
+
             // Email Field
             AuthFormField(
                 label: "Email",
@@ -46,23 +54,14 @@ struct LoginForm: View {
 
             // Login Button
             BaseButton(
-                "Sign in",
+                "Email me a code",
                 configuration: ButtonConfiguration(
-                    style: .custom(background: .white, foreground: .black),
+                    style: .custom(background: .appCard, foreground: .appText),
                     isLoading: isLoading,
                     isEnabled: isFormValid,
                     fullWidth: true
                 ),
                 action: onLogin
-            )
-
-            // Divider
-            DSAuthDivider()
-
-            // Apple Sign In
-            SocialLoginButton(
-                provider: .apple,
-                action: onAppleSignIn
             )
         }
     }

--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -1079,6 +1079,11 @@ struct OnboardingProfileUpdateBuilder {
             updates["gender"] = sex.description
         }
 
+        if let birthYear = bodyScoreInput.birthYear,
+           let dateOfBirth = Calendar.current.date(from: DateComponents(year: birthYear, month: 1, day: 1)) {
+            updates["dateOfBirth"] = dateOfBirth
+        }
+
         if let heightCm = bodyScoreInput.height.inCentimeters {
             updates["height"] = heightCm
 

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
@@ -7,6 +7,11 @@ struct BodyScoreProfileDetailsView: View {
     @State private var firstName: String = ""
     @State private var lastName: String = ""
     @State private var dateOfBirth: Date = Calendar.current.date(byAdding: .year, value: -25, to: Date()) ?? Date()
+    @State private var biologicalSex: BiologicalSex?
+    @State private var heightUnit: HeightUnit = .centimeters
+    @State private var heightCentimetersText: String = ""
+    @State private var heightFeet: Int = 5
+    @State private var heightInches: Int = 10
     @State private var isSaving: Bool = false
     @State private var errorMessage: String?
     @State private var activeSubstep: ProfileSubstep = .firstName
@@ -36,6 +41,10 @@ struct BodyScoreProfileDetailsView: View {
             return isLastNameValid
         case .dateOfBirth:
             return isFirstNameValid && isLastNameValid && isDateOfBirthWithinValidRange
+        case .sex:
+            return biologicalSex != nil
+        case .height:
+            return isHeightValid
         }
     }
 
@@ -46,6 +55,36 @@ struct BodyScoreProfileDetailsView: View {
         return age >= 16 && age <= 80
     }
 
+    private var heightInCentimeters: Double? {
+        switch heightUnit {
+        case .centimeters:
+            return Double(heightCentimetersText)
+        case .inches:
+            let totalInches = Double((heightFeet * 12) + heightInches)
+            return totalInches > 0 ? totalInches * 2.54 : nil
+        }
+    }
+
+    private var isHeightValid: Bool {
+        switch heightUnit {
+        case .centimeters:
+            let value = Double(heightCentimetersText) ?? 0
+            return value >= 100 && value <= 250
+        case .inches:
+            let totalInches = (heightFeet * 12) + heightInches
+            return totalInches >= 48 && totalInches <= 96
+        }
+    }
+
+    private var heightUnitStorageValue: String {
+        switch heightUnit {
+        case .centimeters:
+            return "cm"
+        case .inches:
+            return "in"
+        }
+    }
+
     private var currentTitle: String {
         switch activeSubstep {
         case .firstName:
@@ -54,6 +93,10 @@ struct BodyScoreProfileDetailsView: View {
             return "And your last name?"
         case .dateOfBirth:
             return "Birthday"
+        case .sex:
+            return "Sex at birth"
+        case .height:
+            return "Height"
         }
     }
 
@@ -65,15 +108,19 @@ struct BodyScoreProfileDetailsView: View {
             return "We keep your name private and secure."
         case .dateOfBirth:
             return "Used for age-based insights."
+        case .sex:
+            return "Used only for body composition calculations."
+        case .height:
+            return "Needed for FFMI and body score."
         }
     }
 
     private var primaryButtonTitle: String {
         switch activeSubstep {
-        case .firstName, .lastName:
+        case .firstName, .lastName, .dateOfBirth, .sex:
             return "Continue"
-        case .dateOfBirth:
-            return "Continue"
+        case .height:
+            return "Finish setup"
         }
     }
 
@@ -93,6 +140,14 @@ struct BodyScoreProfileDetailsView: View {
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                         activeSubstep = .lastName
                     }
+                case .sex:
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                        activeSubstep = .dateOfBirth
+                    }
+                case .height:
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                        activeSubstep = .sex
+                    }
                 }
             },
             progress: viewModel.progress(for: .profileDetails),
@@ -103,6 +158,10 @@ struct BodyScoreProfileDetailsView: View {
                         nameSection
                     case .dateOfBirth:
                         dobSection
+                    case .sex:
+                        sexSection
+                    case .height:
+                        heightSection
                     }
                 }
             },
@@ -133,26 +192,12 @@ struct BodyScoreProfileDetailsView: View {
         .onAppear {
             hydrateFromCurrentUser()
             DispatchQueue.main.async {
-                switch activeSubstep {
-                case .firstName:
-                    focusedNameField = .firstName
-                case .lastName:
-                    focusedNameField = .lastName
-                case .dateOfBirth:
-                    focusedNameField = nil
-                }
+                focusNameFieldIfNeeded()
             }
         }
         .onChange(of: activeSubstep) { _, newValue in
             DispatchQueue.main.async {
-                switch newValue {
-                case .firstName:
-                    focusedNameField = .firstName
-                case .lastName:
-                    focusedNameField = .lastName
-                case .dateOfBirth:
-                    focusedNameField = nil
-                }
+                focusNameFieldIfNeeded(newValue)
             }
         }
     }
@@ -225,7 +270,7 @@ struct BodyScoreProfileDetailsView: View {
                             handleLastNameContinue()
                         }
 
-                case .dateOfBirth:
+                case .dateOfBirth, .sex, .height:
                     EmptyView()
                 }
             }
@@ -241,6 +286,91 @@ struct BodyScoreProfileDetailsView: View {
             )
             .datePickerStyle(.wheel)
             .labelsHidden()
+        }
+    }
+
+    private var sexSection: some View {
+        OnboardingFormSection(title: nil, caption: nil) {
+            HStack(spacing: 16) {
+                ForEach(BiologicalSex.allCases, id: \.self) { sex in
+                    OnboardingOptionButton(
+                        title: sex.description,
+                        subtitle: nil,
+                        isSelected: biologicalSex == sex,
+                        action: {
+                            biologicalSex = sex
+                            HapticManager.shared.selection()
+                        }
+                    )
+                    .frame(maxWidth: .infinity)
+                }
+            }
+        }
+    }
+
+    private var heightSection: some View {
+        OnboardingFormSection(title: nil, caption: "You can update this later in Settings.") {
+            VStack(alignment: .leading, spacing: 18) {
+                Picker("Height unit", selection: $heightUnit) {
+                    ForEach(HeightUnit.allCases, id: \.self) { unit in
+                        Text(unit.description).tag(unit)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: heightUnit) { oldValue, newValue in
+                    convertHeightFields(from: oldValue, to: newValue)
+                }
+
+                switch heightUnit {
+                case .centimeters:
+                    TextField("178", text: $heightCentimetersText)
+                        .keyboardType(.decimalPad)
+                        .font(.system(size: 40, weight: .bold, design: .rounded))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                .fill(Color.appCard.opacity(0.6))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                .stroke(Color.appBorder.opacity(0.6), lineWidth: 1)
+                        )
+                        .accessibilityLabel("Height in centimeters")
+
+                    Text("Enter a height from 100 to 250 cm.")
+                        .font(OnboardingTypography.caption)
+                        .foregroundStyle(Color.appTextSecondary)
+
+                case .inches:
+                    HStack(spacing: 12) {
+                        Picker("Feet", selection: $heightFeet) {
+                            ForEach(3...8, id: \.self) { feet in
+                                Text("\(feet) ft").tag(feet)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 150)
+                        .clipped()
+
+                        Picker("Inches", selection: $heightInches) {
+                            ForEach(0...11, id: \.self) { inches in
+                                Text("\(inches) in").tag(inches)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 150)
+                        .clipped()
+                    }
+
+                    Text("Enter a height from 4'0\" to 8'0\".")
+                        .font(OnboardingTypography.caption)
+                        .foregroundStyle(Color.appTextSecondary)
+                }
+            }
         }
     }
 
@@ -263,6 +393,23 @@ struct BodyScoreProfileDetailsView: View {
             dateOfBirth = existingDob
         }
 
+        if let existingGender = user.profile?.gender {
+            biologicalSex = Self.biologicalSex(from: existingGender)
+        }
+
+        if let existingHeight = user.profile?.height, existingHeight > 0 {
+            if user.profile?.heightUnit?.lowercased() == "in" {
+                heightUnit = .inches
+                let totalInches = Int((existingHeight / 2.54).rounded())
+                heightFeet = max(3, min(8, totalInches / 12))
+                heightInches = max(0, min(11, totalInches % 12))
+            } else {
+                heightUnit = .centimeters
+            }
+
+            heightCentimetersText = String(format: "%.0f", existingHeight)
+        }
+
         recomputeActiveSubstep()
     }
 
@@ -281,10 +428,19 @@ struct BodyScoreProfileDetailsView: View {
                     try await authManager.consolidateNameUpdate(fullName)
                 }
 
-                let updates: [String: Any] = [
+                var updates: [String: Any] = [
                     "dateOfBirth": dateOfBirth,
                     "onboardingCompleted": true
                 ]
+
+                if let biologicalSex {
+                    updates["gender"] = biologicalSex.description
+                }
+
+                if let heightInCentimeters {
+                    updates["height"] = heightInCentimeters
+                    updates["heightUnit"] = heightUnitStorageValue
+                }
 
                 await authManager.updateProfile(updates)
 
@@ -301,9 +457,9 @@ struct BodyScoreProfileDetailsView: View {
                             username: existingProfile?.username,
                             fullName: fullName.isEmpty ? existingProfile?.fullName ?? currentUser.name : fullName,
                             dateOfBirth: dateOfBirth,
-                            height: existingProfile?.height,
-                            heightUnit: existingProfile?.heightUnit,
-                            gender: existingProfile?.gender,
+                            height: heightInCentimeters ?? existingProfile?.height,
+                            heightUnit: heightInCentimeters == nil ? existingProfile?.heightUnit : heightUnitStorageValue,
+                            gender: biologicalSex?.description ?? existingProfile?.gender,
                             activityLevel: existingProfile?.activityLevel,
                             goalWeight: existingProfile?.goalWeight,
                             goalWeightUnit: existingProfile?.goalWeightUnit,
@@ -338,6 +494,14 @@ private extension BodyScoreProfileDetailsView {
         case .lastName:
             handleLastNameContinue()
         case .dateOfBirth:
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                activeSubstep = .sex
+            }
+        case .sex:
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                activeSubstep = .height
+            }
+        case .height:
             submit()
         }
     }
@@ -363,9 +527,54 @@ private extension BodyScoreProfileDetailsView {
             activeSubstep = .firstName
         } else if !isLastNameValid {
             activeSubstep = .lastName
-        } else {
+        } else if !isDateOfBirthWithinValidRange {
             activeSubstep = .dateOfBirth
+        } else if biologicalSex == nil {
+            activeSubstep = .sex
+        } else if !isHeightValid {
+            activeSubstep = .height
+        } else {
+            activeSubstep = .height
         }
+    }
+
+    func focusNameFieldIfNeeded(_ step: ProfileSubstep? = nil) {
+        switch step ?? activeSubstep {
+        case .firstName:
+            focusedNameField = .firstName
+        case .lastName:
+            focusedNameField = .lastName
+        case .dateOfBirth, .sex, .height:
+            focusedNameField = nil
+        }
+    }
+
+    func convertHeightFields(from oldUnit: HeightUnit, to newUnit: HeightUnit) {
+        guard oldUnit != newUnit else { return }
+
+        switch (oldUnit, newUnit) {
+        case (.centimeters, .inches):
+            guard let centimeters = Double(heightCentimetersText) else { return }
+            let totalInches = Int((centimeters / 2.54).rounded())
+            heightFeet = max(3, min(8, totalInches / 12))
+            heightInches = max(0, min(11, totalInches % 12))
+        case (.inches, .centimeters):
+            let totalInches = Double((heightFeet * 12) + heightInches)
+            heightCentimetersText = String(format: "%.0f", totalInches * 2.54)
+        default:
+            break
+        }
+    }
+
+    static func biologicalSex(from gender: String) -> BiologicalSex? {
+        let normalized = gender.lowercased()
+        if normalized.contains("female") || normalized.contains("woman") {
+            return .female
+        }
+        if normalized.contains("male") || normalized.contains("man") {
+            return .male
+        }
+        return nil
     }
 }
 
@@ -375,6 +584,8 @@ private enum ProfileSubstep {
     case firstName
     case lastName
     case dateOfBirth
+    case sex
+    case height
 }
 
 private enum NameField: Hashable {

--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -37,7 +37,7 @@ struct LogYourBodyApp: App {
                         .environmentObject(bugReportManager)
                 }
                 .sheet(isPresented: $showAddEntrySheet) {
-                    AddEntrySheet(isPresented: $showAddEntrySheet)
+                    AddEntrySheet(isPresented: $showAddEntrySheet, initialTab: selectedEntryTab)
                         .environmentObject(authManager)
                         .onAppear {
                             // Set the selected tab based on deep link
@@ -176,10 +176,13 @@ struct LogYourBodyApp: App {
             if let path = url.pathComponents.dropFirst().first {
                 switch path {
                 case "weight":
+                    selectedEntryTab = 0
                     UserDefaults.standard.set(0, forKey: "pendingEntryTab")
                 case "bodyfat":
+                    selectedEntryTab = 1
                     UserDefaults.standard.set(1, forKey: "pendingEntryTab")
                 case "photo":
+                    selectedEntryTab = 2
                     UserDefaults.standard.set(2, forKey: "pendingEntryTab")
                 default:
                     break

--- a/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
+++ b/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
@@ -345,6 +345,12 @@ class RealtimeSyncManager: ObservableObject {
 
                     self.savePendingOperations()
                     self.updatePendingSyncCount()
+                    AnalyticsService.shared.track(
+                        event: "sync_failed",
+                        properties: [
+                            "pending_count": String(self.pendingSyncCount)
+                        ]
+                    )
                     onCompletion?()
                 }
             }

--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -70,7 +70,6 @@ struct AddEntrySheet: View {
                     Label("Weight", systemImage: "scalemass").tag(0)
                     Label("Body Fat", systemImage: "percent").tag(1)
                     Label("Photos", systemImage: "photo.fill").tag(2)
-                    Label("GLP-1", systemImage: "syringe").tag(3)
                 }
                 .pickerStyle(SegmentedPickerStyle())
                 .padding(.horizontal)
@@ -161,13 +160,6 @@ struct AddEntrySheet: View {
                 // Set default weight unit based on user preference
                 if weightUnit.isEmpty {
                     weightUnit = currentSystem.weightUnit
-                }
-
-                glp1UserId = authManager.currentUser?.id
-                if let userId = glp1UserId {
-                    Task {
-                        await loadGlp1Medications(userId: userId)
-                    }
                 }
 
                 AnalyticsService.shared.track(event: "add_entry_view")
@@ -619,6 +611,8 @@ struct AddEntrySheet: View {
                     "unit": resolvedWeightUnit
                 ]
             )
+            trackLogEntrySaved(type: "weight")
+            HapticManager.shared.successAction()
 
             dismiss()
         } catch let error as ValidationError {
@@ -648,6 +642,8 @@ struct AddEntrySheet: View {
                 BodyScoreRecalculationService.shared.scheduleRecalculation()
             }
 
+            trackLogEntrySaved(type: "body_fat")
+            HapticManager.shared.successAction()
             dismiss()
         } catch let error as ValidationError {
             handleValidationError(error, for: .bodyFat)
@@ -774,6 +770,17 @@ struct AddEntrySheet: View {
             properties: [
                 "type": "photos",
                 "count": String(selectedPhotos.count)
+            ]
+        )
+        trackLogEntrySaved(type: "photos")
+        HapticManager.shared.successAction()
+    }
+
+    private func trackLogEntrySaved(type: String) {
+        AnalyticsService.shared.track(
+            event: "log_entry_saved",
+            properties: [
+                "type": type
             ]
         )
     }

--- a/apps/ios/LogYourBody/Views/AppleSignInButton.swift
+++ b/apps/ios/LogYourBody/Views/AppleSignInButton.swift
@@ -172,17 +172,12 @@ struct AppleSignInButton: UIViewRepresentable {
                 case .notHandled:
                     // print("🍎 Authorization not handled")
                     showErrorAlert("Apple Sign In request was not handled.")
-                case .notInteractive,
-                     .matchedExcludedCredential,
-                     .credentialImport,
-                     .credentialExport,
-                     .preferSignInWithApple,
-                     .deviceNotConfiguredForPasskeyCreation:
+                case .notInteractive:
                     showErrorAlert("Apple Sign In is not available right now. Please try again or use another sign-in method.")
                 case .unknown:
                     // print("🍎 Unknown error")
                     showErrorAlert("An unknown error occurred with Apple Sign In.")
-                @unknown default:
+                default:
                     // print("🍎 Unknown error case")
                     showErrorAlert("An error occurred with Apple Sign In.")
                 }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
@@ -523,7 +523,7 @@ extension DashboardViewLiquid {
 
     var quickActions: some View {
         HStack(spacing: 12) {
-            GlassPillButton(icon: "plus.circle.fill", title: "Log Weight") {
+            GlassPillButton(icon: "plus.circle.fill", title: "Log") {
                 showAddEntrySheet = true
             }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -211,7 +211,6 @@ struct DashboardViewLiquid: View {
                 if !viewModel.bodyMetrics.isEmpty {
                     updateAnimatedValues(for: selectedIndex)
                 }
-                await loadGlp1DoseLogs()
             }
         )
     }
@@ -244,7 +243,6 @@ struct DashboardViewLiquid: View {
                 if !viewModel.bodyMetrics.isEmpty {
                     updateAnimatedValues(for: selectedIndex)
                 }
-                await loadGlp1DoseLogs()
             }
         }
 
@@ -362,7 +360,6 @@ struct DashboardViewLiquid: View {
             metricsContent: {
                 VStack(spacing: 16) {
                     metricsView
-                    glp1MetricCard
                 }
             },
             onRefresh: {
@@ -370,7 +367,6 @@ struct DashboardViewLiquid: View {
                     authManager: authManager,
                     realtimeSyncManager: realtimeSyncManager
                 )
-                await loadGlp1DoseLogs()
             }
         )
     }

--- a/apps/ios/LogYourBody/Views/EmailVerificationView.swift
+++ b/apps/ios/LogYourBody/Views/EmailVerificationView.swift
@@ -91,9 +91,7 @@ struct EmailVerificationView: View {
                     try await authManager.verifySignInEmail(code: verificationCode)
                     successMessage = "Signed in successfully!"
                     AnalyticsService.shared.track(event: "login_email_code_verified")
-                case .signUp?:
-                    fallthrough
-                case nil:
+                case .signUp?, nil:
                     try await authManager.verifyEmail(code: verificationCode)
                     successMessage = "Email verified successfully!"
                     AnalyticsService.shared.track(event: "email_verified")
@@ -106,9 +104,7 @@ struct EmailVerificationView: View {
                 switch authManager.emailVerificationFlow {
                 case .signIn?:
                     event = "login_email_code_failed"
-                case .signUp?:
-                    fallthrough
-                case nil:
+                case .signUp?, nil:
                     event = "email_verification_failed"
                 }
 
@@ -128,9 +124,7 @@ struct EmailVerificationView: View {
                     try await authManager.resendSignInEmailCode()
                     successMessage = "A new sign-in code has been sent to your email."
                     AnalyticsService.shared.track(event: "login_email_code_resent")
-                case .signUp?:
-                    fallthrough
-                case nil:
+                case .signUp?, nil:
                     try await authManager.resendVerificationEmail()
                     successMessage = "A new verification code has been sent to your email."
                     AnalyticsService.shared.track(event: "email_verification_resent")

--- a/apps/ios/LogYourBody/Views/LoginView.swift
+++ b/apps/ios/LogYourBody/Views/LoginView.swift
@@ -14,7 +14,6 @@ struct LoginView: View {
     @State private var showError = false
     @State private var errorMessage = ""
     @State private var isRetrying = false
-    @State private var showPreAuthOnboarding = false
     @State private var navigateToSignUp = false
 
     var body: some View {
@@ -24,10 +23,6 @@ struct LoginView: View {
         }
         .navigationBarHidden(true)
         .standardErrorAlert(isPresented: $showError, message: errorMessage)
-        .fullScreenCover(isPresented: $showPreAuthOnboarding) {
-            PreAuthBodyScoreOnboardingContainer {
-            }
-        }
         .onAppear {
             AnalyticsService.shared.track(event: "login_view")
         }
@@ -58,14 +53,10 @@ struct LoginView: View {
                 // Molecule: Auth Header
                 AuthHeader(
                     title: "LogYourBody",
-                    subtitle: "Sign in with a one-time code sent to your email."
+                    subtitle: "Log your body in under 10 seconds."
                 )
                 .padding(.top, authManager.isClerkLoaded ? 80 : 20)
                 .padding(.bottom, 24)
-
-                preAuthOnboardingCTA
-                    .padding(.horizontal, 24)
-                    .padding(.bottom, 26)
 
                 // Organism: Login Form
                 LoginForm(
@@ -105,26 +96,6 @@ struct LoginView: View {
             }
         }
         .scrollDismissesKeyboard(.interactively)
-    }
-
-    private var preAuthOnboardingCTA: some View {
-        Button {
-            showPreAuthOnboarding = true
-        } label: {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Preview body score onboarding")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.appText)
-
-                Text("Walk through the body score setup before you create an account.")
-                    .font(.system(size: 13))
-                    .foregroundColor(.appTextSecondary)
-            }
-            .padding(16)
-            .background(Color.black.opacity(0.25))
-            .cornerRadius(12)
-        }
-        .buttonStyle(.plain)
     }
 
     private var sessionStatusBanner: some View {

--- a/apps/ios/LogYourBody/Views/PaywallView.swift
+++ b/apps/ios/LogYourBody/Views/PaywallView.swift
@@ -390,18 +390,11 @@ private struct PaywallFeatureRow: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 16) {
-            // Icon
-            ZStack {
-                Circle()
-                    .fill(Color.appPrimary.opacity(0.14))
-                    .frame(width: 44, height: 44)
+            Image(systemName: icon)
+                .font(.system(size: 21, weight: .semibold))
+                .foregroundColor(.appPrimary)
+                .frame(width: 30, height: 28, alignment: .top)
 
-                Image(systemName: icon)
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(.appPrimary)
-            }
-
-            // Text
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.system(size: 17, weight: .semibold))

--- a/apps/ios/LogYourBody/Views/PaywallView.swift
+++ b/apps/ios/LogYourBody/Views/PaywallView.swift
@@ -19,50 +19,32 @@ struct PaywallView: View {
 
     var body: some View {
         ZStack {
-            // Background gradient
             LinearGradient(
-                colors: [.black, .black.opacity(0.8)],
+                colors: [Color.appBackground, Color.black],
                 startPoint: .top,
                 endPoint: .bottom
             )
             .ignoresSafeArea()
 
             ScrollView {
-                VStack(spacing: 32) {
-                    // Header
+                VStack(spacing: 24) {
                     header
-
-                    // Features List
                     featuresSection
 
-                    // Pricing Card
                     if let package = firstAvailablePackage {
                         pricingCard(package: package)
                     } else if isLoading {
                         ProgressView()
-                            .tint(Color(hex: "#6EE7F0"))
+                            .tint(.appPrimary)
                     } else {
-                        // No packages available - show error
-                        Text("No subscription plans available")
-                            .foregroundColor(.white.opacity(0.7))
-                            .padding()
-
-                        Text("Please check your internet connection and try again")
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal)
+                        plansUnavailableState
                     }
 
-                    // Purchase Button
                     if let package = firstAvailablePackage {
                         purchaseButton(package: package)
                     }
 
-                    // Restore purchases
                     restorePurchasesButton
-
-                    // Legal links
                     legalLinks
 
                     Spacer(minLength: 50)
@@ -140,67 +122,48 @@ struct PaywallView: View {
     // MARK: - Components
 
     private var header: some View {
-        VStack(spacing: 16) {
-            // App icon/logo
+        VStack(spacing: 14) {
             Image(systemName: "chart.line.uptrend.xyaxis.circle.fill")
-                .font(.system(size: 72))
-                .foregroundStyle(
-                    LinearGradient(
-                        colors: [Color(hex: "#6EE7F0"), Color(hex: "#4FA9B1")],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
-                .shadow(color: Color(hex: "#6EE7F0").opacity(0.3), radius: 20, x: 0, y: 10)
+                .font(.system(size: 56))
+                .foregroundStyle(Color.appPrimary)
 
             Text("LogYourBody Pro")
-                .font(.system(size: 32, weight: .bold))
-                .foregroundColor(.white)
+                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .foregroundColor(.appText)
 
-            Text("Track your transformation")
-                .font(.system(size: 17, weight: .medium))
-                .foregroundColor(.white.opacity(0.7))
+            Text("Log your body in under 10 seconds and see if you are moving in the right direction.")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(.appTextSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
     private var featuresSection: some View {
-        VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .leading, spacing: 16) {
             PaywallFeatureRow(
-                icon: "camera.fill",
-                title: "Progress Photos",
-                description: "Visual timeline of your transformation"
+                icon: "scalemass.fill",
+                title: "Daily logging",
+                description: "Save weight and body fat fast."
             )
 
             PaywallFeatureRow(
                 icon: "chart.xyaxis.line",
-                title: "Advanced Analytics",
-                description: "Track weight, body fat, and FFMI trends"
-            )
-
-            PaywallFeatureRow(
-                icon: "heart.fill",
-                title: "HealthKit Sync",
-                description: "Seamless integration with Apple Health"
+                title: "Clear trends",
+                description: "See weight, body fat, FFMI, and body score."
             )
 
             PaywallFeatureRow(
                 icon: "icloud.fill",
-                title: "Cloud Backup",
-                description: "Your data safely synced across devices"
-            )
-
-            PaywallFeatureRow(
-                icon: "sparkles",
-                title: "Premium Features",
-                description: "Unlock all current and future features"
+                title: "Private sync",
+                description: "Keep local data backed up to your account."
             )
         }
         .padding(.horizontal, 8)
     }
 
     private func pricingCard(package: Package) -> some View {
-        VStack(spacing: 16) {
-            // Trial badge
+        VStack(spacing: 14) {
             if let trialText = revenueCatManager.getTrialDurationText(package: package) {
                 HStack(spacing: 8) {
                     Image(systemName: "gift.fill")
@@ -210,74 +173,54 @@ struct PaywallView: View {
                         .font(.system(size: 13, weight: .bold))
                         .tracking(1)
                 }
-                .foregroundColor(.white)
-                .padding(.horizontal, 20)
-                .padding(.vertical, 10)
-                .background(
-                    LinearGradient(
-                        colors: [Color(hex: "#6EE7F0"), Color(hex: "#4FA9B1")],
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    )
-                )
-                .cornerRadius(20)
-                .shadow(color: Color(hex: "#6EE7F0").opacity(0.4), radius: 15, x: 0, y: 5)
+                .foregroundColor(.black)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(Color.appPrimary)
+                .clipShape(Capsule())
             }
 
-            // Price
             VStack(spacing: 8) {
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text(revenueCatManager.formatPrice(package: package))
-                        .font(.system(size: 56, weight: .bold))
-                        .foregroundColor(.white)
+                        .font(.system(size: 48, weight: .bold, design: .rounded))
+                        .foregroundColor(.appText)
 
-                    Text("/year")
-                        .font(.system(size: 20, weight: .medium))
-                        .foregroundColor(.white.opacity(0.6))
+                    Text(billingPeriodSuffix(for: package))
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundColor(.appTextSecondary)
                 }
 
-                Text("Just $5.75 per month, billed annually")
+                Text(packageSummaryText(for: package))
                     .font(.system(size: 15))
-                    .foregroundColor(.white.opacity(0.5))
+                    .foregroundColor(.appTextSecondary)
             }
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 32)
+        .padding(.vertical, 28)
         .padding(.horizontal, 24)
         .background(
             ZStack {
-                // Glass background
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .fill(.ultraThinMaterial)
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(Color.appCard.opacity(0.95))
 
-                // Border
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .strokeBorder(
-                        LinearGradient(
-                            colors: [Color.white.opacity(0.3), Color.white.opacity(0.1)],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        ),
-                        lineWidth: 1
-                    )
-
-                // Accent glow
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .fill(
-                        LinearGradient(
-                            colors: [Color(hex: "#6EE7F0").opacity(0.1), Color.clear],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(Color.appBorder.opacity(0.8), lineWidth: 1)
             }
         )
-        .shadow(color: .black.opacity(0.3), radius: 20, x: 0, y: 10)
+        .shadow(color: .black.opacity(0.25), radius: 18, x: 0, y: 12)
     }
 
     private func purchaseButton(package: Package) -> some View {
         Button {
             Task {
+                AnalyticsService.shared.track(
+                    event: "purchase_start",
+                    properties: [
+                        "package_id": package.identifier
+                    ]
+                )
+
                 let success = await revenueCatManager.purchase(package: package)
                 if !success && revenueCatManager.errorMessage != nil {
                     showPurchaseError = true
@@ -297,21 +240,14 @@ struct PaywallView: View {
                         .font(.system(size: 20, weight: .semibold))
                 }
 
-                Text(revenueCatManager.isPurchasing ? "Processing..." : "Start Free Trial")
+                Text(revenueCatManager.isPurchasing ? "Processing..." : purchaseButtonTitle(for: package))
                     .font(.system(size: 18, weight: .semibold))
             }
-            .foregroundColor(.white)
+            .foregroundColor(.black)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 18)
-            .background(
-                LinearGradient(
-                    colors: [Color(hex: "#6EE7F0"), Color(hex: "#4FA9B1")],
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
-            )
+            .background(Color.appPrimary)
             .cornerRadius(16)
-            .shadow(color: Color(hex: "#6EE7F0").opacity(0.4), radius: 20, x: 0, y: 10)
         }
         .disabled(revenueCatManager.isPurchasing)
     }
@@ -361,6 +297,77 @@ struct PaywallView: View {
         }
     }
 
+    private var plansUnavailableState: some View {
+        VStack(spacing: 12) {
+            Text("Subscription plans are unavailable")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundColor(.appText)
+
+            Text("Check your connection and retry.")
+                .font(.system(size: 14))
+                .foregroundColor(.appTextSecondary)
+
+            Button {
+                Task {
+                    await loadOfferings()
+                }
+            } label: {
+                Label("Retry", systemImage: "arrow.clockwise")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.appText)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(Color.appCard)
+                    .cornerRadius(12)
+            }
+            .disabled(isLoading)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(20)
+        .background(Color.appCard.opacity(0.65))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.appBorder.opacity(0.8), lineWidth: 1)
+        )
+        .cornerRadius(16)
+    }
+
+    private func billingPeriodSuffix(for package: Package) -> String {
+        let period = billingPeriodLabel(for: package)
+        return period.isEmpty ? "" : "/\(period)"
+    }
+
+    private func packageSummaryText(for package: Package) -> String {
+        let period = billingPeriodLabel(for: package)
+        if period.isEmpty {
+            return "Billed by the App Store."
+        }
+
+        return "Billed \(period)ly by the App Store."
+    }
+
+    private func purchaseButtonTitle(for package: Package) -> String {
+        revenueCatManager.getTrialDurationText(package: package) == nil ? "Subscribe" : "Start trial"
+    }
+
+    private func billingPeriodLabel(for package: Package) -> String {
+        let identifier = "\(package.identifier) \(package.storeProduct.productIdentifier)".lowercased()
+
+        if identifier.contains("annual") || identifier.contains("year") {
+            return "year"
+        }
+
+        if identifier.contains("month") {
+            return "month"
+        }
+
+        if identifier.contains("week") {
+            return "week"
+        }
+
+        return ""
+    }
+
     // MARK: - Functions
 
     private func loadOfferings() async {
@@ -386,23 +393,23 @@ private struct PaywallFeatureRow: View {
             // Icon
             ZStack {
                 Circle()
-                    .fill(Color(hex: "#6EE7F0").opacity(0.15))
-                    .frame(width: 48, height: 48)
+                    .fill(Color.appPrimary.opacity(0.14))
+                    .frame(width: 44, height: 44)
 
                 Image(systemName: icon)
                     .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(Color(hex: "#6EE7F0"))
+                    .foregroundColor(.appPrimary)
             }
 
             // Text
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(.appText)
 
                 Text(description)
                     .font(.system(size: 15))
-                    .foregroundColor(.white.opacity(0.6))
+                    .foregroundColor(.appTextSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -88,8 +88,7 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         let height = updates["height"] as? Double
         XCTAssertNotNil(height)
         if let height {
-            let expectedInches = 180.0 / 2.54
-            XCTAssertEqual(height, expectedInches, accuracy: 0.01)
+            XCTAssertEqual(height, 180.0, accuracy: 0.01)
         }
 
         XCTAssertEqual(updates["heightUnit"] as? String, "cm")
@@ -103,7 +102,12 @@ final class OnboardingFlowViewModelTests: XCTestCase {
 
         let updates = viewModel.buildOnboardingProfileUpdates()
 
-        XCTAssertEqual(updates["height"] as? Double, 72)
+        let height = updates["height"] as? Double
+        XCTAssertNotNil(height)
+        if let height {
+            XCTAssertEqual(height, 72 * 2.54, accuracy: 0.01)
+        }
+
         XCTAssertEqual(updates["heightUnit"] as? String, "in")
     }
 

--- a/apps/ios/docs/development/RELEASE_CHECKLIST.md
+++ b/apps/ios/docs/development/RELEASE_CHECKLIST.md
@@ -1,0 +1,71 @@
+# iOS Paid MVP Release Checklist
+
+Use this checklist before sending a LogYourBody iOS build to TestFlight or App Store review.
+
+## Configuration
+
+- Clerk production publishable key is configured in `Config.xcconfig`.
+- Clerk Apple Sign In is enabled for the production app.
+- Supabase production URL and anon key are configured in `Config.xcconfig`.
+- Supabase RLS policies accept Clerk session JWT `sub` for `profiles`, `user_profiles`, `body_metrics`, and `daily_metrics`.
+- RevenueCat production API key is configured.
+- RevenueCat `pro` entitlement matches `Constants.proEntitlementID`.
+- StoreKit/App Store products are attached to the active RevenueCat offering.
+
+## Product Path
+
+- Fresh install opens to auth with Apple Sign In as the primary action.
+- Email one-time code sign-in remains available as fallback.
+- New user can complete name, date of birth, sex at birth, and height setup.
+- Unpaid authenticated user sees the paywall.
+- Purchase success unlocks the dashboard.
+- Restore success unlocks the dashboard.
+- Paid returning user opens directly to the dashboard after loading.
+- Signed-out user opens to auth.
+
+## Data And Sync
+
+- User can save today's weight locally while online.
+- User can save today's weight locally while offline.
+- Sync retries after the device returns online.
+- Supabase rows use the Clerk user ID for `user_id` or profile `id`.
+- Sync failure shows recoverable UI and does not block local logging.
+
+## Legal And Store Review
+
+- Terms and privacy links open in-app from the paywall.
+- Camera, photo library, HealthKit, and Face ID usage strings are accurate.
+- No secrets or local config files are committed.
+- App icon, display name, bundle identifier, and version/build number are correct.
+
+## Validation
+
+From the repository root:
+
+```bash
+pnpm install
+pnpm lint
+pnpm typecheck
+pnpm test:ci
+```
+
+From `apps/ios/`:
+
+```bash
+swiftlint lint --strict
+xcodebuild -project LogYourBody.xcodeproj \
+  -scheme LogYourBody \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  build-for-testing
+xcodebuild -project LogYourBody.xcodeproj \
+  -scheme LogYourBody \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  test
+```
+
+## PR Evidence
+
+- Include screenshots or a simulator recording for auth, onboarding/profile completion, paywall, dashboard, and logging.
+- Include RevenueCat purchase and restore test results.
+- Include Supabase sync test results.
+- Include validation command output and known risks.


### PR DESCRIPTION
## Summary
- Tightens the iOS root route so profile completion requires name, date of birth, sex at birth, and height before the paid gate.
- Extends profile completion to collect sex and height, persists them locally, and sends the Supabase profile payload.
- Makes Apple Sign In the primary auth action, keeps email one-time-code fallback, and removes the pre-auth onboarding preview from the shipping login path.
- Simplifies the paid MVP dashboard/logging path with one Log CTA, add-entry deep-link tab selection, haptics, and `log_entry_saved` / `sync_failed` / `purchase_start` analytics.
- Reworks the paywall around three concrete benefits, calmer design-system colors, dynamic RevenueCat package pricing labels, retry state, restore, legal links, and lighter feature-row icon treatment.
- Adds `apps/ios/docs/development/RELEASE_CHECKLIST.md`.
- Keeps Apple Sign In error handling compatible with the Xcode 16.1 SDK used by GitHub iOS CI.

## Design Review
- Reviewed against the Jovie bar for clean, stable, high-polish product surfaces with one clear primary action and no extra chrome.
- Simulator proof captured for the visible auth shell: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_2ba3b3cf-d2be-4dd4-b261-78ca88abbf8d.jpg`.
- Local ignored iOS config has empty Clerk values, so the screenshot includes the expected Clerk configuration error while still verifying the Apple-first auth hierarchy and neutral dark treatment.
- Auth/paywall/dashboard authenticated screenshots remain blocked locally until real Clerk, Supabase, RevenueCat, and StoreKit test config are present.

## Validation
- GitHub CI `iOS` passed on commit `2b3e0b27`.
- GitHub CI `CI Summary` passed; `JavaScript/TypeScript` skipped because this PR is iOS-only under the repo path filter.
- `pnpm install` passed earlier in this branch.
- `pnpm lint` passed.
- `pnpm typecheck` passed.
- `swiftlint lint --strict` passed from `apps/ios`.
- `git diff --check` passed.
- Pre-commit hook passed `cd apps/ios && swiftlint` for staged Swift files.
- XcodeBuildMCP `test_sim` passed the focused onboarding profile-update tests:
  - `testBuildOnboardingProfileUpdatesIncludesGenderDobAndHeight`
  - `testBuildOnboardingProfileUpdatesRespectsImperialHeightUnit`
- XcodeBuildMCP `build_run_sim` passed on iPhone 17 / iOS 26.5, scheme `LogYourBody`, Debug.
- XcodeBuildMCP `build_sim` passed after the Apple Sign In Xcode 16.1 compatibility fix.
- Root `pnpm test:ci` without local env failed during web prerender because Clerk/Supabase public env vars are missing.
- Root `pnpm test:ci` with throwaway valid-shaped public env made it through the web build, then failed one unrelated web test: `ProfileSettingsPage correctly calculates age from date of birth` expects `(24|25) years old`, but on 2026-06-02 a `2001-06-15` DOB is still 23.
- Full iOS XCTest was not re-run after the focused fix. The earlier full run failed existing sync/auth tests plus the two onboarding builder assertions that this follow-up fixed.

## External Deployment Status
- Vercel preview is failing outside the iOS scope. Build log for `dpl_3yZEHtz1fEszwKGU7g2iYNSjZKYh` fails with `error TS5083: Cannot read file '/tsconfig.base.json'` because the Vercel project builds from the web deployment root while `apps/web/tsconfig.json` extends `../../tsconfig.base.json`.
- I did not mix that web deployment-root fix into this iOS paid-MVP PR because touching web config would activate the JS path and broaden the review surface.

## RevenueCat / Supabase
- RevenueCat product loading, purchase, and restore were not exercised locally because production RevenueCat/StoreKit test configuration is not present in this worktree.
- Supabase sync was not exercised against production because the local ignored `Config.xcconfig` uses placeholder values.

Closes #246.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added height and gender fields to profile setup with metric/imperial unit support and automatic conversion

* **Bug Fixes**
  * Improved Apple Sign-In error messaging

* **UI Updates**
  * Redesigned paywall interface with updated styling and pricing display
  * Reorganized login form with Apple sign-in option moved to the top
  * Renamed "Log Weight" button to "Log"
  * Removed GLP-1 from entry logging options
  * Removed pre-authentication onboarding screen

* **Documentation**
  * Added iOS release checklist for paid MVP rollout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->