### PR TITLE
fix: use App Store price local id format

### DIFF
--- a/.github/scripts/ensure-app-store-free-pricing.rb
+++ b/.github/scripts/ensure-app-store-free-pricing.rb
@@ -119,7 +119,7 @@ def free_price_point_id(token, app_id)
 end
 
 def create_free_price_schedule(token, app_id, price_point_id)
-  included_price_id = "free-price-#{BASE_TERRITORY.downcase}"
+  included_price_id = "${free-price-#{BASE_TERRITORY.downcase}}"
   body = {
     data: {
       type: "appPriceSchedules",


### PR DESCRIPTION
## Summary
- update the App Store free-pricing payload to use Apple JSON:API local-id syntax for inline `appPrices`

## Why
The App Store run `26943504286` reached the new pricing step and failed with:

`ENTITY_ERROR.INCLUDED.INVALID_ID`: inline included IDs must use `${local-id}` format.

## Validation
- `PATH="/opt/homebrew/Cellar/ruby@3.1/3.1.7_1/bin:$PATH" bundle _2.4.10_ check` from `apps/ios`
- `PATH="/opt/homebrew/Cellar/ruby@3.1/3.1.7_1/bin:$PATH" bundle _2.4.10_ exec ruby -c ../../.github/scripts/ensure-app-store-free-pricing.rb` from `apps/ios`
- `ruby -e "require 'yaml'; YAML.load_file('../../.github/workflows/ios-release-loop.yml'); puts 'workflow yaml ok'"` from `apps/ios`
- `git diff --check`
