### PR TITLE
fix: delete account-owned Supabase data

### DIFF
--- a/packages/shared-lib/src/delete-user-assets-account-deletion.test.ts
+++ b/packages/shared-lib/src/delete-user-assets-account-deletion.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  UserDataDeletionError,
+  accountDeletionTargets,
+  deleteUserDatabaseRows,
+} from '../../../supabase/functions/delete-user-assets/account-deletion';
+
+class MockDeleteBuilder {
+  constructor(
+    private readonly table: string,
+    private readonly failures: ReadonlyMap<string, unknown>,
+    private readonly calls: string[],
+  ) {}
+
+  async eq(column: string, value: string): Promise<{ error?: unknown }> {
+    this.calls.push(`${this.table}.${column}=${value}`);
+    const error = this.failures.get(this.table);
+    return error ? { error } : {};
+  }
+}
+
+function createMockSupabase(failures: Record<string, unknown> = {}) {
+  const calls: string[] = [];
+  const failureMap = new Map(Object.entries(failures));
+
+  return {
+    calls,
+    client: {
+      from(table: string) {
+        return {
+          delete() {
+            return new MockDeleteBuilder(table, failureMap, calls);
+          },
+        };
+      },
+    },
+  };
+}
+
+describe('deleteUserDatabaseRows', () => {
+  it('deletes account-owned tables in dependency-safe order', async () => {
+    const mock = createMockSupabase();
+
+    const results = await deleteUserDatabaseRows(mock.client, 'user_123', {
+      error: () => undefined,
+    });
+
+    expect(results.every((result) => result.success)).toBe(true);
+    expect(mock.calls).toEqual([
+      'data_exports.user_id=user_123',
+      'progress_photos.user_id=user_123',
+      'dexa_results.user_id=user_123',
+      'glp1_dose_logs.user_id=user_123',
+      'glp1_medications.user_id=user_123',
+      'daily_metrics.user_id=user_123',
+      'body_metrics.user_id=user_123',
+      'email_subscriptions.user_id=user_123',
+      'profiles.id=user_123',
+    ]);
+  });
+
+  it('allows optional export cleanup to fail without blocking core deletion', async () => {
+    const mock = createMockSupabase({
+      data_exports: { message: 'invalid input syntax for type uuid' },
+    });
+
+    const results = await deleteUserDatabaseRows(mock.client, 'user_123', {
+      error: () => undefined,
+    });
+
+    expect(results.find((result) => result.table === 'data_exports')).toMatchObject({
+      required: false,
+      success: false,
+    });
+    expect(results.find((result) => result.table === 'profiles')).toMatchObject({
+      required: true,
+      success: true,
+    });
+  });
+
+  it('attempts every table before throwing on required-table failures', async () => {
+    const mock = createMockSupabase({
+      body_metrics: { message: 'permission denied for table body_metrics' },
+    });
+
+    await expect(
+      deleteUserDatabaseRows(mock.client, 'user_123', { error: () => undefined }),
+    ).rejects.toBeInstanceOf(UserDataDeletionError);
+
+    expect(mock.calls.at(-1)).toBe('profiles.id=user_123');
+  });
+
+  it('keeps profile deletion last', () => {
+    expect(accountDeletionTargets.at(-1)).toMatchObject({
+      table: 'profiles',
+      column: 'id',
+      required: true,
+    });
+  });
+
+  it('rejects blank user ids', async () => {
+    const mock = createMockSupabase();
+
+    await expect(
+      deleteUserDatabaseRows(mock.client, '   ', { error: () => undefined }),
+    ).rejects.toThrow('Cannot delete account data without a user id');
+  });
+});

--- a/packages/shared-lib/tsconfig.json
+++ b/packages/shared-lib/tsconfig.json
@@ -1,9 +1,8 @@
 {
-    "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "dist"
-    },
-    "include": [
-        "src"
-    ]
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
 }

--- a/supabase/functions/delete-user-assets/account-deletion.ts
+++ b/supabase/functions/delete-user-assets/account-deletion.ts
@@ -1,0 +1,110 @@
+export type AccountDeletionTarget = {
+    table: string
+    column: string
+    required: boolean
+}
+
+export type AccountDeletionResult = AccountDeletionTarget & {
+    success: boolean
+    error?: string
+}
+
+type SupabaseDeleteBuilder = {
+    eq: (column: string, value: string) => Promise<{ error?: unknown }>
+}
+
+type SupabaseDeleteClient = {
+    from: (table: string) => {
+        delete: () => SupabaseDeleteBuilder
+    }
+}
+
+type AccountDeletionLogger = {
+    error: (message: string, context?: unknown) => void
+}
+
+export const accountDeletionTargets: readonly AccountDeletionTarget[] = [
+    // Export rows are temporary, but they can contain a full health-data snapshot.
+    // This table is older and may use Supabase UUID auth ids, so it is best effort.
+    { table: "data_exports", column: "user_id", required: false },
+    { table: "progress_photos", column: "user_id", required: true },
+    { table: "dexa_results", column: "user_id", required: true },
+    { table: "glp1_dose_logs", column: "user_id", required: true },
+    { table: "glp1_medications", column: "user_id", required: true },
+    { table: "daily_metrics", column: "user_id", required: true },
+    { table: "body_metrics", column: "user_id", required: true },
+    { table: "email_subscriptions", column: "user_id", required: true },
+    { table: "profiles", column: "id", required: true },
+]
+
+export class UserDataDeletionError extends Error {
+    constructor(public readonly results: readonly AccountDeletionResult[]) {
+        const failedTables = results
+            .filter((result) => result.required && !result.success)
+            .map((result) => result.table)
+            .join(", ")
+
+        super(`Failed to delete required account data from: ${failedTables}`)
+        this.name = "UserDataDeletionError"
+    }
+}
+
+export async function deleteUserDatabaseRows(
+    supabase: SupabaseDeleteClient,
+    userId: string,
+    logger: AccountDeletionLogger = console,
+): Promise<AccountDeletionResult[]> {
+    if (userId.trim().length === 0) {
+        throw new Error("Cannot delete account data without a user id")
+    }
+
+    const results: AccountDeletionResult[] = []
+
+    for (const target of accountDeletionTargets) {
+        const { error } = await supabase
+            .from(target.table)
+            .delete()
+            .eq(target.column, userId)
+
+        if (error) {
+            const result = {
+                ...target,
+                success: false,
+                error: describeSupabaseError(error),
+            }
+            results.push(result)
+            logger.error("Failed to delete account data table", {
+                table: target.table,
+                column: target.column,
+                required: target.required,
+                error,
+            })
+            continue
+        }
+
+        results.push({ ...target, success: true })
+    }
+
+    const hasRequiredFailure = results.some((result) => result.required && !result.success)
+    if (hasRequiredFailure) {
+        throw new UserDataDeletionError(results)
+    }
+
+    return results
+}
+
+function describeSupabaseError(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message
+    }
+
+    if (typeof error === "object" && error !== null) {
+        const record = error as Record<string, unknown>
+        const message = record.message ?? record.details ?? record.code
+        if (typeof message === "string" && message.length > 0) {
+            return message
+        }
+    }
+
+    return String(error)
+}

--- a/supabase/functions/delete-user-assets/index.ts
+++ b/supabase/functions/delete-user-assets/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.210.0/http/server.ts"
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.4"
+import { deleteUserDatabaseRows } from "./account-deletion.ts"
 
 const corsHeaders = {
     "Access-Control-Allow-Origin": "*",
@@ -73,6 +74,14 @@ serve(async (req) => {
             photo_url: string | null
             thumbnail_url: string | null
         }[]
+
+        if (bodyMetricsResult.error) {
+            console.error("Error loading body metric assets for account deletion", { userId, error: bodyMetricsResult.error })
+        }
+
+        if (progressPhotosResult.error) {
+            console.error("Error loading progress photo assets for account deletion", { userId, error: progressPhotosResult.error })
+        }
 
         const storagePaths = new Set<string>()
         const cloudinaryPublicIds = new Set<string>()
@@ -202,8 +211,10 @@ serve(async (req) => {
             }
         }
 
+        const deletedRows = await deleteUserDatabaseRows(supabase, userId)
+
         return new Response(
-            JSON.stringify({ success: true }),
+            JSON.stringify({ success: true, deletedRows }),
             { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
         )
     } catch (error) {


### PR DESCRIPTION
## Summary
- Add a delete-user-assets helper that removes account-owned Supabase rows after asset cleanup.
- Delete current account data in dependency-safe order: progress photos, DEXA, GLP-1 dose logs/medications, daily metrics, body metrics, email subscriptions, then profile.
- Treat `data_exports` as best-effort because older migrations store `user_id` as UUID while Clerk-safe account ids are text.
- Return per-table deletion results from the edge function for operational evidence.

Closes JovieInc/Jovie#10418

## Validation
- `pnpm --filter @logyourbody/shared-lib lint`
- `pnpm --filter @logyourbody/shared-lib typecheck`
- `pnpm --filter @logyourbody/shared-lib test`
- `pnpm --filter @logyourbody/shared-lib build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`
- Pre-push hook: filtered `turbo run lint`, `turbo run typecheck`, `turbo run test` since `origin/main`

## Notes
- No production auth bypass is introduced.
- This does not change Clerk account deletion; it hardens the Supabase data/assets cleanup called before the existing Clerk delete.
- Runtime proof still needs a deployed edge function plus a test account because local Supabase credentials are not available in this worktree.
