### PR TITLE
fix: build iOS releases with Xcode 26

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
 
   ios-beta:
     name: iOS Beta
-    runs-on: macos-14
+    runs-on: macos-26
     needs: [detect-changes, web]
     if: needs.detect-changes.outputs.ios == 'true' && false  # Enable when ready
     timeout-minutes: 30
@@ -83,7 +83,7 @@ jobs:
       - name: Setup iOS build environment
         uses: ./.github/actions/setup-ios-build
         with:
-          xcode-version: '16.1'
+          xcode-version: 'latest-stable'
           working-directory: apps/ios
           setup-ruby: 'true'
           create-config-files: 'true'

--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   validate-release:
     name: Validate Release
-    runs-on: macos-14
+    runs-on: macos-26
     timeout-minutes: 5
     permissions:
       contents: read
@@ -107,7 +107,7 @@ jobs:
     name: Build Release
     needs: [validate-release, check-existing-build]
     if: needs.check-existing-build.outputs.has_artifact != 'true'
-    runs-on: macos-14
+    runs-on: macos-26
     timeout-minutes: 30
     
     steps:
@@ -116,14 +116,17 @@ jobs:
     - name: Setup iOS Build Environment
       uses: ./.github/actions/setup-ios-build
       with:
-        xcode-version: '16.1'
+        xcode-version: 'latest-stable'
         working-directory: apps/ios
         create-config-files: 'true'
     
     - name: Install Compatible OpenSSL
       run: |
-        brew install openssl@1.1
-        echo "/usr/local/opt/openssl@1.1/bin" >> $GITHUB_PATH
+        if brew list openssl@1.1 >/dev/null 2>&1 || brew install openssl@1.1; then
+          echo "$(brew --prefix openssl@1.1)/bin" >> "$GITHUB_PATH"
+        else
+          echo "::warning::openssl@1.1 unavailable; continuing with the runner OpenSSL"
+        fi
         
     - name: Setup Match Authentication
       env:
@@ -230,7 +233,7 @@ jobs:
     name: Deploy to App Store
     needs: [validate-release, build-release]
     if: github.event.inputs.release_type == 'app_store'
-    runs-on: macos-14
+    runs-on: macos-26
     timeout-minutes: 30
     environment:
       name: production-app-store
@@ -248,7 +251,7 @@ jobs:
     - name: Setup iOS Build Environment
       uses: ./.github/actions/setup-ios-build
       with:
-        xcode-version: '16.1'
+        xcode-version: 'latest-stable'
         working-directory: apps/ios
     
     - name: Set Environment Variables for Build

--- a/.github/workflows/ios-testflight-deploy.yml
+++ b/.github/workflows/ios-testflight-deploy.yml
@@ -52,7 +52,7 @@ on:
 jobs:
   deploy-testflight:
     name: Deploy to TestFlight (${{ inputs.distribution_group }})
-    runs-on: macos-14
+    runs-on: macos-26
     timeout-minutes: 30
     environment:
       name: ${{ inputs.environment }}
@@ -70,7 +70,7 @@ jobs:
     - name: Setup iOS Build Environment
       uses: ./.github/actions/setup-ios-build
       with:
-        xcode-version: '16.1'
+        xcode-version: 'latest-stable'
         working-directory: apps/ios
         create-config-files: 'true'
         setup-ruby: 'true'


### PR DESCRIPTION
## Summary
- move iOS release/TestFlight/App Store artifact jobs to the macos-26 runner
- select latest-stable Xcode for release upload paths so App Store Connect receives an iOS 26 SDK build
- make the legacy openssl@1.1 helper non-blocking on newer runner images

## Validation
- pnpm lint
- pnpm typecheck
- git diff --check
- Ruby YAML parse smoke for touched workflows

## Known existing failures
- pnpm test still fails in apps/web Next build because Clerk/Supabase env vars are missing during prerendering, with the existing read-excel-file export warning
- actionlint still reports pre-existing ShellCheck info warnings outside this patch

## Context
App Store Connect rejected the previous IPA because it was built with the iOS 18.1 SDK from Xcode 16.1.
