### PR TITLE
fix: require auth for progress photo processing

### DIFF
--- a/apps/ios/LogYourBody/Services/PhotoUploadManager.swift
+++ b/apps/ios/LogYourBody/Services/PhotoUploadManager.swift
@@ -61,6 +61,19 @@ class PhotoUploadManager: ObservableObject {
 
     private init() {}
 
+    private func authenticatedJWT() async throws -> String {
+        guard let session = authManager.clerkSession else {
+            throw PhotoError.notAuthenticated
+        }
+
+        let tokenResource = try await session.getToken()
+        guard let token = tokenResource?.jwt else {
+            throw PhotoError.notAuthenticated
+        }
+
+        return token
+    }
+
     // MARK: - Public Methods
 
     func uploadProgressPhoto(for metrics: BodyMetrics, image: UIImage) async throws -> String {
@@ -354,16 +367,7 @@ class PhotoUploadManager: ObservableObject {
     }
 
     private func uploadToSupabase(imageData: Data, fileName: String) async throws -> String {
-        guard let session = authManager.clerkSession else {
-            // print("❌ PhotoUploadManager: No Clerk session for storage upload")
-            throw PhotoError.notAuthenticated
-        }
-
-        let tokenResource = try await session.getToken()
-        guard let token = tokenResource?.jwt else {
-            // print("❌ PhotoUploadManager: Failed to get JWT for storage upload")
-            throw PhotoError.notAuthenticated
-        }
+        let token = try await authenticatedJWT()
 
         // print("📸 PhotoUploadManager: Got JWT token for storage upload")
 
@@ -401,14 +405,13 @@ class PhotoUploadManager: ObservableObject {
     }
 
     private func processImageWithCloudinary(storagePath: String, metricsId: String) async throws -> String {
-        // Edge functions can be called with just the anon key
-        // print("📸 PhotoUploadManager: Calling edge function with anon key")
+        let token = try await authenticatedJWT()
 
         let url = URL(string: "\(Constants.supabaseURL)/functions/v1/process-progress-photo")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue(Constants.supabaseAnonKey, forHTTPHeaderField: "apikey")
-        request.setValue("Bearer \(Constants.supabaseAnonKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         let body: [String: Any] = [

--- a/apps/web/src/utils/photo-utils.ts
+++ b/apps/web/src/utils/photo-utils.ts
@@ -1,70 +1,65 @@
-import { createClient } from '@/lib/supabase/client'
-import { deleteFromStorage, getFilePathFromUrl } from './storage-utils'
+import { createClient } from '@/lib/supabase/client';
+import { deleteFromStorage, getFilePathFromUrl } from './storage-utils';
 
 export interface PhotoData {
-  id: string
-  user_id: string
-  date: string
-  photo_url: string
-  original_photo_url?: string | null
-  weight?: number
-  weight_unit?: string
-  body_fat_percentage?: number
-  notes?: string
-  created_at: string
+  id: string;
+  user_id: string;
+  date: string;
+  photo_url: string;
+  original_photo_url?: string | null;
+  weight?: number;
+  weight_unit?: string;
+  body_fat_percentage?: number;
+  notes?: string;
+  created_at: string;
 }
 
 export interface PhotoUploadResult {
-  success: boolean
-  data?: PhotoData
-  error?: string
+  success: boolean;
+  data?: PhotoData;
+  error?: string;
 }
 
 function isSupabasePhotosUrl(url: string | null | undefined): boolean {
-  if (!url) return false
-  return url.includes('/storage/v1/object') && url.includes('/photos/')
+  if (!url) return false;
+  return url.includes('/storage/v1/object') && url.includes('/photos/');
 }
 
 async function getSignedPhotoUrlIfNeeded(
   supabase: ReturnType<typeof createClient>,
   url: string | null,
 ): Promise<string | null> {
-  if (!url) return url
+  if (!url) return url;
   if (!isSupabasePhotosUrl(url)) {
-    return url
+    return url;
   }
 
-  const path = getFilePathFromUrl(url, 'photos')
+  const path = getFilePathFromUrl(url, 'photos');
   if (!path) {
-    return url
+    return url;
   }
 
-  const { data: signedData, error: signedError } = await supabase
-    .storage
+  const { data: signedData, error: signedError } = await supabase.storage
     .from('photos')
-    .createSignedUrl(path, 60 * 10)
+    .createSignedUrl(path, 60 * 10);
 
   if (signedError || !signedData || !signedData.signedUrl) {
-    console.error('Failed to create signed URL for photo', signedError)
-    return url
+    console.error('Failed to create signed URL for photo', signedError);
+    return url;
   }
 
-  let signedUrl = signedData.signedUrl as string
+  let signedUrl = signedData.signedUrl as string;
 
   if (!signedUrl.startsWith('http')) {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     if (supabaseUrl) {
-      const base = supabaseUrl.endsWith('/')
-        ? supabaseUrl.slice(0, -1)
-        : supabaseUrl
-      const pathPart = signedUrl.startsWith('/')
-        ? signedUrl
-        : `/${signedUrl}`
-      signedUrl = `${base}${pathPart}`
+      const base = supabaseUrl.endsWith('/') ? supabaseUrl.slice(0, -1) : supabaseUrl;
+      const pathPart = signedUrl.startsWith('/') ? signedUrl : `/${signedUrl}`;
+      signedUrl = `${base}${pathPart}`;
     }
   }
 
-  return signedUrl
+  return signedUrl;
 }
 
 /**
@@ -72,32 +67,34 @@ async function getSignedPhotoUrlIfNeeded(
  * @returns Array of photo data
  */
 export async function loadUserPhotos(): Promise<PhotoData[]> {
-  const supabase = createClient()
+  const supabase = createClient();
 
   const { data, error } = await supabase
     .from('body_metrics')
-    .select('id, user_id, date, photo_url, original_photo_url, weight, weight_unit, body_fat_percentage, notes, created_at')
+    .select(
+      'id, user_id, date, photo_url, original_photo_url, weight, weight_unit, body_fat_percentage, notes, created_at',
+    )
     .not('photo_url', 'is', null)
-    .order('date', { ascending: false })
+    .order('date', { ascending: false });
 
   if (error) {
-    console.error('Error loading photos:', error)
-    throw error
+    console.error('Error loading photos:', error);
+    throw error;
   }
 
-  const rows = data || []
+  const rows = data || [];
 
   const photosWithUrls = await Promise.all(
     rows.map(async (photo) => {
-      const signedUrl = await getSignedPhotoUrlIfNeeded(supabase, photo.photo_url)
+      const signedUrl = await getSignedPhotoUrlIfNeeded(supabase, photo.photo_url);
       return {
         ...photo,
         photo_url: signedUrl ?? photo.photo_url,
-      }
+      };
     }),
-  )
+  );
 
-  return photosWithUrls
+  return photosWithUrls;
 }
 
 /**
@@ -106,29 +103,31 @@ export async function loadUserPhotos(): Promise<PhotoData[]> {
  * @returns Photo data or null
  */
 export async function loadPhoto(photoId: string): Promise<PhotoData | null> {
-  const supabase = createClient()
+  const supabase = createClient();
 
   const { data, error } = await supabase
     .from('body_metrics')
-    .select('id, user_id, date, photo_url, original_photo_url, weight, weight_unit, body_fat_percentage, notes, created_at')
+    .select(
+      'id, user_id, date, photo_url, original_photo_url, weight, weight_unit, body_fat_percentage, notes, created_at',
+    )
     .eq('id', photoId)
-    .single()
+    .single();
 
   if (error) {
-    console.error('Error loading photo:', error)
-    return null
+    console.error('Error loading photo:', error);
+    return null;
   }
 
   if (!data) {
-    return null
+    return null;
   }
 
-  const signedUrl = await getSignedPhotoUrlIfNeeded(supabase, data.photo_url)
+  const signedUrl = await getSignedPhotoUrlIfNeeded(supabase, data.photo_url);
 
   return {
     ...data,
     photo_url: signedUrl ?? data.photo_url,
-  }
+  };
 }
 
 /**
@@ -136,34 +135,34 @@ export async function loadPhoto(photoId: string): Promise<PhotoData | null> {
  * @param photoId The photo ID to delete
  */
 export async function deletePhoto(photoId: string): Promise<void> {
-  const supabase = createClient()
+  const supabase = createClient();
 
   try {
     // First, get the photo to extract the storage path
-    const photo = await loadPhoto(photoId)
+    const photo = await loadPhoto(photoId);
     if (!photo) {
-      throw new Error('Photo not found')
+      throw new Error('Photo not found');
     }
 
     // Prefer original_photo_url (storage path) when deleting from storage
-    const storageSource = photo.original_photo_url
-    let filePath: string | null = null
+    const storageSource = photo.original_photo_url;
+    let filePath: string | null = null;
 
     if (storageSource) {
       if (isSupabasePhotosUrl(storageSource)) {
-        filePath = getFilePathFromUrl(storageSource, 'photos')
+        filePath = getFilePathFromUrl(storageSource, 'photos');
       } else {
         // Assume this is already a bucket-relative path
-        filePath = storageSource
+        filePath = storageSource;
       }
     }
 
     // Delete from storage bucket first
     if (filePath) {
       try {
-        await deleteFromStorage('photos', filePath)
+        await deleteFromStorage('photos', filePath);
       } catch (storageError) {
-        console.error('Error deleting from storage:', storageError)
+        console.error('Error deleting from storage:', storageError);
         // Continue with database deletion even if storage fails
       }
     }
@@ -172,15 +171,15 @@ export async function deletePhoto(photoId: string): Promise<void> {
     const { error } = await supabase
       .from('body_metrics')
       .update({ photo_url: null })
-      .eq('id', photoId)
+      .eq('id', photoId);
 
     if (error) {
-      console.error('Error deleting photo from database:', error)
-      throw error
+      console.error('Error deleting photo from database:', error);
+      throw error;
     }
   } catch (error) {
-    console.error('Error in deletePhoto:', error)
-    throw error
+    console.error('Error in deletePhoto:', error);
+    throw error;
   }
 }
 
@@ -191,14 +190,14 @@ export async function uploadPhotoWithMetrics(
   file: File,
   userId: string,
   data?: {
-    weight?: number
-    weight_unit?: string
-    body_fat_percentage?: number
-    notes?: string
-    date?: string
-  }
+    weight?: number;
+    weight_unit?: string;
+    body_fat_percentage?: number;
+    notes?: string;
+    date?: string;
+  },
 ): Promise<PhotoUploadResult> {
-  const supabase = createClient()
+  const supabase = createClient();
 
   try {
     // 1) Create body metrics entry (without photo_url)
@@ -210,87 +209,96 @@ export async function uploadPhotoWithMetrics(
         weight: data?.weight,
         weight_unit: data?.weight_unit,
         body_fat_percentage: data?.body_fat_percentage,
-        notes: data?.notes || 'Progress photo'
+        notes: data?.notes || 'Progress photo',
       })
       .select()
-      .single()
+      .single();
 
     if (metricsError || !metricsData) {
-      throw metricsError || new Error('Failed to create metrics entry')
+      throw metricsError || new Error('Failed to create metrics entry');
     }
 
-    const metricsId = metricsData.id as string
+    const metricsId = metricsData.id as string;
 
     // 2) Upload original photo to Supabase Storage
-    const fileName = `${userId}/${metricsId}-${Date.now()}-progress.jpg`
-    const { error: uploadError } = await supabase.storage
-      .from('photos')
-      .upload(fileName, file, {
-        contentType: file.type,
-        upsert: false
-      })
+    const fileName = `${userId}/${metricsId}-${Date.now()}-progress.jpg`;
+    const { error: uploadError } = await supabase.storage.from('photos').upload(fileName, file, {
+      contentType: file.type,
+      upsert: false,
+    });
 
     if (uploadError) {
       // Best-effort cleanup of the metrics row
       const { error: cleanupError } = await supabase
         .from('body_metrics')
         .delete()
-        .eq('id', metricsId)
+        .eq('id', metricsId);
       if (cleanupError) {
-        console.error('Failed to clean up body_metrics after upload error', cleanupError)
+        console.error('Failed to clean up body_metrics after upload error', cleanupError);
       }
-      throw uploadError
+      throw uploadError;
     }
 
     // 3) Call edge function to process the photo with Cloudinary
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
     if (!supabaseUrl || !supabaseAnonKey) {
-      throw new Error('Missing Supabase environment variables')
+      throw new Error('Missing Supabase environment variables');
     }
 
-    const response = await fetch(
-      `${supabaseUrl}/functions/v1/process-progress-photo`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          apikey: supabaseAnonKey,
-          Authorization: `Bearer ${supabaseAnonKey}`,
-        },
-        body: JSON.stringify({
-          storagePath: fileName,
-          metricsId,
-        }),
+    const {
+      data: { session },
+      error: sessionError,
+    } = await supabase.auth.getSession();
+    const accessToken = session?.access_token;
+
+    if (sessionError || !accessToken) {
+      throw new Error('Please log in to upload photos');
+    }
+
+    if (session.user?.id && session.user.id !== userId) {
+      throw new Error('Authenticated user mismatch');
+    }
+
+    const response = await fetch(`${supabaseUrl}/functions/v1/process-progress-photo`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: supabaseAnonKey,
+        Authorization: `Bearer ${accessToken}`,
       },
-    )
+      body: JSON.stringify({
+        storagePath: fileName,
+        metricsId,
+      }),
+    });
 
     if (!response.ok) {
-      const text = await response.text().catch(() => '')
+      const text = await response.text().catch(() => '');
       console.error('process-progress-photo failed', {
         status: response.status,
         body: text,
-      })
+      });
 
       // Best-effort cleanup of storage and metrics row
-      await deleteFromStorage('photos', fileName).catch(() => { })
+      await deleteFromStorage('photos', fileName).catch(() => {});
       const { error: cleanupError } = await supabase
         .from('body_metrics')
         .delete()
-        .eq('id', metricsId)
+        .eq('id', metricsId);
       if (cleanupError) {
-        console.error('Failed to clean up body_metrics after processing error', cleanupError)
+        console.error('Failed to clean up body_metrics after processing error', cleanupError);
       }
 
-      throw new Error('Photo processing failed')
+      throw new Error('Photo processing failed');
     }
 
-    const result = await response.json().catch(() => null) as { processedUrl?: string } | null
-    const processedUrl = result?.processedUrl
+    const result = (await response.json().catch(() => null)) as { processedUrl?: string } | null;
+    const processedUrl = result?.processedUrl;
 
     if (!processedUrl) {
-      throw new Error('Missing processedUrl from process-progress-photo')
+      throw new Error('Missing processedUrl from process-progress-photo');
     }
 
     // Edge function updates body_metrics.photo_url; return processed URL for client display
@@ -298,14 +306,14 @@ export async function uploadPhotoWithMetrics(
       success: true,
       data: {
         ...metricsData,
-        photo_url: processedUrl
-      }
-    }
+        photo_url: processedUrl,
+      },
+    };
   } catch (error) {
-    console.error('Error uploading photo:', error)
+    console.error('Error uploading photo:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'Failed to upload photo'
-    }
+      error: error instanceof Error ? error.message : 'Failed to upload photo',
+    };
   }
 }

--- a/packages/shared-lib/src/process-progress-photo-auth.test.ts
+++ b/packages/shared-lib/src/process-progress-photo-auth.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const functionSource = readFileSync(
+  new URL('../../../supabase/functions/process-progress-photo/index.ts', import.meta.url),
+  'utf8',
+);
+
+const functionConfig = readFileSync(
+  new URL('../../../supabase/functions/process-progress-photo/config.toml', import.meta.url),
+  'utf8',
+);
+
+const webPhotoUtils = readFileSync(
+  new URL('../../../apps/web/src/utils/photo-utils.ts', import.meta.url),
+  'utf8',
+);
+
+const iosPhotoUploadManager = readFileSync(
+  new URL('../../../apps/ios/LogYourBody/Services/PhotoUploadManager.swift', import.meta.url),
+  'utf8',
+);
+
+describe('process-progress-photo auth boundary', () => {
+  it('requires a verified user token before processing photos', () => {
+    expect(functionConfig).toContain('verify_jwt = true');
+    expect(functionSource).toContain("req.headers.get('Authorization')");
+    expect(functionSource).toContain('supabase.auth.getUser(token)');
+    expect(functionSource).toContain(
+      "return jsonResponse({ error: 'Missing or invalid authorization header' }, 401)",
+    );
+    expect(functionSource).toContain("return jsonResponse({ error: 'Invalid token' }, 401)");
+  });
+
+  it('checks metric and storage ownership before signing or uploading the photo', () => {
+    expect(functionSource).toContain('!normalizedStoragePath.startsWith(`${user.id}/`)');
+    expect(functionSource).toContain(".select('id, user_id')");
+    expect(functionSource).toContain('metric.user_id !== user.id');
+
+    expect(functionSource.indexOf(".select('id, user_id')")).toBeLessThan(
+      functionSource.indexOf('.createSignedUrl(normalizedStoragePath'),
+    );
+    expect(functionSource.indexOf('metric.user_id !== user.id')).toBeLessThan(
+      functionSource.indexOf('fetch(\n      `https://api.cloudinary.com'),
+    );
+  });
+
+  it('keeps the user predicate on the final service-role update', () => {
+    expect(functionSource).toContain(".eq('id', metricsId)\n      .eq('user_id', user.id)");
+    expect(functionSource).toContain(
+      "return jsonResponse({ error: 'Failed to update metrics photo' }, 500)",
+    );
+  });
+
+  it('does not let clients call the function with the anon key as bearer auth', () => {
+    expect(webPhotoUtils).toContain('await supabase.auth.getSession()');
+    expect(webPhotoUtils).toContain('Authorization: `Bearer ${accessToken}`');
+    expect(webPhotoUtils).not.toContain('Authorization: `Bearer ${supabaseAnonKey}`');
+
+    expect(iosPhotoUploadManager).toContain(
+      'private func authenticatedJWT() async throws -> String',
+    );
+    expect(iosPhotoUploadManager).toContain('let token = try await authenticatedJWT()');
+    expect(iosPhotoUploadManager).toContain(
+      'request.setValue("Bearer \\(token)", forHTTPHeaderField: "Authorization")',
+    );
+    expect(iosPhotoUploadManager).not.toContain(
+      'request.setValue("Bearer \\(Constants.supabaseAnonKey)"',
+    );
+  });
+});

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -3,16 +3,19 @@
 ## Setup
 
 1. Install Supabase CLI if not already installed:
+
 ```bash
 brew install supabase/tap/supabase
 ```
 
 2. Link your project:
+
 ```bash
 supabase link --project-ref your-project-ref
 ```
 
 3. Set up environment variables:
+
 ```bash
 # Copy the example env file
 cp .env.example .env
@@ -29,37 +32,36 @@ supabase secrets set CLOUDINARY_API_SECRET=your_api_secret
 ## Deploy Functions
 
 Deploy the process-progress-photo function:
+
 ```bash
 supabase functions deploy process-progress-photo
 ```
 
 ## Storage Setup
 
-Make sure you have a storage bucket named `progress-photos`:
+Make sure you have a storage bucket named `photos`:
 
 ```sql
 -- Run this in Supabase SQL Editor
 INSERT INTO storage.buckets (id, name, public)
-VALUES ('progress-photos', 'progress-photos', true)
+VALUES ('photos', 'photos', false)
 ON CONFLICT (id) DO NOTHING;
 
 -- Set up RLS policies
 CREATE POLICY "Users can upload their own photos" ON storage.objects
 FOR INSERT WITH CHECK (
-  bucket_id = 'progress-photos' AND
+  bucket_id = 'photos' AND
   auth.uid()::text = (storage.foldername(name))[1]
 );
 
 CREATE POLICY "Users can view their own photos" ON storage.objects
 FOR SELECT USING (
-  bucket_id = 'progress-photos' AND
+  bucket_id = 'photos' AND
   auth.uid()::text = (storage.foldername(name))[1]
 );
 
-CREATE POLICY "Public can view processed photos" ON storage.objects
-FOR SELECT USING (
-  bucket_id = 'progress-photos'
-);
+-- Processed photos are served from Cloudinary after the function verifies ownership.
+-- Keep original uploads private in Supabase Storage.
 ```
 
 ## Database Schema Update
@@ -68,7 +70,7 @@ Add the photo-related columns to body_metrics table:
 
 ```sql
 -- Add photo URL columns if they don't exist
-ALTER TABLE body_metrics 
+ALTER TABLE body_metrics
 ADD COLUMN IF NOT EXISTS photo_url TEXT,
 ADD COLUMN IF NOT EXISTS original_photo_url TEXT,
 ADD COLUMN IF NOT EXISTS photo_processed_at TIMESTAMP WITH TIME ZONE;
@@ -80,21 +82,25 @@ CREATE INDEX IF NOT EXISTS idx_body_metrics_photo_url ON body_metrics(photo_url)
 ## Testing
 
 Test the function locally:
+
 ```bash
 supabase functions serve process-progress-photo
 ```
 
 Call the function:
+
 ```bash
 curl -i --location --request POST 'http://localhost:54321/functions/v1/process-progress-photo' \
-  --header 'Authorization: Bearer YOUR_ANON_KEY' \
+  --header 'apikey: YOUR_SUPABASE_ANON_KEY' \
+  --header 'Authorization: Bearer YOUR_USER_JWT' \
   --header 'Content-Type: application/json' \
-  --data '{"originalUrl":"https://example.com/test.jpg","metricsId":"test-123"}'
+  --data '{"storagePath":"user_123/test-123-progress.jpg","metricsId":"test-123"}'
 ```
 
 ## Monitoring
 
 View function logs:
+
 ```bash
 supabase functions logs process-progress-photo
 ```

--- a/supabase/functions/process-progress-photo/config.toml
+++ b/supabase/functions/process-progress-photo/config.toml
@@ -1,2 +1,2 @@
 [functions.process-progress-photo]
-verify_jwt = false
+verify_jwt = true

--- a/supabase/functions/process-progress-photo/index.ts
+++ b/supabase/functions/process-progress-photo/index.ts
@@ -11,6 +11,25 @@ interface RequestBody {
   metricsId: string
 }
 
+function jsonResponse(body: Record<string, unknown>, status: number): Response {
+  return new Response(
+    JSON.stringify(body),
+    {
+      status,
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+}
+
+function bearerToken(authHeader: string | null): string | null {
+  const match = authHeader?.match(/^Bearer\s+(.+)$/i)
+  const token = match?.[1]?.trim()
+  return token || null
+}
+
 serve(async (req) => {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
@@ -18,12 +37,70 @@ serve(async (req) => {
   }
 
   try {
-    // Skip JWT validation - we'll validate by checking if the user owns the metrics record
-    const { storagePath, metricsId } = await req.json() as RequestBody
+    if (req.method !== 'POST') {
+      return jsonResponse({ error: 'Method not allowed' }, 405)
+    }
+
+    const token = bearerToken(req.headers.get('Authorization'))
+    if (!token) {
+      return jsonResponse({ error: 'Missing or invalid authorization header' }, 401)
+    }
+
+    // Get Supabase credentials from environment
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      console.error('Missing Supabase service configuration for process-progress-photo')
+      return jsonResponse({ error: 'Server configuration error' }, 500)
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser(token)
+
+    if (authError || !user) {
+      return jsonResponse({ error: 'Invalid token' }, 401)
+    }
+
+    const body = await req.json().catch(() => null) as Partial<RequestBody> | null
+    const storagePath = body?.storagePath
+    const metricsId = body?.metricsId
 
     // Validate inputs
-    if (!metricsId) {
-      throw new Error('Missing required parameters')
+    if (typeof storagePath !== 'string' || typeof metricsId !== 'string' || !storagePath || !metricsId) {
+      return jsonResponse({ error: 'Missing required parameters' }, 400)
+    }
+
+    const normalizedStoragePath = storagePath.replace(/^\/+/, '')
+    if (
+      normalizedStoragePath !== storagePath ||
+      normalizedStoragePath.includes('..') ||
+      !normalizedStoragePath.startsWith(`${user.id}/`)
+    ) {
+      return jsonResponse({ error: 'Photo path does not belong to the authenticated user' }, 403)
+    }
+
+    const { data: metric, error: metricError } = await supabase
+      .from('body_metrics')
+      .select('id, user_id')
+      .eq('id', metricsId)
+      .maybeSingle()
+
+    if (metricError) {
+      console.error('Failed to load body_metrics owner:', metricError)
+      return jsonResponse({ error: 'Failed to verify metrics ownership' }, 500)
+    }
+
+    if (!metric) {
+      return jsonResponse({ error: 'Metrics record not found' }, 404)
+    }
+
+    if (metric.user_id !== user.id) {
+      return jsonResponse({ error: 'Metrics record does not belong to the authenticated user' }, 403)
     }
 
     // Get Cloudinary credentials from environment
@@ -34,11 +111,6 @@ serve(async (req) => {
     if (!CLOUDINARY_CLOUD_NAME || !CLOUDINARY_API_KEY || !CLOUDINARY_API_SECRET) {
       throw new Error('Cloudinary credentials not configured')
     }
-
-    // Get Supabase credentials from environment
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
-    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-    const supabase = createClient(supabaseUrl, supabaseServiceKey)
 
     // Build Cloudinary transformation URL
     // PNG with transparency already has background removed on device
@@ -65,14 +137,14 @@ serve(async (req) => {
     ].join(',')
 
     // Resolve the original Supabase Storage URL from the storage path
-    const originalUrl = `${supabaseUrl}/storage/v1/object/public/photos/${storagePath}`
+    const originalUrl = `${supabaseUrl}/storage/v1/object/public/photos/${normalizedStoragePath}`
 
     // Create Cloudinary upload URL
     const timestamp = Math.round(Date.now() / 1000)
     const publicId = `progress-photos/${metricsId}_${timestamp}`
 
     // Parameters that need to be included in the signature (in alphabetical order)
-    const params = {
+    const params: Record<string, string | number> = {
       eager: transformations,
       eager_async: 'false',
       invalidate: 'true',
@@ -97,7 +169,7 @@ serve(async (req) => {
     const { data: signedData, error: signedError } = await supabase
       .storage
       .from('photos')
-      .createSignedUrl(storagePath, 60 * 10)
+      .createSignedUrl(normalizedStoragePath, 60 * 10)
 
     if (signedError || !signedData || !signedData.signedUrl) {
       throw new Error('Failed to create signed URL for original photo')
@@ -145,18 +217,25 @@ serve(async (req) => {
     const processedUrl = uploadResult.eager?.[0]?.secure_url || uploadResult.secure_url
 
     // Update the body_metrics record with the processed URL and storage path
-    const { error: updateError } = await supabase
+    const { data: updatedMetric, error: updateError } = await supabase
       .from('body_metrics')
       .update({
         photo_url: processedUrl,
-        original_photo_url: storagePath,
+        original_photo_url: normalizedStoragePath,
         photo_processed_at: new Date().toISOString()
       })
       .eq('id', metricsId)
+      .eq('user_id', user.id)
+      .select('id')
+      .maybeSingle()
 
     if (updateError) {
       console.error('Failed to update body_metrics:', updateError)
-      // Don't fail the whole operation if DB update fails
+      return jsonResponse({ error: 'Failed to update metrics photo' }, 500)
+    }
+
+    if (!updatedMetric) {
+      return jsonResponse({ error: 'Metrics record does not belong to the authenticated user' }, 403)
     }
 
     return new Response(
@@ -175,15 +254,7 @@ serve(async (req) => {
 
   } catch (error) {
     console.error('Error processing image:', error)
-    return new Response(
-      JSON.stringify({ error: error.message }),
-      {
-        status: 500,
-        headers: {
-          ...corsHeaders,
-          'Content-Type': 'application/json'
-        }
-      }
-    )
+    const message = error instanceof Error ? error.message : 'Internal server error'
+    return jsonResponse({ error: message }, 500)
   }
 })


### PR DESCRIPTION
## Summary
- Require a real user JWT for `process-progress-photo` and enable Supabase Edge JWT verification.
- Verify the caller owns both the storage path and `body_metrics` row before creating signed URLs, uploading to Cloudinary, or updating the row with the service role.
- Update iOS and web callers to send the authenticated user token instead of the anon key as bearer auth.
- Add a static regression test covering the auth boundary and caller token handoff.

Closes JovieInc/Jovie#10419

## Security notes
- The function now returns `401` for missing/invalid bearer tokens.
- Storage paths must be bucket-relative, must not contain `..`, and must begin with the authenticated `user.id` folder.
- The service-role update includes both `id` and `user_id` predicates.
- Supabase Storage docs now describe original photos as private; processed image delivery remains via Cloudinary after ownership verification.

## Validation
- `pnpm --filter @logyourbody/shared-lib test` PASS: 3 files, 12 tests.
- `pnpm --filter @logyourbody/shared-lib lint` PASS.
- `pnpm --filter @logyourbody/shared-lib typecheck` PASS.
- `pnpm --filter @logyourbody/shared-lib build` PASS.
- `swiftlint lint --strict` PASS in `apps/ios`.
- XcodeBuildMCP `build_sim` PASS for `LogYourBody` on `iPhone 17`.
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests` PASS: 89 tests.
- `pnpm lint` PASS.
- `pnpm typecheck` PASS.
- `pnpm test:ci` PASS.
- Pre-push Turbo gate PASS: `turbo run lint --filter='...[origin/main]' && turbo run typecheck --filter='...[origin/main]' && turbo run test --filter='...[origin/main]'`.

## Known validation gaps
- Deno is not installed locally, so I did not run `deno check` for the Supabase Edge function.
- The full iOS scheme test run was interrupted by a simulator UI test runner launch denial for `com.logyourbody.app.xctrunner`; the focused unit bundle passed afterward.
- No live Supabase/Cloudinary invocation was run because that requires a valid user JWT, service env, and Cloudinary credentials.
