### PR TITLE
fix: sync deleted body metrics

### DIFF
--- a/apps/ios/LogYourBody/Components/FullMetricChartView.swift
+++ b/apps/ios/LogYourBody/Components/FullMetricChartView.swift
@@ -1331,7 +1331,7 @@ struct FullMetricChartView: View {
             showingHistoryDeleteConfirmation = false
         }
 
-        let success = await CoreDataManager.shared.markBodyMetricDeleted(id: entry.id)
+        let success = await RealtimeSyncManager.shared.deleteBodyMetric(id: entry.id)
         guard success else { return }
 
         var sections = localHistorySections ?? historySections

--- a/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
+++ b/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
@@ -370,10 +370,16 @@ class RealtimeSyncManager: ObservableObject {
         let unsyncedGlp1 = await coreDataManager.fetchUnsyncedGlp1DoseLogs()
         let unsyncedMedications = await coreDataManager.fetchUnsyncedGlp1Medications()
         let unsyncedDexa = await coreDataManager.fetchUnsyncedDexaResults()
+        let deletedBodyMetrics = unsynced.bodyMetrics.filter(\.isMarkedDeleted)
+        let bodyMetricsToUpsert = unsynced.bodyMetrics.filter { !$0.isMarkedDeleted }
 
         // Batch sync for efficiency
-        if !unsynced.bodyMetrics.isEmpty {
-            try await syncBodyMetricsBatch(unsynced.bodyMetrics, token: token)
+        if !deletedBodyMetrics.isEmpty {
+            try await syncDeletedBodyMetricsBatch(deletedBodyMetrics, token: token)
+        }
+
+        if !bodyMetricsToUpsert.isEmpty {
+            try await syncBodyMetricsBatch(bodyMetricsToUpsert, token: token)
         }
 
         if !unsynced.dailyMetrics.isEmpty {
@@ -395,6 +401,23 @@ class RealtimeSyncManager: ObservableObject {
         if !unsyncedDexa.isEmpty {
             try await syncDexaResultsBatch(unsyncedDexa, token: token)
         }
+    }
+
+    nonisolated private func syncDeletedBodyMetricsBatch(_ metrics: [CachedBodyMetrics], token: String) async throws {
+        for metric in metrics {
+            guard let id = metric.id else { continue }
+
+            try await supabaseManager.deleteData(
+                table: "body_metrics",
+                id: id,
+                token: token
+            )
+
+            metric.syncStatus = "synced"
+            metric.isSynced = true
+        }
+
+        coreDataManager.save()
     }
 
     nonisolated private func syncBodyMetricsBatch(_ metrics: [CachedBodyMetrics], token: String) async throws {
@@ -871,6 +894,28 @@ class RealtimeSyncManager: ObservableObject {
     }
 
     // MARK: - Public Methods
+    @discardableResult
+    func deleteBodyMetric(id: String) async -> Bool {
+        let success = await coreDataManager.markBodyMetricDeleted(id: id)
+        guard success else { return false }
+
+        queueOperation(
+            SyncOperation(
+                id: id,
+                type: .delete,
+                data: Data(),
+                tableName: "body_metrics",
+                timestamp: Date()
+            )
+        )
+
+        if isOnline {
+            syncAll()
+        }
+
+        return true
+    }
+
     func logBodyMetrics(_ metrics: BodyMetrics) {
         guard let userId = authManager.currentUser?.id else { return }
 

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -1267,6 +1267,7 @@ final class StubSupabaseManager: SupabaseManager {
     private(set) var bodyMetricsBatches: [[[String: Any]]] = []
     private(set) var dailyMetricsBatches: [[[String: Any]]] = []
     private(set) var dexaPayloads: [[String: Any]] = []
+    private(set) var deletedRecords: [(table: String, id: String)] = []
 
     override func upsertBodyMetricsBatch(_ metrics: [[String: Any]], token: String) async throws -> [[String: Any]] {
         bodyMetricsBatches.append(metrics)
@@ -1292,6 +1293,10 @@ final class StubSupabaseManager: SupabaseManager {
         let jsonObject = try JSONSerialization.jsonObject(with: data)
         let array = jsonObject as? [[String: Any]] ?? []
         dexaPayloads.append(contentsOf: array)
+    }
+
+    override func deleteData(table: String, id: String, token: String) async throws {
+        deletedRecords.append((table: table, id: id))
     }
 }
 
@@ -2013,6 +2018,53 @@ final class SyncIntegrationTests: XCTestCase {
         }
 
         // Verify Core Data entry for this user is no longer unsynced
+        let unsynced = await coreData.fetchUnsyncedEntries()
+        let unsyncedForUser = unsynced.bodyMetrics.filter { $0.userId == userId }
+        XCTAssertTrue(unsyncedForUser.isEmpty)
+    }
+
+    func testSyncLocalChangesDeletesMarkedBodyMetricInsteadOfUpserting() async throws {
+        let coreData = CoreDataManager.shared
+
+        let id = UUID().uuidString
+        let userId = "sync_test_user_deleted_realtime_\(UUID().uuidString)"
+        let date = Date()
+
+        let metricModel = BodyMetrics(
+            id: id,
+            userId: userId,
+            date: date,
+            weight: 81.0,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: "Manual",
+            createdAt: date.addingTimeInterval(-60),
+            updatedAt: date
+        )
+
+        try await coreData.saveBodyMetricsAndWait(metricModel, userId: userId, markAsSynced: true)
+        let didMarkDeleted = await coreData.markBodyMetricDeleted(id: id)
+        XCTAssertTrue(didMarkDeleted)
+
+        let stubSupabase = StubSupabaseManager()
+        let manager = RealtimeSyncManager(
+            coreDataManager: coreData,
+            authManager: AuthManager.shared,
+            supabaseManager: stubSupabase
+        )
+
+        try await manager.syncLocalChanges(token: "test-token")
+
+        XCTAssertTrue(stubSupabase.bodyMetricsBatches.isEmpty)
+        XCTAssertEqual(stubSupabase.deletedRecords.count, 1)
+        XCTAssertEqual(stubSupabase.deletedRecords.first?.table, "body_metrics")
+        XCTAssertEqual(stubSupabase.deletedRecords.first?.id, id)
+
         let unsynced = await coreData.fetchUnsyncedEntries()
         let unsyncedForUser = unsynced.bodyMetrics.filter { $0.userId == userId }
         XCTAssertTrue(unsyncedForUser.isEmpty)


### PR DESCRIPTION
## Summary
- Treat locally tombstoned body metrics as remote `DELETE` work before body-metric upserts.
- Add a sync-aware `deleteBodyMetric(id:)` helper so the chart delete action queues a delete and triggers immediate sync when online.
- Add regression coverage proving marked-deleted body metrics are deleted from `body_metrics` instead of being upserted back to Supabase.

Closes JovieInc/Jovie#10420.

## Validation
- `swiftlint lint --strict --quiet`
- XcodeBuildMCP focused test: `LogYourBodyTests/SyncIntegrationTests/testSyncLocalChangesDeletesMarkedBodyMetricInsteadOfUpserting` passed
- XcodeBuildMCP sync test class: `LogYourBodyTests/SyncIntegrationTests` passed, 15 tests
- XcodeBuildMCP simulator build passed for `LogYourBody` on iPhone 17 simulator
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`
- `git diff --check`
- Pre-push hook ran filtered Turbo lint/typecheck/test; no filtered tasks were selected for the iOS-only diff

## Notes
- Existing local warnings remain: Node 22 vs repo Node 20 engine warning, Next/ESLint deprecation warnings, stale Browserslist/baseline data, and existing Swift 6 actor-isolation warnings in unrelated files.
- I did not run a live Supabase two-device/reinstall proof in this environment. The unit regression pins the client behavior: a tombstoned body metric sends `DELETE body_metrics?id=...` and is not included in the upsert batch.
