### PR TITLE
fix: bootstrap HealthKit body metric sync

### DIFF
--- a/apps/ios/LogYourBody/Info.plist
+++ b/apps/ios/LogYourBody/Info.plist
@@ -37,9 +37,9 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSHealthShareUsageDescription</key>
-	<string>LogYourBody uses HealthKit to read your weight data and sync it with your profile.</string>
+	<string>LogYourBody uses HealthKit to read your weight and body composition data and sync it with your profile.</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>LogYourBody uses HealthKit to save your weight measurements.</string>
+	<string>LogYourBody uses HealthKit to save your weight and body fat measurements.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>LogYourBody uses Face ID to secure your personal health data and progress photos.</string>
 	<key>NSCameraUsageDescription</key>

--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -64,6 +64,8 @@ struct LogYourBodyApp: App {
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
                     // App entering foreground - refresh data
                     Task {
+                        await bootstrapHealthKit()
+
                         if isFullBodyCompositionDashboardEnabled, healthKitManager.isAuthorized {
                             try? await HealthSyncCoordinator.shared.syncStepsFromHealthKit()
                         }
@@ -108,9 +110,7 @@ struct LogYourBodyApp: App {
         }
 
         Task { @MainActor in
-            if isFullBodyCompositionDashboardEnabled {
-                await bootstrapHealthKit()
-            }
+            await bootstrapHealthKit()
         }
 
         await clerkInitializationTask.value

--- a/apps/ios/LogYourBody/Services/HealthKitManager.swift
+++ b/apps/ios/LogYourBody/Services/HealthKitManager.swift
@@ -85,6 +85,7 @@ class HealthKitManager: ObservableObject {
     private var isSyncingWeight = false
     private var syncDebounceTimer: Timer?
     private var weightObserverQuery: HKObserverQuery?
+    private var bodyFatObserverQuery: HKObserverQuery?
     private var stepObserverQuery: HKObserverQuery?
     private var activeQueries: [HKQuery] = []
     private var activeUserId: String?
@@ -573,6 +574,11 @@ class HealthKitManager: ObservableObject {
         if let weightObserverQuery {
             healthStore.stop(weightObserverQuery)
             self.weightObserverQuery = nil
+        }
+
+        if let bodyFatObserverQuery {
+            healthStore.stop(bodyFatObserverQuery)
+            self.bodyFatObserverQuery = nil
         }
 
         if let stepObserverQuery {
@@ -1252,30 +1258,7 @@ class HealthKitManager: ObservableObject {
 
         let query = HKObserverQuery(sampleType: weightType, predicate: nil) { [weak self] _, completionHandler, error in
             if error == nil {
-                // Check if we should sync (not more than once per hour)
-                let currentUserId = AuthManager.shared.currentUser?.id
-                let lastSyncKey = HealthKitDefaultsKey.lastObserverSyncDate.scoped(with: currentUserId)
-                let shouldSync: Bool = {
-                    if let lastSync = UserDefaults.standard.object(forKey: lastSyncKey) as? Date {
-                        let minutesSinceLastSync = Date().timeIntervalSince(lastSync) / 60
-                        return minutesSinceLastSync >= 60 // Only sync if more than 60 minutes have passed
-                    }
-                    return true
-                }()
-
-                if shouldSync {
-                    // Debounce sync requests to prevent multiple concurrent syncs
-                    DispatchQueue.main.async { [weak self] in
-                        self?.syncDebounceTimer?.invalidate()
-                        self?.syncDebounceTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { _ in
-                            UserDefaults.standard.set(Date(), forKey: lastSyncKey)
-                            Task { [weak self] in
-                                // Only sync recent data (last 7 days) when observer triggers
-                                try? await self?.syncWeightFromHealthKitIncremental(days: 7)
-                            }
-                        }
-                    }
-                }
+                self?.scheduleObservedBodyMetricSync()
             }
             completionHandler()
         }
@@ -1283,6 +1266,61 @@ class HealthKitManager: ObservableObject {
         weightObserverQuery = query
         healthStore.execute(query)
         activeQueries.append(query)
+    }
+
+    // Setup observer for new body fat entries in HealthKit
+    func observeBodyFatChanges() {
+        guard isAuthorized else { return }
+
+        if let existingQuery = bodyFatObserverQuery {
+            healthStore.stop(existingQuery)
+            bodyFatObserverQuery = nil
+        }
+
+        let query = HKObserverQuery(sampleType: bodyFatType, predicate: nil) { [weak self] _, completionHandler, error in
+            if error == nil {
+                self?.scheduleObservedBodyMetricSync()
+            }
+            completionHandler()
+        }
+
+        bodyFatObserverQuery = query
+        healthStore.execute(query)
+        activeQueries.append(query)
+    }
+
+    private func scheduleObservedBodyMetricSync() {
+        Task { @MainActor [weak self] in
+            let currentUserId = AuthManager.shared.currentUser?.id
+            self?.scheduleObservedBodyMetricSync(for: currentUserId)
+        }
+    }
+
+    @MainActor
+    private func scheduleObservedBodyMetricSync(for currentUserId: String?) {
+        // Check if we should sync (not more than once per hour)
+        let lastSyncKey = HealthKitDefaultsKey.lastObserverSyncDate.scoped(with: currentUserId)
+        let shouldSync: Bool = {
+            if let lastSync = UserDefaults.standard.object(forKey: lastSyncKey) as? Date {
+                let minutesSinceLastSync = Date().timeIntervalSince(lastSync) / 60
+                return minutesSinceLastSync >= 60
+            }
+            return true
+        }()
+
+        guard shouldSync else { return }
+
+        // Debounce sync requests to prevent multiple concurrent syncs.
+        DispatchQueue.main.async { [weak self] in
+            self?.syncDebounceTimer?.invalidate()
+            self?.syncDebounceTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { _ in
+                UserDefaults.standard.set(Date(), forKey: lastSyncKey)
+                Task { [weak self] in
+                    // Weight sync imports both weight and body fat for the recent window.
+                    try? await self?.syncWeightFromHealthKitIncremental(days: 7)
+                }
+            }
+        }
     }
 
     // Setup observer for new step count entries in HealthKit

--- a/apps/ios/LogYourBody/Services/HealthSyncCoordinator.swift
+++ b/apps/ios/LogYourBody/Services/HealthSyncCoordinator.swift
@@ -5,6 +5,25 @@
 
 import Foundation
 
+protocol HealthKitSyncManaging: AnyObject {
+    var isHealthKitAvailable: Bool { get }
+    var isAuthorized: Bool { get }
+
+    func checkAuthorizationStatus()
+    func observeWeightChanges()
+    func observeBodyFatChanges()
+    func observeStepChanges()
+    func setupBackgroundDelivery() async throws
+    func setupStepCountBackgroundDelivery() async throws
+    func resetForCurrentUser() async
+    func syncWeightFromHealthKit() async throws
+    func syncStepsFromHealthKit() async throws
+    func fetchTodayStepCount() async throws -> Int
+    func forceFullHealthKitSync() async
+}
+
+extension HealthKitManager: HealthKitSyncManaging {}
+
 /// Protocol abstraction for coordinating HealthKit-related sync operations.
 /// This enables easier unit testing for components that depend on
 /// HealthSyncCoordinator by allowing mock implementations.
@@ -28,10 +47,10 @@ protocol HealthSyncCoordinating {
 final class HealthSyncCoordinator: ObservableObject, HealthSyncCoordinating {
     static let shared = HealthSyncCoordinator()
 
-    private let healthKitManager: HealthKitManager
+    private let healthKitManager: HealthKitSyncManaging
     private var hasBootstrappedObservers = false
 
-    private init(healthKitManager: HealthKitManager = .shared) {
+    init(healthKitManager: HealthKitSyncManaging = HealthKitManager.shared) {
         self.healthKitManager = healthKitManager
     }
 
@@ -63,9 +82,11 @@ final class HealthSyncCoordinator: ObservableObject, HealthSyncCoordinating {
         hasBootstrappedObservers = true
 
         healthKitManager.observeWeightChanges()
+        healthKitManager.observeBodyFatChanges()
         healthKitManager.observeStepChanges()
 
         Task {
+            try? await healthKitManager.setupBackgroundDelivery()
             try? await healthKitManager.setupStepCountBackgroundDelivery()
         }
     }
@@ -147,6 +168,7 @@ final class HealthSyncCoordinator: ObservableObject, HealthSyncCoordinating {
             category: "healthKitCoordinator"
         )
 
+        bootstrapIfNeeded(syncEnabled: true)
         try await healthKitManager.setupBackgroundDelivery()
         try await healthKitManager.setupStepCountBackgroundDelivery()
         try await healthKitManager.syncWeightFromHealthKit()
@@ -166,6 +188,8 @@ final class HealthSyncCoordinator: ObservableObject, HealthSyncCoordinating {
         )
 
         guard healthKitManager.isAuthorized else { return }
+
+        bootstrapIfNeeded(syncEnabled: true)
 
         do {
             try await healthKitManager.syncWeightFromHealthKit()

--- a/apps/ios/LogYourBody/Views/IntegrationsView.swift
+++ b/apps/ios/LogYourBody/Views/IntegrationsView.swift
@@ -88,7 +88,10 @@ struct IntegrationsView: View {
                             Button("Connect") {
                                 Task {
                                     let authorized = await healthKitManager.requestAuthorization()
-                                    if !authorized {
+                                    if authorized {
+                                        await HealthSyncCoordinator.shared
+                                            .configureSyncPipelineAfterAuthorizationAndRunInitialWeightAndStepSync()
+                                    } else {
                                         showHealthKitConnect = true
                                     }
                                 }

--- a/apps/ios/LogYourBody/Views/MainTabView.swift
+++ b/apps/ios/LogYourBody/Views/MainTabView.swift
@@ -82,9 +82,7 @@ struct MainTabView: View {
             )
         )
 
-        if selectedSurface != .weightLoggerMVP {
-            HealthSyncCoordinator.shared.bootstrapIfNeeded(syncEnabled: healthKitSyncEnabled)
-        }
+        HealthSyncCoordinator.shared.bootstrapIfNeeded(syncEnabled: healthKitSyncEnabled)
     }
 }
 

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -2866,6 +2866,132 @@ final class MockHealthSyncCoordinator: HealthSyncCoordinating {
     }
 }
 
+final class MockHealthKitSyncManager: HealthKitSyncManaging {
+    var isHealthKitAvailable = true
+    var isAuthorized = true
+
+    private(set) var didCallCheckAuthorizationStatus = false
+    private(set) var didCallObserveWeightChanges = false
+    private(set) var didCallObserveBodyFatChanges = false
+    private(set) var didCallObserveStepChanges = false
+    private(set) var setupBackgroundDeliveryCallCount = 0
+    private(set) var setupStepCountBackgroundDeliveryCallCount = 0
+    private(set) var didCallResetForCurrentUser = false
+    private(set) var syncWeightFromHealthKitCallCount = 0
+    private(set) var syncStepsFromHealthKitCallCount = 0
+    private(set) var fetchTodayStepCountCallCount = 0
+    private(set) var didCallForceFullHealthKitSync = false
+
+    func checkAuthorizationStatus() {
+        didCallCheckAuthorizationStatus = true
+    }
+
+    func observeWeightChanges() {
+        didCallObserveWeightChanges = true
+    }
+
+    func observeBodyFatChanges() {
+        didCallObserveBodyFatChanges = true
+    }
+
+    func observeStepChanges() {
+        didCallObserveStepChanges = true
+    }
+
+    func setupBackgroundDelivery() async throws {
+        setupBackgroundDeliveryCallCount += 1
+    }
+
+    func setupStepCountBackgroundDelivery() async throws {
+        setupStepCountBackgroundDeliveryCallCount += 1
+    }
+
+    func resetForCurrentUser() async {
+        didCallResetForCurrentUser = true
+    }
+
+    func syncWeightFromHealthKit() async throws {
+        syncWeightFromHealthKitCallCount += 1
+    }
+
+    func syncStepsFromHealthKit() async throws {
+        syncStepsFromHealthKitCallCount += 1
+    }
+
+    func fetchTodayStepCount() async throws -> Int {
+        fetchTodayStepCountCallCount += 1
+        return 123
+    }
+
+    func forceFullHealthKitSync() async {
+        didCallForceFullHealthKitSync = true
+    }
+}
+
+@MainActor
+final class HealthSyncCoordinatorPipelineTests: XCTestCase {
+    func testBootstrapSkipsHealthKitWhenSyncIsDisabled() async {
+        let manager = MockHealthKitSyncManager()
+        let coordinator = HealthSyncCoordinator(healthKitManager: manager)
+
+        coordinator.bootstrapIfNeeded(syncEnabled: false)
+        await Task.yield()
+
+        XCTAssertFalse(manager.didCallCheckAuthorizationStatus)
+        XCTAssertFalse(manager.didCallObserveWeightChanges)
+        XCTAssertFalse(manager.didCallObserveBodyFatChanges)
+        XCTAssertFalse(manager.didCallObserveStepChanges)
+        XCTAssertEqual(manager.setupBackgroundDeliveryCallCount, 0)
+        XCTAssertEqual(manager.setupStepCountBackgroundDeliveryCallCount, 0)
+    }
+
+    func testBootstrapConfiguresBodyMetricAndStepObserversWithBackgroundDelivery() async throws {
+        let manager = MockHealthKitSyncManager()
+        let coordinator = HealthSyncCoordinator(healthKitManager: manager)
+
+        coordinator.bootstrapIfNeeded(syncEnabled: true)
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(manager.didCallCheckAuthorizationStatus)
+        XCTAssertTrue(manager.didCallObserveWeightChanges)
+        XCTAssertTrue(manager.didCallObserveBodyFatChanges)
+        XCTAssertTrue(manager.didCallObserveStepChanges)
+        XCTAssertEqual(manager.setupBackgroundDeliveryCallCount, 1)
+        XCTAssertEqual(manager.setupStepCountBackgroundDeliveryCallCount, 1)
+    }
+
+    func testDeferredOnboardingWeightSyncBootstrapsBodyMetricPipelineBeforeImport() async {
+        let manager = MockHealthKitSyncManager()
+        let coordinator = HealthSyncCoordinator(healthKitManager: manager)
+
+        await coordinator.runDeferredOnboardingWeightSync()
+        await Task.yield()
+
+        XCTAssertTrue(manager.didCallObserveWeightChanges)
+        XCTAssertTrue(manager.didCallObserveBodyFatChanges)
+        XCTAssertTrue(manager.didCallObserveStepChanges)
+        XCTAssertEqual(manager.setupBackgroundDeliveryCallCount, 1)
+        XCTAssertEqual(manager.syncWeightFromHealthKitCallCount, 1)
+    }
+
+    func testInitialConnectSyncBootstrapsObserversAndRunsInitialImports() async throws {
+        let manager = MockHealthKitSyncManager()
+        let coordinator = HealthSyncCoordinator(healthKitManager: manager)
+
+        try await coordinator.performInitialConnectSync()
+        await Task.yield()
+
+        XCTAssertTrue(manager.didCallObserveWeightChanges)
+        XCTAssertTrue(manager.didCallObserveBodyFatChanges)
+        XCTAssertTrue(manager.didCallObserveStepChanges)
+        XCTAssertGreaterThanOrEqual(manager.setupBackgroundDeliveryCallCount, 1)
+        XCTAssertGreaterThanOrEqual(manager.setupStepCountBackgroundDeliveryCallCount, 1)
+        XCTAssertEqual(manager.syncWeightFromHealthKitCallCount, 1)
+        XCTAssertEqual(manager.fetchTodayStepCountCallCount, 1)
+    }
+}
+
 @MainActor
 final class DashboardViewModelHealthSyncWiringTests: XCTestCase {
     func testCanInitializeWithMockHealthSyncCoordinator() {


### PR DESCRIPTION
## Summary
- Bootstrap existing HealthKit observers/background delivery from the paid MVP app shell, not only the legacy/full dashboard surfaces.
- Add body-fat HealthKit observer coverage and reuse the existing recent weight/body-fat import pipeline when HealthKit changes arrive.
- Run the initial HealthKit sync pipeline after Settings > Integrations authorization succeeds.
- Update HealthKit permission copy to mention body composition/body fat.
- Add coordinator tests using an internal HealthKit manager seam so observer/background-delivery orchestration is deterministic.

## Autoplan Review
- Decision: optimize for the existing HealthKit pipeline instead of creating a second HealthKit layer.
- Reasoning: weight/body-fat import, metadata preservation, write methods, entitlements, and conflict handling already exist; the launch gap was orchestration reachability for the paid MVP surface and body-fat/background observer registration.
- Risk control: no product gates changed, no HealthKit data model migration, no Supabase contract change, no billing/auth/release config change.

## Validation
- `cd apps/ios && swiftlint lint --strict --quiet`
- `git diff --check`
- `xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' -only-testing:LogYourBodyTests/HealthSyncCoordinatorPipelineTests test`
- `xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' -only-testing:LogYourBodyTests/SyncIntegrationTests/testProcessBatchHealthKitData_AssignsBodyFatForMatchingDate -only-testing:LogYourBodyTests/SyncIntegrationTests/testProcessBatchHealthKitData_AttachesSourceMetadataToImportedMetrics test`
- `xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' -only-testing:LogYourBodyUITests/LogYourBodyUITests/testPaidMVPFixtureRoutesToGateOffDefaultSurface -only-testing:LogYourBodyUITests/LogYourBodyUITests/testBulkPhotoImportLockedByDefaultInIntegrations test`
- `xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' build-for-testing -quiet`
- XcodeBuildMCP `build_sim` for `LogYourBody` on iPhone 17 simulator, succeeded with no diagnostics.
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`

## Evidence Notes
- Simulator UI smoke covered paid MVP routing and Integrations navigation.
- Physical-device Apple Health permission/write/background-delivery proof is still required before closing JovieInc/Jovie#10391, because simulator success does not prove HealthKit background delivery on device.
- Linear MCP is currently blocked by reauthentication, so this PR links back to the GitHub roadmap mirror issue.

Refs JovieInc/Jovie#10391.
