### PR TITLE
Harden BodySpec DEXA import provenance

### DIFF
--- a/apps/ios/LogYourBody/Services/BodySpecAPI.swift
+++ b/apps/ios/LogYourBody/Services/BodySpecAPI.swift
@@ -105,7 +105,7 @@ struct BodySpecDexaCompositionResponse: Decodable {
 }
 
 final class BodySpecAPI {
-    static let shared = BodySpecAPI()
+    @MainActor static let shared = BodySpecAPI(authManager: .shared)
 
     private let baseURL: URL
     private let urlSession: URLSession
@@ -114,7 +114,7 @@ final class BodySpecAPI {
     init(
         baseURL: URL = URL(string: "https://app.bodyspec.com")!,
         urlSession: URLSession = .shared,
-        authManager: BodySpecAuthManager = .shared
+        authManager: BodySpecAuthManager
     ) {
         self.baseURL = baseURL
         self.urlSession = urlSession

--- a/apps/ios/LogYourBody/Services/BodySpecDexaImporter.swift
+++ b/apps/ios/LogYourBody/Services/BodySpecDexaImporter.swift
@@ -1,15 +1,23 @@
 import Foundation
 
-actor BodySpecDexaImporter {
-    static let shared = BodySpecDexaImporter()
+protocol BodySpecDexaAPIClient {
+    func listResults(page: Int, pageSize: Int) async throws -> BodySpecResultsListResponse
+    func getDexaScanInfo(resultId: String) async throws -> BodySpecDexaScanInfoResponse
+    func getDexaComposition(resultId: String) async throws -> BodySpecDexaCompositionResponse
+}
 
-    private let api: BodySpecAPI
+extension BodySpecAPI: BodySpecDexaAPIClient {}
+
+actor BodySpecDexaImporter {
+    @MainActor static let shared = BodySpecDexaImporter(api: BodySpecAPI.shared, authManager: .shared)
+
+    private let api: BodySpecDexaAPIClient
     private let authManager: AuthManager
     private let coreDataManager: CoreDataManager
 
     init(
-        api: BodySpecAPI = .shared,
-        authManager: AuthManager = .shared,
+        api: BodySpecDexaAPIClient,
+        authManager: AuthManager,
         coreDataManager: CoreDataManager = .shared
     ) {
         self.api = api
@@ -85,34 +93,16 @@ actor BodySpecDexaImporter {
         summary: BodySpecResultSummary,
         userId: String
     ) async -> Bool {
-        let metricsId = UUID().uuidString
-
-        let existing = await coreDataManager.fetchBodyMetrics(
-            for: userId,
-            from: summary.startTime,
-            to: summary.startTime
-        )
-
-        let alreadyHasBodySpecEntry = existing.contains { cached in
-            if BodyMetricSource.normalizedRawValue(cached.dataSource) == BodyMetricSource.bodySpecDexa.rawValue {
-                return true
-            }
-
-            if let notes = cached.notes, notes.localizedCaseInsensitiveContains("BodySpec") {
-                return true
-            }
-
-            return false
-        }
-
-        if alreadyHasBodySpecEntry {
-            return false
-        }
-
         do {
             let scanInfo = try await api.getDexaScanInfo(resultId: summary.resultId)
+
+            if await hasImportedResult(summary: summary, scanDate: scanInfo.acquireTime, userId: userId) {
+                return false
+            }
+
             let composition = try await api.getDexaComposition(resultId: summary.resultId)
 
+            let metricsId = UUID().uuidString
             let date = scanInfo.acquireTime
 
             let now = Date()
@@ -133,6 +123,8 @@ actor BodySpecDexaImporter {
                 dataSource: BodyMetricSource.bodySpecDexa.rawValue,
                 sourceMetadata: BodyMetricSourceMetadata(
                     vendor: "bodyspec",
+                    sourceName: "BodySpec DEXA",
+                    externalId: summary.service.serviceId,
                     externalResultId: summary.resultId,
                     scannerModel: scanInfo.scannerModel,
                     locationId: summary.location.locationId,
@@ -143,8 +135,9 @@ actor BodySpecDexaImporter {
                 updatedAt: now
             )
 
+            try await coreDataManager.saveBodyMetricsAndWait(bodyMetrics, userId: userId, markAsSynced: false)
+
             await MainActor.run {
-                CoreDataManager.shared.saveBodyMetrics(bodyMetrics, userId: userId, markAsSynced: false)
                 RealtimeSyncManager.shared.syncIfNeeded()
             }
 
@@ -169,8 +162,9 @@ actor BodySpecDexaImporter {
                 updatedAt: now
             )
 
+            try await coreDataManager.saveDexaResultsAndWait([dexaResult], userId: userId, markAsSynced: false)
+
             await MainActor.run {
-                CoreDataManager.shared.saveDexaResults([dexaResult], userId: userId, markAsSynced: false)
                 RealtimeSyncManager.shared.updatePendingSyncCount()
                 RealtimeSyncManager.shared.syncIfNeeded()
             }
@@ -185,6 +179,30 @@ actor BodySpecDexaImporter {
             )
             ErrorReporter.shared.captureNonFatal(error, context: context)
             return false
+        }
+    }
+
+    private func hasImportedResult(
+        summary: BodySpecResultSummary,
+        scanDate: Date,
+        userId: String
+    ) async -> Bool {
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: scanDate)
+        let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) ?? scanDate
+        let existing = await coreDataManager.fetchBodyMetrics(for: userId, from: startOfDay, to: endOfDay)
+
+        return existing.contains { cached in
+            if BodyMetricSourceMetadata(jsonString: cached.sourceMetadataJSON)?.externalResultId == summary.resultId {
+                return true
+            }
+
+            let isBodySpec = BodyMetricSource.normalizedRawValue(cached.dataSource) ==
+                BodyMetricSource.bodySpecDexa.rawValue
+            let hasLegacyBodySpecNote = cached.notes?.localizedCaseInsensitiveContains("BodySpec") == true
+            let isSameScanTimestamp = cached.date.map { abs($0.timeIntervalSince(scanDate)) < 60 } ?? false
+
+            return isSameScanTimestamp && (isBodySpec || hasLegacyBodySpecNote)
         }
     }
 }

--- a/apps/ios/LogYourBody/Services/CoreDataManager.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager.swift
@@ -320,8 +320,16 @@ class CoreDataManager: ObservableObject {
         }
     }
 
-    func saveDexaResults(_ results: [DexaResult], userId: String, markAsSynced: Bool = false) {
-        guard !results.isEmpty else { return }
+    func saveDexaResults(
+        _ results: [DexaResult],
+        userId: String,
+        markAsSynced: Bool = false,
+        completion: ((Result<Void, Error>) -> Void)? = nil
+    ) {
+        guard !results.isEmpty else {
+            completion?(.success(()))
+            return
+        }
 
         let context = viewContext
 
@@ -364,6 +372,7 @@ class CoreDataManager: ObservableObject {
                 if context.hasChanges {
                     try context.save()
                 }
+                completion?(.success(()))
             } catch {
                 #if DEBUG
                 let appError = AppError.coreData(operation: "saveDexaResults", underlying: error)
@@ -375,6 +384,15 @@ class CoreDataManager: ObservableObject {
                 )
                 ErrorReporter.shared.capture(appError, context: contextInfo)
                 #endif
+                completion?(.failure(error))
+            }
+        }
+    }
+
+    func saveDexaResultsAndWait(_ results: [DexaResult], userId: String, markAsSynced: Bool = false) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            saveDexaResults(results, userId: userId, markAsSynced: markAsSynced) { result in
+                continuation.resume(with: result)
             }
         }
     }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -559,6 +559,36 @@ final class StubSupabaseManager: SupabaseManager {
     }
 }
 
+final class StubBodySpecDexaAPI: BodySpecDexaAPIClient {
+    var pages: [Int: BodySpecResultsListResponse] = [:]
+    var scanInfos: [String: BodySpecDexaScanInfoResponse] = [:]
+    var compositions: [String: BodySpecDexaCompositionResponse] = [:]
+
+    private(set) var compositionRequests: [String] = []
+
+    func listResults(page: Int, pageSize: Int) async throws -> BodySpecResultsListResponse {
+        pages[page] ?? BodySpecResultsListResponse(results: [])
+    }
+
+    func getDexaScanInfo(resultId: String) async throws -> BodySpecDexaScanInfoResponse {
+        guard let scanInfo = scanInfos[resultId] else {
+            throw BodySpecAPIError.invalidResponse
+        }
+
+        return scanInfo
+    }
+
+    func getDexaComposition(resultId: String) async throws -> BodySpecDexaCompositionResponse {
+        compositionRequests.append(resultId)
+
+        guard let composition = compositions[resultId] else {
+            throw BodySpecAPIError.invalidResponse
+        }
+
+        return composition
+    }
+}
+
 @MainActor
 final class SyncIntegrationTests: XCTestCase {
     override func setUp() async throws {
@@ -573,6 +603,198 @@ final class SyncIntegrationTests: XCTestCase {
 
     private func wholeSecondDate(_ offset: TimeInterval = 0) -> Date {
         Date(timeIntervalSince1970: 1_735_000_000 + offset)
+    }
+
+    private func makeBodySpecSummary(
+        resultId: String,
+        startTime: Date,
+        serviceId: String = "svc-dxa"
+    ) -> BodySpecResultSummary {
+        BodySpecResultSummary(
+            resultId: resultId,
+            startTime: startTime,
+            location: BodySpecLocation(locationId: "loc-santa-monica", name: "Santa Monica"),
+            service: BodySpecService(
+                name: "DEXA",
+                description: "DEXA scan",
+                serviceId: serviceId,
+                serviceCode: "DXA"
+            )
+        )
+    }
+
+    private func makeBodySpecComposition(resultId: String) -> BodySpecDexaCompositionResponse {
+        BodySpecDexaCompositionResponse(
+            resultId: resultId,
+            total: BodySpecBodyRegion(
+                fatMassKg: 14.0,
+                leanMassKg: 62.0,
+                boneMassKg: 3.2,
+                totalMassKg: 79.2,
+                tissueFatPct: 18.4,
+                regionFatPct: 17.7
+            )
+        )
+    }
+
+    func testBodySpecDexaImporter_AddsProvenanceWithoutOverwritingManualOrHealthKit() async throws {
+        let coreData = CoreDataManager.shared
+        let authManager = AuthManager()
+
+        let userId = "bodyspec_import_user_\(UUID().uuidString)"
+        let user = LocalUser(
+            id: userId,
+            email: "bodyspec@example.com",
+            name: "BodySpec Import",
+            avatarUrl: nil,
+            profile: nil,
+            onboardingCompleted: true
+        )
+        authManager.currentUser = user
+
+        let scanDate = wholeSecondDate(20_000)
+        let manualMetric = BodyMetrics(
+            id: UUID().uuidString,
+            userId: userId,
+            date: scanDate,
+            weight: 80.0,
+            weightUnit: "kg",
+            bodyFatPercentage: 20.0,
+            bodyFatMethod: "manual",
+            muscleMass: nil,
+            boneMass: nil,
+            notes: "same-day manual entry",
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            sourceMetadata: nil,
+            createdAt: scanDate,
+            updatedAt: scanDate
+        )
+        try await coreData.saveBodyMetricsAndWait(manualMetric, userId: userId, markAsSynced: false)
+
+        let healthKitMetric = BodyMetrics(
+            id: UUID().uuidString,
+            userId: userId,
+            date: scanDate.addingTimeInterval(600),
+            weight: 80.4,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: "same-day HealthKit entry",
+            photoUrl: nil,
+            dataSource: BodyMetricSource.healthKit.rawValue,
+            sourceMetadata: BodyMetricSourceMetadata(vendor: "apple_health", sampleId: "hk-sample"),
+            createdAt: scanDate,
+            updatedAt: scanDate
+        )
+        try await coreData.saveBodyMetricsAndWait(healthKitMetric, userId: userId, markAsSynced: false)
+
+        let resultId = "bodyspec-result-123"
+        let stubAPI = StubBodySpecDexaAPI()
+        stubAPI.pages[1] = BodySpecResultsListResponse(results: [
+            makeBodySpecSummary(resultId: resultId, startTime: scanDate)
+        ])
+        stubAPI.scanInfos[resultId] = BodySpecDexaScanInfoResponse(
+            resultId: resultId,
+            scannerModel: "Hologic Horizon A",
+            acquireTime: scanDate.addingTimeInterval(1_200),
+            analyzeTime: scanDate.addingTimeInterval(1_500)
+        )
+        stubAPI.compositions[resultId] = makeBodySpecComposition(resultId: resultId)
+
+        let importer = BodySpecDexaImporter(
+            api: stubAPI,
+            authManager: authManager,
+            coreDataManager: coreData
+        )
+
+        let importResult = await importer.importDexaResults()
+
+        XCTAssertEqual(importResult.importedCount, 1)
+        XCTAssertEqual(importResult.skippedCount, 0)
+
+        let metrics = await coreData.fetchAllBodyMetrics(for: userId)
+        XCTAssertEqual(metrics.count, 3)
+
+        let manual = try XCTUnwrap(metrics.first { $0.id == manualMetric.id })
+        XCTAssertEqual(manual.dataSource, "manual")
+        XCTAssertEqual(try XCTUnwrap(manual.weight), 80.0, accuracy: 0.001)
+
+        let healthKit = try XCTUnwrap(metrics.first { $0.id == healthKitMetric.id })
+        XCTAssertEqual(healthKit.dataSource, "healthkit")
+        XCTAssertEqual(try XCTUnwrap(healthKit.weight), 80.4, accuracy: 0.001)
+
+        let dexa = try XCTUnwrap(metrics.first { $0.dataSource == BodyMetricSource.bodySpecDexa.rawValue })
+        XCTAssertEqual(dexa.bodyFatMethod, "DEXA (BodySpec)")
+        XCTAssertEqual(try XCTUnwrap(dexa.weight), 79.2, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(dexa.bodyFatPercentage), 17.7, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(dexa.muscleMass), 62.0, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(dexa.boneMass), 3.2, accuracy: 0.001)
+
+        let sourceMetadata = try XCTUnwrap(dexa.sourceMetadata)
+        XCTAssertEqual(sourceMetadata.vendor, "bodyspec")
+        XCTAssertEqual(sourceMetadata.sourceName, "BodySpec DEXA")
+        XCTAssertEqual(sourceMetadata.externalId, "svc-dxa")
+        XCTAssertEqual(sourceMetadata.externalResultId, resultId)
+        XCTAssertEqual(sourceMetadata.scannerModel, "Hologic Horizon A")
+        XCTAssertEqual(sourceMetadata.locationId, "loc-santa-monica")
+        XCTAssertEqual(sourceMetadata.locationName, "Santa Monica")
+        XCTAssertNotNil(sourceMetadata.importedAt)
+
+        let dexaResults = await coreData.fetchDexaResults(for: userId, limit: 10)
+        XCTAssertEqual(dexaResults.count, 1)
+        XCTAssertEqual(dexaResults.first?.bodyMetricsId, dexa.id)
+        XCTAssertEqual(dexaResults.first?.externalSource, "bodyspec")
+        XCTAssertEqual(dexaResults.first?.externalResultId, resultId)
+    }
+
+    func testBodySpecDexaImporter_SkipsExistingExternalResultId() async throws {
+        let coreData = CoreDataManager.shared
+        let authManager = AuthManager()
+
+        let userId = "bodyspec_duplicate_user_\(UUID().uuidString)"
+        authManager.currentUser = LocalUser(
+            id: userId,
+            email: "bodyspec-duplicate@example.com",
+            name: "BodySpec Duplicate",
+            avatarUrl: nil,
+            profile: nil,
+            onboardingCompleted: true
+        )
+
+        let scanDate = wholeSecondDate(30_000)
+        let resultId = "bodyspec-result-duplicate"
+        let stubAPI = StubBodySpecDexaAPI()
+        stubAPI.pages[1] = BodySpecResultsListResponse(results: [
+            makeBodySpecSummary(resultId: resultId, startTime: scanDate)
+        ])
+        stubAPI.scanInfos[resultId] = BodySpecDexaScanInfoResponse(
+            resultId: resultId,
+            scannerModel: "Hologic Horizon A",
+            acquireTime: scanDate,
+            analyzeTime: scanDate.addingTimeInterval(300)
+        )
+        stubAPI.compositions[resultId] = makeBodySpecComposition(resultId: resultId)
+
+        let importer = BodySpecDexaImporter(
+            api: stubAPI,
+            authManager: authManager,
+            coreDataManager: coreData
+        )
+
+        let firstImport = await importer.importDexaResults()
+        let secondImport = await importer.importDexaResults()
+
+        XCTAssertEqual(firstImport.importedCount, 1)
+        XCTAssertEqual(firstImport.skippedCount, 0)
+        XCTAssertEqual(secondImport.importedCount, 0)
+        XCTAssertEqual(secondImport.skippedCount, 1)
+        XCTAssertEqual(stubAPI.compositionRequests.filter { $0 == resultId }.count, 1)
+
+        let metrics = await coreData.fetchAllBodyMetrics(for: userId)
+        XCTAssertEqual(metrics.filter { $0.dataSource == BodyMetricSource.bodySpecDexa.rawValue }.count, 1)
     }
 
     func testUpdateOrCreateBodyMetric_MapsSupabasePayload() async throws {

--- a/docs/audits/jov-2869/bodyspec-dexa-import-contract.md
+++ b/docs/audits/jov-2869/bodyspec-dexa-import-contract.md
@@ -1,0 +1,33 @@
+# JOV-2869 BodySpec DEXA Import Contract
+
+## Scope
+
+BodySpec DEXA imports are additive body-composition events. They should enrich the timeline without replacing manual or HealthKit body metrics.
+
+## Source Contract
+
+Imported DEXA body metric rows must use:
+
+- `data_source`: `bodyspec_dexa`
+- `body_fat_method`: `DEXA (BodySpec)`
+- `source_metadata.vendor`: `bodyspec`
+- `source_metadata.source_name`: `BodySpec DEXA`
+- `source_metadata.external_result_id`: BodySpec result ID
+- `source_metadata.external_id`: BodySpec service ID when available
+- scanner, location, and imported-at metadata when available
+
+`dexa_results.external_source` remains `bodyspec` and links back to the imported body metric through `body_metrics_id`.
+
+## Reconciliation
+
+DEXA imports never overwrite manual or HealthKit body metrics. If a manual or HealthKit value exists on the same day, the DEXA importer creates a separate `bodyspec_dexa` row with its own timestamp and provenance.
+
+Duplicate handling is deterministic:
+
+- Skip an import when an existing body metric has the same `source_metadata.external_result_id`.
+- Also skip legacy BodySpec rows with no metadata only when they are within 60 seconds of the scan timestamp.
+- Do not skip unrelated same-day manual, HealthKit, or different BodySpec result rows.
+
+## Done When
+
+DEXA scans can enter the local timeline and Supabase sync as auditable, additive metric events with predictable duplicate handling.


### PR DESCRIPTION
## Summary
- make BodySpec DEXA imports additive `bodyspec_dexa` metric rows with explicit source metadata
- skip duplicates by `source_metadata.external_result_id` while preserving unrelated same-day manual/HealthKit metrics
- persist linked `dexa_results` through an async save path and document the import/reconciliation contract
- add focused importer tests for provenance, duplicate handling, and non-overwrite behavior

## Validation
- `swiftlint lint --strict`
- XcodeBuildMCP simulator tests on iPhone 17 Pro, iOS 26.5: 6 passed / 0 failed
  - `LogYourBodyTests/SyncIntegrationTests/testBodySpecDexaImporter_AddsProvenanceWithoutOverwritingManualOrHealthKit`
  - `LogYourBodyTests/SyncIntegrationTests/testBodySpecDexaImporter_SkipsExistingExternalResultId`
  - `LogYourBodyTests/SyncIntegrationTests/testSyncLocalChanges_UsesSupabaseAndMarksDexaResultsSynced`
  - `LogYourBodyTests/SyncIntegrationTests/testCachedDexaResult_toDexaResultMapsFieldsAndNormalizesVatValues`
  - `LogYourBodyTests/BodyMetricSourceContractTests`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (235 web tests passed)

## Notes
- Root pnpm commands continue to warn that local Node is v22.22.1 while the repo requests Node 20.x.
- The focused iOS test run still reports unrelated existing Swift 6 actor-isolation warnings in `LoadingManager`, `HealthSyncCoordinator`, and `DashboardViewModel`.

Fixes JOV-2869
