### PR TITLE
fix(ios): pass absolute TestFlight changelog path

### DIFF
--- a/.github/workflows/ios-testflight-deploy.yml
+++ b/.github/workflows/ios-testflight-deploy.yml
@@ -212,10 +212,16 @@ jobs:
         
         echo "Found IPA: $IPA_PATH"
 
+        CHANGELOG_PATH="$PWD/release_notes.txt"
+        if [ ! -f "$CHANGELOG_PATH" ]; then
+          echo "::error::Release notes file not found at $CHANGELOG_PATH"
+          exit 1
+        fi
+
         bundle exec fastlane upload_testflight \
           ipa_path:"$IPA_PATH" \
           groups:"$TESTFLIGHT_GROUPS" \
-          changelog_file:release_notes.txt
+          changelog_file:"$CHANGELOG_PATH"
       env:
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         APP_STORE_APP_ID: ${{ secrets.APP_STORE_APP_ID }}


### PR DESCRIPTION
## Summary
- Pass an absolute release notes path to the Fastlane TestFlight upload lane
- Assert the generated release notes file exists before invoking Fastlane

## Validation
- git diff --check
- pnpm lint
- pnpm typecheck
- actionlint .github/workflows/ios-testflight-deploy.yml (pre-existing info-level warnings remain outside the edited upload step)