### PR TITLE
fix(ios): default match branch for release signing

### DIFF
--- a/.github/actions/sync-match/action.yml
+++ b/.github/actions/sync-match/action.yml
@@ -13,6 +13,7 @@ inputs:
   match_git_branch:
     description: 'Git branch to use for Match certificates'
     required: false
+    default: 'main'
 runs:
   using: 'composite'
   steps:
@@ -37,7 +38,7 @@ runs:
         MATCH_PASSWORD: ${{ inputs.match_password }}
         MATCH_GIT_URL: ${{ inputs.match_git_url }}
         MATCH_GIT_BASIC_AUTHORIZATION: ${{ inputs.match_git_basic }}
-        MATCH_GIT_BRANCH: ${{ inputs.match_git_branch }}
+        MATCH_GIT_BRANCH: ${{ inputs.match_git_branch || 'main' }}
         MATCH_KEYCHAIN_NAME: login.keychain
         MATCH_KEYCHAIN_PASSWORD: 
         FL_OUTPUT_DIR: ./logs

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -851,7 +851,7 @@ platform :ios do
           app_identifier: [ENV["APP_IDENTIFIER"] || "com.logyourbody.app"],
           readonly: readonly,
           git_url: ENV["MATCH_GIT_URL"],
-          git_branch: ENV["MATCH_GIT_BRANCH"] || "main",
+          git_branch: ENV["MATCH_GIT_BRANCH"].to_s.empty? ? "main" : ENV["MATCH_GIT_BRANCH"],
           git_basic_authorization: ENV["MATCH_GIT_BASIC_AUTHORIZATION"],
           team_id: ENV["APPLE_TEAM_ID"],
           generate_apple_certs: false, # Never generate certs due to OpenSSL issues and cert limits
@@ -951,7 +951,7 @@ platform :ios do
     # Set up match parameters that work with our authentication
     match_params = {
       git_url: ENV["MATCH_GIT_URL"],
-      git_branch: ENV["MATCH_GIT_BRANCH"] || "main",
+      git_branch: ENV["MATCH_GIT_BRANCH"].to_s.empty? ? "main" : ENV["MATCH_GIT_BRANCH"],
       git_basic_authorization: ENV["MATCH_GIT_BASIC_AUTHORIZATION"],
       team_id: ENV["APPLE_TEAM_ID"],
       skip_confirmation: true


### PR DESCRIPTION
## Summary
- default the shared sync-match action to the `main` match branch
- make Fastlane treat an empty `MATCH_GIT_BRANCH` as `main`
- update release secrets separately so the iOS Release Loop uses the live App Store Connect app id and verified API key

## Why
The post-merge iOS Release Loop for PR #247 failed while syncing signing assets because the release workflow omitted `match_git_branch`; the action exported it as an empty string, so Fastlane attempted to check out branch `''`.

## Validation
- `ruby -c apps/ios/fastlane/Fastfile`
- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`