### PR TITLE
fix: preserve main release workflow runs

### DIFF
--- a/.github/scripts/verify-workflow-concurrency.mjs
+++ b/.github/scripts/verify-workflow-concurrency.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const workflowFiles = [
+  '.github/workflows/ci.yml',
+  '.github/workflows/deploy.yml',
+  '.github/workflows/ios-release-loop.yml',
+];
+
+const readWorkflow = file => readFileSync(file, 'utf8');
+const failures = [];
+
+const ci = readWorkflow('.github/workflows/ci.yml');
+if (!ci.includes("github.ref == 'refs/heads/main'")) {
+  failures.push('ci.yml must special-case refs/heads/main in its concurrency policy.');
+}
+if (!ci.includes('github.sha')) {
+  failures.push('ci.yml must key main-branch concurrency by github.sha.');
+}
+if (!ci.includes("cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}")) {
+  failures.push('ci.yml must keep PR cancellation while preserving main runs.');
+}
+if (!ci.includes('node .github/scripts/verify-workflow-concurrency.mjs')) {
+  failures.push('ci.yml must run the workflow concurrency verifier.');
+}
+
+for (const file of ['.github/workflows/deploy.yml', '.github/workflows/ios-release-loop.yml']) {
+  const workflow = readWorkflow(file);
+  if (!workflow.includes('cancel-in-progress: false')) {
+    failures.push(`${file} must not cancel in-progress production runs.`);
+  }
+}
+
+for (const file of workflowFiles) {
+  const workflow = readWorkflow(file);
+  if (/cancel-in-progress:\s*true\b/.test(workflow)) {
+    failures.push(`${file} must not use unconditional cancel-in-progress: true.`);
+  }
+}
+
+if (failures.length) {
+  console.error('Workflow concurrency policy check failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('Workflow concurrency policy check passed.');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,15 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Main-branch runs must not cancel each other. A rapid second merge can
+  # otherwise kill the release/deploy evidence for the first merge.
+  group: >-
+    ci-${{ github.workflow }}-${{
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        && github.sha
+        || github.ref
+    }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   detect-changes:
@@ -19,6 +26,10 @@ jobs:
       ios: ${{ steps.filter.outputs.ios }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Verify workflow concurrency policy
+        run: node .github/scripts/verify-workflow-concurrency.mjs
+
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: production-deploy-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   detect-changes:

--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -33,8 +33,8 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ios-release-loop-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   LOGYOURBODY_APP_IDENTIFIER: com.logyourbody.app


### PR DESCRIPTION
## Summary
- Prevent `main` CI runs from canceling each other by scoping the CI concurrency group to `github.sha` on `push` to `main` while keeping stale PR runs cancelable.
- Stop production deploy and iOS release-loop workflows from canceling in-progress runs.
- Add `.github/scripts/verify-workflow-concurrency.mjs` and run it in CI so this policy is checked on future PRs.

## Linear
- JOV-2971

## Validation
- `node .github/scripts/verify-workflow-concurrency.mjs`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "YAML OK #{f}" }' .github/workflows/ci.yml .github/workflows/deploy.yml .github/workflows/ios-release-loop.yml`
- `actionlint -ignore 'SC2086' -ignore 'SC2129' .github/workflows/ci.yml .github/workflows/deploy.yml .github/workflows/ios-release-loop.yml`
- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`

Notes: local `pnpm` commands report the existing Node 22 vs `node: 20.x` engine warning. `actionlint` without ignores still reports pre-existing shellcheck SC2086/SC2129 findings in `deploy.yml`; no new workflow syntax findings were introduced.
