### PR TITLE
fix: keep TestFlight notifications non-blocking

### DIFF
--- a/.github/workflows/ios-testflight-deploy.yml
+++ b/.github/workflows/ios-testflight-deploy.yml
@@ -54,6 +54,8 @@ jobs:
     name: Deploy to TestFlight (${{ inputs.distribution_group }})
     runs-on: macos-26
     timeout-minutes: 30
+    permissions:
+      contents: write
     environment:
       name: ${{ inputs.environment }}
       url: https://testflight.apple.com
@@ -239,6 +241,7 @@ jobs:
     
     - name: Post deployment notification
       if: success()
+      continue-on-error: true
       uses: actions/github-script@v8
       with:
         script: |
@@ -261,7 +264,7 @@ jobs:
           
           ${group === 'production' ? '⚠️ This is a production release candidate.' : `This is a ${group} build for testing.`}`;
           
-          github.rest.repos.createCommitComment({
+          await github.rest.repos.createCommitComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             commit_sha: context.sha,


### PR DESCRIPTION
## Summary
- grant the reusable TestFlight deploy job contents:write for commit comments
- await the GitHub commit-comment call
- make the post-upload notification non-blocking so a valid TestFlight upload is not marked failed by a comment permission issue

## Validation
- pnpm lint
- pnpm typecheck
- git diff --check
- Ruby YAML parse smoke for .github/workflows/ios-testflight-deploy.yml

## Known existing failures
- pnpm test still fails in apps/web Next build because Clerk/Supabase env vars are missing during prerendering, with the existing read-excel-file export warning
- actionlint still reports pre-existing ShellCheck info warnings in the distribution-group switch

## Context
The Xcode 26 TestFlight upload succeeded for build 20260602130101; the run failed only when actions/github-script tried to create a commit comment with read-only contents permission.
