### PR TITLE
fix: generate valid App Store Connect API key JSON

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,20 +89,30 @@ jobs:
           create-config-files: 'true'
 
       - name: Setup App Store Connect API key
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
         run: |
           cd apps/ios
           mkdir -p fastlane
-          cat > fastlane/api_key.json << 'EOFKEY'
-          {
-            "key_id": "${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}",
-            "issuer_id": "${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}",
-            "key": "${{ secrets.APP_STORE_CONNECT_API_KEY }}",
-            "duration": 1200,
-            "in_house": false
-          }
-          EOFKEY
 
-          echo "APP_STORE_CONNECT_API_KEY_PATH=$(pwd)/fastlane/api_key.json" >> $GITHUB_ENV
+          ruby <<'RUBY'
+          require "json"
+
+          api_key = {
+            "key_id" => ENV.fetch("ASC_KEY_ID"),
+            "issuer_id" => ENV.fetch("ASC_ISSUER_ID"),
+            "key" => ENV.fetch("ASC_PRIVATE_KEY").gsub("\\n", "\n"),
+            "duration" => 1200,
+            "in_house" => false
+          }
+
+          File.write("fastlane/api_key.json", JSON.pretty_generate(api_key))
+          JSON.parse(File.read("fastlane/api_key.json"))
+          RUBY
+
+          echo "APP_STORE_CONNECT_API_KEY_PATH=$(pwd)/fastlane/api_key.json" >> "$GITHUB_ENV"
 
       - name: Generate build number
         id: build

--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -126,22 +126,31 @@ jobs:
         echo "/usr/local/opt/openssl@1.1/bin" >> $GITHUB_PATH
         
     - name: Setup Match Authentication
+      env:
+        ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+        ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+        ASC_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
       run: |
         cd apps/ios
-        # Create API key file from secret
         mkdir -p fastlane
-        cat > fastlane/api_key.json << 'EOFKEY'
-        {
-          "key_id": "${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}",
-          "issuer_id": "${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}",
-          "key": "${{ secrets.APP_STORE_CONNECT_API_KEY }}",
-          "duration": 1200,
-          "in_house": false
+
+        ruby <<'RUBY'
+        require "json"
+
+        api_key = {
+          "key_id" => ENV.fetch("ASC_KEY_ID"),
+          "issuer_id" => ENV.fetch("ASC_ISSUER_ID"),
+          "key" => ENV.fetch("ASC_PRIVATE_KEY").gsub("\\n", "\n"),
+          "duration" => 1200,
+          "in_house" => false
         }
-        EOFKEY
+
+        File.write("fastlane/api_key.json", JSON.pretty_generate(api_key))
+        JSON.parse(File.read("fastlane/api_key.json"))
+        RUBY
         
         # Set API key path for subsequent steps
-        echo "APP_STORE_CONNECT_API_KEY_PATH=$(pwd)/fastlane/api_key.json" >> $GITHUB_ENV
+        echo "APP_STORE_CONNECT_API_KEY_PATH=$(pwd)/fastlane/api_key.json" >> "$GITHUB_ENV"
       
       
     - name: Sync Certificates with Match

--- a/.github/workflows/ios-testflight-deploy.yml
+++ b/.github/workflows/ios-testflight-deploy.yml
@@ -98,22 +98,31 @@ jobs:
         esac
     
     - name: Setup App Store Connect Authentication
+      env:
+        ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+        ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+        ASC_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
       run: |
         cd apps/ios
-        # Create API key file from secret
         mkdir -p fastlane
-        cat > fastlane/api_key.json << 'EOFKEY'
-        {
-          "key_id": "${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}",
-          "issuer_id": "${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}",
-          "key": "${{ secrets.APP_STORE_CONNECT_API_KEY }}",
-          "duration": 1200,
-          "in_house": false
+
+        ruby <<'RUBY'
+        require "json"
+
+        api_key = {
+          "key_id" => ENV.fetch("ASC_KEY_ID"),
+          "issuer_id" => ENV.fetch("ASC_ISSUER_ID"),
+          "key" => ENV.fetch("ASC_PRIVATE_KEY").gsub("\\n", "\n"),
+          "duration" => 1200,
+          "in_house" => false
         }
-        EOFKEY
+
+        File.write("fastlane/api_key.json", JSON.pretty_generate(api_key))
+        JSON.parse(File.read("fastlane/api_key.json"))
+        RUBY
         
         # Set API key path for subsequent steps
-        echo "APP_STORE_CONNECT_API_KEY_PATH=$(pwd)/fastlane/api_key.json" >> $GITHUB_ENV
+        echo "APP_STORE_CONNECT_API_KEY_PATH=$(pwd)/fastlane/api_key.json" >> "$GITHUB_ENV"
     
     - name: Sync Certificates with Match
       uses: ./.github/actions/sync-match


### PR DESCRIPTION
## Summary
- generate Fastlane App Store Connect API key JSON with Ruby JSON encoding instead of raw heredocs
- preserve multiline PEM secrets safely for TestFlight, release-loop, and deploy workflows
- quote GITHUB_ENV writes in touched steps

## Validation
- pnpm lint
- pnpm typecheck
- git diff --check
- ruby YAML parse smoke for touched workflows
- local API-key JSON smoke with escaped PEM newlines

## Known existing failures
- pnpm test still fails in apps/web Next build because Clerk publishable key is missing during prerendering
- actionlint still reports pre-existing ShellCheck info warnings outside this patch
