### PR TITLE
fix: run old-data cleanup on core data queue

### DIFF
--- a/apps/ios/LogYourBody/Services/AppVersionManager.swift
+++ b/apps/ios/LogYourBody/Services/AppVersionManager.swift
@@ -197,7 +197,9 @@ class AppVersionManager {
         // print("🗑️ Cleaning up old data...")
 
         // Clean up CoreData
-        CoreDataManager.shared.cleanupOldData()
+        Task(priority: .utility) {
+            await CoreDataManager.shared.cleanupOldData()
+        }
 
         // Clean up old user defaults
         cleanupOldUserDefaults()

--- a/apps/ios/LogYourBody/Services/CoreDataManager.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager.swift
@@ -1612,21 +1612,34 @@ class CoreDataManager: ObservableObject {
 
     // MARK: - Cleanup
 
-    func cleanupOldData() {
-        // Delete body metrics older than 1 year
-        let oneYearAgo = Date().addingTimeInterval(-365 * 24 * 60 * 60)
+    func cleanupOldData() async {
+        let context = viewContext
 
-        let bodyMetricsRequest: NSFetchRequest<NSFetchRequestResult> = CachedBodyMetrics.fetchRequest()
-        bodyMetricsRequest.predicate = NSPredicate(format: "date < %@ AND isMarkedDeleted == true", oneYearAgo as NSDate)
+        await context.perform {
+            // Delete body metrics older than 1 year
+            let oneYearAgo = Date().addingTimeInterval(-365 * 24 * 60 * 60)
 
-        let deleteRequest = NSBatchDeleteRequest(fetchRequest: bodyMetricsRequest)
-        deleteRequest.resultType = .resultTypeCount
+            let bodyMetricsRequest: NSFetchRequest<NSFetchRequestResult> = CachedBodyMetrics.fetchRequest()
+            bodyMetricsRequest.predicate = NSPredicate(
+                format: "date < %@ AND isMarkedDeleted == true",
+                oneYearAgo as NSDate
+            )
 
-        do {
-            _ = try viewContext.execute(deleteRequest) as? NSBatchDeleteResult
-            // print("Deleted \(result?.result ?? 0) old body metrics")
-        } catch {
-            // print("Error cleaning up old data: \(error)")
+            let deleteRequest = NSBatchDeleteRequest(fetchRequest: bodyMetricsRequest)
+            deleteRequest.resultType = .resultTypeObjectIDs
+
+            do {
+                if let result = try context.execute(deleteRequest) as? NSBatchDeleteResult,
+                   let objectIDs = result.result as? [NSManagedObjectID],
+                   !objectIDs.isEmpty {
+                    NSManagedObjectContext.mergeChanges(
+                        fromRemoteContextSave: [NSDeletedObjectsKey: objectIDs],
+                        into: [context]
+                    )
+                }
+            } catch {
+                // print("Error cleaning up old data: \(error)")
+            }
         }
     }
 

--- a/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
+++ b/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
@@ -311,7 +311,7 @@ class RealtimeSyncManager: ObservableObject {
 
                 try await self.syncLocalChanges(token: token)
                 try await self.pullLatestData(userId: userId, lastSync: lastSyncSnapshot, token: token)
-                self.coreDataManager.cleanupOldData()
+                await self.coreDataManager.cleanupOldData()
 
                 await MainActor.run {
                     self.isSyncing = false

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -4,6 +4,7 @@
 //
 import XCTest
 import AVFoundation
+import CoreData
 @testable import LogYourBody
 
 // swiftlint:disable single_test_class
@@ -1376,6 +1377,91 @@ final class SyncIntegrationTests: XCTestCase {
                 regionFatPct: 17.7
             )
         )
+    }
+
+    func testCleanupOldDataDeletesOnlyOldTombstonedBodyMetrics() async throws {
+        let coreData = CoreDataManager.shared
+
+        let userId = "cleanup_user_\(UUID().uuidString)"
+        let oldDeletedId = UUID().uuidString
+        let recentDeletedId = UUID().uuidString
+        let oldLiveId = UUID().uuidString
+        let now = Date()
+        let oldDate = now.addingTimeInterval(-370 * 24 * 60 * 60)
+        let recentDate = now.addingTimeInterval(-10 * 24 * 60 * 60)
+
+        let oldDeletedMetric = BodyMetrics(
+            id: oldDeletedId,
+            userId: userId,
+            date: oldDate,
+            weight: 80.0,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: "Manual",
+            createdAt: oldDate,
+            updatedAt: oldDate
+        )
+        let recentDeletedMetric = BodyMetrics(
+            id: recentDeletedId,
+            userId: userId,
+            date: recentDate,
+            weight: 81.0,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: "Manual",
+            createdAt: recentDate,
+            updatedAt: recentDate
+        )
+        let oldLiveMetric = BodyMetrics(
+            id: oldLiveId,
+            userId: userId,
+            date: oldDate,
+            weight: 82.0,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: "Manual",
+            createdAt: oldDate,
+            updatedAt: oldDate
+        )
+
+        try await coreData.saveBodyMetricsAndWait(oldDeletedMetric, userId: userId, markAsSynced: true)
+        try await coreData.saveBodyMetricsAndWait(recentDeletedMetric, userId: userId, markAsSynced: true)
+        try await coreData.saveBodyMetricsAndWait(oldLiveMetric, userId: userId, markAsSynced: true)
+
+        let didMarkOldDeleted = await coreData.markBodyMetricDeleted(id: oldDeletedId)
+        let didMarkRecentDeleted = await coreData.markBodyMetricDeleted(id: recentDeletedId)
+        XCTAssertTrue(didMarkOldDeleted)
+        XCTAssertTrue(didMarkRecentDeleted)
+
+        await coreData.cleanupOldData()
+
+        let context = coreData.viewContext
+        let remainingIds = await context.perform {
+            let request: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+            request.predicate = NSPredicate(format: "userId == %@", userId)
+
+            let metrics = (try? context.fetch(request)) ?? []
+            return Set(metrics.compactMap(\.id))
+        }
+
+        XCTAssertFalse(remainingIds.contains(oldDeletedId))
+        XCTAssertTrue(remainingIds.contains(recentDeletedId))
+        XCTAssertTrue(remainingIds.contains(oldLiveId))
     }
 
     func testBodySpecDexaImporter_AddsProvenanceWithoutOverwritingManualOrHealthKit() async throws {


### PR DESCRIPTION
## Summary
- fixes JovieInc/Jovie#10428
- makes `CoreDataManager.cleanupOldData()` async and executes the batch delete inside `viewContext.perform`
- merges batch-delete object IDs back into the context so loaded `CachedBodyMetrics` rows stay consistent
- updates sync and app-version cleanup call sites, and adds a regression test for old tombstoned metric cleanup

## Validation
- `swiftlint lint --strict --quiet`
- focused simulator regression: `LogYourBodyTests/SyncIntegrationTests/testCleanupOldDataDeletesOnlyOldTombstonedBodyMetrics` passed on iPhone 17 simulator; XcodeBuildMCP timed out waiting for the command wrapper, but the underlying xcodebuild log ended with `** TEST EXECUTE SUCCEEDED **`
- simulator class run: `LogYourBodyTests/SyncIntegrationTests` passed 16 tests on iPhone 17 simulator; XcodeBuildMCP timed out waiting for the command wrapper, but the underlying xcodebuild log ended with `** TEST EXECUTE SUCCEEDED **`
- XcodeBuildMCP simulator build passed for `LogYourBody`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`
- `git diff --check`

## Notes
- Did not run a separate Instruments Thread Sanitizer capture or an explicit Core Data concurrency-debug launch session in this environment; the fix keeps the affected cleanup work on the managed object context queue and is covered by the focused simulator regression.
