### PR TITLE
fix: grant TestFlight release caller write permission

### DIFF
--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -209,6 +209,8 @@ jobs:
     name: Deploy to TestFlight
     needs: [validate-release, build-release]
     if: github.event.inputs.release_type != 'app_store'
+    permissions:
+      contents: write
     uses: ./.github/workflows/ios-testflight-deploy.yml
     with:
       distribution_group: production


### PR DESCRIPTION
## Summary
- grant contents:write on the iOS release-loop job that calls the reusable TestFlight deploy workflow
- fixes workflow_dispatch startup failure after the reusable workflow requested write permission for commit comments

## Validation
- pnpm lint
- pnpm typecheck
- git diff --check
- Ruby YAML parse smoke for .github/workflows/ios-release-loop.yml

## Known existing failures
- pnpm test still fails in apps/web Next build because Clerk/Supabase env vars are missing during prerendering, with the existing read-excel-file export warning
- actionlint still reports pre-existing ShellCheck info warnings outside this patch

## Context
The latest TestFlight upload itself succeeded and App Store Connect reports build 20260602130101 as VALID; this patch lets the release workflow start and complete cleanly after the non-blocking notification fix.
