### PR TITLE
fix(ios): use supported App Store upload identifier

### DIFF
--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -834,7 +834,7 @@ platform :ios do
       submit_for_review: submit_for_review,
       automatic_release: automatic_release,
       phased_release: phased_release,
-      apple_id: ENV["APP_STORE_APP_ID"],
+      app_identifier: ENV["APP_IDENTIFIER"] || "com.logyourbody.app",
       team_id: ENV["APPLE_TEAM_ID"]
     )
   end
@@ -861,7 +861,7 @@ platform :ios do
       skip_screenshots: false,
       submit_for_review: false,
       automatic_release: false,
-      apple_id: ENV["APP_STORE_APP_ID"],
+      app_identifier: ENV["APP_IDENTIFIER"] || "com.logyourbody.app",
       team_id: ENV["APPLE_TEAM_ID"]
     )
     


### PR DESCRIPTION
## Summary
- replace unsupported Fastlane `upload_to_app_store` option `apple_id` with supported `app_identifier`
- apply the same fix to both App Store upload lanes

## Validation
- `ruby -c apps/ios/fastlane/Fastfile`
- `git diff --check`
- pre-push Turbo ran with no applicable non-package tasks

## Release failure fixed
- Run `26937377260` failed at `Deploy to App Store / Submit to App Store` because Fastlane 2.229 rejected `apple_id` for `upload_to_app_store`.