### PR TITLE
fix: allow iOS release tags

### DIFF
--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -307,6 +307,8 @@ jobs:
     needs: [validate-release, deploy-testflight, deploy-app-store]
     if: always() && (needs.deploy-testflight.result == 'success' || needs.deploy-app-store.result == 'success')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- grant the iOS release creation job `contents: write` so it can push release tags and create GitHub releases

## Validation
- pnpm lint
- pnpm typecheck
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-release-loop.yml"); puts "yaml ok"'
- git diff --check
- actionlint .github/workflows/ios-release-loop.yml (fails only on pre-existing ShellCheck info warnings for unquoted existing GITHUB_ENV writes)
