### PR TITLE
feat: preserve HealthKit import provenance

### DIFF
--- a/apps/ios/LogYourBody/Models/BodyMetrics.swift
+++ b/apps/ios/LogYourBody/Models/BodyMetrics.swift
@@ -91,6 +91,8 @@ struct BodyMetricSourceMetadata: Codable, Equatable {
     let deviceManufacturer: String?
     let deviceModel: String?
     let sampleId: String?
+    let quantityType: String?
+    let bodyFatSampleId: String?
     let externalId: String?
     let externalResultId: String?
     let scannerModel: String?
@@ -107,6 +109,8 @@ struct BodyMetricSourceMetadata: Codable, Equatable {
         deviceManufacturer: String? = nil,
         deviceModel: String? = nil,
         sampleId: String? = nil,
+        quantityType: String? = nil,
+        bodyFatSampleId: String? = nil,
         externalId: String? = nil,
         externalResultId: String? = nil,
         scannerModel: String? = nil,
@@ -122,6 +126,8 @@ struct BodyMetricSourceMetadata: Codable, Equatable {
         self.deviceManufacturer = Self.clean(deviceManufacturer)
         self.deviceModel = Self.clean(deviceModel)
         self.sampleId = Self.clean(sampleId)
+        self.quantityType = Self.clean(quantityType)
+        self.bodyFatSampleId = Self.clean(bodyFatSampleId)
         self.externalId = Self.clean(externalId)
         self.externalResultId = Self.clean(externalResultId)
         self.scannerModel = Self.clean(scannerModel)
@@ -139,6 +145,8 @@ struct BodyMetricSourceMetadata: Codable, Equatable {
         case deviceManufacturer = "device_manufacturer"
         case deviceModel = "device_model"
         case sampleId = "sample_id"
+        case quantityType = "quantity_type"
+        case bodyFatSampleId = "body_fat_sample_id"
         case externalId = "external_id"
         case externalResultId = "external_result_id"
         case scannerModel = "scanner_model"
@@ -161,6 +169,8 @@ struct BodyMetricSourceMetadata: Codable, Equatable {
         object["device_manufacturer"] = deviceManufacturer
         object["device_model"] = deviceModel
         object["sample_id"] = sampleId
+        object["quantity_type"] = quantityType
+        object["body_fat_sample_id"] = bodyFatSampleId
         object["external_id"] = externalId
         object["external_result_id"] = externalResultId
         object["scanner_model"] = scannerModel

--- a/apps/ios/LogYourBody/Services/HealthKitManager.swift
+++ b/apps/ios/LogYourBody/Services/HealthKitManager.swift
@@ -17,6 +17,30 @@ enum HealthKitDefaultsKey: String {
     }
 }
 
+struct HealthKitWeightImportSample: Equatable {
+    let weight: Double
+    let date: Date
+    let sourceMetadata: BodyMetricSourceMetadata?
+
+    init(weight: Double, date: Date, sourceMetadata: BodyMetricSourceMetadata? = nil) {
+        self.weight = weight
+        self.date = date
+        self.sourceMetadata = sourceMetadata
+    }
+}
+
+struct HealthKitBodyFatImportSample: Equatable {
+    let percentage: Double
+    let date: Date
+    let sourceMetadata: BodyMetricSourceMetadata?
+
+    init(percentage: Double, date: Date, sourceMetadata: BodyMetricSourceMetadata? = nil) {
+        self.percentage = percentage
+        self.date = date
+        self.sourceMetadata = sourceMetadata
+    }
+}
+
 class HealthKitManager: ObservableObject {
     static let shared = HealthKitManager()
 
@@ -218,6 +242,42 @@ class HealthKitManager: ObservableObject {
         return result.isEmpty ? nil : result
     }
 
+    private func sourceMetadata(from sample: HKQuantitySample) -> BodyMetricSourceMetadata {
+        let deviceId = sample.device?.localIdentifier ?? sample.device?.udiDeviceIdentifier
+
+        return BodyMetricSourceMetadata(
+            vendor: "apple_health",
+            sourceName: sample.sourceRevision.source.name,
+            sourceBundleId: sample.sourceRevision.source.bundleIdentifier,
+            deviceId: deviceId,
+            deviceManufacturer: sample.device?.manufacturer,
+            deviceModel: sample.device?.model,
+            sampleId: sample.uuid.uuidString,
+            quantityType: sample.quantityType.identifier
+        )
+    }
+
+    private func combinedHealthKitMetadata(
+        weightMetadata: BodyMetricSourceMetadata?,
+        bodyFatMetadata: BodyMetricSourceMetadata?
+    ) -> BodyMetricSourceMetadata? {
+        guard weightMetadata != nil || bodyFatMetadata != nil else { return nil }
+
+        let primary = weightMetadata ?? bodyFatMetadata
+
+        return BodyMetricSourceMetadata(
+            vendor: primary?.vendor ?? "apple_health",
+            sourceName: primary?.sourceName ?? bodyFatMetadata?.sourceName,
+            sourceBundleId: primary?.sourceBundleId ?? bodyFatMetadata?.sourceBundleId,
+            deviceId: primary?.deviceId ?? bodyFatMetadata?.deviceId,
+            deviceManufacturer: primary?.deviceManufacturer ?? bodyFatMetadata?.deviceManufacturer,
+            deviceModel: primary?.deviceModel ?? bodyFatMetadata?.deviceModel,
+            sampleId: primary?.sampleId ?? bodyFatMetadata?.sampleId,
+            quantityType: primary?.quantityType ?? bodyFatMetadata?.quantityType,
+            bodyFatSampleId: bodyFatMetadata?.sampleId
+        )
+    }
+
     // Request authorization
     func requestAuthorization() async -> Bool {
         guard isHealthKitAvailable else { return false }
@@ -323,6 +383,14 @@ class HealthKitManager: ObservableObject {
 
     // New function to fetch weight history in a specific date range
     func fetchWeightHistoryInRange(startDate: Date, endDate: Date) async throws -> [(weight: Double, date: Date)] {
+        let samples = try await fetchWeightImportSamplesInRange(startDate: startDate, endDate: endDate)
+        return samples.map { (weight: $0.weight, date: $0.date) }
+    }
+
+    private func fetchWeightImportSamplesInRange(
+        startDate: Date,
+        endDate: Date
+    ) async throws -> [HealthKitWeightImportSample] {
         guard isAuthorized else {
             throw HealthKitError.notAuthorized
         }
@@ -356,7 +424,11 @@ class HealthKitManager: ObservableObject {
 
                 let results = hkSamples.map { sample in
                     let weightInKg = sample.quantity.doubleValue(for: HKUnit.gramUnit(with: .kilo))
-                    return (weight: weightInKg, date: sample.startDate)  // Return in kg
+                    return HealthKitWeightImportSample(
+                        weight: weightInKg,
+                        date: sample.startDate,
+                        sourceMetadata: self.sourceMetadata(from: sample)
+                    )
                 }
 
                 continuation.resume(returning: results)
@@ -405,6 +477,11 @@ class HealthKitManager: ObservableObject {
 
     // Fetch body fat percentage history
     func fetchBodyFatHistory(startDate: Date) async throws -> [(percentage: Double, date: Date)] {
+        let samples = try await fetchBodyFatImportSamples(startDate: startDate)
+        return samples.map { (percentage: $0.percentage, date: $0.date) }
+    }
+
+    private func fetchBodyFatImportSamples(startDate: Date) async throws -> [HealthKitBodyFatImportSample] {
         guard isAuthorized else {
             throw HealthKitError.notAuthorized
         }
@@ -438,7 +515,11 @@ class HealthKitManager: ObservableObject {
 
                 let results = hkSamples.map { sample in
                     let percentage = sample.quantity.doubleValue(for: HKUnit.percent()) * 100
-                    return (percentage: percentage, date: sample.startDate)
+                    return HealthKitBodyFatImportSample(
+                        percentage: percentage,
+                        date: sample.startDate,
+                        sourceMetadata: self.sourceMetadata(from: sample)
+                    )
                 }
 
                 continuation.resume(returning: results)
@@ -730,15 +811,18 @@ class HealthKitManager: ObservableObject {
 
     private func fetchRecentWeightAndBodyFatHistory() async throws
     -> (
-        weightHistory: [(weight: Double, date: Date)],
-        bodyFatHistory: [(percentage: Double, date: Date)]
+        weightHistory: [HealthKitWeightImportSample],
+        bodyFatHistory: [HealthKitBodyFatImportSample]
     ) {
         let endDate = Date()
         let recentStartDate = Calendar.current.date(byAdding: .day, value: -30, to: endDate)!
 
         // Fetch recent weight and body fat data
-        let recentWeightHistory = try await fetchWeightHistory(days: 30)
-        let recentBodyFatHistory = try await fetchBodyFatHistory(startDate: recentStartDate)
+        let recentWeightHistory = try await fetchWeightImportSamplesInRange(
+            startDate: recentStartDate,
+            endDate: endDate
+        )
+        let recentBodyFatHistory = try await fetchBodyFatImportSamples(startDate: recentStartDate)
 
         return (weightHistory: recentWeightHistory, bodyFatHistory: recentBodyFatHistory)
     }
@@ -795,11 +879,12 @@ class HealthKitManager: ObservableObject {
         // print("📅 Fetching data from \(batchStartDate) to \(endDate)")
 
         // Fetch weight and body fat data for the specified period
-        // Calculate days between dates
-        let daysBetween = Calendar.current.dateComponents([.day], from: batchStartDate, to: endDate).day ?? 30
-        let weightHistory = try await fetchWeightHistory(days: daysBetween)
+        let weightHistory = try await fetchWeightImportSamplesInRange(
+            startDate: batchStartDate,
+            endDate: endDate
+        )
             .filter { $0.date >= batchStartDate && $0.date <= endDate }
-        let bodyFatHistory = try await fetchBodyFatHistory(startDate: batchStartDate)
+        let bodyFatHistory = try await fetchBodyFatImportSamples(startDate: batchStartDate)
             .filter { $0.date <= endDate }
 
         // print("📈 Found \(weightHistory.count) weight entries and \(bodyFatHistory.count) body fat entries")
@@ -811,13 +896,6 @@ class HealthKitManager: ObservableObject {
                 // Show first 5 entries
                 // print("    - \(date): \(weight)kg")
             }
-        }
-
-        // Create a dictionary of body fat data by date for easy lookup
-        var bodyFatByDate: [Date: Double] = [:]
-        for (percentage, date) in bodyFatHistory {
-            let normalizedDate = Calendar.current.startOfDay(for: date)
-            bodyFatByDate[normalizedDate] = percentage
         }
 
         // Process weight and body fat entries using shared batch logic
@@ -933,8 +1011,11 @@ class HealthKitManager: ObservableObject {
             }
 
             // Fetch weight and body fat data for this batch
-            let weightBatch = try await fetchWeightHistoryInRange(startDate: currentDate, endDate: actualBatchEndDate)
-            let bodyFatBatch = try await fetchBodyFatHistory(startDate: currentDate)
+            let weightBatch = try await fetchWeightImportSamplesInRange(
+                startDate: currentDate,
+                endDate: actualBatchEndDate
+            )
+            let bodyFatBatch = try await fetchBodyFatImportSamples(startDate: currentDate)
                 .filter { $0.date < actualBatchEndDate }
 
             // Process this batch
@@ -1004,14 +1085,28 @@ class HealthKitManager: ObservableObject {
         weightHistory: [(weight: Double, date: Date)],
         bodyFatHistory: [(percentage: Double, date: Date)]
     ) async -> (imported: Int, skipped: Int) {
+        await processBatchHealthKitData(
+            weightHistory: weightHistory.map {
+                HealthKitWeightImportSample(weight: $0.weight, date: $0.date)
+            },
+            bodyFatHistory: bodyFatHistory.map {
+                HealthKitBodyFatImportSample(percentage: $0.percentage, date: $0.date)
+            }
+        )
+    }
+
+    func processBatchHealthKitData(
+        weightHistory: [HealthKitWeightImportSample],
+        bodyFatHistory: [HealthKitBodyFatImportSample]
+    ) async -> (imported: Int, skipped: Int) {
         var imported = 0
         var skipped = 0
 
         // Create a dictionary of body fat data by date
-        var bodyFatByDate: [Date: Double] = [:]
-        for (percentage, date) in bodyFatHistory {
-            let normalizedDate = Calendar.current.startOfDay(for: date)
-            bodyFatByDate[normalizedDate] = percentage
+        var bodyFatByDate: [Date: HealthKitBodyFatImportSample] = [:]
+        for sample in bodyFatHistory {
+            let normalizedDate = Calendar.current.startOfDay(for: sample.date)
+            bodyFatByDate[normalizedDate] = sample
         }
 
         // Get existing entries for this date range to check for duplicates
@@ -1038,22 +1133,23 @@ class HealthKitManager: ObservableObject {
             }
         }
 
-        for (weight, date) in weightHistory {
+        for sample in weightHistory {
             // Check if entry exists within the same hour
             let calendar = Calendar.current
-            let components = calendar.dateComponents([.year, .month, .day, .hour], from: date)
-            let roundedDate = calendar.date(from: components) ?? date
+            let components = calendar.dateComponents([.year, .month, .day, .hour], from: sample.date)
+            let roundedDate = calendar.date(from: components) ?? sample.date
             let hourKey = ISO8601DateFormatter().string(from: roundedDate)
 
             if !existingEntriesByHour.contains(hourKey) {
-                let normalizedDate = calendar.startOfDay(for: date)
-                let bodyFatPercentage = bodyFatByDate[normalizedDate]
+                let normalizedDate = calendar.startOfDay(for: sample.date)
+                let bodyFatSample = bodyFatByDate[normalizedDate]
+                let bodyFatPercentage = bodyFatSample?.percentage
 
                 let metrics = BodyMetrics(
                     id: UUID().uuidString,
                     userId: userId,
-                    date: date,
-                    weight: weight,
+                    date: sample.date,
+                    weight: sample.weight,
                     weightUnit: "kg",
                     bodyFatPercentage: bodyFatPercentage,
                     bodyFatMethod: bodyFatPercentage != nil ? "HealthKit" : nil,
@@ -1062,6 +1158,10 @@ class HealthKitManager: ObservableObject {
                     notes: "Imported from HealthKit",
                     photoUrl: nil,
                     dataSource: BodyMetricSource.healthKit.rawValue,
+                    sourceMetadata: combinedHealthKitMetadata(
+                        weightMetadata: sample.sourceMetadata,
+                        bodyFatMetadata: bodyFatSample?.sourceMetadata
+                    ),
                     createdAt: Date(),
                     updatedAt: Date()
                 )

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -820,6 +820,12 @@ final class SyncIntegrationTests: XCTestCase {
 
         let metrics = await coreData.fetchAllBodyMetrics(for: userId)
         XCTAssertEqual(metrics.count, 2)
+        XCTAssertEqual(metrics.filter { $0.dataSource == "manual" }.count, 1)
+        XCTAssertEqual(metrics.filter { $0.dataSource == "healthkit" }.count, 1)
+
+        let manualMetric = try XCTUnwrap(metrics.first { $0.dataSource == "manual" })
+        XCTAssertEqual(manualMetric.weight, 80.0)
+        XCTAssertEqual(manualMetric.notes, "existing-healthkit")
     }
 
     func testProcessBatchHealthKitData_DeduplicatesMultipleWeightsInSameHour() async throws {
@@ -905,6 +911,77 @@ final class SyncIntegrationTests: XCTestCase {
         XCTAssertEqual(bodyFat, 19.5, accuracy: 0.001)
         XCTAssertEqual(metric.bodyFatMethod, "HealthKit")
         XCTAssertEqual(metric.dataSource, "healthkit")
+    }
+
+    func testProcessBatchHealthKitData_AttachesSourceMetadataToImportedMetrics() async throws {
+        let coreData = CoreDataManager.shared
+        let healthKitManager = HealthKitManager.shared
+
+        let userId = "healthkit_test_user_metadata_\(UUID().uuidString)"
+        let user = LocalUser(
+            id: userId,
+            email: "hk_metadata@example.com",
+            name: "HK Metadata",
+            avatarUrl: nil,
+            profile: nil,
+            onboardingCompleted: false
+        )
+        AuthManager.shared.currentUser = user
+
+        let calendar = Calendar.current
+        let day = calendar.startOfDay(for: Date())
+        let weightDate = calendar.date(byAdding: DateComponents(hour: 7, minute: 10), to: day) ?? day
+        let bodyFatDate = calendar.date(byAdding: DateComponents(hour: 7, minute: 12), to: day) ?? day
+
+        let result = await healthKitManager.processBatchHealthKitData(
+            weightHistory: [
+                HealthKitWeightImportSample(
+                    weight: 76.5,
+                    date: weightDate,
+                    sourceMetadata: BodyMetricSourceMetadata(
+                        vendor: "apple_health",
+                        sourceName: "Apple Health",
+                        sourceBundleId: "com.apple.Health",
+                        deviceId: "scale-local-id",
+                        deviceManufacturer: "Withings",
+                        deviceModel: "Body Scan",
+                        sampleId: "weight-sample-123",
+                        quantityType: "HKQuantityTypeIdentifierBodyMass"
+                    )
+                )
+            ],
+            bodyFatHistory: [
+                HealthKitBodyFatImportSample(
+                    percentage: 18.4,
+                    date: bodyFatDate,
+                    sourceMetadata: BodyMetricSourceMetadata(
+                        vendor: "apple_health",
+                        sourceName: "Apple Health",
+                        sourceBundleId: "com.apple.Health",
+                        sampleId: "body-fat-sample-456",
+                        quantityType: "HKQuantityTypeIdentifierBodyFatPercentage"
+                    )
+                )
+            ]
+        )
+
+        XCTAssertEqual(result.imported, 1)
+        XCTAssertEqual(result.skipped, 0)
+
+        let metrics = await coreData.fetchAllBodyMetrics(for: userId)
+        let metric = try XCTUnwrap(metrics.first)
+        let sourceMetadata = try XCTUnwrap(metric.sourceMetadata)
+        XCTAssertEqual(metric.dataSource, "healthkit")
+        XCTAssertEqual(metric.bodyFatPercentage, 18.4)
+        XCTAssertEqual(sourceMetadata.vendor, "apple_health")
+        XCTAssertEqual(sourceMetadata.sourceName, "Apple Health")
+        XCTAssertEqual(sourceMetadata.sourceBundleId, "com.apple.Health")
+        XCTAssertEqual(sourceMetadata.deviceId, "scale-local-id")
+        XCTAssertEqual(sourceMetadata.deviceManufacturer, "Withings")
+        XCTAssertEqual(sourceMetadata.deviceModel, "Body Scan")
+        XCTAssertEqual(sourceMetadata.sampleId, "weight-sample-123")
+        XCTAssertEqual(sourceMetadata.bodyFatSampleId, "body-fat-sample-456")
+        XCTAssertEqual(sourceMetadata.quantityType, "HKQuantityTypeIdentifierBodyMass")
     }
 
     func testSyncLocalChanges_UsesSupabaseAndMarksBodyMetricSynced() async throws {
@@ -1300,6 +1377,58 @@ final class DashboardViewModelHealthSyncWiringTests: XCTestCase {
         )
 
         XCTAssertNotNil(viewModel)
+    }
+
+    func testRefreshSkipsHealthKitSyncWhenDeniedAndKeepsLocalMetrics() async throws {
+        let userId = "dashboard_healthkit_denied_\(UUID().uuidString)"
+        let user = LocalUser(
+            id: userId,
+            email: "hk_denied@example.com",
+            name: "HealthKit Denied",
+            avatarUrl: nil,
+            profile: nil,
+            onboardingCompleted: true
+        )
+        let authManager = AuthManager()
+        authManager.currentUser = user
+        authManager.isAuthenticated = true
+
+        let localMetric = BodyMetrics(
+            id: UUID().uuidString,
+            userId: userId,
+            date: Date(),
+            weight: 82.1,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: "manual still works",
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            sourceMetadata: nil,
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+        CoreDataManager.shared.saveBodyMetrics(localMetric, userId: userId, markAsSynced: false)
+
+        let healthKitManager = HealthKitManager.shared
+        healthKitManager.isAuthorized = false
+        let mockCoordinator = MockHealthSyncCoordinator()
+        let viewModel = DashboardViewModel(
+            healthKitManager: healthKitManager,
+            healthSyncCoordinator: mockCoordinator
+        )
+
+        await viewModel.refreshData(
+            authManager: authManager,
+            realtimeSyncManager: RealtimeSyncManager.shared
+        )
+
+        XCTAssertFalse(mockCoordinator.didCallSyncWeightFromHealthKit)
+        XCTAssertTrue(viewModel.hasLoadedInitialData)
+        XCTAssertEqual(viewModel.bodyMetrics.first?.id, localMetric.id)
+        XCTAssertEqual(viewModel.bodyMetrics.first?.dataSource, "manual")
     }
 }
 

--- a/apps/web/src/types/body-metrics.ts
+++ b/apps/web/src/types/body-metrics.ts
@@ -58,6 +58,8 @@ export interface BodyMetricSourceMetadata {
   device_manufacturer?: string;
   device_model?: string;
   sample_id?: string;
+  quantity_type?: string;
+  body_fat_sample_id?: string;
   external_id?: string;
   external_result_id?: string;
   scanner_model?: string;

--- a/docs/audits/jov-2867/body-metric-source-contract.md
+++ b/docs/audits/jov-2867/body-metric-source-contract.md
@@ -24,7 +24,7 @@ Compact provenance is stored as JSON in `body_metrics.source_metadata` and as `C
 - vendor/source identifiers
 - source bundle identifier
 - device manufacturer/model/id
-- HealthKit sample ID when available
+- HealthKit sample ID, quantity type, and paired body-fat sample ID when available
 - external importer/result IDs
 - scanner/location identifiers
 - imported timestamp

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -66,5 +66,5 @@ The `photos` bucket is configured with:
 ## Body Metric Source Provenance
 
 - `body_metrics.data_source` stores canonical `BodyMetricSource` values: `manual`, `healthkit`, `smart_scale`, `bodyspec_dexa`, `caliper`, and `photo`.
-- `body_metrics.source_metadata` stores compact pointer-style provenance such as HealthKit sample IDs, source bundle/device identifiers, BodySpec result IDs, scanner/location IDs, or legacy source labels.
+- `body_metrics.source_metadata` stores compact pointer-style provenance such as HealthKit sample IDs, quantity types, source bundle/device identifiers, BodySpec result IDs, scanner/location IDs, or legacy source labels.
 - Do not store raw vendor payloads, access tokens, refresh tokens, or unnecessary personal data in source metadata.


### PR DESCRIPTION
## Summary
- preserve HealthKit sample/source/device metadata on imported body metrics using the BodyMetricSource metadata contract
- keep public tuple-based HealthKit fetch/process APIs while routing sync internals through metadata-aware import samples
- add focused coverage for same-hour manual duplicate protection, HealthKit metadata mapping, and denied/non-blocking dashboard refresh behavior

## Validation
- swiftlint lint --strict
- XcodeBuildMCP focused simulator tests on iPhone 17 Pro: 7 passed / 0 failed
- pnpm lint
- pnpm typecheck
- pnpm test
- pre-push scoped turbo lint/typecheck/test

Linear: JOV-2868