### PR TITLE
fix: scope MVP pending sync state to active user

### DIFF
--- a/apps/ios/LogYourBody/Services/CoreDataManager.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager.swift
@@ -264,12 +264,16 @@ class CoreDataManager: ObservableObject {
         }
     }
 
-    func fetchUnsyncedDexaResults() async -> [CachedDexaResult] {
+    func fetchUnsyncedDexaResults(for userId: String? = nil) async -> [CachedDexaResult] {
         let context = viewContext
 
         return await context.perform {
             let request: NSFetchRequest<CachedDexaResult> = CachedDexaResult.fetchRequest()
-            request.predicate = NSPredicate(format: "isSynced == %@", NSNumber(value: false))
+            var predicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+            if let userId {
+                predicates.append(NSPredicate(format: "userId == %@", userId))
+            }
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
 
             do {
                 return try context.fetch(request)
@@ -976,7 +980,7 @@ class CoreDataManager: ObservableObject {
     // MARK: - Sync Operations
 
     /// Async version - does NOT block the main thread
-    func fetchUnsyncedEntries() async -> (
+    func fetchUnsyncedEntries(for userId: String? = nil) async -> (
         bodyMetrics: [CachedBodyMetrics],
         dailyMetrics: [CachedDailyMetrics],
         profiles: [CachedProfile]
@@ -985,13 +989,25 @@ class CoreDataManager: ObservableObject {
 
         return await context.perform {
             let bodyMetricsFetch: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
-            bodyMetricsFetch.predicate = NSPredicate(format: "isSynced == %@", NSNumber(value: false))
+            var bodyPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+            if let userId {
+                bodyPredicates.append(NSPredicate(format: "userId == %@", userId))
+            }
+            bodyMetricsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: bodyPredicates)
 
             let dailyMetricsFetch: NSFetchRequest<CachedDailyMetrics> = CachedDailyMetrics.fetchRequest()
-            dailyMetricsFetch.predicate = NSPredicate(format: "isSynced == %@", NSNumber(value: false))
+            var dailyPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+            if let userId {
+                dailyPredicates.append(NSPredicate(format: "userId == %@", userId))
+            }
+            dailyMetricsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: dailyPredicates)
 
             let profilesFetch: NSFetchRequest<CachedProfile> = CachedProfile.fetchRequest()
-            profilesFetch.predicate = NSPredicate(format: "isSynced == %@", NSNumber(value: false))
+            var profilePredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+            if let userId {
+                profilePredicates.append(NSPredicate(format: "id == %@", userId))
+            }
+            profilesFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: profilePredicates)
 
             do {
                 let bodyMetrics = try context.fetch(bodyMetricsFetch)
@@ -1016,12 +1032,16 @@ class CoreDataManager: ObservableObject {
         }
     }
 
-    func fetchUnsyncedGlp1DoseLogs() async -> [CachedGlp1DoseLog] {
+    func fetchUnsyncedGlp1DoseLogs(for userId: String? = nil) async -> [CachedGlp1DoseLog] {
         let context = viewContext
 
         return await context.perform {
             let request: NSFetchRequest<CachedGlp1DoseLog> = CachedGlp1DoseLog.fetchRequest()
-            request.predicate = NSPredicate(format: "isSynced == %@", NSNumber(value: false))
+            var predicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+            if let userId {
+                predicates.append(NSPredicate(format: "userId == %@", userId))
+            }
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
 
             do {
                 return try context.fetch(request)
@@ -1041,12 +1061,16 @@ class CoreDataManager: ObservableObject {
         }
     }
 
-    func fetchUnsyncedGlp1Medications() async -> [CachedGlp1Medication] {
+    func fetchUnsyncedGlp1Medications(for userId: String? = nil) async -> [CachedGlp1Medication] {
         let context = viewContext
 
         return await context.perform {
             let request: NSFetchRequest<CachedGlp1Medication> = CachedGlp1Medication.fetchRequest()
-            request.predicate = NSPredicate(format: "isSynced == %@", NSNumber(value: false))
+            var predicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+            if let userId {
+                predicates.append(NSPredicate(format: "userId == %@", userId))
+            }
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
 
             do {
                 return try context.fetch(request)

--- a/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
+++ b/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
@@ -60,6 +60,7 @@ class RealtimeSyncManager: ObservableObject {
 
     struct SyncOperation: Codable {
         let id: String
+        let userId: String?
         let type: OperationType
         let data: Data
         let tableName: String
@@ -267,28 +268,27 @@ class RealtimeSyncManager: ObservableObject {
             onCompletion?()
             return
         }
+        guard let userIdSnapshot = authManager.currentUser?.id else {
+            onCompletion?()
+            return
+        }
 
         lastSyncAttempt = Date()
         isSyncing = true
         syncStatus = .syncing
         error = nil
 
-        let operationsToProcess = pendingOperations
-        pendingOperations.removeAll()
+        let operationsToProcess = pendingOperations.filter { $0.userId == userIdSnapshot }
+        pendingOperations.removeAll { $0.userId == userIdSnapshot || $0.userId == nil }
         savePendingOperations()
 
         let lastSyncSnapshot = lastSyncDate
-        let userIdSnapshot = authManager.currentUser?.id
 
         Task.detached(priority: .utility) { [weak self] in
             guard let self else { return }
             var operationsNeedingRetry = operationsToProcess
 
             do {
-                guard let userId = userIdSnapshot else {
-                    throw SyncError.noAuthSession
-                }
-
                 let session = await MainActor.run { self.authManager.clerkSession }
                 guard let session else {
                     throw SyncError.noAuthSession
@@ -309,8 +309,8 @@ class RealtimeSyncManager: ObservableObject {
                     }
                 }
 
-                try await self.syncLocalChanges(token: token)
-                try await self.pullLatestData(userId: userId, lastSync: lastSyncSnapshot, token: token)
+                try await self.syncLocalChanges(for: userIdSnapshot, token: token)
+                try await self.pullLatestData(userId: userIdSnapshot, lastSync: lastSyncSnapshot, token: token)
                 await self.coreDataManager.cleanupOldData()
 
                 await MainActor.run {
@@ -366,10 +366,14 @@ class RealtimeSyncManager: ObservableObject {
     }
 
     nonisolated func syncLocalChanges(token: String) async throws {
-        let unsynced = await coreDataManager.fetchUnsyncedEntries()
-        let unsyncedGlp1 = await coreDataManager.fetchUnsyncedGlp1DoseLogs()
-        let unsyncedMedications = await coreDataManager.fetchUnsyncedGlp1Medications()
-        let unsyncedDexa = await coreDataManager.fetchUnsyncedDexaResults()
+        try await syncLocalChanges(for: nil, token: token)
+    }
+
+    nonisolated func syncLocalChanges(for userId: String?, token: String) async throws {
+        let unsynced = await coreDataManager.fetchUnsyncedEntries(for: userId)
+        let unsyncedGlp1 = await coreDataManager.fetchUnsyncedGlp1DoseLogs(for: userId)
+        let unsyncedMedications = await coreDataManager.fetchUnsyncedGlp1Medications(for: userId)
+        let unsyncedDexa = await coreDataManager.fetchUnsyncedDexaResults(for: userId)
         let deletedBodyMetrics = unsynced.bodyMetrics.filter(\.isMarkedDeleted)
         let bodyMetricsToUpsert = unsynced.bodyMetrics.filter { !$0.isMarkedDeleted }
 
@@ -838,14 +842,29 @@ class RealtimeSyncManager: ObservableObject {
 
     // MARK: - Helpers
     func updatePendingSyncCount() {
+        let userId = authManager.currentUser?.id
         pendingCountTask?.cancel()
         pendingCountTask = Task(priority: .utility) { [weak self] in
             guard let self else { return }
-            let unsynced = await self.coreDataManager.fetchUnsyncedEntries()
-            let unsyncedGlp1 = await self.coreDataManager.fetchUnsyncedGlp1DoseLogs()
-            let unsyncedMedications = await self.coreDataManager.fetchUnsyncedGlp1Medications()
-            let unsyncedDexa = await self.coreDataManager.fetchUnsyncedDexaResults()
-            let operationsCount = await MainActor.run { self.pendingOperations.count }
+            guard let userId else {
+                await MainActor.run {
+                    self.unsyncedBodyCount = 0
+                    self.unsyncedDailyCount = 0
+                    self.unsyncedProfileCount = 0
+                    self.unsyncedGlp1Count = 0
+                    self.unsyncedDexaCount = 0
+                    self.pendingSyncCount = 0
+                }
+                return
+            }
+
+            let unsynced = await self.coreDataManager.fetchUnsyncedEntries(for: userId)
+            let unsyncedGlp1 = await self.coreDataManager.fetchUnsyncedGlp1DoseLogs(for: userId)
+            let unsyncedMedications = await self.coreDataManager.fetchUnsyncedGlp1Medications(for: userId)
+            let unsyncedDexa = await self.coreDataManager.fetchUnsyncedDexaResults(for: userId)
+            let operationsCount = await MainActor.run {
+                self.pendingOperations.filter { $0.userId == userId }.count
+            }
             await MainActor.run {
                 self.unsyncedBodyCount = unsynced.bodyMetrics.count
                 self.unsyncedDailyCount = unsynced.dailyMetrics.count
@@ -864,17 +883,21 @@ class RealtimeSyncManager: ObservableObject {
     }
 
     func hasPendingSyncOperations() async -> Bool {
-        let unsynced = await coreDataManager.fetchUnsyncedEntries()
-        let unsyncedGlp1 = await coreDataManager.fetchUnsyncedGlp1DoseLogs()
-        let unsyncedMedications = await coreDataManager.fetchUnsyncedGlp1Medications()
-        let unsyncedDexa = await coreDataManager.fetchUnsyncedDexaResults()
+        guard let userId = authManager.currentUser?.id else {
+            return false
+        }
+
+        let unsynced = await coreDataManager.fetchUnsyncedEntries(for: userId)
+        let unsyncedGlp1 = await coreDataManager.fetchUnsyncedGlp1DoseLogs(for: userId)
+        let unsyncedMedications = await coreDataManager.fetchUnsyncedGlp1Medications(for: userId)
+        let unsyncedDexa = await coreDataManager.fetchUnsyncedDexaResults(for: userId)
         return !unsynced.bodyMetrics.isEmpty ||
             !unsynced.dailyMetrics.isEmpty ||
             !unsynced.profiles.isEmpty ||
             !unsyncedGlp1.isEmpty ||
             !unsyncedMedications.isEmpty ||
             !unsyncedDexa.isEmpty ||
-            !pendingOperations.isEmpty
+            pendingOperations.contains { $0.userId == userId }
     }
     private func shouldPullLatestData() -> Bool {
         guard let lastSync = lastSyncDate else { return true }
@@ -902,6 +925,7 @@ class RealtimeSyncManager: ObservableObject {
         queueOperation(
             SyncOperation(
                 id: id,
+                userId: authManager.currentUser?.id,
                 type: .delete,
                 data: Data(),
                 tableName: "body_metrics",

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -2189,6 +2189,125 @@ final class SyncIntegrationTests: XCTestCase {
         XCTAssertTrue(unsyncedForUser.isEmpty)
     }
 
+    func testSyncLocalChangesScopesUnsyncedRowsToActiveUser() async throws {
+        let coreData = CoreDataManager.shared
+
+        let activeUserId = "sync_active_user_\(UUID().uuidString)"
+        let otherUserId = "sync_other_user_\(UUID().uuidString)"
+        let activeMetricId = UUID().uuidString
+        let otherMetricId = UUID().uuidString
+        let date = Date()
+
+        let activeMetric = BodyMetrics(
+            id: activeMetricId,
+            userId: activeUserId,
+            date: date,
+            weight: 80.0,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: "Manual",
+            createdAt: date,
+            updatedAt: date
+        )
+        let otherMetric = BodyMetrics(
+            id: otherMetricId,
+            userId: otherUserId,
+            date: date,
+            weight: 82.0,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: "Manual",
+            createdAt: date,
+            updatedAt: date
+        )
+
+        try await coreData.saveBodyMetricsAndWait(activeMetric, userId: activeUserId)
+        try await coreData.saveBodyMetricsAndWait(otherMetric, userId: otherUserId)
+
+        let stubSupabase = StubSupabaseManager()
+        let manager = RealtimeSyncManager(
+            coreDataManager: coreData,
+            authManager: AuthManager.shared,
+            supabaseManager: stubSupabase
+        )
+
+        try await manager.syncLocalChanges(for: activeUserId, token: "test-token")
+
+        let syncedPayloads = stubSupabase.bodyMetricsBatches.flatMap { $0 }
+        XCTAssertEqual(syncedPayloads.count, 1)
+        XCTAssertEqual(syncedPayloads.first?["id"] as? String, activeMetricId)
+        XCTAssertEqual(syncedPayloads.first?["user_id"] as? String, activeUserId)
+
+        let activeUnsynced = await coreData.fetchUnsyncedEntries(for: activeUserId)
+        XCTAssertTrue(activeUnsynced.bodyMetrics.isEmpty)
+
+        let otherUnsynced = await coreData.fetchUnsyncedEntries(for: otherUserId)
+        XCTAssertEqual(otherUnsynced.bodyMetrics.map(\.id), [otherMetricId])
+    }
+
+    func testPendingSyncOperationsAreScopedToActiveUser() async throws {
+        UserDefaults.standard.removeObject(forKey: "pendingSyncOperations")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "pendingSyncOperations")
+        }
+
+        let activeUserId = "pending_active_user_\(UUID().uuidString)"
+        let otherUserId = "pending_other_user_\(UUID().uuidString)"
+        let authManager = AuthManager()
+        authManager.currentUser = LocalUser(
+            id: activeUserId,
+            email: "pending-active@example.com",
+            name: "Pending Active",
+            avatarUrl: nil,
+            profile: nil,
+            onboardingCompleted: true
+        )
+        authManager.isAuthenticated = true
+
+        let manager = RealtimeSyncManager(
+            coreDataManager: CoreDataManager.shared,
+            authManager: authManager,
+            supabaseManager: StubSupabaseManager()
+        )
+        manager.isOnline = false
+
+        manager.queueOperation(
+            RealtimeSyncManager.SyncOperation(
+                id: UUID().uuidString,
+                userId: otherUserId,
+                type: .delete,
+                data: Data(),
+                tableName: "body_metrics",
+                timestamp: Date()
+            )
+        )
+        let hasOtherUserPendingOperations = await manager.hasPendingSyncOperations()
+        XCTAssertFalse(hasOtherUserPendingOperations)
+
+        manager.queueOperation(
+            RealtimeSyncManager.SyncOperation(
+                id: UUID().uuidString,
+                userId: activeUserId,
+                type: .delete,
+                data: Data(),
+                tableName: "body_metrics",
+                timestamp: Date()
+            )
+        )
+        let hasActiveUserPendingOperations = await manager.hasPendingSyncOperations()
+        XCTAssertTrue(hasActiveUserPendingOperations)
+    }
+
     func testSyncLocalChangesDeletesMarkedBodyMetricInsteadOfUpserting() async throws {
         let coreData = CoreDataManager.shared
 


### PR DESCRIPTION
## Summary
- Scope unsynced Core Data fetches to the active user for body metrics, daily metrics, profile, GLP-1, and DEXA rows.
- Persist pending sync delete operations with the active user id and hide/process only operations for the current user.
- Add focused sync coverage proving cross-user unsynced rows and queued delete operations do not pollute the active MVP session.

## Context
Launch smoke for JovieInc/Jovie#10226 uncovered a stale sync banner on the paid MVP weight flow: the fixture had zero visible entries but still showed prior pending sync state. This keeps the MVP manual weight flow user-scoped while preserving the existing local-first sync behavior.

## Validation
- `cd apps/ios && swiftlint lint --strict --quiet`
- `git diff --check`
- `xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' -only-testing:LogYourBodyTests/SyncIntegrationTests/testSyncLocalChangesScopesUnsyncedRowsToActiveUser -only-testing:LogYourBodyTests/SyncIntegrationTests/testPendingSyncOperationsAreScopedToActiveUser test`\n- `xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' -only-testing:LogYourBodyUITests/LogYourBodyUITests/testPaidMVPWeightEntrySavesWithKeyboardOpen -only-testing:LogYourBodyUITests/LogYourBodyUITests/testPaidMVPFixtureRoutesToGateOffDefaultSurface test`\n- `xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' build-for-testing -quiet`\n- `pnpm lint`\n- `pnpm typecheck`\n- `pnpm test:ci`\n\n## Evidence\n- Local screenshot after fix: `reports/logyourbody-release/2026-06-11-smoke/paid-mvp-weight-log-scoped-sync-fixed.png` shows the paid MVP weight screen with 0 entries and `Offline`, not stale `Saved offline`.\n- Earlier smoke screenshots in the same local report folder cover signed-out email-primary auth, paywall restore/logout, and weight entry.\n\n## Out of scope\n- No billing product/config changes.\n- No Apple Sign-In enablement change.\n- No release workflow or App Store Connect agreement changes.