### PR TITLE
fix(ios): trust fastlane archive exit code

### DIFF
--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -156,16 +156,11 @@ jobs:
     
     - name: Archive and export
       run: |
+        set -o pipefail
         cd apps/ios
         
-        # Use Fastlane to build, capturing output for error detection
+        # Use Fastlane to build while preserving its exit status through tee.
         bundle exec fastlane build_release 2>&1 | tee fastlane.log
-        
-        # Check for errors and surface them in the summary
-        if grep -E "error:|duplicate|signing|Error:|ERROR:|Failed|FAILED" fastlane.log; then
-          echo "::error::Build errors detected - see highlighted lines above"
-          exit 1
-        fi
       env:
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}


### PR DESCRIPTION
## Summary
- preserve Fastlane archive exit status through `tee` with `set -o pipefail`
- remove the broad post-build grep heuristic that failed successful archives on historical diagnostic output

## Why
The latest iOS Release Loop successfully exported `LogYourBody.ipa`, then failed because `grep` matched an earlier Fastlane diagnostic line even though `fastlane build_release` finished successfully.

## Validation
- `git diff --check`
- `actionlint .github/workflows/ios-release-loop.yml` (existing shellcheck info warnings only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS build pipeline reliability by enhancing error detection in the release workflow to better capture and report build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->