### PR TITLE
fix: release approved App Store builds automatically

### DIFF
--- a/.github/scripts/release-approved-app-store-version.rb
+++ b/.github/scripts/release-approved-app-store-version.rb
@@ -1,0 +1,179 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "jwt"
+require "net/http"
+require "openssl"
+require "uri"
+
+API_BASE = "https://api.appstoreconnect.apple.com"
+PLATFORM = ENV.fetch("APP_STORE_PLATFORM", "IOS")
+
+REVIEW_STATES = %w[
+  READY_FOR_REVIEW
+  WAITING_FOR_REVIEW
+  IN_REVIEW
+  PENDING_APPLE_RELEASE
+  PROCESSING_FOR_DISTRIBUTION
+  PROCESSING_FOR_APP_STORE
+].freeze
+
+SUCCESS_STATES = %w[
+  READY_FOR_SALE
+  PREORDER_READY_FOR_SALE
+].freeze
+
+FAILURE_STATES = %w[
+  DEVELOPER_REJECTED
+  METADATA_REJECTED
+  REJECTED
+  PENDING_CONTRACT
+].freeze
+
+def fail_with(message)
+  warn "::error::#{message}"
+  exit 1
+end
+
+def warn_with(message)
+  warn "::warning::#{message}"
+end
+
+def api_key
+  path = ENV.fetch("APP_STORE_CONNECT_API_KEY_PATH", "fastlane/api_key.json")
+  JSON.parse(File.read(path))
+rescue KeyError
+  fail_with("APP_STORE_CONNECT_API_KEY_PATH is required")
+rescue Errno::ENOENT
+  fail_with("App Store Connect API key file not found")
+rescue JSON::ParserError => e
+  fail_with("App Store Connect API key file is invalid JSON: #{e.message}")
+end
+
+def bearer_token
+  key = api_key
+  private_key = OpenSSL::PKey::EC.new(key.fetch("key"))
+  payload = {
+    iss: key.fetch("issuer_id"),
+    exp: Time.now.to_i + key.fetch("duration", 1200).to_i,
+    aud: "appstoreconnect-v1"
+  }
+  headers = {
+    kid: key.fetch("key_id"),
+    typ: "JWT"
+  }
+
+  JWT.encode(payload, private_key, "ES256", headers)
+rescue KeyError => e
+  fail_with("App Store Connect API key is missing #{e.key}")
+rescue OpenSSL::PKey::ECError => e
+  fail_with("App Store Connect private key is invalid: #{e.message}")
+end
+
+def request(method, path, token, body: nil)
+  uri = URI("#{API_BASE}#{path}")
+  request_class = {
+    get: Net::HTTP::Get,
+    post: Net::HTTP::Post
+  }.fetch(method)
+
+  req = request_class.new(uri)
+  req["Authorization"] = "Bearer #{token}"
+  req["Content-Type"] = "application/json"
+  req.body = JSON.generate(body) if body
+
+  response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+    http.request(req)
+  end
+
+  [response.code.to_i, response.body.empty? ? {} : JSON.parse(response.body)]
+rescue JSON::ParserError => e
+  fail_with("App Store Connect returned invalid JSON for #{path}: #{e.message}")
+end
+
+def expect(method, path, token, body: nil, expected: [200])
+  status, parsed = request(method, path, token, body: body)
+  return parsed if expected.include?(status)
+
+  fail_with("App Store Connect #{method.upcase} #{path} returned #{status}: #{JSON.pretty_generate(parsed)}")
+end
+
+def app_id(token)
+  configured = ENV["APP_STORE_APP_ID"].to_s.strip
+  return configured unless configured.empty?
+
+  bundle_id = ENV.fetch("APP_IDENTIFIER", "com.logyourbody.app")
+  query = URI.encode_www_form("filter[bundleId]" => bundle_id, "limit" => "1")
+  response = expect(:get, "/v1/apps?#{query}", token)
+  app = response.fetch("data", []).first
+  fail_with("No App Store Connect app found for bundle ID #{bundle_id}") unless app
+
+  app.fetch("id")
+end
+
+def app_store_versions(token, app_id)
+  query = URI.encode_www_form(
+    "filter[platform]" => PLATFORM,
+    "fields[appStoreVersions]" => "versionString,appVersionState,platform",
+    "limit" => "20"
+  )
+  response = expect(:get, "/v1/apps/#{app_id}/appStoreVersions?#{query}", token)
+  response.fetch("data", [])
+end
+
+def selected_version(versions)
+  requested_version = ENV["APP_VERSION"].to_s.strip
+  if requested_version.empty?
+    versions.find { |version| version.dig("attributes", "appVersionState") == "PENDING_DEVELOPER_RELEASE" } ||
+      versions.find { |version| REVIEW_STATES.include?(version.dig("attributes", "appVersionState").to_s) } ||
+      versions.first
+  else
+    versions.find { |version| version.dig("attributes", "versionString") == requested_version }
+  end
+end
+
+def request_release(token, app_store_version_id)
+  body = {
+    data: {
+      type: "appStoreVersionReleaseRequests",
+      relationships: {
+        appStoreVersion: {
+          data: {
+            type: "appStoreVersions",
+            id: app_store_version_id
+          }
+        }
+      }
+    }
+  }
+
+  expect(:post, "/v1/appStoreVersionReleaseRequests", token, body: body, expected: [201])
+end
+
+token = bearer_token
+id = app_id(token)
+version = selected_version(app_store_versions(token, id))
+
+if version.nil?
+  app_version = ENV["APP_VERSION"].to_s.strip
+  fail_with(app_version.empty? ? "No App Store versions found for #{id}" : "App Store version #{app_version} was not found for #{id}")
+end
+
+version_id = version.fetch("id")
+version_string = version.dig("attributes", "versionString")
+state = version.dig("attributes", "appVersionState").to_s
+
+case state
+when "PENDING_DEVELOPER_RELEASE"
+  request_release(token, version_id)
+  puts "Released approved App Store version #{version_string} (#{version_id})."
+when *SUCCESS_STATES
+  puts "App Store version #{version_string} is already #{state}; no release action needed."
+when *REVIEW_STATES
+  puts "App Store version #{version_string} is #{state}; waiting for Apple approval."
+when *FAILURE_STATES
+  fail_with("App Store version #{version_string} is #{state}; release needs remediation.")
+else
+  warn_with("App Store version #{version_string} is #{state}; no release action taken.")
+end

--- a/.github/workflows/ios-app-store-approved-release.yml
+++ b/.github/workflows/ios-app-store-approved-release.yml
@@ -1,0 +1,90 @@
+name: iOS App Store Approved Release
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+    inputs:
+      app_version:
+        description: 'Optional App Store version to release after Apple approval'
+        required: false
+        type: string
+
+concurrency:
+  group: ios-app-store-approved-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-approved-version:
+    name: Release Approved App Store Version
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Ruby and Bundler
+        uses: ./.github/actions/setup-ruby-bundler
+        with:
+          working-directory: apps/ios
+          cache-key-prefix: ios-release-monitor-gems
+
+      - name: Setup App Store Connect Authentication
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+        run: |
+          cd apps/ios
+          mkdir -p fastlane
+
+          ruby <<'RUBY'
+          require "json"
+
+          api_key = {
+            "key_id" => ENV.fetch("ASC_KEY_ID"),
+            "issuer_id" => ENV.fetch("ASC_ISSUER_ID"),
+            "key" => ENV.fetch("ASC_PRIVATE_KEY").gsub("\\n", "\n"),
+            "duration" => 1200,
+            "in_house" => false
+          }
+
+          File.write("fastlane/api_key.json", JSON.pretty_generate(api_key))
+          JSON.parse(File.read("fastlane/api_key.json"))
+          RUBY
+
+          echo "APP_STORE_CONNECT_API_KEY_PATH=$(pwd)/fastlane/api_key.json" >> "$GITHUB_ENV"
+
+      - name: Resolve App Version
+        id: app_version
+        env:
+          INPUT_APP_VERSION: ${{ github.event.inputs.app_version }}
+        run: |
+          if [ -n "$INPUT_APP_VERSION" ]; then
+            version="$INPUT_APP_VERSION"
+          else
+            version="$(awk -F ' = ' '/MARKETING_VERSION = / { gsub(/[;[:space:]]/, "", $2); if ($2 ~ /^[0-9]+[.][0-9]+/) { print $2; exit } }' apps/ios/LogYourBody.xcodeproj/project.pbxproj)"
+          fi
+
+          if [ -z "$version" ]; then
+            echo "::error::Unable to resolve App Store version"
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Release Approved Version
+        run: |
+          cd apps/ios
+          bundle exec ruby ../../.github/scripts/release-approved-app-store-version.rb
+        env:
+          APP_STORE_APP_ID: ${{ secrets.APP_STORE_APP_ID }}
+          APP_IDENTIFIER: com.logyourbody.app
+          APP_VERSION: ${{ steps.app_version.outputs.version }}
+
+      - name: Cleanup
+        if: always()
+        run: rm -f apps/ios/fastlane/api_key.json

--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -24,7 +24,7 @@ on:
         description: 'Automatically release after Apple approval'
         required: false
         type: boolean
-        default: false
+        default: true
       phased_release:
         description: 'Use phased release for approved App Store builds'
         required: false
@@ -338,7 +338,7 @@ jobs:
           cd apps/ios
 
           SUBMIT_FOR_REVIEW="${{ github.event.inputs.submit_for_review || 'true' }}"
-          AUTOMATIC_RELEASE="${{ github.event.inputs.automatic_release || 'false' }}"
+          AUTOMATIC_RELEASE="${{ github.event.inputs.automatic_release || 'true' }}"
           PHASED_RELEASE="${{ github.event.inputs.phased_release || 'true' }}"
 
           IPA_PATH="$(find "$GITHUB_WORKSPACE/apps/ios/build" -name "*.ipa" -type f -print -quit)"

--- a/apps/ios/docs/development/RELEASE_CHECKLIST.md
+++ b/apps/ios/docs/development/RELEASE_CHECKLIST.md
@@ -17,7 +17,8 @@ Use this checklist before sending a LogYourBody iOS build to TestFlight or App S
 - StoreKit/App Store products are attached to the active RevenueCat offering.
 - Release workflow verifies the RevenueCat current iOS offering exposes `$rc_annual` -> `com.logyourbody.app.pro1.annual.3daytrial` and `$rc_monthly` -> `com.logyourbody.app.pro1.monthly.3daytrial`.
 - Release workflow validates the actual release ref/SHA instead of the unrelated `preview` branch.
-- App Store release workflow is run from `main` with `release_type=app_store` and `submit_for_review=true` after the TestFlight build is accepted.
+- App Store release workflow is run from `main` with `release_type=app_store`, `submit_for_review=true`, and automatic release enabled after the TestFlight build is accepted.
+- The approved-release monitor is enabled so Apple-approved builds that enter `PENDING_DEVELOPER_RELEASE` are released without a manual App Store Connect click.
 - Optional GitHub `Production` secrets `STATSIG_CLIENT_SDK_KEY` and `SENTRY_DSN` are real values if present.
 - `ios_full_body_composition_dashboard` stays off for the v0.1 App Store launch unless the full dashboard has separate approval.
 


### PR DESCRIPTION
## Summary
- add a scheduled/manual App Store approved-release workflow that runs on `main` every 30 minutes
- add a small App Store Connect API script that releases the version only when its state is `PENDING_DEVELOPER_RELEASE`
- default future App Store submissions to `automatic_release=true`
- document the approved-release monitor in the iOS release checklist

## Why
The App Store run succeeded and submitted `1.2.0 (20260604154019)` for review, but that run used `automatic_release=false`. If Apple approves into `PENDING_DEVELOPER_RELEASE`, the app would still need a manual App Store Connect click. This PR turns that into an autonomous no-op-until-approved closeout loop.

## Safety
- The workflow only runs from `main`.
- It does not bypass Apple review.
- It only posts an App Store release request for versions already in `PENDING_DEVELOPER_RELEASE`.
- Review states (`WAITING_FOR_REVIEW`, `IN_REVIEW`, `PENDING_APPLE_RELEASE`, etc.) no-op.
- Rejection/contract states fail loudly for remediation.

## Validation
- `PATH="/opt/homebrew/Cellar/ruby@3.1/3.1.7_1/bin:$PATH" bundle _2.4.10_ check` from `apps/ios`
- `PATH="/opt/homebrew/Cellar/ruby@3.1/3.1.7_1/bin:$PATH" bundle _2.4.10_ exec ruby -c ../../.github/scripts/release-approved-app-store-version.rb` from `apps/ios`
- YAML parse for `.github/workflows/ios-app-store-approved-release.yml` and `.github/workflows/ios-release-loop.yml`
- `git diff --check HEAD~1..HEAD`

## Release evidence
- App Store run `26962363636` completed successfully.
- The deploy job configured free pricing, processed build `1.2.0 (20260604154019)`, selected the build, and logged `Successfully submitted the app for review!`.
