### PR TITLE
JOV-2870 Complete global timeline aggregation

### DIFF
--- a/apps/ios/LogYourBody/Models/GlobalTimelineModels.swift
+++ b/apps/ios/LogYourBody/Models/GlobalTimelineModels.swift
@@ -8,8 +8,36 @@ enum GlobalTimelineScale: String, Codable {
 
 enum MetricPresence: String, Codable {
     case present
-    case estimated
+    case interpolated
+    case lastKnown = "last_known"
     case missing
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+
+        switch rawValue {
+        case "present":
+            self = .present
+        case "interpolated", "estimated":
+            self = .interpolated
+        case "last_known":
+            self = .lastKnown
+        case "missing":
+            self = .missing
+        default:
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unknown metric presence: \(rawValue)"
+            )
+        }
+    }
+}
+
+enum GlobalTimelineMetricConfidence: String, Codable {
+    case high
+    case medium
+    case low
 }
 
 enum BodyScoreCompleteness: String, Codable {
@@ -21,6 +49,17 @@ enum BodyScoreCompleteness: String, Codable {
 struct GlobalTimelineMetricValue: Codable, Equatable {
     let value: Double?
     let presence: MetricPresence
+    let confidence: GlobalTimelineMetricConfidence?
+
+    init(
+        value: Double?,
+        presence: MetricPresence,
+        confidence: GlobalTimelineMetricConfidence? = nil
+    ) {
+        self.value = value
+        self.presence = presence
+        self.confidence = confidence
+    }
 }
 
 struct GlobalTimelineMetricsSnapshot: Codable, Equatable {
@@ -30,7 +69,9 @@ struct GlobalTimelineMetricsSnapshot: Codable, Equatable {
     let steps: GlobalTimelineMetricValue
 
     let canonicalPhotoId: String?
+    let canonicalPhotoDate: Date?
     let hasPhotosInRange: Bool
+    let photoCount: Int
 
     let bodyScore: Double?
     let bodyScoreCompleteness: BodyScoreCompleteness

--- a/apps/ios/LogYourBody/Services/GlobalTimelineService.swift
+++ b/apps/ios/LogYourBody/Services/GlobalTimelineService.swift
@@ -1,34 +1,91 @@
 import Foundation
 
-/// Service responsible for building weekly, monthly, and yearly buckets
-/// for the global timeline scrubber. Aggregation rules are defined in
-/// TIMELINE_SPEC.md and will be implemented incrementally.
+/// Service responsible for building week, month, and year buckets for the
+/// global timeline. The output is intentionally explicit about measured,
+/// interpolated, last-known, and missing values so UI layers do not infer
+/// provenance from a plain number.
 final class GlobalTimelineService {
     private let calendar: Calendar
+    private let interpolationService: MetricsInterpolationService
 
-    init(calendar: Calendar = .current) {
+    init(
+        calendar: Calendar = .current,
+        interpolationService: MetricsInterpolationService = .shared
+    ) {
         self.calendar = calendar
+        self.interpolationService = interpolationService
     }
 
     // MARK: - Public API
 
-    func makeBuckets(for scale: GlobalTimelineScale, metrics: [BodyMetrics]) -> [GlobalTimelineBucket] {
-        guard !metrics.isEmpty else { return [] }
+    func makeBuckets(
+        for scale: GlobalTimelineScale,
+        metrics: [BodyMetrics],
+        dailyMetrics: [DailyMetrics] = [],
+        heightInches: Double? = nil
+    ) -> [GlobalTimelineBucket] {
+        let sortedMetrics = metrics.sorted { $0.date < $1.date }
+        let sortedDailyMetrics = dailyMetrics.sorted { $0.date < $1.date }
 
-        switch scale {
-        case .week:
-            return makeWeeklyBuckets(from: metrics)
-        case .month:
-            return makeMonthlyBuckets(from: metrics)
-        case .year:
-            return makeYearlyBuckets(from: metrics)
+        guard let range = makeTimelineDateRange(metrics: sortedMetrics, dailyMetrics: sortedDailyMetrics),
+              var bucketStart = startOfBucket(containing: range.earliest, scale: scale),
+              let latestBucketStart = startOfBucket(containing: range.latest, scale: scale) else {
+            return []
         }
+
+        let contexts = InterpolationContexts(
+            weight: interpolationService.makeWeightInterpolationContext(for: sortedMetrics),
+            bodyFat: interpolationService.makeBodyFatInterpolationContext(for: sortedMetrics),
+            ffmi: heightInches.flatMap {
+                interpolationService.makeFFMIInterpolationContext(for: sortedMetrics, heightInches: $0)
+            }
+        )
+
+        var buckets: [GlobalTimelineBucket] = []
+
+        while bucketStart <= latestBucketStart {
+            guard let bucketEnd = endOfBucket(startingAt: bucketStart, scale: scale) else {
+                break
+            }
+
+            let bucketMetrics = sortedMetrics.filter { $0.date >= bucketStart && $0.date < bucketEnd }
+            let bucketDailyMetrics = sortedDailyMetrics.filter { $0.date >= bucketStart && $0.date < bucketEnd }
+            let midpoint = midpoint(start: bucketStart, end: bucketEnd)
+
+            let snapshot = makeMetricsSnapshot(
+                bucketMetrics: bucketMetrics,
+                bucketDailyMetrics: bucketDailyMetrics,
+                midpoint: midpoint,
+                contexts: contexts,
+                heightInches: heightInches
+            )
+
+            if snapshot.hasRenderableData {
+                buckets.append(
+                    GlobalTimelineBucket(
+                        id: makeIdentifier(scale: scale, startDate: bucketStart),
+                        scale: scale,
+                        startDate: bucketStart,
+                        endDate: bucketEnd,
+                        metrics: snapshot
+                    )
+                )
+            }
+
+            guard let nextBucketStart = startOfNextBucket(after: bucketStart, scale: scale) else {
+                break
+            }
+            bucketStart = nextBucketStart
+        }
+
+        return buckets
     }
 
-    func makeInitialCursor(for metrics: [BodyMetrics]) -> GlobalTimelineCursor? {
-        guard !metrics.isEmpty else { return nil }
-
-        let weeklyBuckets = makeWeeklyBuckets(from: metrics)
+    func makeInitialCursor(
+        for metrics: [BodyMetrics],
+        dailyMetrics: [DailyMetrics] = []
+    ) -> GlobalTimelineCursor? {
+        let weeklyBuckets = makeBuckets(for: .week, metrics: metrics, dailyMetrics: dailyMetrics)
         guard let mostRecentBucket = weeklyBuckets.last else {
             return nil
         }
@@ -40,170 +97,156 @@ final class GlobalTimelineService {
         )
     }
 
-    // MARK: - Bucket builders (stubs)
+    // MARK: - Snapshot builders
 
-    private func makeWeeklyBuckets(from metrics: [BodyMetrics]) -> [GlobalTimelineBucket] {
-        let sortedMetrics = metrics.sorted { $0.date < $1.date }
-        guard let mostRecentDate = sortedMetrics.last?.date else {
-            return []
-        }
-
-        guard let recentWeekInterval = calendar.dateInterval(of: .weekOfYear, for: mostRecentDate) else {
-            return []
-        }
-
-        let interpolationService = MetricsInterpolationService.shared
-        let maxWeeks = 4
-        var buckets: [GlobalTimelineBucket] = []
-
-        let earliestDate = sortedMetrics.first?.date ?? mostRecentDate
-        var weekStart = recentWeekInterval.start
-
-        while buckets.count < maxWeeks {
-            guard let weekEnd = calendar.date(byAdding: .day, value: 7, to: weekStart) else {
-                break
-            }
-
-            // Stop if this entire week is before the first metric
-            if weekEnd <= earliestDate {
-                break
-            }
-
-            let weekMetrics = sortedMetrics.filter { metric in
-                metric.date >= weekStart && metric.date < weekEnd
-            }
-
-            let hasAnyData = weekMetrics.contains { metric in
-                let hasWeight = metric.weight != nil
-                let hasBodyFat = metric.bodyFatPercentage != nil
-                let hasPhoto = metric.photoUrl != nil && !(metric.photoUrl?.isEmpty ?? true)
-                return hasWeight || hasBodyFat || hasPhoto
-            }
-
-            if hasAnyData {
-                let midpoint = calendar.date(byAdding: .day, value: 3, to: weekStart) ?? weekStart
-
-                let weight = makeWeeklyWeightValue(
-                    weekMetrics: weekMetrics,
-                    allMetrics: sortedMetrics,
-                    midpoint: midpoint,
-                    interpolationService: interpolationService
-                )
-
-                let bodyFat = makeWeeklyBodyFatValue(
-                    weekMetrics: weekMetrics,
-                    allMetrics: sortedMetrics,
-                    midpoint: midpoint,
-                    interpolationService: interpolationService
-                )
-
-                let ffmi = GlobalTimelineMetricValue(value: nil, presence: .missing)
-                let steps = GlobalTimelineMetricValue(value: nil, presence: .missing)
-
-                let photoSelection = makeWeeklyPhotoSelection(weekMetrics: weekMetrics, midpoint: midpoint)
-
-                let snapshot = GlobalTimelineMetricsSnapshot(
-                    weight: weight,
-                    bodyFat: bodyFat,
-                    ffmi: ffmi,
-                    steps: steps,
-                    canonicalPhotoId: photoSelection.canonicalPhotoId,
-                    hasPhotosInRange: photoSelection.hasPhotosInRange,
-                    bodyScore: nil,
-                    bodyScoreCompleteness: .none
-                )
-
-                let bucketId = makeWeekIdentifier(startDate: weekStart)
-                let bucket = GlobalTimelineBucket(
-                    id: bucketId,
-                    scale: .week,
-                    startDate: weekStart,
-                    endDate: weekEnd,
-                    metrics: snapshot
-                )
-
-                buckets.append(bucket)
-            }
-
-            guard let previousWeekStart = calendar.date(byAdding: .day, value: -7, to: weekStart) else {
-                break
-            }
-            weekStart = previousWeekStart
-        }
-
-        return buckets.sorted { $0.startDate < $1.startDate }
+    private struct TimelineDateRange {
+        let earliest: Date
+        let latest: Date
     }
 
-    private func makeMonthlyBuckets(from metrics: [BodyMetrics]) -> [GlobalTimelineBucket] {
-        // TODO: Implement monthly aggregation rules.
-        _ = metrics
-        return []
+    private struct InterpolationContexts {
+        let weight: MetricsInterpolationService.WeightInterpolationContext?
+        let bodyFat: MetricsInterpolationService.BodyFatInterpolationContext?
+        let ffmi: MetricsInterpolationService.FFMIInterpolationContext?
     }
 
-    private func makeYearlyBuckets(from metrics: [BodyMetrics]) -> [GlobalTimelineBucket] {
-        // TODO: Implement yearly aggregation rules.
-        _ = metrics
-        return []
-    }
-
-    // MARK: - Weekly helpers
-
-    private func makeWeeklyWeightValue(
-        weekMetrics: [BodyMetrics],
-        allMetrics: [BodyMetrics],
-        midpoint: Date,
-        interpolationService: MetricsInterpolationService
-    ) -> GlobalTimelineMetricValue {
-        let weekWeights = weekMetrics.compactMap { $0.weight }
-
-        if let directValue = median(weekWeights) {
-            return GlobalTimelineMetricValue(value: directValue, presence: .present)
-        }
-
-        if let interpolated = interpolationService.estimateWeight(for: midpoint, metrics: allMetrics) {
-            let presence: MetricPresence = interpolated.isInterpolated ? .estimated : .present
-            return GlobalTimelineMetricValue(value: interpolated.value, presence: presence)
-        }
-
-        return GlobalTimelineMetricValue(value: nil, presence: .missing)
-    }
-
-    private func makeWeeklyBodyFatValue(
-        weekMetrics: [BodyMetrics],
-        allMetrics: [BodyMetrics],
-        midpoint: Date,
-        interpolationService: MetricsInterpolationService
-    ) -> GlobalTimelineMetricValue {
-        let weekBodyFat = weekMetrics.compactMap { $0.bodyFatPercentage }
-
-        if let directValue = median(weekBodyFat) {
-            return GlobalTimelineMetricValue(value: directValue, presence: .present)
-        }
-
-        if let interpolated = interpolationService.estimateBodyFat(for: midpoint, metrics: allMetrics) {
-            let presence: MetricPresence = interpolated.isInterpolated ? .estimated : .present
-            return GlobalTimelineMetricValue(value: interpolated.value, presence: presence)
-        }
-
-        return GlobalTimelineMetricValue(value: nil, presence: .missing)
-    }
-
-    private struct WeeklyPhotoSelectionResult {
+    private struct PhotoSelectionResult {
         let canonicalPhotoId: String?
-        let hasPhotosInRange: Bool
+        let canonicalPhotoDate: Date?
+        let photoCount: Int
+
+        var hasPhotosInRange: Bool {
+            photoCount > 0
+        }
     }
 
-    private func makeWeeklyPhotoSelection(
-        weekMetrics: [BodyMetrics],
-        midpoint: Date
-    ) -> WeeklyPhotoSelectionResult {
-        let photoCandidates = weekMetrics.filter { metric in
+    private func makeMetricsSnapshot(
+        bucketMetrics: [BodyMetrics],
+        bucketDailyMetrics: [DailyMetrics],
+        midpoint: Date,
+        contexts: InterpolationContexts,
+        heightInches: Double?
+    ) -> GlobalTimelineMetricsSnapshot {
+        let weight = makeBodyMetricValue(
+            directValues: bucketMetrics.compactMap { $0.weight },
+            interpolated: contexts.weight?.estimate(for: midpoint)
+        )
+        let bodyFat = makeBodyMetricValue(
+            directValues: bucketMetrics.compactMap { $0.bodyFatPercentage },
+            interpolated: contexts.bodyFat?.estimate(for: midpoint)
+        )
+        let ffmi = makeFFMIValue(
+            weight: weight,
+            bodyFat: bodyFat,
+            interpolated: contexts.ffmi?.estimate(for: midpoint),
+            heightInches: heightInches
+        )
+        let steps = makeStepsValue(bucketDailyMetrics: bucketDailyMetrics)
+        let photoSelection = makePhotoSelection(metrics: bucketMetrics, midpoint: midpoint)
+
+        return GlobalTimelineMetricsSnapshot(
+            weight: weight,
+            bodyFat: bodyFat,
+            ffmi: ffmi,
+            steps: steps,
+            canonicalPhotoId: photoSelection.canonicalPhotoId,
+            canonicalPhotoDate: photoSelection.canonicalPhotoDate,
+            hasPhotosInRange: photoSelection.hasPhotosInRange,
+            photoCount: photoSelection.photoCount,
+            bodyScore: nil,
+            bodyScoreCompleteness: .none
+        )
+    }
+
+    private func makeBodyMetricValue(
+        directValues: [Double],
+        interpolated: InterpolatedMetric?
+    ) -> GlobalTimelineMetricValue {
+        if let directValue = median(directValues) {
+            return GlobalTimelineMetricValue(value: directValue, presence: .present)
+        }
+
+        return makeInterpolatedValue(interpolated)
+    }
+
+    private func makeFFMIValue(
+        weight: GlobalTimelineMetricValue,
+        bodyFat: GlobalTimelineMetricValue,
+        interpolated: InterpolatedMetric?,
+        heightInches: Double?
+    ) -> GlobalTimelineMetricValue {
+        guard let heightInches, heightInches > 0 else {
+            return missingValue()
+        }
+
+        if weight.presence == .present,
+           bodyFat.presence == .present,
+           let weightKg = weight.value,
+           let bodyFatPercentage = bodyFat.value {
+            let heightMeters = heightInches * 0.0254
+            let leanMassKg = weightKg * (1 - bodyFatPercentage / 100)
+            let ffmi = leanMassKg / (heightMeters * heightMeters)
+
+            return GlobalTimelineMetricValue(
+                value: roundedOneDecimal(ffmi),
+                presence: .present
+            )
+        }
+
+        return makeInterpolatedValue(interpolated)
+    }
+
+    private func makeStepsValue(bucketDailyMetrics: [DailyMetrics]) -> GlobalTimelineMetricValue {
+        let stepValues = bucketDailyMetrics.compactMap { metric -> Int? in
+            guard let steps = metric.steps, steps > 0 else { return nil }
+            return steps
+        }
+
+        guard !stepValues.isEmpty else {
+            return missingValue()
+        }
+
+        return GlobalTimelineMetricValue(
+            value: Double(stepValues.reduce(0, +)),
+            presence: .present
+        )
+    }
+
+    private func makeInterpolatedValue(_ metric: InterpolatedMetric?) -> GlobalTimelineMetricValue {
+        guard let metric else {
+            return missingValue()
+        }
+
+        if metric.isInterpolated {
+            return GlobalTimelineMetricValue(
+                value: metric.value,
+                presence: .interpolated,
+                confidence: makeConfidence(metric.confidenceLevel)
+            )
+        }
+
+        if metric.isLastKnown {
+            return GlobalTimelineMetricValue(
+                value: metric.value,
+                presence: .lastKnown
+            )
+        }
+
+        return GlobalTimelineMetricValue(value: metric.value, presence: .present)
+    }
+
+    private func missingValue() -> GlobalTimelineMetricValue {
+        GlobalTimelineMetricValue(value: nil, presence: .missing)
+    }
+
+    private func makePhotoSelection(metrics: [BodyMetrics], midpoint: Date) -> PhotoSelectionResult {
+        let photoCandidates = metrics.filter { metric in
             guard let url = metric.photoUrl else { return false }
             return !url.isEmpty
         }
 
         guard !photoCandidates.isEmpty else {
-            return WeeklyPhotoSelectionResult(canonicalPhotoId: nil, hasPhotosInRange: false)
+            return PhotoSelectionResult(canonicalPhotoId: nil, canonicalPhotoDate: nil, photoCount: 0)
         }
 
         let selected = photoCandidates.min { lhs, rhs in
@@ -212,19 +255,98 @@ final class GlobalTimelineService {
             return lhsDiff < rhsDiff
         }
 
-        return WeeklyPhotoSelectionResult(canonicalPhotoId: selected?.photoUrl, hasPhotosInRange: true)
+        return PhotoSelectionResult(
+            canonicalPhotoId: selected?.photoUrl,
+            canonicalPhotoDate: selected?.date,
+            photoCount: photoCandidates.count
+        )
     }
 
-    private func makeWeekIdentifier(startDate: Date) -> String {
-        let components = calendar.dateComponents([
-            .yearForWeekOfYear,
-            .weekOfYear
-        ], from: startDate)
+    // MARK: - Date helpers
 
-        let year = components.yearForWeekOfYear ?? calendar.component(.year, from: startDate)
-        let week = components.weekOfYear ?? calendar.component(.weekOfYear, from: startDate)
+    private func makeTimelineDateRange(metrics: [BodyMetrics], dailyMetrics: [DailyMetrics]) -> TimelineDateRange? {
+        let bodyDates = metrics.compactMap { metric -> Date? in
+            let hasWeight = metric.weight != nil
+            let hasBodyFat = metric.bodyFatPercentage != nil
+            let hasPhoto = metric.photoUrl?.isEmpty == false
+            return hasWeight || hasBodyFat || hasPhoto ? metric.date : nil
+        }
+        let dailyDates = dailyMetrics.compactMap { metric -> Date? in
+            guard let steps = metric.steps, steps > 0 else { return nil }
+            return metric.date
+        }
+        let dates = bodyDates + dailyDates
 
-        return String(format: "%04d-W%02d", year, week)
+        guard let earliest = dates.min(), let latest = dates.max() else {
+            return nil
+        }
+
+        return TimelineDateRange(earliest: earliest, latest: latest)
+    }
+
+    private func startOfBucket(containing date: Date, scale: GlobalTimelineScale) -> Date? {
+        switch scale {
+        case .week:
+            return calendar.dateInterval(of: .weekOfYear, for: date)?.start
+        case .month:
+            return calendar.dateInterval(of: .month, for: date)?.start
+        case .year:
+            return calendar.dateInterval(of: .year, for: date)?.start
+        }
+    }
+
+    private func endOfBucket(startingAt startDate: Date, scale: GlobalTimelineScale) -> Date? {
+        startOfNextBucket(after: startDate, scale: scale)
+    }
+
+    private func startOfNextBucket(after startDate: Date, scale: GlobalTimelineScale) -> Date? {
+        switch scale {
+        case .week:
+            return calendar.date(byAdding: .day, value: 7, to: startDate)
+        case .month:
+            return calendar.date(byAdding: .month, value: 1, to: startDate)
+        case .year:
+            return calendar.date(byAdding: .year, value: 1, to: startDate)
+        }
+    }
+
+    private func midpoint(start: Date, end: Date) -> Date {
+        start.addingTimeInterval(end.timeIntervalSince(start) / 2)
+    }
+
+    private func makeIdentifier(scale: GlobalTimelineScale, startDate: Date) -> String {
+        switch scale {
+        case .week:
+            let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: startDate)
+            let year = components.yearForWeekOfYear ?? calendar.component(.year, from: startDate)
+            let week = components.weekOfYear ?? calendar.component(.weekOfYear, from: startDate)
+            return String(format: "%04d-W%02d", year, week)
+        case .month:
+            let components = calendar.dateComponents([.year, .month], from: startDate)
+            let year = components.year ?? calendar.component(.year, from: startDate)
+            let month = components.month ?? calendar.component(.month, from: startDate)
+            return String(format: "%04d-M%02d", year, month)
+        case .year:
+            let year = calendar.component(.year, from: startDate)
+            return String(format: "%04d", year)
+        }
+    }
+
+    // MARK: - Value helpers
+
+    private func makeConfidence(
+        _ confidence: InterpolatedMetric.ConfidenceLevel?
+    ) -> GlobalTimelineMetricConfidence? {
+        switch confidence {
+        case .high:
+            return .high
+        case .medium:
+            return .medium
+        case .low:
+            return .low
+        case nil:
+            return nil
+        }
     }
 
     private func median(_ values: [Double]) -> Double? {
@@ -234,12 +356,29 @@ final class GlobalTimelineService {
         let count = sortedValues.count
         let middleIndex = count / 2
 
+        let value: Double
         if count.isMultiple(of: 2) {
             let lower = sortedValues[middleIndex - 1]
             let upper = sortedValues[middleIndex]
-            return (lower + upper) / 2.0
+            value = (lower + upper) / 2.0
         } else {
-            return sortedValues[middleIndex]
+            value = sortedValues[middleIndex]
         }
+
+        return roundedOneDecimal(value)
+    }
+
+    private func roundedOneDecimal(_ value: Double) -> Double {
+        (value * 10).rounded() / 10
+    }
+}
+
+private extension GlobalTimelineMetricsSnapshot {
+    var hasRenderableData: Bool {
+        weight.presence != .missing ||
+            bodyFat.presence != .missing ||
+            ffmi.presence != .missing ||
+            steps.presence != .missing ||
+            hasPhotosInRange
     }
 }

--- a/apps/ios/LogYourBody/ViewModels/GlobalTimelineStore.swift
+++ b/apps/ios/LogYourBody/ViewModels/GlobalTimelineStore.swift
@@ -16,15 +16,34 @@ final class GlobalTimelineStore: ObservableObject {
 
     // MARK: - Public API
 
-    func updateMetrics(_ metrics: [BodyMetrics]) {
-        weeklyBuckets = service.makeBuckets(for: .week, metrics: metrics)
-        monthlyBuckets = service.makeBuckets(for: .month, metrics: metrics)
-        yearlyBuckets = service.makeBuckets(for: .year, metrics: metrics)
+    func updateMetrics(
+        _ metrics: [BodyMetrics],
+        dailyMetrics: [DailyMetrics] = [],
+        heightInches: Double? = nil
+    ) {
+        weeklyBuckets = service.makeBuckets(
+            for: .week,
+            metrics: metrics,
+            dailyMetrics: dailyMetrics,
+            heightInches: heightInches
+        )
+        monthlyBuckets = service.makeBuckets(
+            for: .month,
+            metrics: metrics,
+            dailyMetrics: dailyMetrics,
+            heightInches: heightInches
+        )
+        yearlyBuckets = service.makeBuckets(
+            for: .year,
+            metrics: metrics,
+            dailyMetrics: dailyMetrics,
+            heightInches: heightInches
+        )
 
         if cursor == nil {
-            cursor = service.makeInitialCursor(for: metrics)
+            cursor = service.makeInitialCursor(for: metrics, dailyMetrics: dailyMetrics)
         } else if let currentCursor = cursor, bucket(for: currentCursor) == nil {
-            cursor = service.makeInitialCursor(for: metrics)
+            cursor = service.makeInitialCursor(for: metrics, dailyMetrics: dailyMetrics)
         }
     }
 

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -1521,6 +1521,209 @@ final class SyncIntegrationTests: XCTestCase {
     }
 }
 
+final class GlobalTimelineServiceTests: XCTestCase {
+    private var calendar: Calendar!
+    private var service: GlobalTimelineService!
+
+    override func setUp() {
+        super.setUp()
+
+        calendar = Calendar(identifier: .iso8601)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        service = GlobalTimelineService(calendar: calendar)
+    }
+
+    func testBuildsWeekMonthYearBucketsWithDirectMetricsPhotosStepsAndFFMI() throws {
+        let januaryPhoto = "https://example.com/january.jpg"
+        let februaryPhoto = "https://example.com/february.jpg"
+        let metrics = [
+            makeTimelineMetric(
+                date: makeDate(year: 2_026, month: 1, day: 2),
+                weight: 80,
+                bodyFatPercentage: 20,
+                photoUrl: januaryPhoto
+            ),
+            makeTimelineMetric(
+                date: makeDate(year: 2_026, month: 1, day: 7),
+                weight: 82,
+                bodyFatPercentage: 18
+            ),
+            makeTimelineMetric(
+                date: makeDate(year: 2_026, month: 2, day: 5),
+                weight: 78,
+                bodyFatPercentage: 17,
+                photoUrl: februaryPhoto
+            )
+        ]
+        let dailyMetrics = [
+            makeTimelineDailyMetric(date: makeDate(year: 2_026, month: 1, day: 3), steps: 5_000),
+            makeTimelineDailyMetric(date: makeDate(year: 2_026, month: 1, day: 4), steps: 7_000),
+            makeTimelineDailyMetric(date: makeDate(year: 2_026, month: 2, day: 6), steps: 10_000)
+        ]
+
+        let monthlyBuckets = service.makeBuckets(
+            for: .month,
+            metrics: metrics,
+            dailyMetrics: dailyMetrics,
+            heightInches: 70
+        )
+        let yearlyBuckets = service.makeBuckets(
+            for: .year,
+            metrics: metrics,
+            dailyMetrics: dailyMetrics,
+            heightInches: 70
+        )
+
+        let january = try XCTUnwrap(monthlyBuckets.first { $0.id == "2026-M01" })
+        XCTAssertEqual(january.metrics.weight.presence, .present)
+        XCTAssertEqual(try XCTUnwrap(january.metrics.weight.value), 81, accuracy: 0.001)
+        XCTAssertEqual(january.metrics.bodyFat.presence, .present)
+        XCTAssertEqual(try XCTUnwrap(january.metrics.bodyFat.value), 19, accuracy: 0.001)
+        XCTAssertEqual(january.metrics.ffmi.presence, .present)
+        XCTAssertNotNil(january.metrics.ffmi.value)
+        XCTAssertEqual(january.metrics.steps.presence, .present)
+        XCTAssertEqual(try XCTUnwrap(january.metrics.steps.value), 12_000, accuracy: 0.001)
+        XCTAssertEqual(january.metrics.canonicalPhotoId, januaryPhoto)
+        XCTAssertEqual(january.metrics.photoCount, 1)
+
+        let february = try XCTUnwrap(monthlyBuckets.first { $0.id == "2026-M02" })
+        XCTAssertEqual(february.metrics.weight.presence, .present)
+        XCTAssertEqual(february.metrics.canonicalPhotoId, februaryPhoto)
+        XCTAssertEqual(try XCTUnwrap(february.metrics.steps.value), 10_000, accuracy: 0.001)
+
+        let year = try XCTUnwrap(yearlyBuckets.first { $0.id == "2026" })
+        XCTAssertEqual(year.metrics.weight.presence, .present)
+        XCTAssertEqual(try XCTUnwrap(year.metrics.weight.value), 80, accuracy: 0.001)
+        XCTAssertEqual(year.metrics.bodyFat.presence, .present)
+        XCTAssertEqual(try XCTUnwrap(year.metrics.bodyFat.value), 18, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(year.metrics.steps.value), 22_000, accuracy: 0.001)
+        XCTAssertEqual(year.metrics.photoCount, 2)
+    }
+
+    func testSparseBucketsSurfaceInterpolatedAndLastKnownWithoutMeasuredPresence() throws {
+        let metrics = [
+            makeTimelineMetric(
+                date: makeDate(year: 2_026, month: 1, day: 1),
+                weight: 80,
+                bodyFatPercentage: 20
+            ),
+            makeTimelineMetric(
+                date: makeDate(year: 2_026, month: 1, day: 15),
+                weight: 82,
+                bodyFatPercentage: 18
+            )
+        ]
+        let dailyMetrics = [
+            makeTimelineDailyMetric(date: makeDate(year: 2_026, month: 2, day: 10), steps: 3_000)
+        ]
+
+        let weeklyBuckets = service.makeBuckets(
+            for: .week,
+            metrics: metrics,
+            dailyMetrics: dailyMetrics,
+            heightInches: 70
+        )
+
+        let interpolatedWeek = try XCTUnwrap(weeklyBuckets.first { $0.id == "2026-W02" })
+        XCTAssertEqual(interpolatedWeek.metrics.weight.presence, .interpolated)
+        XCTAssertEqual(interpolatedWeek.metrics.weight.confidence, .medium)
+        XCTAssertEqual(try XCTUnwrap(interpolatedWeek.metrics.weight.value), 81, accuracy: 0.2)
+        XCTAssertEqual(interpolatedWeek.metrics.bodyFat.presence, .interpolated)
+        XCTAssertEqual(interpolatedWeek.metrics.bodyFat.confidence, .medium)
+        XCTAssertEqual(interpolatedWeek.metrics.ffmi.presence, .interpolated)
+
+        let lastKnownWeek = try XCTUnwrap(weeklyBuckets.first { $0.id == "2026-W07" })
+        XCTAssertEqual(lastKnownWeek.metrics.weight.presence, .lastKnown)
+        XCTAssertEqual(try XCTUnwrap(lastKnownWeek.metrics.weight.value), 82, accuracy: 0.001)
+        XCTAssertEqual(lastKnownWeek.metrics.bodyFat.presence, .lastKnown)
+        XCTAssertEqual(try XCTUnwrap(lastKnownWeek.metrics.bodyFat.value), 18, accuracy: 0.001)
+        XCTAssertEqual(lastKnownWeek.metrics.ffmi.presence, .lastKnown)
+        XCTAssertEqual(lastKnownWeek.metrics.steps.presence, .present)
+        XCTAssertEqual(try XCTUnwrap(lastKnownWeek.metrics.steps.value), 3_000, accuracy: 0.001)
+    }
+
+    func testMissingValuesStayMissingWhenInterpolationGapIsTooWide() throws {
+        let metrics = [
+            makeTimelineMetric(
+                date: makeDate(year: 2_026, month: 1, day: 1),
+                weight: 80,
+                bodyFatPercentage: 20
+            ),
+            makeTimelineMetric(
+                date: makeDate(year: 2_026, month: 3, day: 15),
+                weight: 85,
+                bodyFatPercentage: 18
+            )
+        ]
+        let dailyMetrics = [
+            makeTimelineDailyMetric(date: makeDate(year: 2_026, month: 2, day: 15), steps: 9_000)
+        ]
+
+        let monthlyBuckets = service.makeBuckets(
+            for: .month,
+            metrics: metrics,
+            dailyMetrics: dailyMetrics,
+            heightInches: 70
+        )
+
+        let february = try XCTUnwrap(monthlyBuckets.first { $0.id == "2026-M02" })
+        XCTAssertEqual(february.metrics.weight.presence, .missing)
+        XCTAssertNil(february.metrics.weight.value)
+        XCTAssertEqual(february.metrics.bodyFat.presence, .missing)
+        XCTAssertNil(february.metrics.bodyFat.value)
+        XCTAssertEqual(february.metrics.ffmi.presence, .missing)
+        XCTAssertEqual(february.metrics.steps.presence, .present)
+        XCTAssertEqual(try XCTUnwrap(february.metrics.steps.value), 9_000, accuracy: 0.001)
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int) -> Date {
+        calendar.date(from: DateComponents(
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: 12
+        ))!
+    }
+
+    private func makeTimelineMetric(
+        date: Date,
+        weight: Double? = nil,
+        bodyFatPercentage: Double? = nil,
+        photoUrl: String? = nil
+    ) -> BodyMetrics {
+        BodyMetrics(
+            id: UUID().uuidString,
+            userId: "timeline-user",
+            date: date,
+            weight: weight,
+            weightUnit: weight == nil ? nil : "kg",
+            bodyFatPercentage: bodyFatPercentage,
+            bodyFatMethod: bodyFatPercentage == nil ? nil : "manual",
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: photoUrl,
+            dataSource: BodyMetricSource.manual.rawValue,
+            sourceMetadata: nil,
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+
+    private func makeTimelineDailyMetric(date: Date, steps: Int) -> DailyMetrics {
+        DailyMetrics(
+            id: UUID().uuidString,
+            userId: "timeline-user",
+            date: date,
+            steps: steps,
+            notes: nil,
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+}
+
 final class MockHealthSyncCoordinator: HealthSyncCoordinating {
     private(set) var didCallBootstrapIfNeeded = false
     private(set) var lastBootstrapSyncEnabled: Bool?

--- a/apps/ios/docs/architecture/TIMELINE_SPEC.md
+++ b/apps/ios/docs/architecture/TIMELINE_SPEC.md
@@ -43,17 +43,19 @@ All types below are **conceptual contracts**, not final Swift APIs.
 
 - **MetricPresence**
   - `.present` – metric has direct observations in the bucket window
-  - `.estimated` – metric is derived from interpolation / carry-forward
+  - `.interpolated` – metric is derived between nearby observations
+  - `.lastKnown` – metric is carried forward from the latest usable observation
   - `.missing` – no reasonable value can be produced
 
 - **BodyScoreCompleteness**
-  - `.full` – all core metrics are present (or high-confidence estimates)
+  - `.full` – all core metrics are present (or high-confidence interpolations)
   - `.partial` – body score computed from a subset of core metrics
   - `.none` – not enough data to compute a reasonable score
 
 - **MetricValue** (per metric, per bucket)
   - `value: Double?`
   - `presence: MetricPresence`
+  - `confidence: GlobalTimelineMetricConfidence?` – optional confidence for interpolated values
 
 - **MetricsSnapshot** (per bucket)
   - Scalar metrics (examples – not exhaustive):
@@ -63,7 +65,9 @@ All types below are **conceptual contracts**, not final Swift APIs.
     - `steps: MetricValue` (or activity)
   - Visual / media:
     - `canonicalPhotoId: String?` – representative photo for bucket, if any
+    - `canonicalPhotoDate: Date?`
     - `hasPhotosInRange: Bool`
+    - `photoCount: Int`
   - Body score:
     - `bodyScore: Double?` – output of the current body score algorithm
     - `bodyScoreCompleteness: BodyScoreCompleteness`
@@ -115,7 +119,8 @@ The header timeline is divided into three logical zones, arranged from right (mo
   - No interpolation between weekly buckets in Zone A.
   - All `MetricValue` instances in Zone A are either:
     - `.present` – directly derived from events in that week
-    - `.estimated` – via short-range carry-forward within a bounded window (per-metric)
+    - `.interpolated` – between nearby observations inside a bounded window
+    - `.lastKnown` – via carry-forward from the latest usable observation
     - `.missing` – if nothing usable is available
 
 ### 3.2 Zone B – Recent months (medium)
@@ -155,7 +160,8 @@ Each weekly bucket is built from events in its `DateInterval`.
   - `weight.value` = median of all weight events in the week (or the last event if only one).
   - `weight.presence`:
     - `.present` if ≥1 weight event in week.
-    - `.estimated` if no weight events this week but a recent week (within N weeks) has weight (carry-forward with decay).
+    - `.interpolated` if no weight events this week but nearby observations support interpolation.
+    - `.lastKnown` if the latest usable observation is carried forward.
     - `.missing` if the last weight measurement is older than the acceptable freshness window.
 
 - **Body fat**
@@ -164,7 +170,7 @@ Each weekly bucket is built from events in its `DateInterval`.
 
 - **FFMI / composition metrics**
   - Derived from DEXA or other composition events.
-  - If composition last measured within a longer freshness window (e.g. several months), can be treated as `.estimated` in more recent weeks.
+  - If composition last measured within a longer freshness window (e.g. several months), can be treated as `.lastKnown` in more recent weeks.
 
 - **Steps / activity**
   - `steps.value` = mean daily steps across the week (from daily step events).
@@ -181,8 +187,8 @@ Each weekly bucket is built from events in its `DateInterval`.
 - We treat the body score function as `f(metrics, version)`.
 - Inputs come from the weekly `MetricsSnapshot`.
 - Completeness rules:
-  - `.full` – all core metrics for `f` are `.present` (or high-confidence `.estimated`).
-  - `.partial` – at least one core metric is `.present` but others are `.estimated` or `.missing`.
+  - `.full` – all core metrics for `f` are `.present` (or high-confidence `.interpolated`).
+  - `.partial` – at least one core metric is `.present` but others are `.interpolated`, `.lastKnown`, or `.missing`.
   - `.none` – not enough core metrics to compute a meaningful score.
 
 ### 4.2 Monthly buckets (Zone B)
@@ -193,14 +199,15 @@ Monthly buckets aggregate across weekly buckets that fall in the given calendar 
 
 - Use precomputed weekly `MetricValue`s as inputs.
 - For each metric:
-  - Consider only weeks where `presence` is `.present` or high-confidence `.estimated`.
+  - Consider only weeks where `presence` is `.present` or high-confidence `.interpolated`.
   - Compute a representative monthly value, e.g.:
     - `weightMonth.value` = median of `weightWeekly.value` for eligible weeks in the month.
     - `bodyFatMonth.value` = median of body fat weekly values.
     - `stepsMonth.value` = mean of weekly steps.
   - `presence` rules:
     - `.present` if ≥1 eligible weekly value in the month.
-    - `.estimated` if derived mainly from estimated weekly inputs but still reasonably grounded.
+    - `.interpolated` if derived mainly from interpolated weekly inputs but still reasonably grounded.
+    - `.lastKnown` if derived mainly from carried-forward weekly inputs.
     - `.missing` if no eligible weekly values exist.
 
 **Monthly interpolation:**
@@ -208,7 +215,7 @@ Monthly buckets aggregate across weekly buckets that fall in the given calendar 
 - Only interpolate **between months that have data**.
 - For a month with no data but neighbors with present values:
   - Interpolate each metric separately (e.g. linear interpolation on the aggregated values).
-  - Mark `presence = .estimated` for that metric.
+  - Mark `presence = .interpolated` for that metric.
   - Cap the interpolation window (e.g. do not interpolate across gaps of >2 consecutive missing months).
 
 **Monthly body score:**
@@ -229,7 +236,8 @@ Yearly buckets aggregate across monthly buckets in the given calendar year.
   - Similar logic for body fat, FFMI, steps, etc.
   - `presence` rules:
     - `.present` if enough months have present values.
-    - `.estimated` if primarily derived from estimated months.
+    - `.interpolated` if primarily derived from interpolated months.
+    - `.lastKnown` if primarily derived from carried-forward months.
     - `.missing` if the year has almost no usable data.
 
 **Yearly interpolation:**
@@ -238,7 +246,7 @@ Yearly buckets aggregate across monthly buckets in the given calendar year.
 - Optionally interpolate **one or two bridge years** only when:
   - The year has no data.
   - Surrounding years both have strong data.
-- Bridge years are always `presence = .estimated` for all metrics and visually de-emphasized.
+- Bridge years are always `presence = .interpolated` for all metrics and visually de-emphasized.
 
 **Yearly body score:**
 
@@ -301,7 +309,7 @@ All three main surfaces subscribe to the same `TimelineCursor` and `TimelineBuck
 - **Secondary metric tiles**
   - Each tile reads its `MetricValue` from the bucket snapshot.
   - Deltas are always computed **relative to the previous bucket at the same scale**.
-  - Tiles must handle `present`, `estimated`, and `missing` states explicitly.
+  - Tiles must handle `present`, `interpolated`, `lastKnown`, and `missing` states explicitly.
 
 ### 6.2 Photos Tab
 
@@ -388,14 +396,15 @@ Rules:
 - Body score uses whatever subset of metrics is available and reports `BodyScoreCompleteness`.
 - Screens must visually distinguish:
   - Real values.
-  - Estimated values.
+  - Interpolated values.
+  - Last-known values.
   - Missing values.
 
 Examples:
 
 - **Weight only** week:
   - Weight: `.present`.
-  - Body fat: `.missing` or `.estimated` (if recently measured elsewhere).
+  - Body fat: `.missing`, `.interpolated`, or `.lastKnown` (if recently measured elsewhere).
   - Body score: `.partial` (weight-driven).
 
 - **Photo only** week:

--- a/docs/audits/jov-2870/timeline-aggregation-evidence.md
+++ b/docs/audits/jov-2870/timeline-aggregation-evidence.md
@@ -1,0 +1,45 @@
+# JOV-2870 Timeline Aggregation Evidence
+
+## Populated History Sample
+
+Fixture:
+
+- January 2, 2026: weight 80 kg, body fat 20%, progress photo
+- January 7, 2026: weight 82 kg, body fat 18%
+- February 5, 2026: weight 78 kg, body fat 17%, progress photo
+- January step days: 5,000 + 7,000
+- February step day: 10,000
+
+Expected monthly output:
+
+- `2026-M01`: weight `81.0` present, body fat `19.0` present, FFMI present, steps `12000`, photo count `1`
+- `2026-M02`: weight `78.0` present, body fat `17.0` present, FFMI present, steps `10000`, photo count `1`
+
+Expected yearly output:
+
+- `2026`: weight `80.0` present, body fat `18.0` present, steps `22000`, photo count `2`
+
+## Sparse History Sample
+
+Fixture:
+
+- January 1, 2026: weight 80 kg, body fat 20%
+- January 15, 2026: weight 82 kg, body fat 18%
+- February 10, 2026: 3,000 steps
+
+Expected weekly output:
+
+- `2026-W02`: weight/body-fat/FFMI are `interpolated` with `medium` confidence.
+- `2026-W07`: weight/body-fat/FFMI are `last_known`; steps are present.
+
+## Wide Gap Sample
+
+Fixture:
+
+- January 1, 2026: weight 80 kg, body fat 20%
+- February 15, 2026: 9,000 steps
+- March 15, 2026: weight 85 kg, body fat 18%
+
+Expected monthly output:
+
+- `2026-M02`: weight/body-fat/FFMI remain `missing` because the interpolation gap is wider than 30 days; steps are present.


### PR DESCRIPTION
## Summary
- builds week/month/year timeline buckets from body metrics, daily steps, and progress photos through one `GlobalTimelineService` path
- surfaces measured, interpolated, last-known, and missing metric states with interpolation confidence
- adds FFMI, step totals, canonical photo date/count, sparse-history tests, and timeline contract evidence
- updates the timeline architecture spec to match the new state contract

## Validation
- `swiftlint lint --strict`
- `xcodebuild` focused simulator result: `LogYourBodyTests/GlobalTimelineServiceTests`, 3 passed / 0 failed, result bundle `/Users/timwhite/Library/Developer/XcodeBuildMCP/workspaces/LogYourBody-03988719e21b/result-bundles/test_sim_2026-06-07T07-12-18-072Z_pid45897_41e200f2.xcresult`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `git diff --check`

## Evidence
- Sparse/populated sample output documented in `docs/audits/jov-2870/timeline-aggregation-evidence.md`

## Notes
- The XcodeBuildMCP command timed out in the tool wrapper after 120s, but the underlying `.xcresult` completed and reports all 3 focused tests passed.
- Existing Swift 6 concurrency warnings remain in unrelated files.
- Local Node is v22.22.1 while the repo requests Node 20.x; root pnpm commands still completed.

Linear: JOV-2870