### PR TITLE
fix: accept Apple auth sessions without email identifier

### DIFF
--- a/apps/ios/LogYourBody/Services/AuthManager.swift
+++ b/apps/ios/LogYourBody/Services/AuthManager.swift
@@ -210,6 +210,32 @@ class AuthManager: NSObject, ObservableObject {
         value ? "true" : "false"
     }
 
+    nonisolated static func normalizedAuthEmailCandidate(_ value: String?) -> String? {
+        let candidate = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard candidate.contains("@"),
+              !candidate.contains(" ") else {
+            return nil
+        }
+
+        return candidate
+    }
+
+    nonisolated static func syntheticAuthEmail(userId: String) -> String? {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        let sanitized = userId
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .unicodeScalars
+            .map { allowed.contains($0) ? String($0) : "-" }
+            .joined()
+        let localPart = sanitized.trimmingCharacters(in: CharacterSet(charactersIn: ".-_"))
+
+        guard !localPart.isEmpty else {
+            return nil
+        }
+
+        return "\(localPart)@apple.local.logyourbody"
+    }
+
     private func logAuthDiagnostic(_ stage: String, details: [String: String] = [:]) {
         let summary = details
             .sorted { $0.key < $1.key }
@@ -493,8 +519,15 @@ class AuthManager: NSObject, ObservableObject {
     @discardableResult
     private func updateLocalUser(clerkSession session: Session) -> Bool {
         guard let publicUserData = session.publicUserData,
-              let userId = publicUserData.userId,
-              publicUserData.identifier.contains("@") else {
+              let userId = publicUserData.userId else {
+            return false
+        }
+
+        let email = Self.normalizedAuthEmailCandidate(publicUserData.identifier)
+            ?? Self.syntheticAuthEmail(userId: userId)
+
+        guard let email else {
+            logAuthDiagnostic("local_user_projection_failed", details: ["source": "session"])
             return false
         }
 
@@ -508,10 +541,10 @@ class AuthManager: NSObject, ObservableObject {
 
         applyLocalUser(
             userId: userId,
-            email: publicUserData.identifier,
+            email: email,
             username: nil,
             imageUrl: publicUserData.imageUrl.isEmpty ? nil : publicUserData.imageUrl,
-            displayName: name
+            displayName: name.isEmpty ? getUserDisplayName() : name
         )
 
         return true
@@ -537,6 +570,7 @@ class AuthManager: NSObject, ObservableObject {
         // Extract properties using Mirror
         var userId = ""
         var emailAddresses: [Any] = []
+        var externalAccounts: [Any] = []
         var username: String?
         var imageUrl: String?
 
@@ -546,6 +580,8 @@ class AuthManager: NSObject, ObservableObject {
                 userId = child.value as? String ?? ""
             case "emailAddresses":
                 emailAddresses = child.value as? [Any] ?? []
+            case "externalAccounts":
+                externalAccounts = child.value as? [Any] ?? []
             case "username":
                 username = child.value as? String
             case "imageUrl":
@@ -555,17 +591,10 @@ class AuthManager: NSObject, ObservableObject {
             }
         }
 
-        // Extract email from first email address
-        var email = ""
-        if let firstEmailAddress = emailAddresses.first {
-            let emailMirror = Mirror(reflecting: firstEmailAddress)
-            for child in emailMirror.children {
-                if child.label == "emailAddress" {
-                    email = child.value as? String ?? ""
-                    break
-                }
-            }
-        }
+        let email = firstEmailAddress(in: emailAddresses)
+            ?? firstEmailAddress(in: externalAccounts)
+            ?? Self.syntheticAuthEmail(userId: userId)
+            ?? ""
 
         return applyLocalUser(
             userId: userId,
@@ -576,6 +605,20 @@ class AuthManager: NSObject, ObservableObject {
         )
     }
 
+    private func firstEmailAddress(in values: [Any]) -> String? {
+        for value in values {
+            let mirror = Mirror(reflecting: value)
+
+            for child in mirror.children where child.label == "emailAddress" {
+                if let email = Self.normalizedAuthEmailCandidate(child.value as? String) {
+                    return email
+                }
+            }
+        }
+
+        return nil
+    }
+
     @discardableResult
     private func applyLocalUser(
         userId: String,
@@ -584,7 +627,7 @@ class AuthManager: NSObject, ObservableObject {
         imageUrl: String?,
         displayName: String
     ) -> Bool {
-        guard !email.isEmpty else {
+        guard !userId.isEmpty, !email.isEmpty else {
             self.currentUser = nil
             self.isAuthenticated = false
             return false

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -230,6 +230,89 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         XCTAssertTrue(manager.isAuthenticated)
         XCTAssertEqual(manager.currentUser?.email, "test@example.com")
     }
+
+    func testUpdateLocalUserUsesExternalAccountEmailWhenPrimaryEmailsMissing() {
+        let manager = AuthManager()
+
+        struct FakeExternalAccount {
+            let provider: String
+            let emailAddress: String
+        }
+
+        struct FakeClerkUser {
+            let id: String
+            let emailAddresses: [String]
+            let externalAccounts: [FakeExternalAccount]
+            let firstName: String?
+            let lastName: String?
+            let username: String?
+            let imageUrl: String?
+        }
+
+        let fakeUser = FakeClerkUser(
+            id: "user_apple_123",
+            emailAddresses: [],
+            externalAccounts: [
+                FakeExternalAccount(
+                    provider: "oauth_apple",
+                    emailAddress: "private@example.com"
+                )
+            ],
+            firstName: "Apple",
+            lastName: "User",
+            username: nil,
+            imageUrl: nil
+        )
+
+        manager.updateLocalUser(clerkUser: fakeUser)
+
+        XCTAssertTrue(manager.isAuthenticated)
+        XCTAssertEqual(manager.currentUser?.email, "private@example.com")
+    }
+
+    func testUpdateLocalUserSynthesizesEmailWhenClerkEmailMissing() {
+        let manager = AuthManager()
+
+        struct FakeClerkUser {
+            let id: String
+            let emailAddresses: [String]
+            let externalAccounts: [String]
+            let firstName: String?
+            let lastName: String?
+            let username: String?
+            let imageUrl: String?
+        }
+
+        let fakeUser = FakeClerkUser(
+            id: "user_apple_123",
+            emailAddresses: [],
+            externalAccounts: [],
+            firstName: nil,
+            lastName: nil,
+            username: nil,
+            imageUrl: nil
+        )
+
+        manager.updateLocalUser(clerkUser: fakeUser)
+
+        XCTAssertTrue(manager.isAuthenticated)
+        XCTAssertEqual(manager.currentUser?.email, "user_apple_123@apple.local.logyourbody")
+    }
+
+    func testSyntheticAuthEmailSanitizesClerkUserId() {
+        XCTAssertEqual(
+            AuthManager.syntheticAuthEmail(userId: " user:abc/123 "),
+            "user-abc-123@apple.local.logyourbody"
+        )
+    }
+
+    func testNormalizedAuthEmailRejectsNonEmailIdentifier() {
+        XCTAssertNil(AuthManager.normalizedAuthEmailCandidate("user_apple_123"))
+        XCTAssertEqual(
+            AuthManager.normalizedAuthEmailCandidate(" private@example.com "),
+            "private@example.com"
+        )
+    }
 }
 
 final class AuthConfigurationValidationTests: XCTestCase {


### PR DESCRIPTION
## Summary
- accept active Clerk Apple sessions when `publicUserData.identifier` is not email-shaped
- derive local profile email from Clerk email addresses, OAuth external account email, or a deterministic internal fallback from Clerk user id
- add focused coverage for external-account email and no-email Apple session projection

## Validation
- `swiftlint lint --strict`
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,name=iPhone 17' build-for-testing`
- `xcodebuild test-without-building -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:LogYourBodyTests/OnboardingFlowViewModelTests`
- `xcodebuild test-without-building -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:LogYourBodyTests`
- pre-push `turbo run lint/typecheck/test --filter=...[origin/main]` executed; no JS tasks were in scope for this iOS-only diff