### PR TITLE
fix: handle unavailable paywall offerings

### DIFF
--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -270,6 +270,9 @@ struct LogYourBodyApp: App {
         revenueCatManager.currentOffering = nil
         revenueCatManager.errorMessage = nil
         revenueCatManager.isPurchasing = false
+        if usesPaywallFixture {
+            revenueCatManager.applyCachedPaywallOfferingUITestFixture()
+        }
         UserDefaults.standard.set(isSubscribed, forKey: "revenuecat_isSubscribed")
 
         UserDefaults.standard.set(

--- a/apps/ios/LogYourBody/Services/RevenueCatManager.swift
+++ b/apps/ios/LogYourBody/Services/RevenueCatManager.swift
@@ -9,6 +9,30 @@ import Combine
 import RevenueCat
 import SwiftUI
 
+struct CachedPaywallOfferingDisplay: Codable, Equatable {
+    struct PackageDisplay: Codable, Equatable {
+        let packageIdentifier: String
+        let productIdentifier: String
+        let localizedPrice: String
+        let billingPeriod: String
+        let trialText: String?
+    }
+
+    let generatedAt: Date
+    let packages: [PackageDisplay]
+
+    var preferredPackage: PackageDisplay? {
+        packages.first { $0.packageIdentifier == "$rc_annual" }
+            ?? packages.first { $0.billingPeriod == "year" }
+            ?? packages.first { $0.packageIdentifier == "$rc_monthly" }
+            ?? packages.first
+    }
+
+    var isEmpty: Bool {
+        packages.isEmpty
+    }
+}
+
 @MainActor
 class RevenueCatManager: NSObject, ObservableObject {
     static let shared = RevenueCatManager()
@@ -30,6 +54,9 @@ class RevenueCatManager: NSObject, ObservableObject {
     /// Error message for display
     @Published var errorMessage: String?
 
+    /// Last successfully loaded offering shape, used only for display when offerings fail to load.
+    @Published private(set) var cachedPaywallOfferingDisplay: CachedPaywallOfferingDisplay?
+
     // MARK: - Cached Properties (AppStorage)
 
     /// Cached subscription status for faster app startup
@@ -47,8 +74,16 @@ class RevenueCatManager: NSObject, ObservableObject {
     /// Cache expiry duration (24 hours)
     private let cacheExpiryDuration: TimeInterval = 24 * 60 * 60
 
+    /// Last successful paywall offering display snapshot.
+    private let cachedPaywallOfferingDisplayKey = "revenuecat_cachedPaywallOfferingDisplay"
+
     /// Flag to track if SDK has been configured
     private var isConfigured: Bool = false
+
+    #if DEBUG
+    /// Keeps the paywall unavailable-state fixture deterministic without touching production purchase paths.
+    private var shouldForceOfferingsUnavailableForUITests = false
+    #endif
 
     // MARK: - Initialization
 
@@ -58,6 +93,7 @@ class RevenueCatManager: NSObject, ObservableObject {
 
         // Load cached subscription status for instant UI update
         self.isSubscribed = cachedIsSubscribed
+        self.cachedPaywallOfferingDisplay = loadCachedPaywallOfferingDisplay()
         // print("💰 Loaded cached subscription status: \(cachedIsSubscribed)")
     }
 
@@ -205,6 +241,14 @@ class RevenueCatManager: NSObject, ObservableObject {
 
     /// Fetch available offerings from RevenueCat
     func fetchOfferings() async {
+        #if DEBUG
+        if shouldForceOfferingsUnavailableForUITests {
+            currentOffering = nil
+            errorMessage = "Failed to load subscription options"
+            return
+        }
+        #endif
+
         // Wait for SDK to be configured (with timeout)
         var retries = 0
         while !isConfigured && retries < 50 {
@@ -227,6 +271,9 @@ class RevenueCatManager: NSObject, ObservableObject {
             let offerings = try await Purchases.shared.offerings()
             await MainActor.run {
                 self.currentOffering = offerings.current
+                if let current = offerings.current {
+                    self.cachePaywallOfferingDisplay(from: current)
+                }
                 // print("💰 Fetched \(offerings.all.count) offerings")
 
                 // Debug: Print details about current offering
@@ -407,7 +454,105 @@ class RevenueCatManager: NSObject, ObservableObject {
         return nil
     }
 
+    func cachePaywallOfferingDisplay(_ display: CachedPaywallOfferingDisplay) {
+        guard !display.isEmpty else {
+            return
+        }
+
+        cachedPaywallOfferingDisplay = display
+
+        do {
+            let data = try JSONEncoder().encode(display)
+            UserDefaults.standard.set(data, forKey: cachedPaywallOfferingDisplayKey)
+        } catch {
+            ErrorReporter.shared.capture(
+                AppError.billing(operation: "cachePaywallOfferingDisplay", underlying: error),
+                context: ErrorContext(
+                    feature: "billing",
+                    operation: "cachePaywallOfferingDisplay",
+                    screen: "PaywallView",
+                    userId: nil
+                )
+            )
+        }
+    }
+
+    #if DEBUG
+    func applyCachedPaywallOfferingUITestFixture() {
+        shouldForceOfferingsUnavailableForUITests = true
+        currentOffering = nil
+        errorMessage = "Failed to load subscription options"
+
+        cachePaywallOfferingDisplay(
+            CachedPaywallOfferingDisplay(
+                generatedAt: Date(),
+                packages: [
+                    CachedPaywallOfferingDisplay.PackageDisplay(
+                        packageIdentifier: "$rc_annual",
+                        productIdentifier: "com.logyourbody.app.pro1.annual.3daytrial",
+                        localizedPrice: "$79.99",
+                        billingPeriod: "year",
+                        trialText: "3 days free"
+                    ),
+                    CachedPaywallOfferingDisplay.PackageDisplay(
+                        packageIdentifier: "$rc_monthly",
+                        productIdentifier: "com.logyourbody.app.pro1.monthly.3daytrial",
+                        localizedPrice: "$9.99",
+                        billingPeriod: "month",
+                        trialText: "3 days free"
+                    )
+                ]
+            )
+        )
+    }
+    #endif
+
     // MARK: - Private Helper Methods
+
+    private func cachePaywallOfferingDisplay(from offering: Offering) {
+        let packageDisplays = offering.availablePackages.map { package in
+            CachedPaywallOfferingDisplay.PackageDisplay(
+                packageIdentifier: package.identifier,
+                productIdentifier: package.storeProduct.productIdentifier,
+                localizedPrice: package.localizedPriceString,
+                billingPeriod: billingPeriodLabel(for: package),
+                trialText: getTrialDurationText(package: package)
+            )
+        }
+
+        cachePaywallOfferingDisplay(
+            CachedPaywallOfferingDisplay(
+                generatedAt: Date(),
+                packages: packageDisplays
+            )
+        )
+    }
+
+    private func loadCachedPaywallOfferingDisplay() -> CachedPaywallOfferingDisplay? {
+        guard let data = UserDefaults.standard.data(forKey: cachedPaywallOfferingDisplayKey) else {
+            return nil
+        }
+
+        return try? JSONDecoder().decode(CachedPaywallOfferingDisplay.self, from: data)
+    }
+
+    private func billingPeriodLabel(for package: Package) -> String {
+        let identifier = "\(package.identifier) \(package.storeProduct.productIdentifier)".lowercased()
+
+        if identifier.contains("annual") || identifier.contains("year") {
+            return "year"
+        }
+
+        if identifier.contains("month") {
+            return "month"
+        }
+
+        if identifier.contains("week") {
+            return "week"
+        }
+
+        return ""
+    }
 
     /// Update subscription status and cache it for faster app startup
     /// Call this method whenever customerInfo is updated to keep cache in sync

--- a/apps/ios/LogYourBody/Views/PaywallView.swift
+++ b/apps/ios/LogYourBody/Views/PaywallView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 import RevenueCat
 
 struct PaywallView: View {
+    @Environment(\.openURL) private var openURL
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var revenueCatManager: RevenueCatManager
     @State private var isLoading = true
@@ -38,7 +39,9 @@ struct PaywallView: View {
                         ProgressView()
                             .tint(.appPrimary)
                     } else {
-                        plansUnavailableState
+                        plansUnavailableState(
+                            cachedPackage: revenueCatManager.cachedPaywallOfferingDisplay?.preferredPackage
+                        )
                     }
 
                     if let package = firstAvailablePackage {
@@ -333,30 +336,55 @@ struct PaywallView: View {
         }
     }
 
-    private var plansUnavailableState: some View {
+    private func plansUnavailableState(
+        cachedPackage: CachedPaywallOfferingDisplay.PackageDisplay?
+    ) -> some View {
         VStack(spacing: 12) {
             Text("Subscription plans are unavailable")
                 .font(.system(size: 17, weight: .semibold))
                 .foregroundColor(.appText)
 
-            Text("Check your connection and retry.")
+            if let cachedPackage {
+                cachedPricingSummary(package: cachedPackage)
+            }
+
+            Text("Check your connection and retry. You can still restore a purchase or log out below.")
                 .font(.system(size: 14))
                 .foregroundColor(.appTextSecondary)
+                .multilineTextAlignment(.center)
 
-            Button {
-                Task {
-                    await loadOfferings()
+            HStack(spacing: 10) {
+                Button {
+                    Task {
+                        await loadOfferings()
+                    }
+                } label: {
+                    Label("Retry", systemImage: "arrow.clockwise")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(.appText)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(Color.appCard)
+                        .cornerRadius(12)
                 }
-            } label: {
-                Label("Retry", systemImage: "arrow.clockwise")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.appText)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(Color.appCard)
-                    .cornerRadius(12)
+                .disabled(isLoading)
+                .accessibilityIdentifier("paywall_retry_offerings_button")
+
+                Button {
+                    contactSupportAboutUnavailablePlans()
+                } label: {
+                    Label("Contact Support", systemImage: "envelope")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(.appTextSecondary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(Color.appCard.opacity(0.45))
+                        .cornerRadius(12)
+                }
+                .accessibilityLabel("Contact Support")
+                .accessibilityHint("Opens an email to LogYourBody support.")
+                .accessibilityIdentifier("paywall_contact_support_button")
             }
-            .disabled(isLoading)
         }
         .frame(maxWidth: .infinity)
         .padding(20)
@@ -367,6 +395,45 @@ struct PaywallView: View {
         )
         .cornerRadius(16)
         .accessibilityIdentifier("paywall_plans_unavailable_state")
+    }
+
+    private func cachedPricingSummary(package: CachedPaywallOfferingDisplay.PackageDisplay) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Last loaded price")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.appTextSecondary)
+                    .textCase(.uppercase)
+
+                HStack(alignment: .firstTextBaseline, spacing: 3) {
+                    Text(package.localizedPrice)
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                        .foregroundColor(.appText)
+
+                    Text(package.billingPeriod.isEmpty ? "" : "/\(package.billingPeriod)")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.appTextSecondary)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            if let trialText = package.trialText {
+                Text(trialText.uppercased())
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(.black)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color.appPrimary.opacity(0.8))
+                    .clipShape(Capsule())
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(Color.appCard.opacity(0.65))
+        .cornerRadius(14)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("paywall_cached_pricing_card")
     }
 
     private func billingPeriodSuffix(for package: Package) -> String {
@@ -403,6 +470,16 @@ struct PaywallView: View {
         }
 
         return ""
+    }
+
+    private func contactSupportAboutUnavailablePlans() {
+        let subject = "Subscription plans unavailable"
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "Subscription%20plans%20unavailable"
+        let body = "I cannot load subscription plans in the iOS app."
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        if let url = URL(string: "mailto:support@logyourbody.com?subject=\(subject)&body=\(body)") {
+            openURL(url)
+        }
     }
 
     // MARK: - Functions

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -989,6 +989,54 @@ final class RevenueCatProductConfigurationTests: XCTestCase {
     }
 }
 
+final class CachedPaywallOfferingDisplayTests: XCTestCase {
+    func testPreferredPackageUsesAnnualBeforeMonthly() {
+        let display = CachedPaywallOfferingDisplay(
+            generatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            packages: [
+                CachedPaywallOfferingDisplay.PackageDisplay(
+                    packageIdentifier: "$rc_monthly",
+                    productIdentifier: "com.logyourbody.app.pro1.monthly.3daytrial",
+                    localizedPrice: "$9.99",
+                    billingPeriod: "month",
+                    trialText: "3 days free"
+                ),
+                CachedPaywallOfferingDisplay.PackageDisplay(
+                    packageIdentifier: "$rc_annual",
+                    productIdentifier: "com.logyourbody.app.pro1.annual.3daytrial",
+                    localizedPrice: "$79.99",
+                    billingPeriod: "year",
+                    trialText: "3 days free"
+                )
+            ]
+        )
+
+        XCTAssertEqual(display.preferredPackage?.packageIdentifier, "$rc_annual")
+        XCTAssertEqual(display.preferredPackage?.localizedPrice, "$79.99")
+    }
+
+    func testCachedPaywallOfferingDisplayPersistsAsDisplayOnlyData() throws {
+        let display = CachedPaywallOfferingDisplay(
+            generatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            packages: [
+                CachedPaywallOfferingDisplay.PackageDisplay(
+                    packageIdentifier: "$rc_annual",
+                    productIdentifier: "com.logyourbody.app.pro1.annual.3daytrial",
+                    localizedPrice: "$79.99",
+                    billingPeriod: "year",
+                    trialText: "3 days free"
+                )
+            ]
+        )
+
+        let data = try JSONEncoder().encode(display)
+        let decoded = try JSONDecoder().decode(CachedPaywallOfferingDisplay.self, from: data)
+
+        XCTAssertEqual(decoded, display)
+        XCTAssertEqual(decoded.preferredPackage?.productIdentifier, "com.logyourbody.app.pro1.annual.3daytrial")
+    }
+}
+
 final class AuthLegacyStorageMigrationTests: XCTestCase {
     func testMigrateLegacyAuthStorageRemovesSensitiveDefaultsOnly() {
         let suiteName = "auth-legacy-\(UUID().uuidString)"

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -83,6 +83,11 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(
             app.descendants(matching: .any)["paywall_plans_unavailable_state"].waitForExistence(timeout: 8)
         )
+        XCTAssertTrue(app.staticTexts["$79.99"].waitForExistence(timeout: 3))
+
+        let supportButton = app.buttons["Contact Support"]
+        XCTAssertTrue(supportButton.waitForExistence(timeout: 3))
+        XCTAssertTrue(supportButton.isHittable)
 
         let restoreButton = app.buttons["paywall_restore_purchases_button"]
         XCTAssertTrue(restoreButton.waitForExistence(timeout: 3))


### PR DESCRIPTION
## Summary
- cache a display-only RevenueCat offering snapshot after successful offering fetches
- show cached price context when the hard paywall has no live offering, without enabling stale-data purchases
- add Retry + Contact Support to the unavailable state and keep Restore Purchases / Log out visible
- make the nil-offering UI fixture deterministic for smoke coverage

## Linear
JOV-2954

## Validation
- `swiftlint lint --strict`
- `git diff --check`
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' -parallel-testing-enabled NO -only-testing:LogYourBodyTests/CachedPaywallOfferingDisplayTests test`
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' -parallel-testing-enabled NO -only-testing:LogYourBodyUITests/LogYourBodyUITests/testPaywallFixtureShowsRestoreAndLogoutEscapePaths test`
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' build-for-testing`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`

## Evidence
- Simulator screenshot captured locally at `/tmp/logyourbody-screens/jov-2954-paywall-fixture-final.png` showing cached `$79.99/year`, Retry, Contact Support, Restore Purchases, and Log out visible in the nil-offering fixture.

## Notes
- Purchase remains hidden when no live RevenueCat `Package` exists; cached data is display-only.
- Local pnpm commands still warn that this shell uses Node `v22.22.1` while the repo expects Node `20.x`; all commands passed.
