### PR TITLE
fix: harden App Shortcut registration

### DIFF
--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -4,6 +4,7 @@
 //
 import SwiftUI
 import Clerk
+import AppIntents
 
 @main
 struct LogYourBodyApp: App {
@@ -17,6 +18,10 @@ struct LogYourBodyApp: App {
     @State private var selectedEntryTab = 0
 
     let persistenceController = CoreDataManager.shared
+
+    init() {
+        LogYourBodyAppShortcuts.updateAppShortcutParameters()
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/apps/ios/LogYourBody/Services/BodyMetricAppIntents.swift
+++ b/apps/ios/LogYourBody/Services/BodyMetricAppIntents.swift
@@ -30,8 +30,14 @@ struct LogWeightIntent: AppIntent {
     static var title: LocalizedStringResource = "Log Weight"
     static var description = IntentDescription("Log a body weight measurement in LogYourBody.")
     static var openAppWhenRun = false
+    static var parameterSummary: some ParameterSummary {
+        Summary("Log \(\.$weight) \(\.$unit)")
+    }
 
-    @Parameter(title: "Weight")
+    @Parameter(
+        title: "Weight",
+        requestValueDialog: "What weight do you want to log?"
+    )
     var weight: Double
 
     @Parameter(title: "Unit", default: .pounds)
@@ -52,8 +58,14 @@ struct LogBodyFatIntent: AppIntent {
     static var title: LocalizedStringResource = "Log Body Fat"
     static var description = IntentDescription("Log a body fat percentage in LogYourBody.")
     static var openAppWhenRun = false
+    static var parameterSummary: some ParameterSummary {
+        Summary("Log \(\.$bodyFatPercentage)% body fat")
+    }
 
-    @Parameter(title: "Body Fat Percentage")
+    @Parameter(
+        title: "Body Fat Percentage",
+        requestValueDialog: "What body fat percentage do you want to log?"
+    )
     var bodyFatPercentage: Double
 
     func perform() async throws -> some IntentResult & ProvidesDialog {


### PR DESCRIPTION
## Summary
- Register `LogYourBodyAppShortcuts` from `LogYourBodyApp.init()` so App Shortcut metadata is refreshed at app initialization time.
- Add parameter summaries and request-value dialogs for the weight and body-fat App Intents so Shortcuts/Siri have explicit prompts for required metric values.

Refs JovieInc/Jovie#10363.

## Validation
- `swiftlint lint --strict --quiet`
- `git diff --check`
- `xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' build-for-testing -quiet`
- `mcp__xcodebuildmcp.build_run_sim` on simulator `iPhone 17` / `7A8ECED1-02CF-40F6-BD43-0A2F127D6A74`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`
- Husky pre-commit SwiftLint
- Husky pre-push turbo lint/typecheck/test for branch diff

## Runtime Evidence
- Manual Shortcuts action-editor execution still reaches LogYourBody app code and returns the expected signed-out auth guard.
- Simulator auto-generated App Shortcut tiles still show `Unable to run App Shortcut` for both `Log Weight` and no-parameter `Latest Metrics`; logs continue to show `linkd.autoShortcut` / `requiresValidBundle` and `Couldn't find AppShortcutsProvider`.
- Local screenshot evidence: `reports/ios-app-intents/2026-06-11/shortcuts-auto-tile-still-fails-after-provider-hardening.jpg`.

## Out of Scope
- This PR does not close JovieInc/Jovie#10363.
- Real-device or TestFlight signed-in proof is still required before the App Intents launch-blocker is fully accepted.
- No Siri entitlement or new App Intents extension target is added here; that should be a deliberate signing/provisioning decision if physical-device evidence proves it is required.
