### PR TITLE
fix(ci): resolve App Store IPA path

### DIFF
--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -332,9 +332,18 @@ jobs:
           AUTOMATIC_RELEASE="${{ github.event.inputs.automatic_release || 'false' }}"
           PHASED_RELEASE="${{ github.event.inputs.phased_release || 'true' }}"
 
+          IPA_PATH="$(find "$GITHUB_WORKSPACE/apps/ios/build" -name "*.ipa" -type f -print -quit)"
+          if [ -z "$IPA_PATH" ]; then
+            echo "::error::No IPA file found in downloaded build artifact"
+            find "$GITHUB_WORKSPACE/apps/ios/build" -maxdepth 4 -type f -print || true
+            exit 1
+          fi
+
+          echo "Submitting IPA: $IPA_PATH"
+
           # Submit for review
           bundle exec fastlane submit_app_store \
-            ipa_path:build/*.ipa \
+            ipa_path:"$IPA_PATH" \
             submit_for_review:$SUBMIT_FOR_REVIEW \
             automatic_release:$AUTOMATIC_RELEASE \
             phased_release:$PHASED_RELEASE 2>&1 | tee submit.log


### PR DESCRIPTION
## Summary
- resolve the downloaded iOS release artifact to a concrete IPA path before App Store submission
- pass that concrete path to Fastlane instead of the unexpanded `ipa_path:build/*.ipa` glob
- add a useful artifact listing if the IPA is ever missing again

## Validation
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ios-release-loop.yml'); puts 'workflow yaml ok'"`
- pre-push Turbo ran with no applicable workflow-only tasks

## Release failure fixed
- Run `26936673155` failed at `Deploy to App Store / Submit to App Store` because Fastlane received the literal path `build/*.ipa`.