### PR TITLE
fix: use old altool for TestFlight uploads

### DIFF
--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -64,6 +64,10 @@ platform :ios do
     # Set up environment
     ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "180"
     ENV["FASTLANE_XCODEBUILD_SETTINGS_RETRIES"] = "10"
+    # Xcode 26 altool can fail resolving the Apple ID even when pilot has one.
+    if ENV["CI"] && ENV["DELIVER_ALTOOL_ADDITIONAL_UPLOAD_PARAMETERS"].to_s.strip.empty?
+      ENV["DELIVER_ALTOOL_ADDITIONAL_UPLOAD_PARAMETERS"] = "--use-old-altool"
+    end
     
     # Ensure project path is correct
     ios_dir = File.expand_path("..", Dir.pwd.end_with?("/fastlane") ? Dir.pwd : "#{Dir.pwd}/fastlane")
@@ -701,7 +705,7 @@ platform :ios do
     test_groups = options[:groups] ? options[:groups].split(",") : ["Internal Testers"]
     
     upload_to_testflight(
-      testflight_upload_options.call(
+      **testflight_upload_options.call(
         ipa: build_result[:output_path],
         groups: test_groups,
         changelog: release_notes,
@@ -744,7 +748,7 @@ platform :ios do
     
     # Upload to TestFlight
     upload_to_testflight(
-      testflight_upload_options.call(
+      **testflight_upload_options.call(
         ipa: build_result[:output_path],
         groups: ["Beta Testers"],
         distribute_external: true # Beta includes external testers
@@ -822,7 +826,7 @@ platform :ios do
     
     # Upload IPA
     upload_to_testflight(
-      testflight_upload_options.call(
+      **testflight_upload_options.call(
         ipa: options[:ipa_path],
         groups: options[:groups] ? options[:groups].split(",") : ["Beta Testers"],
         changelog: options[:changelog_file] ? File.read(options[:changelog_file]) : "New build",


### PR DESCRIPTION
## Summary

- set `DELIVER_ALTOOL_ADDITIONAL_UPLOAD_PARAMETERS=--use-old-altool` for CI uploads unless explicitly overridden
- keyword-splat the shared TestFlight upload options so Fastlane receives `ipa`, `app_identifier`, `apple_id`, and related options as action keywords

## Context

PR #299 made the LogYourBody bundle id and App Store app id explicit, then merged and reran the release loop. The replacement main release loop still failed in the TestFlight upload step with the same Xcode 26 altool error:

- run: https://github.com/JovieInc/LogYourBody/actions/runs/27320895786
- merge commit: `ed58a733c46bd31f54d56d213aa17b7147c2a795`
- build/export: passed
- RevenueCat offering preflight: passed
- production app-id drift checks: passed
- upload error: altool cannot determine the Apple ID from bundle id `com.logyourbody.app`

Fastlane’s current `upload_to_testflight` docs list `provider_public_id` for Xcode 26 multi-provider cases, and the upstream Fastlane Xcode 26 issue documents `--use-old-altool` as the working workaround when passing `apple_id` still fails.

Linear: JOV-3032.

## Validation

- `ruby -c apps/ios/fastlane/Fastfile`
- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`

Notes: local Node is v22.22.1 while the repo wants 20.x, matching the existing warning pattern.

## Out of scope

- no RevenueCat product changes
- no billing product changes
- no signing/provisioning regeneration
