### PR TITLE
fix: extend iOS release validation timeout

### DIFF
--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -40,7 +40,7 @@ jobs:
   validate-release:
     name: Validate Release
     runs-on: macos-26
-    timeout-minutes: 5
+    timeout-minutes: 20
     permissions:
       contents: read
       checks: read


### PR DESCRIPTION
## Summary
- extend the iOS release validation job timeout from 5 to 20 minutes
- align the job timeout with the existing 15 minute required-check polling window

## Validation
- ruby YAML parse for .github/workflows/ios-release-loop.yml
- git diff --check
- pre-push turbo lint/typecheck/test filter ran; no affected tasks

## Context
The push-triggered iOS Release Loop on main cancelled during version extraction after waiting for CI checks because the job timeout was shorter than the release-source CI polling window.