### PR TITLE
feat: add core body metric App Intents

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		AD050C4D2EC135360082A313 /* ReceiptParser in Frameworks */ = {isa = PBXBuildFile; productRef = AD050C4C2EC135360082A313 /* ReceiptParser */; };
 		AD050C4F2EC135360082A313 /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = AD050C4E2EC135360082A313 /* RevenueCat */; };
 		AD050C512EC135360082A313 /* RevenueCatUI in Frameworks */ = {isa = PBXBuildFile; productRef = AD050C502EC135360082A313 /* RevenueCatUI */; };
+		AD1036332F00000100ABCDEF /* BodyMetricAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1036322F00000100ABCDEF /* BodyMetricAppIntents.swift */; };
+		AD1036352F00000100ABCDEF /* BodyMetricLoggingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1036342F00000100ABCDEF /* BodyMetricLoggingService.swift */; };
 		AD0B7BF52EC552FA008B29E7 /* LogYourBody.storekit in Resources */ = {isa = PBXBuildFile; fileRef = AD0B7BF42EC552FA008B29E7 /* LogYourBody.storekit */; };
 		AD0B7BF72EC692ED008B29E7 /* MetricChartDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0B7BF62EC692ED008B29E7 /* MetricChartDataHelper.swift */; };
 		AD0B7BFB2EC6930D008B29E7 /* PeriodSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0B7BFA2EC6930D008B29E7 /* PeriodSelector.swift */; };
@@ -371,6 +373,8 @@
 		AD723AE42E15FA5C002376C6 /* AuthManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		AD723AE62E15FA5C002376C6 /* CoreDataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		AD723AE72E15FA5C002376C6 /* HealthKitManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthKitManager.swift; sourceTree = "<group>"; };
+		AD1036322F00000100ABCDEF /* BodyMetricAppIntents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyMetricAppIntents.swift; sourceTree = "<group>"; };
+		AD1036342F00000100ABCDEF /* BodyMetricLoggingService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyMetricLoggingService.swift; sourceTree = "<group>"; };
 		AD723AE82E15FA5C002376C6 /* LoadingManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingManager.swift; sourceTree = "<group>"; };
 		AD723AEA2E15FA5C002376C6 /* SupabaseDataClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupabaseDataClient.swift; sourceTree = "<group>"; };
 		AD723AEE2E15FA5C002376C6 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
@@ -899,6 +903,8 @@
 				ADA600272ED259DB00088042 /* BodyScoreRecalculationService.swift */,
 				ADA4B74C2ED00F1500F4262A /* KeychainManager.swift */,
 				ADA4B74A2ED00E1F00F4262A /* ValidationService.swift */,
+				AD1036322F00000100ABCDEF /* BodyMetricAppIntents.swift */,
+				AD1036342F00000100ABCDEF /* BodyMetricLoggingService.swift */,
 				ADA4B7382ECD44C800F4262A /* BodyScoreCache.swift */,
 				ADA4B7362ECC3A7A00F4262A /* EntryVisibilityManager.swift */,
 				AD050C482EC12E390082A313 /* RevenueCatManager.swift */,
@@ -1555,6 +1561,8 @@
 				ADDC47A92E2D89F3003C97E7 /* DailyLog.swift in Sources */,
 				ADDC47AA2E2D89F3003C97E7 /* DailyMetrics.swift in Sources */,
 				ADDC47AB2E2D89F3003C97E7 /* LogYourBody.xcdatamodeld in Sources */,
+				AD1036332F00000100ABCDEF /* BodyMetricAppIntents.swift in Sources */,
+				AD1036352F00000100ABCDEF /* BodyMetricLoggingService.swift in Sources */,
 				AD8872452EB87F480041C426 /* LiquidGlassCard.swift in Sources */,
 				ADDC47AD2E2D89F3003C97E7 /* User.swift in Sources */,
 				ADDC487C2E2D8A6B003C97E7 /* ProgressPhotoCarouselView.swift in Sources */,

--- a/apps/ios/LogYourBody/Info.plist
+++ b/apps/ios/LogYourBody/Info.plist
@@ -48,6 +48,8 @@
 	<string>LogYourBody needs access to scan your photo library for progress photos to import.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>LogYourBody saves your shared body score images to your photo library.</string>
+	<key>NSSiriUsageDescription</key>
+	<string>LogYourBody uses Siri to log and read your body metrics when you ask.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/apps/ios/LogYourBody/Services/BodyMetricAppIntents.swift
+++ b/apps/ios/LogYourBody/Services/BodyMetricAppIntents.swift
@@ -1,0 +1,133 @@
+//
+// BodyMetricAppIntents.swift
+// LogYourBody
+//
+import AppIntents
+import Foundation
+import SwiftUI
+
+enum BodyMetricIntentWeightUnit: String, AppEnum {
+    case pounds
+    case kilograms
+
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Weight Unit")
+    static var caseDisplayRepresentations: [BodyMetricIntentWeightUnit: DisplayRepresentation] = [
+        .pounds: DisplayRepresentation(title: "Pounds", subtitle: "lbs"),
+        .kilograms: DisplayRepresentation(title: "Kilograms", subtitle: "kg")
+    ]
+
+    var storageUnit: String {
+        switch self {
+        case .pounds:
+            return "lbs"
+        case .kilograms:
+            return "kg"
+        }
+    }
+}
+
+struct LogWeightIntent: AppIntent {
+    static var title: LocalizedStringResource = "Log Weight"
+    static var description = IntentDescription("Log a body weight measurement in LogYourBody.")
+    static var openAppWhenRun = false
+
+    @Parameter(title: "Weight")
+    var weight: Double
+
+    @Parameter(title: "Unit", default: .pounds)
+    var unit: BodyMetricIntentWeightUnit
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let result = try await BodyMetricLoggingService.shared.log(
+            weight: String(weight),
+            bodyFat: nil,
+            unit: unit.storageUnit
+        )
+
+        return .result(dialog: IntentDialog(stringLiteral: result.dialog))
+    }
+}
+
+struct LogBodyFatIntent: AppIntent {
+    static var title: LocalizedStringResource = "Log Body Fat"
+    static var description = IntentDescription("Log a body fat percentage in LogYourBody.")
+    static var openAppWhenRun = false
+
+    @Parameter(title: "Body Fat Percentage")
+    var bodyFatPercentage: Double
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let result = try await BodyMetricLoggingService.shared.log(
+            weight: nil,
+            bodyFat: String(bodyFatPercentage),
+            unit: MeasurementSystem.preferredFromDefaults.weightUnit
+        )
+
+        return .result(dialog: IntentDialog(stringLiteral: result.dialog))
+    }
+}
+
+struct ShowLatestMetricsIntent: AppIntent {
+    static var title: LocalizedStringResource = "Show Latest Metrics"
+    static var description = IntentDescription("Show the latest logged weight and body fat values.")
+    static var openAppWhenRun = false
+
+    func perform() async throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
+        let latest = try await BodyMetricLoggingService.shared.latestMetricsSummary()
+
+        return .result(dialog: IntentDialog(stringLiteral: latest.dialog)) {
+            LatestMetricsIntentSnippet(summary: latest)
+        }
+    }
+}
+
+struct LatestMetricsIntentSnippet: View {
+    let summary: BodyMetricLatestSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Latest Metrics")
+                .font(.headline)
+
+            Text(summary.dialog)
+                .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding()
+    }
+}
+
+struct LogYourBodyAppShortcuts: AppShortcutsProvider {
+    @AppShortcutsBuilder
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: LogWeightIntent(),
+            phrases: [
+                "Log my weight in \(.applicationName)",
+                "Record my weight with \(.applicationName)"
+            ],
+            shortTitle: "Log Weight",
+            systemImageName: "scalemass"
+        )
+
+        AppShortcut(
+            intent: LogBodyFatIntent(),
+            phrases: [
+                "Log my body fat in \(.applicationName)",
+                "Record body fat with \(.applicationName)"
+            ],
+            shortTitle: "Log Body Fat",
+            systemImageName: "percent"
+        )
+
+        AppShortcut(
+            intent: ShowLatestMetricsIntent(),
+            phrases: [
+                "Show my latest metrics in \(.applicationName)",
+                "Show my current weight in \(.applicationName)"
+            ],
+            shortTitle: "Latest Metrics",
+            systemImageName: "chart.line.uptrend.xyaxis"
+        )
+    }
+}

--- a/apps/ios/LogYourBody/Services/BodyMetricLoggingService.swift
+++ b/apps/ios/LogYourBody/Services/BodyMetricLoggingService.swift
@@ -1,0 +1,240 @@
+//
+// BodyMetricLoggingService.swift
+// LogYourBody
+//
+import Foundation
+
+enum BodyMetricLoggingError: LocalizedError {
+    case notAuthenticated
+    case noMetrics
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated:
+            return "Sign in to LogYourBody before logging body metrics."
+        case .noMetrics:
+            return "No body metrics have been logged yet."
+        }
+    }
+}
+
+struct BodyMetricLoggingResult {
+    let metrics: BodyMetrics
+    let dialog: String
+}
+
+struct BodyMetricLatestSummary {
+    let metrics: BodyMetrics
+    let dialog: String
+}
+
+final class BodyMetricLoggingService {
+    static let shared = BodyMetricLoggingService()
+
+    private let coreDataManager: CoreDataManager
+    private let healthKitManager: HealthKitManager
+
+    init(
+        coreDataManager: CoreDataManager = .shared,
+        healthKitManager: HealthKitManager = .shared
+    ) {
+        self.coreDataManager = coreDataManager
+        self.healthKitManager = healthKitManager
+    }
+
+    func log(
+        weight weightText: String?,
+        bodyFat bodyFatText: String?,
+        unit: String,
+        date: Date = Date()
+    ) async throws -> BodyMetricLoggingResult {
+        let validation = LogWeightFormValidator.validate(
+            weight: weightText ?? "",
+            bodyFat: bodyFatText ?? "",
+            unit: unit
+        )
+
+        if let error = validation.formError ?? validation.weightError ?? validation.bodyFatError {
+            throw ValidationError.invalidWeight(error)
+        }
+
+        guard validation.isValid else {
+            throw ValidationError.invalidWeight("Please enter at least one measurement")
+        }
+
+        guard let userId = await currentAuthenticatedUserId() else {
+            throw BodyMetricLoggingError.notAuthenticated
+        }
+
+        let weightInKg = Self.storedWeightInKilograms(
+            displayWeight: validation.weightValue,
+            unit: unit
+        )
+
+        if healthKitManager.isAuthorized {
+            if let weightValue = validation.weightValue {
+                let weightInPounds = unit == "kg" ? weightValue.kgToLbs : weightValue
+                try await healthKitManager.saveWeight(weightInPounds, date: date)
+            }
+
+            if let bodyFatValue = validation.bodyFatValue {
+                try await healthKitManager.saveBodyFatPercentage(bodyFatValue, date: date)
+            }
+        }
+
+        let finalWeight = await resolvedWeight(
+            suppliedWeightInKg: weightInKg,
+            bodyFatValue: validation.bodyFatValue,
+            userId: userId,
+            date: date
+        )
+
+        let metrics = BodyMetrics(
+            id: UUID().uuidString,
+            userId: userId,
+            date: date,
+            localDate: BodyMetricLocalDate.key(for: date),
+            weight: finalWeight,
+            weightUnit: finalWeight != nil ? "kg" : nil,
+            bodyFatPercentage: validation.bodyFatValue,
+            bodyFatMethod: validation.bodyFatValue != nil ? "Manual" : nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+
+        try await coreDataManager.saveBodyMetricsAndWait(
+            metrics,
+            userId: userId,
+            markAsSynced: false
+        )
+
+        await MainActor.run {
+            RealtimeSyncManager.shared.syncIfNeeded()
+        }
+
+        Self.donateLoggedMetricActivity(metrics)
+
+        return BodyMetricLoggingResult(
+            metrics: metrics,
+            dialog: Self.loggedSummary(for: metrics, preferredSystem: .preferredFromDefaults)
+        )
+    }
+
+    func latestMetricsSummary() async throws -> BodyMetricLatestSummary {
+        guard let userId = await currentAuthenticatedUserId() else {
+            throw BodyMetricLoggingError.notAuthenticated
+        }
+
+        guard let metrics = await coreDataManager.fetchLatestBodyMetric(for: userId)?.toBodyMetrics() else {
+            throw BodyMetricLoggingError.noMetrics
+        }
+
+        return BodyMetricLatestSummary(
+            metrics: metrics,
+            dialog: Self.latestSummary(for: metrics, preferredSystem: .preferredFromDefaults)
+        )
+    }
+
+    static func storedWeightInKilograms(displayWeight: Double?, unit: String) -> Double? {
+        guard let displayWeight else { return nil }
+        return unit == "lbs" ? displayWeight.lbsToKg : displayWeight
+    }
+
+    static func formattedWeight(_ weightKg: Double, preferredSystem: MeasurementSystem) -> String {
+        let displayValue = preferredSystem.weightUnit == "lbs" ? weightKg.kgToLbs : weightKg
+        return "\(formatDecimal(displayValue)) \(preferredSystem.weightUnit)"
+    }
+
+    static func loggedSummary(for metrics: BodyMetrics, preferredSystem: MeasurementSystem) -> String {
+        let parts = metricParts(for: metrics, preferredSystem: preferredSystem)
+        guard !parts.isEmpty else {
+            return "Logged your body metrics."
+        }
+
+        return "Logged \(parts.joined(separator: " and "))."
+    }
+
+    static func latestSummary(for metrics: BodyMetrics, preferredSystem: MeasurementSystem) -> String {
+        let parts = metricParts(for: metrics, preferredSystem: preferredSystem)
+        guard !parts.isEmpty else {
+            return "Your latest entry has no weight or body fat value."
+        }
+
+        return "Your latest metrics are \(parts.joined(separator: " and "))."
+    }
+
+    private func currentAuthenticatedUserId() async -> String? {
+        let initializationTask = await MainActor.run {
+            AuthManager.shared.ensureClerkInitializationTask(priority: .userInitiated)
+        }
+
+        await initializationTask.value
+        await Task.yield()
+
+        return await MainActor.run {
+            AuthManager.shared.currentUser?.id
+        }
+    }
+
+    private func resolvedWeight(
+        suppliedWeightInKg: Double?,
+        bodyFatValue: Double?,
+        userId: String,
+        date: Date
+    ) async -> Double? {
+        guard suppliedWeightInKg == nil, bodyFatValue != nil else {
+            return suppliedWeightInKg
+        }
+
+        let fromDate = Calendar.current.date(byAdding: .day, value: -7, to: date) ?? date
+        let cachedMetrics = await coreDataManager.fetchBodyMetrics(
+            for: userId,
+            from: fromDate,
+            to: date
+        )
+
+        return cachedMetrics
+            .compactMap { $0.toBodyMetrics() }
+            .max { $0.date < $1.date }?
+            .weight
+    }
+
+    private static func metricParts(for metrics: BodyMetrics, preferredSystem: MeasurementSystem) -> [String] {
+        var parts: [String] = []
+
+        if let weight = metrics.weight {
+            parts.append(formattedWeight(weight, preferredSystem: preferredSystem))
+        }
+
+        if let bodyFatPercentage = metrics.bodyFatPercentage {
+            parts.append("\(formatDecimal(bodyFatPercentage))% body fat")
+        }
+
+        return parts
+    }
+
+    private static func formatDecimal(_ value: Double) -> String {
+        String(format: "%.1f", value)
+    }
+
+    private static func donateLoggedMetricActivity(_ metrics: BodyMetrics) {
+        let activity = NSUserActivity(activityType: "com.logyourbody.metric.logged")
+        activity.title = "Log body metrics"
+        activity.isEligibleForSearch = true
+        activity.isEligibleForPrediction = true
+        activity.suggestedInvocationPhrase = "Log my weight in LogYourBody"
+        activity.persistentIdentifier = NSUserActivityPersistentIdentifier(metrics.id)
+        activity.userInfo = [
+            "metricId": metrics.id,
+            "localDate": metrics.localDate,
+            "hasWeight": metrics.weight != nil,
+            "hasBodyFat": metrics.bodyFatPercentage != nil
+        ]
+        activity.becomeCurrent()
+    }
+}

--- a/apps/ios/LogYourBody/Views/LogWeightView.swift
+++ b/apps/ios/LogYourBody/Views/LogWeightView.swift
@@ -6,7 +6,6 @@ import SwiftUI
 
 struct LogWeightView: View {
     @EnvironmentObject var authManager: AuthManager
-    @StateObject private var healthKitManager = HealthKitManager.shared
     @State private var weight: String = ""
     @State private var bodyFat: String = ""
     @State private var weightError: String?
@@ -361,78 +360,11 @@ struct LogWeightView: View {
 
         Task {
             do {
-                let weightValue = validation.weightValue
-                let bodyFatValue = validation.bodyFatValue
-                let now = Date()
-
-                // Convert weight to kg for storage
-                let weightInKg = weightValue != nil
-                    ? (
-                        currentSystem.weightUnit == "lbs"
-                            ? weightValue!.lbsToKg
-                            : weightValue!
-                    )
-                    : nil
-
-                // Save to HealthKit if authorized
-                if healthKitManager.isAuthorized {
-                    if let w = weightValue {
-                        let weightInLbs = currentSystem.weightUnit == "kg"
-                            ? w.kgToLbs
-                            : w
-                        try await healthKitManager.saveWeight(weightInLbs, date: now)
-                    }
-
-                    if let bf = bodyFatValue {
-                        try await healthKitManager.saveBodyFatPercentage(bf / 100, date: now)
-                    }
-                }
-
-                // If only body fat is provided, try to get latest weight
-                var finalWeight = weightInKg
-                if weightInKg == nil && bodyFatValue != nil, let userId = authManager.currentUser?.id {
-                    let fromDate = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
-                    let cachedMetrics = await CoreDataManager.shared.fetchBodyMetrics(
-                        for: userId,
-                        from: fromDate,
-                        to: Date()
-                    )
-                    let recentMetrics = cachedMetrics
-                        .compactMap { $0.toBodyMetrics() }
-                        .sorted { $0.date > $1.date }
-                    finalWeight = recentMetrics.first?.weight
-                }
-
-                // Create body metrics
-                let metrics = BodyMetrics(
-                    id: UUID().uuidString,
-                    userId: authManager.currentUser?.id ?? "",
-                    date: now,
-                    localDate: BodyMetricLocalDate.key(for: now),
-                    weight: finalWeight,
-                    weightUnit: finalWeight != nil ? "kg" : nil,
-                    bodyFatPercentage: bodyFatValue,
-                    bodyFatMethod: bodyFatValue != nil ? "Manual" : nil,
-                    muscleMass: nil,
-                    boneMass: nil,
-                    notes: nil,
-                    photoUrl: nil,
-                    dataSource: "Manual",
-                    createdAt: now,
-                    updatedAt: now
+                _ = try await BodyMetricLoggingService.shared.log(
+                    weight: weight,
+                    bodyFat: bodyFat,
+                    unit: currentSystem.weightUnit
                 )
-
-                // Save to local storage and sync
-                if let userId = authManager.currentUser?.id {
-                    await MainActor.run {
-                        CoreDataManager.shared.saveBodyMetrics(
-                            metrics,
-                            userId: userId,
-                            markAsSynced: false
-                        )
-                    }
-                    RealtimeSyncManager.shared.syncIfNeeded()
-                }
 
                 await MainActor.run {
                     isLoading = false

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -151,6 +151,51 @@ final class PhotoTimelineHUDPolicyTests: XCTestCase {
     }
 }
 
+final class BodyMetricLoggingServiceTests: XCTestCase {
+    func testStoredWeightConvertsPoundsToKilograms() {
+        let stored = BodyMetricLoggingService.storedWeightInKilograms(
+            displayWeight: 180,
+            unit: "lbs"
+        )
+
+        XCTAssertEqual(stored ?? 0, 81.6467, accuracy: 0.001)
+    }
+
+    func testStoredWeightKeepsKilograms() {
+        let stored = BodyMetricLoggingService.storedWeightInKilograms(
+            displayWeight: 82.5,
+            unit: "kg"
+        )
+
+        XCTAssertEqual(stored, 82.5)
+    }
+
+    func testLoggedSummaryUsesPreferredWeightUnitAndBodyFatPercent() {
+        let metric = BodyMetrics(
+            id: "metric-1",
+            userId: "user-1",
+            date: Date(timeIntervalSince1970: 0),
+            localDate: "1970-01-01",
+            weight: 81.6467,
+            weightUnit: "kg",
+            bodyFatPercentage: 14.8,
+            bodyFatMethod: "Manual",
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(
+            BodyMetricLoggingService.loggedSummary(for: metric, preferredSystem: .imperial),
+            "Logged 180.0 lbs and 14.8% body fat."
+        )
+    }
+}
+
 final class PhaseInsightPolicyTests: XCTestCase {
     private var calendar: Calendar!
 


### PR DESCRIPTION
## Summary
- add App Intents and App Shortcuts for logging weight, logging body fat, and showing latest metrics
- extract manual body metric persistence into BodyMetricLoggingService so the SwiftUI form and intents share validation, kg storage, HealthKit writes, Core Data save, sync kick-off, and NSUserActivity donation
- add Siri usage copy and unit tests for conversion/summary behavior

## Validation
- swiftlint lint --strict --quiet
- plutil -lint apps/ios/LogYourBody/Info.plist apps/ios/LogYourBody/LogYourBody.entitlements
- xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' build-for-testing -quiet
- xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' -only-testing:LogYourBodyTests/BodyMetricLoggingServiceTests test -quiet (xcresult summary: 3 passed, 0 failed)
- pnpm lint
- pnpm typecheck
- pnpm test:ci
- git diff --check

## Evidence / Limits
- Simulator build proves App Intents compile and are included in the app target.
- Real Siri/Shortcuts listing and voice execution still need device/simulator UI evidence before closing Jovie #10363 as fully verified.
- Did not add the Siri entitlement because this is app-target App Intents/App Shortcuts, not an Intents extension, avoiding a new provisioning-profile dependency.

Refs JovieInc/Jovie#10363