### PR TITLE
feat: add iOS product design guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,17 @@ LogYourBody/
   - **Data**: Core Data for local storage, Supabase for cloud sync, HealthKit for weight and step data.
   - **Feature Flags**: Statsig for controlled rollouts and A/B testing.
 
+### Product Scope Guardrails
+
+- Treat the native paid iOS app as the only default product surface until usage proves otherwise.
+- Core product promise: answer "How am I doing?" from weight, body-composition, HealthKit, and progress-photo data with minimal user input.
+- Design should follow the Joby/Jovie-style system: dark-only, clean, concise, generous white space, pill-shaped auth controls, neutral surfaces, and Geist-like accent colors only where they communicate metric meaning or state.
+- Do not build a web app before the product has at least 1,000 activated iOS users, or 250 paying subscribers plus repeated web-access requests. Web work before then is limited to marketing, legal, support, and billing/account surfaces that unblock iOS.
+- Do not build an Apple Watch app unless users explicitly ask for it. Initial Watch scope is read-only basic stats and trend direction.
+- Do not build iPad-specific layouts unless there is clear user pull, a measurable kiosk experiment, or enough active iPad usage to justify it. Target future landscape layout: photo left, stats right, timeline along the bottom.
+- AI starts as short deterministic insight, not chat: classify cutting, maintenance, or gaining from trends and warn when a phase has likely gone too long. Jovie-style chat comes later only after the timeline is retained and users ask for recommendations.
+- Do not build a food logger or workout tracker. This app is a body-composition heads-up display for people who already have those systems.
+
 ---
 
 ## Branching Model

--- a/apps/ios/LogYourBody/DesignSystem/Atoms/BaseButton.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Atoms/BaseButton.swift
@@ -14,6 +14,7 @@ struct ButtonConfiguration {
     var fullWidth: Bool = false
     var icon: String?
     var iconPosition: IconPosition = .leading
+    var cornerRadius: CGFloat?
     var hapticFeedback: UIImpactFeedbackGenerator.FeedbackStyle? = .light
 
     enum ButtonStyleVariant {
@@ -117,6 +118,10 @@ struct BaseButton<Label: View>: View {
         configuration.isEnabled && !configuration.isLoading && isEnvironmentEnabled
     }
 
+    private var cornerRadius: CGFloat {
+        configuration.cornerRadius ?? 10
+    }
+
     var body: some View {
         Button(action: handleTap, label: {
             buttonContent
@@ -124,7 +129,7 @@ struct BaseButton<Label: View>: View {
                 .frame(height: configuration.size.height)
                 .padding(configuration.size.padding)
                 .background(backgroundView)
-                .cornerRadius(10)
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
                 .overlay(borderOverlay)
                 .scaleEffect(isPressed || configuration.isLoading ? 0.98 : 1.0)
                 .opacity(isEnabled ? 1.0 : 0.6)
@@ -166,7 +171,7 @@ struct BaseButton<Label: View>: View {
     @ViewBuilder
     private var borderOverlay: some View {
         if let borderColor = configuration.style.borderColor {
-            RoundedRectangle(cornerRadius: 10)
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                 .stroke(borderColor, lineWidth: 1.5)
         }
     }

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/SocialLoginButton.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/SocialLoginButton.swift
@@ -37,9 +37,9 @@ struct SocialLoginButton: View {
         var backgroundColor: Color {
             switch self {
             case .apple:
-                return .white
+                return Color.metricSurface
             case .google:
-                return .white
+                return Color.metricSurface
             case .facebook:
                 return Color(red: 0.258, green: 0.406, blue: 0.697)
             }
@@ -48,9 +48,27 @@ struct SocialLoginButton: View {
         var foregroundColor: Color {
             switch self {
             case .apple, .google:
-                return .black
+                return .appText
             case .facebook:
                 return .white
+            }
+        }
+
+        var borderColor: Color {
+            switch self {
+            case .apple, .google:
+                return Color.white.opacity(0.14)
+            case .facebook:
+                return Color.clear
+            }
+        }
+
+        var borderWidth: CGFloat {
+            switch self {
+            case .apple, .google:
+                return 1
+            case .facebook:
+                return 0
             }
         }
     }
@@ -80,18 +98,14 @@ struct SocialLoginButton: View {
                 size: .medium,
                 isLoading: isLoading,
                 fullWidth: true,
-                icon: provider.icon
+                icon: provider.icon,
+                cornerRadius: 9_999
             ),
             action: action
         )
         .overlay(
-            // Add border for certain providers
-            Group {
-                if provider == .apple || provider == .google {
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.appBorder, lineWidth: 1)
-                }
-            }
+            RoundedRectangle(cornerRadius: 9_999, style: .continuous)
+                .stroke(provider.borderColor, lineWidth: provider.borderWidth)
         )
     }
 }

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/LoginForm.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/LoginForm.swift
@@ -59,7 +59,8 @@ struct LoginForm: View {
                     style: .custom(background: .appCard, foreground: .appText),
                     isLoading: isLoading,
                     isEnabled: isFormValid,
-                    fullWidth: true
+                    fullWidth: true,
+                    cornerRadius: 9_999
                 ),
                 action: onLogin
             )

--- a/apps/ios/docs/architecture/APP_STORE_LAUNCH_PLAN.md
+++ b/apps/ios/docs/architecture/APP_STORE_LAUNCH_PLAN.md
@@ -1,6 +1,9 @@
 # LogYourBody iOS App Store Launch Plan
 
+> Current product sequencing lives in [`../../../../docs/product-development-roadmap.md`](../../../../docs/product-development-roadmap.md). Use that roadmap for KPI gates, iOS-first scope, and web/iPad/Watch/AI expansion triggers; this file is historical launch readiness context.
+
 ## Current Status Assessment
+
 **Last Updated: January 12, 2025**
 **Launch Readiness: 85%**
 
@@ -9,10 +12,10 @@ The app has reached feature-complete status with major functionality implemented
 ## 🚨 CRITICAL BLOCKERS for App Store Launch
 
 ### Immediate Action Required (1-2 hours)
+
 1. **Add Photo Library Permissions to Info.plist**
    - [ ] ❌ NSPhotoLibraryUsageDescription
    - [ ] ❌ NSPhotoLibraryAddUsageDescription
-   
 2. **Fix Version Number Synchronization**
    - [ ] ❌ Info.plist: 1.0.0 → 1.2.0
    - [ ] ❌ Constants.swift: 1.0.0 → 1.2.0
@@ -29,6 +32,7 @@ The app has reached feature-complete status with major functionality implemented
 ## 🚀 MUST HAVE for App Store Launch
 
 ### 1. Critical Bug Fixes
+
 - [x] ✅ Fix duplicate LiquidGlass component declarations
 - [x] ✅ Fix onboarding completion crash
 - [x] ✅ Remove debug shake-to-reset from production builds
@@ -41,6 +45,7 @@ The app has reached feature-complete status with major functionality implemented
 - [x] ✅ Fix image rotation with Vision framework
 
 ### 2. App Store Requirements
+
 - [x] ✅ **Privacy Policy URL** - Implemented at logyourbody.com/privacy
 - [x] ✅ **Terms of Service URL** - Implemented at logyourbody.com/terms
 - [ ] ❌ **App Store Connect Screenshots** (6.5", 5.5" required minimum)
@@ -50,6 +55,7 @@ The app has reached feature-complete status with major functionality implemented
 - [x] ✅ **Age Rating** - Set to 17+ (health data collection)
 
 ### 3. Authentication & Security
+
 - [x] ✅ Clerk authentication implemented
 - [x] ✅ Email verification flow
 - [x] ✅ **Apple Sign In** - Implemented with browser-based OAuth flow
@@ -57,6 +63,7 @@ The app has reached feature-complete status with major functionality implemented
 - [x] ✅ Secure token management
 
 ### 4. Core Feature Stability
+
 - [x] ✅ Weight logging with manual and HealthKit sync
 - [x] ✅ Body fat % tracking with multiple methods
 - [x] ✅ Photo capture/upload with background removal
@@ -66,6 +73,7 @@ The app has reached feature-complete status with major functionality implemented
 - [x] ✅ Offline mode support
 
 ### 5. Legal Compliance & GDPR
+
 - [x] ✅ **Support Page** - Implemented at logyourbody.com/support
 - [x] ✅ **Privacy Policy** - Accessible from app and web
 - [x] ✅ **Terms of Service** - Accessible from app and web
@@ -77,6 +85,7 @@ The app has reached feature-complete status with major functionality implemented
 - [ ] ❌ **Complete Account Deletion** - Server-side deletion needed
 
 ### 6. Performance & Stability
+
 - [x] ✅ Test on real devices
 - [x] ✅ Memory optimization for photo handling
 - [x] ✅ Remove debug logging from Apple Sign In
@@ -85,6 +94,7 @@ The app has reached feature-complete status with major functionality implemented
 - [ ] ❌ Analytics integration (optional)
 
 ### 7. Design & UX Polish
+
 - [x] ✅ iOS 26 Liquid Glass design implementation
 - [x] ✅ Professional onboarding flow
 - [x] ✅ Consistent black/white/grayscale theme
@@ -100,49 +110,56 @@ The app has reached feature-complete status with major functionality implemented
 ## 🎯 Critical Action Items Before Submission
 
 ### PHASE 1: Code Fixes (1-2 hours) - HIGHEST PRIORITY
-   - [ ] ❌ Add NSPhotoLibraryUsageDescription to Info.plist
-   - [ ] ❌ Add NSPhotoLibraryAddUsageDescription to Info.plist
-   - [ ] ❌ Synchronize version numbers (1.2.0) across all files
-   - [ ] ❌ Fix LSApplicationCategoryType in Info.plist
-   - [ ] ❌ Replace all fatalError calls with proper error handling
+
+- [ ] ❌ Add NSPhotoLibraryUsageDescription to Info.plist
+- [ ] ❌ Add NSPhotoLibraryAddUsageDescription to Info.plist
+- [ ] ❌ Synchronize version numbers (1.2.0) across all files
+- [ ] ❌ Fix LSApplicationCategoryType in Info.plist
+- [ ] ❌ Replace all fatalError calls with proper error handling
 
 ### PHASE 2: Code Cleanup (2-3 hours)
-   - [ ] ❌ Remove 200+ print statements or wrap in #if DEBUG
-   - [ ] ❌ Remove mock authentication code from AuthManager
-   - [ ] ❌ Address TODO comments in CompletionStepView and HealthKitManager
-   - [ ] ❌ Implement or remove "Coming Soon" forgot password feature
-   - [ ] ❌ Remove debug-only UI elements from production builds
+
+- [ ] ❌ Remove 200+ print statements or wrap in #if DEBUG
+- [ ] ❌ Remove mock authentication code from AuthManager
+- [ ] ❌ Address TODO comments in CompletionStepView and HealthKitManager
+- [ ] ❌ Implement or remove "Coming Soon" forgot password feature
+- [ ] ❌ Remove debug-only UI elements from production builds
 
 ### PHASE 3: Configuration & Security (1 hour)
-   - [ ] ⚠️ Consider moving API keys to secure configuration
-   - [ ] ⏳ Verify server-side account deletion for GDPR compliance
-   - [x] ✅ Data export functionality implemented in ExportDataView
+
+- [ ] ⚠️ Consider moving API keys to secure configuration
+- [ ] ⏳ Verify server-side account deletion for GDPR compliance
+- [x] ✅ Data export functionality implemented in ExportDataView
 
 ### PHASE 4: App Store Assets (3-4 hours)
-   - [ ] ❌ Screenshots for 6.5" (iPhone 14 Pro Max)
-   - [ ] ❌ Screenshots for 5.5" (iPhone 8 Plus) 
-   - [ ] ❌ App Description focusing on privacy and simplicity
-   - [ ] ❌ Keywords: body composition, weight tracker, progress photos, FFMI
-   - [ ] App Preview Video (optional but recommended)
+
+- [ ] ❌ Screenshots for 6.5" (iPhone 14 Pro Max)
+- [ ] ❌ Screenshots for 5.5" (iPhone 8 Plus)
+- [ ] ❌ App Description focusing on privacy and simplicity
+- [ ] ❌ Keywords: body composition, weight tracker, progress photos, FFMI
+- [ ] App Preview Video (optional but recommended)
 
 ### PHASE 5: Final Testing Checklist (2-3 hours)
-   - [ ] Complete onboarding flow
-   - [ ] Log weight, body fat, and photo
-   - [ ] Test HealthKit sync
-   - [ ] Test Apple Sign In
-   - [ ] Test data export
-   - [ ] Test account deletion
-   - [ ] Verify offline functionality
-   - [ ] Check all external links
+
+- [ ] Complete onboarding flow
+- [ ] Log weight, body fat, and photo
+- [ ] Test HealthKit sync
+- [ ] Test Apple Sign In
+- [ ] Test data export
+- [ ] Test account deletion
+- [ ] Verify offline functionality
+- [ ] Check all external links
 
 ### 5. **App Store Connect Setup** (1 hour)
-   - ✅ Set age rating to 17+
-   - ✅ Add privacy policy URL (logyourbody.com/privacy)
-   - ✅ Add support URL (logyourbody.com/support)
-   - Configure in-app purchases (if any)
-   - ✅ Set up TestFlight
+
+- ✅ Set age rating to 17+
+- ✅ Add privacy policy URL (logyourbody.com/privacy)
+- ✅ Add support URL (logyourbody.com/support)
+- Configure in-app purchases (if any)
+- ✅ Set up TestFlight
 
 ## 📱 TestFlight Strategy
+
 1. Internal testing with team (1-2 days)
 2. External beta with 20-50 users (3-5 days)
 3. Address critical feedback
@@ -151,26 +168,30 @@ The app has reached feature-complete status with major functionality implemented
 ## 🚀 Post-Launch Roadmap
 
 ### Version 1.1 (2-4 weeks)
+
 - Widgets for home screen
 - Data export improvements
 - Performance optimizations
 - Bug fixes from user feedback
 
 ### Version 1.2 (1-2 months)
+
 - iPad optimization
 - Advanced charting options
 - Measurement tracking (waist, arms, etc.)
 - Backup/restore functionality
 
 ### Version 2.0 (3-6 months)
+
 - Apple Watch companion app
 - AI-powered insights
 - Social features (optional)
 - Premium themes
 
 ## Time Estimate for Launch
+
 - **Phase 1 (Code Fixes)**: 1-2 hours
-- **Phase 2 (Code Cleanup)**: 2-3 hours  
+- **Phase 2 (Code Cleanup)**: 2-3 hours
 - **Phase 3 (Configuration)**: 1 hour
 - **Phase 4 (App Store Assets)**: 3-4 hours
 - **Phase 5 (Final Testing)**: 2-3 hours
@@ -179,10 +200,11 @@ The app has reached feature-complete status with major functionality implemented
 - **Total**: ~10-15 days (was 8-12 days)
 
 ## Next Immediate Steps (Priority Order)
+
 1. 🚨 **FIX CRITICAL BLOCKERS** (1-2 hours)
    - Add photo library permissions to Info.plist
    - Synchronize version numbers to 1.2.0
-   - Fix LSApplicationCategoryType 
+   - Fix LSApplicationCategoryType
    - Remove fatalError calls
 
 2. 🧹 **CLEAN UP CODE** (2-3 hours)
@@ -202,17 +224,20 @@ The app has reached feature-complete status with major functionality implemented
 5. 🚀 **SUBMIT TO TESTFLIGHT**
 
 ## Success Metrics
+
 - Crash-free rate > 99.5%
 - App Store rating > 4.5 stars
 - User retention > 60% after 30 days
 - HealthKit adoption > 40%
 
 ## Summary
+
 **Launch Readiness: 85%** (was 98% - adjusted after thorough review)
 
 The app has excellent features and UI but needs critical fixes before App Store submission:
 
 ### ✅ What's Complete:
+
 - Premium dashboard with minimal aesthetic
 - Full accessibility support (WCAG AA+)
 - Vision framework for image orientation
@@ -225,12 +250,14 @@ The app has excellent features and UI but needs critical fixes before App Store 
 - Offline support
 
 ### ❌ Critical Blockers (1-2 hours to fix):
+
 1. Missing photo library permissions in Info.plist
 2. Version number mismatch (should be 1.2.0 everywhere)
 3. Empty LSApplicationCategoryType
 4. Fatal errors that could crash app
 
 ### ⚠️ Important Issues (3-4 hours to fix):
+
 1. 200+ debug print statements in production
 2. Mock auth code still present
 3. "Coming Soon" placeholder content
@@ -238,6 +265,7 @@ The app has excellent features and UI but needs critical fixes before App Store 
 5. Hardcoded API keys (though they're public keys)
 
 ### 📋 Remaining Work:
+
 - Code fixes and cleanup (5-6 hours)
 - App Store screenshots and description (3-4 hours)
 - Final testing (2-3 hours)

--- a/docs/product-development-roadmap.md
+++ b/docs/product-development-roadmap.md
@@ -1,0 +1,142 @@
+# LogYourBody Product Roadmap And Build Guardrails
+
+Last updated: 2026-06-05
+
+## Operating Principle
+
+LogYourBody is an iOS-first paid product. It should not become another food logger, workout tracker, or dashboard suite. The job is to answer one question with almost no input:
+
+> How am I doing?
+
+The first shippable wedge is a native iOS app where a user can sign in, pay, log weight/body composition/progress photos, and see a clear body-composition trend. Everything else waits for measured user pull.
+
+## Design System Direction
+
+- Use the Joby/Jovie-style product language: dark-only, minimal, quiet, high-contrast, generous white space, and crisp system typography.
+- Prefer neutral black, near-black, white, and gray surfaces. Use Geist-like accents only for metric meaning, status, focus, and small visual cues.
+- Auth controls should be pill-shaped, concise, and touch-friendly. Avoid square, boxy login CTAs.
+- Metrics keep stable accent colors:
+  - Body fat: pink/red
+  - Weight: violet
+  - FFMI/FMI: purple
+  - Steps/activity: amber
+  - Waist/measurements: blue
+- No decorative gradients, heavy marketing surfaces, or dense product education inside the app.
+
+## North Star
+
+The app should feel like a body-composition heads-up display:
+
+- Open app.
+- See the latest body/photo state immediately.
+- Know whether weight/body fat/FFMI are moving in the right direction.
+- Scrub the timeline to understand how the body changed over time.
+- Get a short, low-friction signal like "cutting", "maintenance", or "gaining" only when the data supports it.
+
+## KPI Ladder
+
+These metrics decide what gets built next:
+
+- Activation: user signs in, completes paywall/free trial decision, and logs at least one weight or imports one HealthKit weight within 24 hours.
+- Photo activation: user adds or imports at least one progress photo.
+- Core retention: user opens the app and views or logs data on day 7 and day 30.
+- Paid signal: trial start rate, paid conversion rate, refund/cancel reasons.
+- Reliability: crash-free sessions above 99.5 percent and no auth/paywall dead ends.
+- Pull signals: support requests, bug reports, App Store reviews, and repeated user asks.
+
+## Phase 0: Paid iOS MVP
+
+Ship only the paid native iOS loop:
+
+- Apple Sign In and email OTP.
+- Working paywall/free trial with a logout escape.
+- Manual weight logging.
+- HealthKit weight import where already stable.
+- Minimal dashboard showing latest weight/body-composition state.
+- Stable settings screen with account, subscription, export/delete, HealthKit, and support.
+- Deterministic App Store screenshot generation based on the Jovie public-profile carousel style: iPhone aspect-ratio screenshots, concise copy above, dark product system, no one-off manual screenshots.
+
+Do not expand scope if this loop is not stable.
+
+## Phase 1: Photo-First Timeline
+
+Build the product around a 4:5 full-width progress photo surface with a timeline scrubber below it.
+
+Core interactions:
+
+- Swipe progress photos left and right.
+- Scrub the timeline by date.
+- Switch timeline mode between photo date, body fat percentage, weight, and FFMI/FMI.
+- Start with body fat percentage plus photo first.
+- Show weight/body fat/FFMI as compact metric cards, not a dense analytics console.
+
+The timeline is the product. A feature that does not improve timeline clarity, data import, or daily "how am I doing" feedback should be deferred.
+
+## Phase 2: Analytics And Import
+
+After activation and retention are healthy, expand into Apple Health-style analytics:
+
+- Individual metric cards over time.
+- Better HealthKit import and scale-data ingestion.
+- DEXA/body-composition events.
+- Interpolation between strong composition measurements and photo/weight trends.
+- Bulk progress photo import when photo activation and user requests justify it.
+
+Photo import should eventually identify likely progress photos and crop them consistently for comparison and morphing, but this is not Phase 0 scope.
+
+## Expansion Triggers
+
+Do not spend meaningful build tokens on these surfaces before their trigger is met.
+
+### Web
+
+Build a web version only after one of these is true:
+
+- 1,000 activated iOS users, or
+- 250 paying subscribers and web access is a top recurring support request.
+
+Until then, web work is limited to marketing, legal, support, and account/billing surfaces that unblock the iOS app.
+
+### iPad
+
+Build iPad-specific UI only after one of these is true:
+
+- 100 active iPad users, or
+- 25 explicit iPad/kiosk requests, or
+- a founder-approved kiosk experiment with a clear validation goal.
+
+Target layout: portrait behaves like iPhone; landscape uses photo on the left, stats on the right, and timeline across the bottom. Kiosk mode is a future premium/experimentation surface, not the first paid MVP.
+
+### Apple Watch
+
+Do not build a Watch app speculatively. Start only after repeated user pull:
+
+- 25 explicit Apple Watch requests, or
+- 10 paying users asking for watch-visible basic stats.
+
+Initial Watch scope is read-only basic stats and latest trend direction. No logging-first Watch app unless usage proves it.
+
+### AI
+
+AI starts as deterministic, low-text insight, not chat.
+
+First AI-adjacent surface:
+
+- Classify current phase from weight/body-fat trend: cutting, maintenance, gaining.
+- Warn when a cut or bulk has likely gone on too long.
+- Keep copy short and non-medical.
+
+Only consider a Jovie-style chat after the core timeline is retained and users are asking for interactive recommendations. The app should "just tell me" before it asks the user to have a conversation.
+
+### Food And Workouts
+
+Do not build a food logger or workout tracker. This product is for people who already have those systems and want a body-composition HUD.
+
+## Agent Build Rules
+
+- Build the smallest iOS-native product increment that improves activation, retention, paid conversion, or reliability.
+- Put risky/new user-visible behavior behind Statsig gates.
+- Prefer follow-up PRs over bloating an active PR.
+- Treat App Store/TestFlight, RevenueCat, Clerk, HealthKit, Supabase, and device validation as real closeout surfaces.
+- Open issues only after the roadmap item has a clear trigger, KPI, and acceptance criteria.
+- When a user asks for Watch, iPad, web, AI, or bulk import, first check whether the trigger is met. If it is not met, propose the smallest validation step instead.


### PR DESCRIPTION
## Summary
- add an iOS-first product roadmap with KPI gates for web, iPad, Apple Watch, AI, and bulk import work
- add the same product-scope guardrails to `AGENTS.md` so autonomous agents inherit them
- update the auth button system so login CTAs can render as dark, minimal pills

## Validation
- `cd apps/ios && swiftlint lint --strict`
- `cd apps/ios && xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination "platform=iOS Simulator,name=iPhone 17" build-for-testing`
- simulator smoke: installed and launched clean build on iPhone 17 simulator; captured `/tmp/logyourbody-login-pill-buttons.png` to confirm dark pill login buttons