### PR TITLE
fix(ios): sync release signing in archive keychain

### DIFF
--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -168,6 +168,10 @@ jobs:
         fi
       env:
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+        MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+        MATCH_GIT_BRANCH: ${{ secrets.MATCH_GIT_BRANCH || 'main' }}
     
     - name: Upload build artifact
       uses: actions/upload-artifact@v5

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -732,6 +732,10 @@ platform :ios do
     release_profile = ENV["PROVISIONING_PROFILE_SPECIFIER"].to_s
     release_profile = "match AppStore com.logyourbody.app 1780400349" if release_profile.empty?
 
+    if ENV["MATCH_GIT_URL"] && ENV["MATCH_PASSWORD"]
+      setup_provisioning(type: "appstore", readonly: true)
+    end
+
     build_app(
       project: project,
       scheme: scheme,


### PR DESCRIPTION
## Summary
- re-sync Match signing assets inside `build_release` when Match env is available
- pass Match credentials into the iOS Release Loop archive step

## Why
The release workflow synced Match in one Fastlane invocation, then `build_release` created a fresh CI keychain in a second Fastlane invocation. Archive then failed because the signing private key was not available in that new keychain.

## Validation
- `ruby -c apps/ios/fastlane/Fastfile`
- `git diff --check`
- `actionlint .github/workflows/ios-release-loop.yml` (existing shellcheck info warnings only)