### PR TITLE
fix(ios): skip duplicate App Store precheck

### DIFF
--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -834,6 +834,7 @@ platform :ios do
       submit_for_review: submit_for_review,
       automatic_release: automatic_release,
       phased_release: phased_release,
+      run_precheck_before_submit: false,
       app_identifier: ENV["APP_IDENTIFIER"] || "com.logyourbody.app",
       team_id: ENV["APPLE_TEAM_ID"]
     )
@@ -861,6 +862,7 @@ platform :ios do
       skip_screenshots: false,
       submit_for_review: false,
       automatic_release: false,
+      run_precheck_before_submit: false,
       app_identifier: ENV["APP_IDENTIFIER"] || "com.logyourbody.app",
       team_id: ENV["APPLE_TEAM_ID"]
     )


### PR DESCRIPTION
## Summary
- disable Fastlane's internal `upload_to_app_store` precheck for App Store upload lanes
- keep the workflow's explicit `Run Fastlane Precheck` step before submission

## Validation
- `ruby -c apps/ios/fastlane/Fastfile`
- `git diff --check`
- pre-push Turbo ran with no applicable non-package tasks

## Release failure fixed
- Run `26938455688` failed at `Deploy to App Store / Submit to App Store` because Fastlane internal precheck cannot check in-app purchases when authenticated with an App Store Connect API key.