### PR TITLE
fix: validate manual weight logging bounds

### DIFF
--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -91,7 +91,7 @@ struct AddEntrySheet: View {
 
                     Spacer()
 
-                    DatePicker("", selection: $selectedDate, displayedComponents: .date)
+                    DatePicker("", selection: $selectedDate, in: ...Date(), displayedComponents: .date)
                         .labelsHidden()
                 }
                 .padding(.horizontal)

--- a/apps/ios/LogYourBody/Views/LogWeightView.swift
+++ b/apps/ios/LogYourBody/Views/LogWeightView.swift
@@ -9,6 +9,8 @@ struct LogWeightView: View {
     @StateObject private var healthKitManager = HealthKitManager.shared
     @State private var weight: String = ""
     @State private var bodyFat: String = ""
+    @State private var weightError: String?
+    @State private var bodyFatError: String?
     @AppStorage(Constants.preferredMeasurementSystemKey) private var measurementSystem = PreferencesView.defaultMeasurementSystem
     @State private var isLoading = false
     @State private var showError = false
@@ -89,11 +91,20 @@ struct LogWeightView: View {
                                             .keyboardType(.decimalPad)
                                             .focused($focusedField, equals: .weight)
                                             .frame(maxWidth: 150)
+                                            .accessibilityIdentifier("log_weight_weight_field")
+                                            .onChange(of: weight) { _, newValue in
+                                                validateWeight(newValue)
+                                            }
 
                                         Text(currentSystem.weightUnit)
                                             .font(.system(size: 20, weight: .medium))
                                             .foregroundColor(.appTextSecondary)
                                             .padding(.bottom, 6)
+                                    }
+
+                                    if let weightError {
+                                        validationMessage(weightError)
+                                            .accessibilityIdentifier("log_weight_weight_error")
                                     }
                                 }
                                 .padding(20)
@@ -137,11 +148,20 @@ struct LogWeightView: View {
                                             .keyboardType(.decimalPad)
                                             .focused($focusedField, equals: .bodyFat)
                                             .frame(maxWidth: 150)
+                                            .accessibilityIdentifier("log_weight_body_fat_field")
+                                            .onChange(of: bodyFat) { _, newValue in
+                                                validateBodyFat(newValue)
+                                            }
 
                                         Text("%")
                                             .font(.system(size: 20, weight: .medium))
                                             .foregroundColor(.appTextSecondary)
                                             .padding(.bottom, 6)
+                                    }
+
+                                    if let bodyFatError {
+                                        validationMessage(bodyFatError)
+                                            .accessibilityIdentifier("log_weight_body_fat_error")
                                     }
                                 }
                                 .padding(20)
@@ -247,6 +267,7 @@ struct LogWeightView: View {
                             .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFormValid())
                         }
                         .disabled(!isFormValid() || isLoading)
+                        .accessibilityIdentifier("log_weight_save_measurement_button")
                         .padding(.horizontal, 20)
                         .padding(.bottom, 34)
                     }
@@ -275,7 +296,29 @@ struct LogWeightView: View {
     }
 
     private func isFormValid() -> Bool {
-        return !weight.isEmpty || !bodyFat.isEmpty
+        LogWeightFormValidator
+            .validate(weight: weight, bodyFat: bodyFat, unit: currentSystem.weightUnit)
+            .isValid
+    }
+
+    private func validateWeight(_ value: String) {
+        weightError = LogWeightFormValidator.fieldError(for: value, field: .weight, unit: currentSystem.weightUnit)
+    }
+
+    private func validateBodyFat(_ value: String) {
+        bodyFatError = LogWeightFormValidator.fieldError(for: value, field: .bodyFat, unit: currentSystem.weightUnit)
+    }
+
+    private func validationMessage(_ message: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.circle.fill")
+                .font(.system(size: 12, weight: .semibold))
+            Text(message)
+                .font(.system(size: 13, weight: .medium))
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .foregroundColor(.red)
     }
 
     private func quickAdd() {
@@ -301,49 +344,25 @@ struct LogWeightView: View {
     }
 
     private func saveMeasurement() {
+        let validation = LogWeightFormValidator.validate(weight: weight, bodyFat: bodyFat, unit: currentSystem.weightUnit)
+        weightError = validation.weightError
+        bodyFatError = validation.bodyFatError
+
+        guard validation.isValid else {
+            if let formError = validation.formError {
+                errorMessage = formError
+                showError = true
+            }
+            return
+        }
+
         isLoading = true
         hideKeyboard()
 
         Task {
             do {
-                var weightValue: Double?
-                var bodyFatValue: Double?
-
-                // Parse weight if provided
-                if !weight.isEmpty {
-                    guard let w = Double(weight) else {
-                        await MainActor.run {
-                            errorMessage = "Please enter a valid weight"
-                            showError = true
-                            isLoading = false
-                        }
-                        return
-                    }
-                    weightValue = w
-                }
-
-                // Parse body fat if provided
-                if !bodyFat.isEmpty {
-                    guard let bf = Double(bodyFat), bf >= 0, bf <= 100 else {
-                        await MainActor.run {
-                            errorMessage = "Please enter a valid body fat percentage (0-100)"
-                            showError = true
-                            isLoading = false
-                        }
-                        return
-                    }
-                    bodyFatValue = bf
-                }
-
-                // At least one value must be provided
-                guard weightValue != nil || bodyFatValue != nil else {
-                    await MainActor.run {
-                        errorMessage = "Please enter at least one measurement"
-                        showError = true
-                        isLoading = false
-                    }
-                    return
-                }
+                let weightValue = validation.weightValue
+                let bodyFatValue = validation.bodyFatValue
 
                 // Convert weight to kg for storage
                 let weightInKg = weightValue != nil
@@ -432,6 +451,82 @@ struct LogWeightView: View {
                 }
             }
         }
+    }
+}
+
+enum LogWeightInputField {
+    case weight
+    case bodyFat
+}
+
+struct LogWeightFormValidation: Equatable {
+    let weightValue: Double?
+    let bodyFatValue: Double?
+    let weightError: String?
+    let bodyFatError: String?
+    let formError: String?
+
+    var isValid: Bool {
+        formError == nil
+            && weightError == nil
+            && bodyFatError == nil
+            && (weightValue != nil || bodyFatValue != nil)
+    }
+}
+
+enum LogWeightFormValidator {
+    static func validate(weight: String, bodyFat: String, unit: String) -> LogWeightFormValidation {
+        var weightValue: Double?
+        var bodyFatValue: Double?
+        var weightError: String?
+        var bodyFatError: String?
+
+        if hasValue(weight) {
+            do {
+                weightValue = try ValidationService.shared.validateWeight(weight, unit: unit)
+            } catch let error as ValidationError {
+                weightError = error.errorDescription
+            } catch {
+                weightError = "Please enter a valid number"
+            }
+        }
+
+        if hasValue(bodyFat) {
+            do {
+                bodyFatValue = try ValidationService.shared.validateBodyFat(bodyFat)
+            } catch let error as ValidationError {
+                bodyFatError = error.errorDescription
+            } catch {
+                bodyFatError = "Please enter a valid percentage"
+            }
+        }
+
+        let formError = !hasValue(weight) && !hasValue(bodyFat)
+            ? "Please enter at least one measurement"
+            : nil
+
+        return LogWeightFormValidation(
+            weightValue: weightValue,
+            bodyFatValue: bodyFatValue,
+            weightError: weightError,
+            bodyFatError: bodyFatError,
+            formError: formError
+        )
+    }
+
+    static func fieldError(for value: String, field: LogWeightInputField, unit: String) -> String? {
+        guard hasValue(value) else { return nil }
+
+        switch field {
+        case .weight:
+            return validate(weight: value, bodyFat: "", unit: unit).weightError
+        case .bodyFat:
+            return validate(weight: "", bodyFat: value, unit: unit).bodyFatError
+        }
+    }
+
+    private static func hasValue(_ value: String) -> Bool {
+        !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }
 

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -463,6 +463,50 @@ final class PaidWeightLoggerMVPPolicyTests: XCTestCase {
     }
 }
 
+final class LogWeightFormValidatorTests: XCTestCase {
+    func testRejectsOutOfRangeWeightValues() {
+        let zeroPounds = LogWeightFormValidator.validate(weight: "0", bodyFat: "", unit: "lbs")
+        XCTAssertFalse(zeroPounds.isValid)
+        XCTAssertEqual(zeroPounds.weightError, "Weight must be between 44-1100 lbs")
+        XCTAssertNil(zeroPounds.weightValue)
+
+        let extremePounds = LogWeightFormValidator.validate(weight: "9999", bodyFat: "", unit: "lbs")
+        XCTAssertFalse(extremePounds.isValid)
+        XCTAssertEqual(extremePounds.weightError, "Weight must be between 44-1100 lbs")
+        XCTAssertNil(extremePounds.weightValue)
+    }
+
+    func testRejectsOutOfRangeBodyFatValues() {
+        let tooLow = LogWeightFormValidator.validate(weight: "", bodyFat: "1", unit: "lbs")
+        XCTAssertFalse(tooLow.isValid)
+        XCTAssertEqual(tooLow.bodyFatError, "Body fat must be between 3-50%")
+        XCTAssertNil(tooLow.bodyFatValue)
+
+        let tooHigh = LogWeightFormValidator.validate(weight: "", bodyFat: "60", unit: "lbs")
+        XCTAssertFalse(tooHigh.isValid)
+        XCTAssertEqual(tooHigh.bodyFatError, "Body fat must be between 3-50%")
+        XCTAssertNil(tooHigh.bodyFatValue)
+    }
+
+    func testAllowsValidWeightAndBodyFat() {
+        let validation = LogWeightFormValidator.validate(weight: "175", bodyFat: "18", unit: "lbs")
+
+        XCTAssertTrue(validation.isValid)
+        XCTAssertEqual(validation.weightValue, 175)
+        XCTAssertEqual(validation.bodyFatValue, 18)
+        XCTAssertNil(validation.weightError)
+        XCTAssertNil(validation.bodyFatError)
+        XCTAssertNil(validation.formError)
+    }
+
+    func testRequiresAtLeastOneMeasurement() {
+        let validation = LogWeightFormValidator.validate(weight: " ", bodyFat: "", unit: "lbs")
+
+        XCTAssertFalse(validation.isValid)
+        XCTAssertEqual(validation.formError, "Please enter at least one measurement")
+    }
+}
+
 final class ProgressPhotoAttachPolicyTests: XCTestCase {
     func testProgressPhotoAttachStateCopyCoversCoreStates() {
         XCTAssertEqual(ProgressPhotoAttachPolicy.statusTitle(for: .empty), "Choose a photo")


### PR DESCRIPTION
## Summary
- routes LogWeightView manual weight/body-fat saves through the shared ValidationService rules
- shows inline field errors and disables save for impossible values like 0 lb, 9999 lb, 1% BF, and 60% BF
- bounds the shared AddEntrySheet date picker to today-or-earlier so manual entries cannot be future dated

## Validation
- swiftlint lint --strict
- xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination "platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74" -parallel-testing-enabled NO -only-testing:LogYourBodyTests/LogWeightFormValidatorTests test
- xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination "platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74" build-for-testing
- pnpm lint
- pnpm typecheck
- pnpm test:ci

## Notes
- Current main does not expose a date picker inside LogWeightView; the future-date acceptance criterion maps to AddEntrySheet, which is now bounded.
- Local output still includes existing Node 22 vs repo Node 20.x engine warnings and existing Swift 6 actor-isolation warnings outside this diff.

Closes JovieInc/Jovie#10426
Refs JOV-2950