### PR TITLE
feat: define body metric source provenance

### DIFF
--- a/apps/ios/LogYourBody/Models/BodyCompMethod.swift
+++ b/apps/ios/LogYourBody/Models/BodyCompMethod.swift
@@ -11,7 +11,7 @@ enum BodyCompMethod: String, Codable, CaseIterable {
         let normalized = bodyFatMethod?.lowercased() ?? ""
         let source = dataSource?.lowercased() ?? ""
 
-        if normalized.contains("dexa") {
+        if normalized.contains("dexa") || source.contains("bodyspec_dexa") {
             return .dexa
         }
 
@@ -23,7 +23,7 @@ enum BodyCompMethod: String, Codable, CaseIterable {
             return .visualEstimate
         }
 
-        if source.contains("healthkit") {
+        if source.contains("healthkit") || source.contains("smart_scale") {
             return .biaScale
         }
 
@@ -39,6 +39,8 @@ enum BodyCompSourceType: String, Codable, CaseIterable {
     case healthKit = "healthkit"
     case manual = "manual"
     case partner = "partner"
+    case smartScale = "smart_scale"
+    case photo = "photo"
     case unknown = "unknown"
 
     static func infer(from dataSource: String?) -> BodyCompSourceType {
@@ -48,7 +50,15 @@ enum BodyCompSourceType: String, Codable, CaseIterable {
             return .healthKit
         }
 
-        if source.contains("partner") {
+        if source.contains("smart_scale") {
+            return .smartScale
+        }
+
+        if source.contains("photo") {
+            return .photo
+        }
+
+        if source.contains("partner") || source.contains("bodyspec_dexa") {
             return .partner
         }
 

--- a/apps/ios/LogYourBody/Models/BodyMetrics.swift
+++ b/apps/ios/LogYourBody/Models/BodyMetrics.swift
@@ -4,6 +4,222 @@
 //
 import Foundation
 
+struct BodyMetricSource: Codable, Equatable, Hashable {
+    let rawValue: String
+
+    static let manual = BodyMetricSource(rawValue: "manual")
+    static let healthKit = BodyMetricSource(rawValue: "healthkit")
+    static let smartScale = BodyMetricSource(rawValue: "smart_scale")
+    static let bodySpecDexa = BodyMetricSource(rawValue: "bodyspec_dexa")
+    static let caliper = BodyMetricSource(rawValue: "caliper")
+    static let photo = BodyMetricSource(rawValue: "photo")
+
+    static let allowedRawValues: Set<String> = [
+        manual.rawValue,
+        healthKit.rawValue,
+        smartScale.rawValue,
+        bodySpecDexa.rawValue,
+        caliper.rawValue,
+        photo.rawValue
+    ]
+
+    init(rawValue: String) {
+        self.rawValue = Self.normalizedRawValue(rawValue)
+    }
+
+    init(_ rawValue: String?) {
+        self.rawValue = Self.normalizedRawValue(rawValue)
+    }
+
+    static func normalizedRawValue(_ rawValue: String?) -> String {
+        let normalized = rawValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_") ?? ""
+
+        guard !normalized.isEmpty else {
+            return "manual"
+        }
+
+        if ["manual", "user", "user_entered", "user_entry"].contains(normalized) {
+            return "manual"
+        }
+
+        if ["healthkit", "health_kit", "apple_health", "apple_healthkit"].contains(normalized) {
+            return "healthkit"
+        }
+
+        if [
+            "smart_scale",
+            "scale",
+            "bia_scale",
+            "body_scale",
+            "connected_scale"
+        ].contains(normalized) {
+            return "smart_scale"
+        }
+
+        if [
+            "bodyspec_dexa",
+            "bodyspec",
+            "partner:bodyspec",
+            "partner_bodyspec",
+            "dexa",
+            "dxa"
+        ].contains(normalized) || normalized.contains("bodyspec") {
+            return "bodyspec_dexa"
+        }
+
+        if normalized.contains("caliper") || normalized.contains("skinfold") {
+            return "caliper"
+        }
+
+        if ["photo", "photo_import", "progress_photo"].contains(normalized) {
+            return "photo"
+        }
+
+        return "manual"
+    }
+}
+
+struct BodyMetricSourceMetadata: Codable, Equatable {
+    let vendor: String?
+    let sourceName: String?
+    let sourceBundleId: String?
+    let deviceId: String?
+    let deviceManufacturer: String?
+    let deviceModel: String?
+    let sampleId: String?
+    let externalId: String?
+    let externalResultId: String?
+    let scannerModel: String?
+    let locationId: String?
+    let locationName: String?
+    let importedAt: String?
+    let legacyDataSource: String?
+
+    init(
+        vendor: String? = nil,
+        sourceName: String? = nil,
+        sourceBundleId: String? = nil,
+        deviceId: String? = nil,
+        deviceManufacturer: String? = nil,
+        deviceModel: String? = nil,
+        sampleId: String? = nil,
+        externalId: String? = nil,
+        externalResultId: String? = nil,
+        scannerModel: String? = nil,
+        locationId: String? = nil,
+        locationName: String? = nil,
+        importedAt: String? = nil,
+        legacyDataSource: String? = nil
+    ) {
+        self.vendor = Self.clean(vendor)
+        self.sourceName = Self.clean(sourceName)
+        self.sourceBundleId = Self.clean(sourceBundleId)
+        self.deviceId = Self.clean(deviceId)
+        self.deviceManufacturer = Self.clean(deviceManufacturer)
+        self.deviceModel = Self.clean(deviceModel)
+        self.sampleId = Self.clean(sampleId)
+        self.externalId = Self.clean(externalId)
+        self.externalResultId = Self.clean(externalResultId)
+        self.scannerModel = Self.clean(scannerModel)
+        self.locationId = Self.clean(locationId)
+        self.locationName = Self.clean(locationName)
+        self.importedAt = Self.clean(importedAt)
+        self.legacyDataSource = Self.clean(legacyDataSource)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case vendor
+        case sourceName = "source_name"
+        case sourceBundleId = "source_bundle_id"
+        case deviceId = "device_id"
+        case deviceManufacturer = "device_manufacturer"
+        case deviceModel = "device_model"
+        case sampleId = "sample_id"
+        case externalId = "external_id"
+        case externalResultId = "external_result_id"
+        case scannerModel = "scanner_model"
+        case locationId = "location_id"
+        case locationName = "location_name"
+        case importedAt = "imported_at"
+        case legacyDataSource = "legacy_data_source"
+    }
+
+    var isEmpty: Bool {
+        jsonObject.isEmpty
+    }
+
+    var jsonObject: [String: String] {
+        var object: [String: String] = [:]
+        object["vendor"] = vendor
+        object["source_name"] = sourceName
+        object["source_bundle_id"] = sourceBundleId
+        object["device_id"] = deviceId
+        object["device_manufacturer"] = deviceManufacturer
+        object["device_model"] = deviceModel
+        object["sample_id"] = sampleId
+        object["external_id"] = externalId
+        object["external_result_id"] = externalResultId
+        object["scanner_model"] = scannerModel
+        object["location_id"] = locationId
+        object["location_name"] = locationName
+        object["imported_at"] = importedAt
+        object["legacy_data_source"] = legacyDataSource
+        return object
+    }
+
+    var jsonString: String? {
+        let object = jsonObject
+        guard !object.isEmpty,
+              JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]) else {
+            return nil
+        }
+
+        return String(data: data, encoding: .utf8)
+    }
+
+    init?(jsonString: String?) {
+        guard let jsonString,
+              let data = jsonString.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(Self.self, from: data) else {
+            return nil
+        }
+
+        self = decoded
+    }
+
+    init?(jsonObject: Any?) {
+        guard let jsonObject, !(jsonObject is NSNull) else {
+            return nil
+        }
+
+        if let string = jsonObject as? String {
+            self.init(jsonString: string)
+            return
+        }
+
+        guard let dictionary = jsonObject as? [String: Any],
+              JSONSerialization.isValidJSONObject(dictionary),
+              let data = try? JSONSerialization.data(withJSONObject: dictionary),
+              let decoded = try? JSONDecoder().decode(Self.self, from: data) else {
+            return nil
+        }
+
+        self = decoded
+    }
+
+    private static func clean(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return String(trimmed.prefix(256))
+    }
+}
+
 struct BodyMetrics: Identifiable, Codable, Equatable {
     let id: String
     let userId: String
@@ -20,6 +236,7 @@ struct BodyMetrics: Identifiable, Codable, Equatable {
     let notes: String?
     let photoUrl: String?
     let dataSource: String?
+    let sourceMetadata: BodyMetricSourceMetadata?
     let createdAt: Date
     let updatedAt: Date
 
@@ -39,6 +256,7 @@ struct BodyMetrics: Identifiable, Codable, Equatable {
         notes: String?,
         photoUrl: String?,
         dataSource: String?,
+        sourceMetadata: BodyMetricSourceMetadata? = nil,
         createdAt: Date,
         updatedAt: Date
     ) {
@@ -56,7 +274,8 @@ struct BodyMetrics: Identifiable, Codable, Equatable {
         self.waistUnit = waistUnit
         self.notes = notes
         self.photoUrl = photoUrl
-        self.dataSource = dataSource
+        self.dataSource = BodyMetricSource.normalizedRawValue(dataSource)
+        self.sourceMetadata = sourceMetadata?.isEmpty == true ? nil : sourceMetadata
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -77,7 +296,37 @@ struct BodyMetrics: Identifiable, Codable, Equatable {
         case notes
         case photoUrl = "photo_url"
         case dataSource = "data_source"
+        case sourceMetadata = "source_metadata"
         case createdAt = "created_at"
         case updatedAt = "updated_at"
+    }
+
+    var metricSource: BodyMetricSource {
+        BodyMetricSource(dataSource)
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decode(String.self, forKey: .id)
+        userId = try container.decode(String.self, forKey: .userId)
+        date = try container.decode(Date.self, forKey: .date)
+        weight = try container.decodeIfPresent(Double.self, forKey: .weight)
+        weightUnit = try container.decodeIfPresent(String.self, forKey: .weightUnit)
+        bodyFatPercentage = try container.decodeIfPresent(Double.self, forKey: .bodyFatPercentage)
+        bodyFatMethod = try container.decodeIfPresent(String.self, forKey: .bodyFatMethod)
+        muscleMass = try container.decodeIfPresent(Double.self, forKey: .muscleMass)
+        boneMass = try container.decodeIfPresent(Double.self, forKey: .boneMass)
+        waistCm = try container.decodeIfPresent(Double.self, forKey: .waistCm)
+        hipCm = try container.decodeIfPresent(Double.self, forKey: .hipCm)
+        waistUnit = try container.decodeIfPresent(String.self, forKey: .waistUnit)
+        notes = try container.decodeIfPresent(String.self, forKey: .notes)
+        photoUrl = try container.decodeIfPresent(String.self, forKey: .photoUrl)
+        dataSource = BodyMetricSource.normalizedRawValue(
+            try container.decodeIfPresent(String.self, forKey: .dataSource)
+        )
+        sourceMetadata = try container.decodeIfPresent(BodyMetricSourceMetadata.self, forKey: .sourceMetadata)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
     }
 }

--- a/apps/ios/LogYourBody/Models/LogYourBody.xcdatamodeld/LogYourBody.xcdatamodel/contents
+++ b/apps/ios/LogYourBody/Models/LogYourBody.xcdatamodeld/LogYourBody.xcdatamodel/contents
@@ -16,6 +16,7 @@
         <attribute name="photoProcessedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="photoUrl" optional="YES" attributeType="String"/>
         <attribute name="dataSource" optional="YES" attributeType="String" defaultValueString="Manual"/>
+        <attribute name="sourceMetadataJSON" optional="YES" attributeType="String"/>
         <attribute name="syncStatus" attributeType="String" defaultValueString="pending"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="userId" attributeType="String"/>

--- a/apps/ios/LogYourBody/Services/BackgroundPhotoUploadService+Processing.swift
+++ b/apps/ios/LogYourBody/Services/BackgroundPhotoUploadService+Processing.swift
@@ -58,6 +58,7 @@ extension BackgroundPhotoUploadService {
                             notes: existing.notes,
                             photoUrl: existing.photoUrl,
                             dataSource: existing.dataSource,
+                            sourceMetadata: BodyMetricSourceMetadata(jsonString: existing.sourceMetadataJSON),
                             createdAt: existing.createdAt ?? date,
                             updatedAt: existing.updatedAt ?? date
                         )
@@ -75,7 +76,7 @@ extension BackgroundPhotoUploadService {
                             boneMass: nil,
                             notes: nil,
                             photoUrl: nil,
-                            dataSource: "manual",
+                            dataSource: BodyMetricSource.photo.rawValue,
                             createdAt: date,
                             updatedAt: date
                         )

--- a/apps/ios/LogYourBody/Services/BackgroundPhotoUploadService.swift
+++ b/apps/ios/LogYourBody/Services/BackgroundPhotoUploadService.swift
@@ -164,6 +164,7 @@ class BackgroundPhotoUploadService: ObservableObject {
                 notes: existing.notes,
                 photoUrl: existing.photoUrl,
                 dataSource: existing.dataSource,
+                sourceMetadata: BodyMetricSourceMetadata(jsonString: existing.sourceMetadataJSON),
                 createdAt: existing.createdAt ?? Date(),
                 updatedAt: existing.updatedAt ?? Date()
             )
@@ -183,7 +184,7 @@ class BackgroundPhotoUploadService: ObservableObject {
             boneMass: nil,
             notes: nil,
             photoUrl: nil,
-            dataSource: "Manual",
+            dataSource: BodyMetricSource.photo.rawValue,
             createdAt: Date(),
             updatedAt: Date()
         )

--- a/apps/ios/LogYourBody/Services/BodySpecDexaImporter.swift
+++ b/apps/ios/LogYourBody/Services/BodySpecDexaImporter.swift
@@ -94,7 +94,7 @@ actor BodySpecDexaImporter {
         )
 
         let alreadyHasBodySpecEntry = existing.contains { cached in
-            if let source = cached.dataSource, source.lowercased() == "partner:bodyspec" {
+            if BodyMetricSource.normalizedRawValue(cached.dataSource) == BodyMetricSource.bodySpecDexa.rawValue {
                 return true
             }
 
@@ -116,6 +116,7 @@ actor BodySpecDexaImporter {
             let date = scanInfo.acquireTime
 
             let now = Date()
+            let importedAt = ISO8601DateFormatter().string(from: now)
 
             let bodyMetrics = BodyMetrics(
                 id: metricsId,
@@ -129,7 +130,15 @@ actor BodySpecDexaImporter {
                 boneMass: composition.total.boneMassKg,
                 notes: "Imported from BodySpec DEXA",
                 photoUrl: nil,
-                dataSource: "partner:bodyspec",
+                dataSource: BodyMetricSource.bodySpecDexa.rawValue,
+                sourceMetadata: BodyMetricSourceMetadata(
+                    vendor: "bodyspec",
+                    externalResultId: summary.resultId,
+                    scannerModel: scanInfo.scannerModel,
+                    locationId: summary.location.locationId,
+                    locationName: summary.location.name,
+                    importedAt: importedAt
+                ),
                 createdAt: now,
                 updatedAt: now
             )

--- a/apps/ios/LogYourBody/Services/BulkImportManager.swift
+++ b/apps/ios/LogYourBody/Services/BulkImportManager.swift
@@ -157,7 +157,7 @@ class BulkImportManager: ObservableObject {
                     boneMass: nil,
                     notes: "Imported from photo library",
                     photoUrl: nil, // Will be set after upload
-                    dataSource: "Photo Import",
+                    dataSource: BodyMetricSource.photo.rawValue,
                     createdAt: Date(),
                     updatedAt: Date()
                 )

--- a/apps/ios/LogYourBody/Services/CoreDataManager.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager.swift
@@ -517,7 +517,16 @@ class CoreDataManager: ObservableObject {
                 cached.boneMass = metrics.boneMass ?? 0
                 cached.notes = metrics.notes
                 cached.photoUrl = metrics.photoUrl
-                cached.dataSource = metrics.dataSource ?? "Manual"
+                cached.dataSource = BodyMetricSource.normalizedRawValue(metrics.dataSource)
+                if let sourceMetadataJSON = metrics.sourceMetadata?.jsonString {
+                    cached.sourceMetadataJSON = sourceMetadataJSON
+                } else if cached.sourceMetadataJSON == nil,
+                          let legacyDataSource = metrics.dataSource,
+                          BodyMetricSource.normalizedRawValue(legacyDataSource) != legacyDataSource {
+                    cached.sourceMetadataJSON = BodyMetricSourceMetadata(
+                        legacyDataSource: legacyDataSource
+                    ).jsonString
+                }
                 cached.updatedAt = Date()
                 cached.lastModified = Date()
                 cached.isSynced = markAsSynced
@@ -1285,6 +1294,18 @@ class CoreDataManager: ObservableObject {
                 metric.boneMass = data["bone_mass"] as? Double ?? 0
                 metric.notes = data["notes"] as? String
                 metric.photoUrl = data["photo_url"] as? String
+                let rawDataSource = data["data_source"] as? String
+                metric.dataSource = BodyMetricSource.normalizedRawValue(rawDataSource)
+                if let sourceMetadata = BodyMetricSourceMetadata(jsonObject: data["source_metadata"]) {
+                    metric.sourceMetadataJSON = sourceMetadata.jsonString
+                } else if let rawDataSource,
+                          BodyMetricSource.normalizedRawValue(rawDataSource) != rawDataSource {
+                    metric.sourceMetadataJSON = BodyMetricSourceMetadata(
+                        legacyDataSource: rawDataSource
+                    ).jsonString
+                } else {
+                    metric.sourceMetadataJSON = nil
+                }
 
                 if let dateString = data["date"] as? String {
                     metric.date = formatter.date(from: dateString)
@@ -2004,7 +2025,8 @@ extension CachedBodyMetrics {
             waistUnit: waistUnit,
             notes: notes,
             photoUrl: photoUrl,
-            dataSource: dataSource ?? "Manual",
+            dataSource: BodyMetricSource.normalizedRawValue(dataSource),
+            sourceMetadata: BodyMetricSourceMetadata(jsonString: sourceMetadataJSON),
             createdAt: createdAt,
             updatedAt: updatedAt
         )

--- a/apps/ios/LogYourBody/Services/HealthKitManager.swift
+++ b/apps/ios/LogYourBody/Services/HealthKitManager.swift
@@ -1061,7 +1061,7 @@ class HealthKitManager: ObservableObject {
                     boneMass: nil,
                     notes: "Imported from HealthKit",
                     photoUrl: nil,
-                    dataSource: "HealthKit",
+                    dataSource: BodyMetricSource.healthKit.rawValue,
                     createdAt: Date(),
                     updatedAt: Date()
                 )
@@ -1110,6 +1110,7 @@ class HealthKitManager: ObservableObject {
             notes: metrics.notes,
             photoUrl: metrics.photoUrl,
             dataSource: metrics.dataSource,
+            sourceMetadata: metrics.sourceMetadata,
             createdAt: metrics.createdAt,
             updatedAt: metrics.updatedAt
         )

--- a/apps/ios/LogYourBody/Services/PhotoMetadataService.swift
+++ b/apps/ios/LogYourBody/Services/PhotoMetadataService.swift
@@ -126,6 +126,7 @@ class PhotoMetadataService {
                 notes: existing.notes,
                 photoUrl: photoUrl ?? existing.photoUrl,
                 dataSource: existing.dataSource,
+                sourceMetadata: existing.sourceMetadata,
                 createdAt: existing.createdAt,
                 updatedAt: Date()
             )
@@ -146,7 +147,7 @@ class PhotoMetadataService {
                 boneMass: nil,
                 notes: nil,
                 photoUrl: photoUrl,
-                dataSource: "Manual",
+                dataSource: BodyMetricSource.photo.rawValue,
                 createdAt: Date(),
                 updatedAt: Date()
             )

--- a/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
+++ b/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
@@ -423,6 +423,8 @@ class RealtimeSyncManager: ObservableObject {
                     "bone_mass": metric.boneMass as Any,
                     "photo_url": metric.photoUrl as Any,
                     "notes": metric.notes as Any,
+                    "data_source": BodyMetricSource.normalizedRawValue(metric.dataSource),
+                    "source_metadata": BodyMetricSourceMetadata(jsonString: metric.sourceMetadataJSON)?.jsonObject ?? [:],
                     "created_at": formatter.string(from: createdAt),
                     "updated_at": formatter.string(from: updatedAt)
                 ]
@@ -884,6 +886,7 @@ class RealtimeSyncManager: ObservableObject {
             notes: metrics.notes,
             photoUrl: metrics.photoUrl,
             dataSource: metrics.dataSource,
+            sourceMetadata: metrics.sourceMetadata,
             createdAt: metrics.createdAt,
             updatedAt: metrics.updatedAt
         )

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -123,6 +123,36 @@ final class PaidWeightLoggerMVPPolicyTests: XCTestCase {
     }
 }
 
+final class BodyMetricSourceContractTests: XCTestCase {
+    func testSourceNormalizationCoversLaunchImportSources() {
+        XCTAssertEqual(BodyMetricSource.normalizedRawValue(nil), "manual")
+        XCTAssertEqual(BodyMetricSource.normalizedRawValue("Manual"), "manual")
+        XCTAssertEqual(BodyMetricSource.normalizedRawValue("HealthKit"), "healthkit")
+        XCTAssertEqual(BodyMetricSource.normalizedRawValue("smart scale"), "smart_scale")
+        XCTAssertEqual(BodyMetricSource.normalizedRawValue("partner:bodyspec"), "bodyspec_dexa")
+        XCTAssertEqual(BodyMetricSource.normalizedRawValue("skinfold caliper"), "caliper")
+        XCTAssertEqual(BodyMetricSource.normalizedRawValue("Photo Import"), "photo")
+    }
+
+    func testSourceMetadataTrimsEmptyValuesAndSerializesPointersOnly() throws {
+        let metadata = BodyMetricSourceMetadata(
+            vendor: " BodySpec ",
+            sourceName: "",
+            deviceModel: "Scanner X",
+            externalResultId: " result-123 "
+        )
+
+        let jsonString = try XCTUnwrap(metadata.jsonString)
+        let decoded = try XCTUnwrap(BodyMetricSourceMetadata(jsonString: jsonString))
+
+        XCTAssertEqual(decoded.vendor, "BodySpec")
+        XCTAssertNil(decoded.sourceName)
+        XCTAssertEqual(decoded.deviceModel, "Scanner X")
+        XCTAssertEqual(decoded.externalResultId, "result-123")
+        XCTAssertEqual(decoded.jsonObject["vendor"], "BodySpec")
+    }
+}
+
 @MainActor
 final class OnboardingFlowViewModelTests: XCTestCase {
     func testAdvanceAfterHealthConfirmationSkipsToLoadingWhenMetricsExist() {
@@ -567,6 +597,11 @@ final class SyncIntegrationTests: XCTestCase {
             "bone_mass": 4.2,
             "photo_url": "https://example.com/photo.jpg",
             "notes": "supabase-mapped",
+            "data_source": "HealthKit",
+            "source_metadata": [
+                "sample_id": "hk-sample-123",
+                "device_model": "Withings Body Scan"
+            ],
             "created_at": formatter.string(from: createdAt),
             "updated_at": formatter.string(from: updatedAt)
         ]
@@ -596,6 +631,9 @@ final class SyncIntegrationTests: XCTestCase {
 
         XCTAssertEqual(metric.photoUrl, "https://example.com/photo.jpg")
         XCTAssertEqual(metric.notes, "supabase-mapped")
+        XCTAssertEqual(metric.dataSource, "healthkit")
+        XCTAssertEqual(metric.sourceMetadata?.sampleId, "hk-sample-123")
+        XCTAssertEqual(metric.sourceMetadata?.deviceModel, "Withings Body Scan")
 
         XCTAssertEqual(metric.createdAt.timeIntervalSince(createdAt), 0, accuracy: 0.001)
         XCTAssertEqual(metric.updatedAt.timeIntervalSince(updatedAt), 0, accuracy: 0.001)
@@ -866,6 +904,7 @@ final class SyncIntegrationTests: XCTestCase {
         let bodyFat = try XCTUnwrap(metric.bodyFatPercentage)
         XCTAssertEqual(bodyFat, 19.5, accuracy: 0.001)
         XCTAssertEqual(metric.bodyFatMethod, "HealthKit")
+        XCTAssertEqual(metric.dataSource, "healthkit")
     }
 
     func testSyncLocalChanges_UsesSupabaseAndMarksBodyMetricSynced() async throws {
@@ -890,6 +929,9 @@ final class SyncIntegrationTests: XCTestCase {
             notes: "unsynced-local",
             photoUrl: "https://example.com/photo.jpg",
             dataSource: "Manual",
+            sourceMetadata: BodyMetricSourceMetadata(
+                legacyDataSource: "Manual"
+            ),
             createdAt: createdAt,
             updatedAt: updatedAt
         )
@@ -922,6 +964,10 @@ final class SyncIntegrationTests: XCTestCase {
         XCTAssertEqual(payload["weight_unit"] as? String, "kg")
         XCTAssertEqual(payload["photo_url"] as? String, "https://example.com/photo.jpg")
         XCTAssertEqual(payload["notes"] as? String, "unsynced-local")
+        XCTAssertEqual(payload["data_source"] as? String, "manual")
+
+        let sourceMetadata = try XCTUnwrap(payload["source_metadata"] as? [String: String])
+        XCTAssertEqual(sourceMetadata["legacy_data_source"], "Manual")
 
         if let dateString = payload["date"] as? String {
             let formatter = ISO8601DateFormatter()

--- a/apps/web/src/types/body-metrics.ts
+++ b/apps/web/src/types/body-metrics.ts
@@ -1,119 +1,157 @@
 export interface BodyMetrics {
-  id: string
-  user_id: string
-  date: string
-  weight?: number
-  weight_unit?: 'kg' | 'lbs'
-  body_fat_percentage?: number
-  body_fat_method?: 'navy' | '3-site' | '7-site' | 'dexa' | 'bodpod'
+  id: string;
+  user_id: string;
+  date: string;
+  weight?: number;
+  weight_unit?: 'kg' | 'lbs';
+  body_fat_percentage?: number;
+  body_fat_method?: 'navy' | '3-site' | '7-site' | 'dexa' | 'bodpod';
 
   // Measurements for body fat calculations and ratios
-  waist?: number
-  waist_circumference?: number // More explicit naming
-  hip?: number // For female navy method
-  hip_circumference?: number // More explicit naming
-  neck?: number
-  waist_unit?: 'cm' | 'in'
+  waist?: number;
+  waist_circumference?: number; // More explicit naming
+  hip?: number; // For female navy method
+  hip_circumference?: number; // More explicit naming
+  neck?: number;
+  waist_unit?: 'cm' | 'in';
 
   // Skinfold measurements
-  chest_skinfold?: number
-  abdominal_skinfold?: number
-  thigh_skinfold?: number
-  tricep_skinfold?: number
-  suprailiac_skinfold?: number
-  subscapular_skinfold?: number
-  midaxillary_skinfold?: number
+  chest_skinfold?: number;
+  abdominal_skinfold?: number;
+  thigh_skinfold?: number;
+  tricep_skinfold?: number;
+  suprailiac_skinfold?: number;
+  subscapular_skinfold?: number;
+  midaxillary_skinfold?: number;
 
   // Calculated values
-  lean_body_mass?: number
-  ffmi?: number // Fat-Free Mass Index
+  lean_body_mass?: number;
+  ffmi?: number; // Fat-Free Mass Index
 
   // Additional data
-  photo_url?: string
-  notes?: string
-  step_count?: number
+  photo_url?: string;
+  notes?: string;
+  step_count?: number;
+  data_source?: BodyMetricSource;
+  source_metadata?: BodyMetricSourceMetadata;
 
-  created_at: string
-  updated_at: string
-  sync_status?: 'pending' | 'synced' | 'error'
-  is_deleted?: boolean
-  last_modified?: string | Date
+  created_at: string;
+  updated_at: string;
+  sync_status?: 'pending' | 'synced' | 'error';
+  is_deleted?: boolean;
+  last_modified?: string | Date;
+}
+
+export type BodyMetricSource =
+  | 'manual'
+  | 'healthkit'
+  | 'smart_scale'
+  | 'bodyspec_dexa'
+  | 'caliper'
+  | 'photo';
+
+export interface BodyMetricSourceMetadata {
+  vendor?: string;
+  source_name?: string;
+  source_bundle_id?: string;
+  device_id?: string;
+  device_manufacturer?: string;
+  device_model?: string;
+  sample_id?: string;
+  external_id?: string;
+  external_result_id?: string;
+  scanner_model?: string;
+  location_id?: string;
+  location_name?: string;
+  imported_at?: string;
+  legacy_data_source?: string;
 }
 
 export interface UserProfile {
-  id: string
-  email: string
-  username?: string
-  full_name?: string
-  first_name?: string | null
-  last_name?: string | null
-  avatar_url?: string
-  bio?: string
-  date_of_birth?: string
-  height?: number
-  height_unit?: 'cm' | 'ft'
-  gender?: 'male' | 'female'
-  activity_level?: 'sedentary' | 'lightly_active' | 'moderately_active' | 'very_active' | 'extremely_active'
+  id: string;
+  email: string;
+  username?: string;
+  full_name?: string;
+  first_name?: string | null;
+  last_name?: string | null;
+  avatar_url?: string;
+  bio?: string;
+  date_of_birth?: string;
+  height?: number;
+  height_unit?: 'cm' | 'ft';
+  gender?: 'male' | 'female';
+  activity_level?:
+    | 'sedentary'
+    | 'lightly_active'
+    | 'moderately_active'
+    | 'very_active'
+    | 'extremely_active';
 
   // Goal metrics based on research
-  goal_body_fat_percentage?: number
-  goal_ffmi?: number
-  goal_waist_to_hip_ratio?: number
-  goal_waist_to_height_ratio?: number
-  goal_weight?: number
-  goal_weight_unit?: 'kg' | 'lbs'
+  goal_body_fat_percentage?: number;
+  goal_ffmi?: number;
+  goal_waist_to_hip_ratio?: number;
+  goal_waist_to_height_ratio?: number;
+  goal_weight?: number;
+  goal_weight_unit?: 'kg' | 'lbs';
 
-  email_verified: boolean
-  onboarding_completed: boolean
-  settings: UserSettings
-  created_at: string
-  updated_at: string
-  sync_status?: 'pending' | 'synced' | 'error'
-  is_deleted?: boolean
-  last_modified?: string | Date
+  email_verified: boolean;
+  onboarding_completed: boolean;
+  settings: UserSettings;
+  created_at: string;
+  updated_at: string;
+  sync_status?: 'pending' | 'synced' | 'error';
+  is_deleted?: boolean;
+  last_modified?: string | Date;
 }
 
 export interface UserSettings {
   units?: {
-    weight?: 'kg' | 'lbs'
-    height?: 'cm' | 'ft'
-    measurements?: 'cm' | 'in'
-  }
+    weight?: 'kg' | 'lbs';
+    height?: 'cm' | 'ft';
+    measurements?: 'cm' | 'in';
+  };
   notifications?: {
-    daily_reminder?: boolean
-    reminder_time?: string
-    weekly_report?: boolean
-    progress_milestones?: boolean
-  }
+    daily_reminder?: boolean;
+    reminder_time?: string;
+    weekly_report?: boolean;
+    progress_milestones?: boolean;
+  };
   privacy?: {
-    public_profile?: boolean
-    show_progress_photos?: boolean
-  }
+    public_profile?: boolean;
+    show_progress_photos?: boolean;
+  };
 }
 
 export interface ProgressPhoto {
-  id: string
-  user_id: string
-  body_metrics_id?: string
-  photo_url: string
-  thumbnail_url?: string
-  angle: 'front' | 'side' | 'back'
-  date: string
-  notes?: string
-  created_at: string
+  id: string;
+  user_id: string;
+  body_metrics_id?: string;
+  photo_url: string;
+  thumbnail_url?: string;
+  angle: 'front' | 'side' | 'back';
+  date: string;
+  notes?: string;
+  created_at: string;
 }
 
 // Calculation helpers
 export interface FFMIResult {
-  ffmi: number
-  normalized_ffmi: number
-  fat_free_mass: number
-  interpretation: 'below_average' | 'average' | 'above_average' | 'excellent' | 'superior' | 'suspiciously_high'
+  ffmi: number;
+  normalized_ffmi: number;
+  fat_free_mass: number;
+  interpretation:
+    | 'below_average'
+    | 'average'
+    | 'above_average'
+    | 'excellent'
+    | 'superior'
+    | 'suspiciously_high';
 }
 
 export interface BodyFatResult {
-  percentage: number
-  lean_mass: number
-  fat_mass: number
-  category: 'essential' | 'athletic' | 'fit' | 'average' | 'above_average' | 'obese'
+  percentage: number;
+  lean_mass: number;
+  fat_mass: number;
+  category: 'essential' | 'athletic' | 'fit' | 'average' | 'above_average' | 'obese';
 }

--- a/docs/audits/jov-2867/body-metric-source-contract.md
+++ b/docs/audits/jov-2867/body-metric-source-contract.md
@@ -1,0 +1,59 @@
+# JOV-2867 BodyMetricSource Storage and Sync Contract
+
+## Scope
+
+This issue defines the provenance contract that future body metric imports must use before expanding HealthKit, BodySpec/DEXA, smart-scale, caliper, or photo-derived data.
+
+## Canonical Source Values
+
+`BodyMetricSource` is stored in `body_metrics.data_source` and in the iOS local `CachedBodyMetrics.dataSource` field as one of:
+
+- `manual`
+- `healthkit`
+- `smart_scale`
+- `bodyspec_dexa`
+- `caliper`
+- `photo`
+
+Legacy labels are normalized on read/write. Examples: `Manual` becomes `manual`, `HealthKit` becomes `healthkit`, `partner:bodyspec` becomes `bodyspec_dexa`, and `Photo Import` becomes `photo`.
+
+## Metadata
+
+Compact provenance is stored as JSON in `body_metrics.source_metadata` and as `CachedBodyMetrics.sourceMetadataJSON` on iOS. The metadata shape is pointer-style only:
+
+- vendor/source identifiers
+- source bundle identifier
+- device manufacturer/model/id
+- HealthKit sample ID when available
+- external importer/result IDs
+- scanner/location identifiers
+- imported timestamp
+- legacy source label for unknown historical rows
+
+Do not store raw vendor payloads, access tokens, refresh tokens, or unnecessary personal data in `source_metadata`.
+
+## Migration
+
+The additive Supabase migration is:
+
+- `supabase/migrations/20260607043000_define_body_metric_source.sql`
+
+It adds `source_metadata`, normalizes legacy `data_source` values, defaults future rows to `manual`, and constrains future writes to the six canonical values.
+
+## iOS Mapping
+
+- `BodyMetrics` now normalizes `dataSource` at construction and decode time.
+- `CoreDataManager.saveBodyMetrics` persists canonical `dataSource` and optional metadata JSON.
+- `CoreDataManager.updateOrCreateBodyMetric` maps `data_source` and `source_metadata` from Supabase payloads.
+- `RealtimeSyncManager.syncBodyMetricsBatch` sends both fields during local-to-remote sync.
+- HealthKit body metric rows use `healthkit`; raw sample metadata remains in `HKRawSample`.
+- BodySpec-created body metric rows use `bodyspec_dexa` and include scan/result metadata.
+- Photo-only metric rows use `photo`.
+
+## Deferred
+
+This does not add importer UI, smart-scale import, caliper entry, HealthKit sample-to-metric reconciliation, or DEXA conflict handling. Those remain separate roadmap issues.
+
+## Done When
+
+Future metric import code can declare source provenance using the stable source values and optional metadata without changing product/UI call sites or rewriting the sync layer.

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -16,11 +16,13 @@ supabase/
 ## Setup
 
 1. **Install Supabase CLI**:
+
    ```bash
    brew install supabase/tap/supabase
    ```
 
 2. **Link your project**:
+
    ```bash
    cd supabase
    supabase link --project-ref <your-project-ref>
@@ -47,6 +49,7 @@ Example: `20250706_120000_add_photo_fields.sql`
 ## Storage Configuration
 
 The `photos` bucket is configured with:
+
 - Public access (for processed images)
 - 50MB file size limit
 - Allowed types: JPEG, PNG, HEIC, HEIF, WebP
@@ -59,3 +62,9 @@ The `photos` bucket is configured with:
 - The `weight_logs` identifier is preserved as a read-only compatibility view over `body_metrics` by the `20250705000001_convert_weight_logs_to_view.sql` migration. New writes must target `body_metrics`, not `weight_logs`.
 
 **Canonical source of truth for weight:** `public.body_metrics`.
+
+## Body Metric Source Provenance
+
+- `body_metrics.data_source` stores canonical `BodyMetricSource` values: `manual`, `healthkit`, `smart_scale`, `bodyspec_dexa`, `caliper`, and `photo`.
+- `body_metrics.source_metadata` stores compact pointer-style provenance such as HealthKit sample IDs, source bundle/device identifiers, BodySpec result IDs, scanner/location IDs, or legacy source labels.
+- Do not store raw vendor payloads, access tokens, refresh tokens, or unnecessary personal data in source metadata.

--- a/supabase/migrations/20260607043000_define_body_metric_source.sql
+++ b/supabase/migrations/20260607043000_define_body_metric_source.sql
@@ -1,0 +1,106 @@
+-- Define stable body metric source provenance before expanding imports.
+-- This migration is additive and normalizes existing legacy labels in place.
+
+ALTER TABLE public.body_metrics
+ADD COLUMN IF NOT EXISTS data_source TEXT DEFAULT 'manual',
+ADD COLUMN IF NOT EXISTS source_metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.body_metrics
+ALTER COLUMN data_source SET DEFAULT 'manual';
+
+ALTER TABLE public.body_metrics
+ALTER COLUMN source_metadata SET DEFAULT '{}'::jsonb;
+
+UPDATE public.body_metrics
+SET source_metadata = '{}'::jsonb
+WHERE source_metadata IS NULL OR jsonb_typeof(source_metadata) <> 'object';
+
+WITH normalized AS (
+    SELECT
+        id,
+        data_source AS original_data_source,
+        regexp_replace(lower(trim(coalesce(data_source, ''))), '[ -]+', '_', 'g') AS source_key
+    FROM public.body_metrics
+),
+resolved AS (
+    SELECT
+        id,
+        original_data_source,
+        source_key,
+        CASE
+            WHEN source_key IN ('', 'manual', 'user', 'user_entered', 'user_entry') THEN 'manual'
+            WHEN source_key IN ('healthkit', 'health_kit', 'apple_health', 'apple_healthkit') THEN 'healthkit'
+            WHEN source_key IN ('smart_scale', 'scale', 'bia_scale', 'body_scale', 'connected_scale') THEN 'smart_scale'
+            WHEN source_key IN ('bodyspec_dexa', 'bodyspec', 'partner:bodyspec', 'partner_bodyspec', 'dexa', 'dxa')
+                OR source_key LIKE '%bodyspec%' THEN 'bodyspec_dexa'
+            WHEN source_key LIKE '%caliper%' OR source_key LIKE '%skinfold%' THEN 'caliper'
+            WHEN source_key IN ('photo', 'photo_import', 'progress_photo') THEN 'photo'
+            ELSE 'manual'
+        END AS canonical_data_source
+    FROM normalized
+)
+UPDATE public.body_metrics AS body_metrics
+SET
+    data_source = resolved.canonical_data_source,
+    source_metadata = CASE
+        WHEN resolved.canonical_data_source = 'manual'
+            AND resolved.source_key NOT IN ('', 'manual', 'user', 'user_entered', 'user_entry')
+            AND resolved.original_data_source IS NOT NULL
+        THEN body_metrics.source_metadata || jsonb_build_object('legacy_data_source', resolved.original_data_source)
+        ELSE body_metrics.source_metadata
+    END
+FROM resolved
+WHERE body_metrics.id = resolved.id;
+
+ALTER TABLE public.body_metrics
+ALTER COLUMN data_source SET NOT NULL;
+
+ALTER TABLE public.body_metrics
+ALTER COLUMN source_metadata SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'body_metrics_data_source_allowed'
+          AND conrelid = 'public.body_metrics'::regclass
+    ) THEN
+        ALTER TABLE public.body_metrics
+        ADD CONSTRAINT body_metrics_data_source_allowed
+        CHECK (
+            data_source IN (
+                'manual',
+                'healthkit',
+                'smart_scale',
+                'bodyspec_dexa',
+                'caliper',
+                'photo'
+            )
+        ) NOT VALID;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'body_metrics_source_metadata_object'
+          AND conrelid = 'public.body_metrics'::regclass
+    ) THEN
+        ALTER TABLE public.body_metrics
+        ADD CONSTRAINT body_metrics_source_metadata_object
+        CHECK (jsonb_typeof(source_metadata) = 'object') NOT VALID;
+    END IF;
+END
+$$;
+
+ALTER TABLE public.body_metrics VALIDATE CONSTRAINT body_metrics_data_source_allowed;
+ALTER TABLE public.body_metrics VALIDATE CONSTRAINT body_metrics_source_metadata_object;
+
+CREATE INDEX IF NOT EXISTS idx_body_metrics_data_source
+ON public.body_metrics(data_source);
+
+COMMENT ON COLUMN public.body_metrics.data_source IS
+'Canonical BodyMetricSource: manual, healthkit, smart_scale, bodyspec_dexa, caliper, or photo.';
+
+COMMENT ON COLUMN public.body_metrics.source_metadata IS
+'Compact source provenance such as sample, external result, vendor, or device identifiers. Do not store raw vendor payloads or secrets.';


### PR DESCRIPTION
## Summary
- define canonical `BodyMetricSource` values for manual, HealthKit, smart scale, BodySpec DEXA, caliper, and photo-derived metrics
- add additive Supabase and Core Data source metadata storage for compact provenance pointers
- normalize legacy source labels on iOS read/write and Supabase migration, preserving unknown labels in `legacy_data_source`
- update HealthKit, BodySpec, photo, realtime sync, and web shared types to use the stable contract
- document the storage/sync contract in `docs/audits/jov-2867/body-metric-source-contract.md`

## Validation
- `git diff --check`
- `cd apps/ios && swiftlint lint --strict`
- XcodeBuildMCP `build_run_sim` on iPhone 17 Pro / iOS 26.5
- focused XcodeBuildMCP tests: `BodyMetricSourceContractTests`, affected sync tests, and HealthKit import test, 8/8 passed
- focused XcodeBuildMCP UI smoke: `LogYourBodyUITests/testPaidMVPWeightEntrySavesWithKeyboardOpen`, 1/1 passed
- full XcodeBuildMCP simulator test result passed: 52 tests, 0 failures, 0 skipped
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` after warm rerun: 28 suites, 235 tests passed
- pre-push hook: filtered lint, typecheck, web build, and test passed

## Notes
- Local JS commands warn that the workstation is on Node v22.22.1 while the repo declares Node 20.x.
- Existing web build warnings remain for `read-excel-file/web`, stale browser data, and Tailwind package module type.

Closes JOV-2867
