### PR TITLE
Fix App Store release source validation

### DIFF
--- a/.github/scripts/validate-release-source.sh
+++ b/.github/scripts/validate-release-source.sh
@@ -40,7 +40,7 @@ case "$STATUS_STATE" in
     echo "Commit statuses are successful."
     ;;
   failure|error)
-    fail "Commit status state for $SHA is $STATUS_STATE."
+    warn "Commit status state for $SHA is $STATUS_STATE; continuing because required check runs are validated explicitly."
     ;;
   pending)
     warn "Commit status state for $SHA is pending; continuing because required check runs are validated separately when present."


### PR DESCRIPTION
## Summary
- Treat broad combined commit status as advisory in `validate-release-source.sh`
- Keep enforcement on explicit required check runs (`CI Summary`, `JavaScript/TypeScript`, `iOS`)

## Why
The App Store release run from `main` failed because the combined commit status was `failure` due a non-required Vercel status context, while the required release checks were green. This blocked iOS release even though the release gates passed.

## Validation
- `bash -n .github/scripts/validate-release-source.sh`
- `git diff --check`
- Live SHA validation against `e1f56b1cea287679f5a84270a4a24ba5a01f0ff5` with `RELEASE_TYPE=app_store`: passed required checks and completed successfully
