### PR TITLE
feat: index logged body metrics in Spotlight

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		AD050C512EC135360082A313 /* RevenueCatUI in Frameworks */ = {isa = PBXBuildFile; productRef = AD050C502EC135360082A313 /* RevenueCatUI */; };
 		AD1036332F00000100ABCDEF /* BodyMetricAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1036322F00000100ABCDEF /* BodyMetricAppIntents.swift */; };
 		AD1036352F00000100ABCDEF /* BodyMetricLoggingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1036342F00000100ABCDEF /* BodyMetricLoggingService.swift */; };
+		AD1036372F00000200ABCDEF /* BodyMetricSpotlightIndexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1036362F00000200ABCDEF /* BodyMetricSpotlightIndexer.swift */; };
 		AD0B7BF52EC552FA008B29E7 /* LogYourBody.storekit in Resources */ = {isa = PBXBuildFile; fileRef = AD0B7BF42EC552FA008B29E7 /* LogYourBody.storekit */; };
 		AD0B7BF72EC692ED008B29E7 /* MetricChartDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0B7BF62EC692ED008B29E7 /* MetricChartDataHelper.swift */; };
 		AD0B7BFB2EC6930D008B29E7 /* PeriodSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0B7BFA2EC6930D008B29E7 /* PeriodSelector.swift */; };
@@ -374,6 +375,7 @@
 		AD723AE72E15FA5C002376C6 /* HealthKitManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthKitManager.swift; sourceTree = "<group>"; };
 		AD1036322F00000100ABCDEF /* BodyMetricAppIntents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyMetricAppIntents.swift; sourceTree = "<group>"; };
 		AD1036342F00000100ABCDEF /* BodyMetricLoggingService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyMetricLoggingService.swift; sourceTree = "<group>"; };
+		AD1036362F00000200ABCDEF /* BodyMetricSpotlightIndexer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyMetricSpotlightIndexer.swift; sourceTree = "<group>"; };
 		AD723AE82E15FA5C002376C6 /* LoadingManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingManager.swift; sourceTree = "<group>"; };
 		AD723AEA2E15FA5C002376C6 /* SupabaseDataClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupabaseDataClient.swift; sourceTree = "<group>"; };
 		AD723AEE2E15FA5C002376C6 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
@@ -901,6 +903,7 @@
 				ADA4B74A2ED00E1F00F4262A /* ValidationService.swift */,
 				AD1036322F00000100ABCDEF /* BodyMetricAppIntents.swift */,
 				AD1036342F00000100ABCDEF /* BodyMetricLoggingService.swift */,
+				AD1036362F00000200ABCDEF /* BodyMetricSpotlightIndexer.swift */,
 				ADA4B7382ECD44C800F4262A /* BodyScoreCache.swift */,
 				ADA4B7362ECC3A7A00F4262A /* EntryVisibilityManager.swift */,
 				AD050C482EC12E390082A313 /* RevenueCatManager.swift */,
@@ -1558,6 +1561,7 @@
 				ADDC47AB2E2D89F3003C97E7 /* LogYourBody.xcdatamodeld in Sources */,
 				AD1036332F00000100ABCDEF /* BodyMetricAppIntents.swift in Sources */,
 				AD1036352F00000100ABCDEF /* BodyMetricLoggingService.swift in Sources */,
+				AD1036372F00000200ABCDEF /* BodyMetricSpotlightIndexer.swift in Sources */,
 				AD8872452EB87F480041C426 /* LiquidGlassCard.swift in Sources */,
 				ADDC47AD2E2D89F3003C97E7 /* User.swift in Sources */,
 				ADDC487C2E2D8A6B003C97E7 /* ProgressPhotoCarouselView.swift in Sources */,

--- a/apps/ios/LogYourBody/Services/AuthManager.swift
+++ b/apps/ios/LogYourBody/Services/AuthManager.swift
@@ -1181,6 +1181,7 @@ class AuthManager: NSObject, ObservableObject {
 
         Self.migrateLegacyAuthStorage(in: userDefaults)
         try? KeychainManager.shared.clearAll()
+        BodyMetricSpotlightIndexer.deleteAllIndexedMetrics()
         ErrorTrackingService.shared.updateUserId(nil)
         AnalyticsService.shared.reset()
 

--- a/apps/ios/LogYourBody/Services/BodyMetricLoggingService.swift
+++ b/apps/ios/LogYourBody/Services/BodyMetricLoggingService.swift
@@ -119,6 +119,7 @@ final class BodyMetricLoggingService {
         }
 
         Self.donateLoggedMetricActivity(metrics)
+        BodyMetricSpotlightIndexer.indexLatestMetric(metrics)
 
         return BodyMetricLoggingResult(
             metrics: metrics,
@@ -205,7 +206,7 @@ final class BodyMetricLoggingService {
             .weight
     }
 
-    private static func metricParts(for metrics: BodyMetrics, preferredSystem: MeasurementSystem) -> [String] {
+    static func metricParts(for metrics: BodyMetrics, preferredSystem: MeasurementSystem) -> [String] {
         var parts: [String] = []
 
         if let weight = metrics.weight {

--- a/apps/ios/LogYourBody/Services/BodyMetricSpotlightIndexer.swift
+++ b/apps/ios/LogYourBody/Services/BodyMetricSpotlightIndexer.swift
@@ -1,0 +1,107 @@
+//
+// BodyMetricSpotlightIndexer.swift
+// LogYourBody
+//
+import Foundation
+
+#if canImport(CoreSpotlight)
+import CoreSpotlight
+import UniformTypeIdentifiers
+#endif
+
+struct BodyMetricSpotlightDocument: Equatable {
+    static let domainIdentifier = "com.logyourbody.body-metrics"
+
+    let identifier: String
+    let title: String
+    let contentDescription: String
+    let keywords: [String]
+
+    static func make(
+        for metrics: BodyMetrics,
+        preferredSystem: MeasurementSystem
+    ) -> BodyMetricSpotlightDocument? {
+        let parts = BodyMetricLoggingService.metricParts(
+            for: metrics,
+            preferredSystem: preferredSystem
+        )
+
+        guard !parts.isEmpty else {
+            return nil
+        }
+
+        let title = "Latest LogYourBody metrics"
+        let contentDescription = "\(parts.joined(separator: ", ")) on \(metrics.localDate)"
+        var keywords = [
+            "LogYourBody",
+            "body metrics",
+            "weight",
+            "body composition",
+            metrics.localDate
+        ]
+
+        if metrics.weight != nil {
+            keywords.append("latest weight")
+        }
+
+        if metrics.bodyFatPercentage != nil {
+            keywords.append("body fat")
+        }
+
+        return BodyMetricSpotlightDocument(
+            identifier: "body-metric-\(metrics.id)",
+            title: title,
+            contentDescription: contentDescription,
+            keywords: keywords
+        )
+    }
+}
+
+enum BodyMetricSpotlightIndexer {
+    private static let logger = AppLogger(category: "spotlight")
+
+    static func indexLatestMetric(
+        _ metrics: BodyMetrics,
+        preferredSystem: MeasurementSystem = .preferredFromDefaults
+    ) {
+        guard let document = BodyMetricSpotlightDocument.make(
+            for: metrics,
+            preferredSystem: preferredSystem
+        ) else {
+            return
+        }
+
+        #if canImport(CoreSpotlight)
+        let attributeSet = CSSearchableItemAttributeSet(contentType: .data)
+        attributeSet.title = document.title
+        attributeSet.contentDescription = document.contentDescription
+        attributeSet.keywords = document.keywords
+        attributeSet.displayName = document.title
+
+        let item = CSSearchableItem(
+            uniqueIdentifier: document.identifier,
+            domainIdentifier: BodyMetricSpotlightDocument.domainIdentifier,
+            attributeSet: attributeSet
+        )
+        item.expirationDate = Calendar.current.date(byAdding: .year, value: 1, to: Date())
+
+        CSSearchableIndex.default().indexSearchableItems([item]) { error in
+            if let error {
+                logger.error("Failed to index body metric in Spotlight: \(error.localizedDescription)")
+            }
+        }
+        #endif
+    }
+
+    static func deleteAllIndexedMetrics() {
+        #if canImport(CoreSpotlight)
+        CSSearchableIndex.default().deleteSearchableItems(
+            withDomainIdentifiers: [BodyMetricSpotlightDocument.domainIdentifier]
+        ) { error in
+            if let error {
+                logger.error("Failed to clear body metric Spotlight index: \(error.localizedDescription)")
+            }
+        }
+        #endif
+    }
+}

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -194,6 +194,66 @@ final class BodyMetricLoggingServiceTests: XCTestCase {
             "Logged 180.0 lbs and 14.8% body fat."
         )
     }
+
+    func testSpotlightDocumentUsesLatestMetricSearchCopy() {
+        let metric = BodyMetrics(
+            id: "metric-spotlight",
+            userId: "user-1",
+            date: Date(timeIntervalSince1970: 0),
+            localDate: "1970-01-01",
+            weight: 81.6467,
+            weightUnit: "kg",
+            bodyFatPercentage: 14.8,
+            bodyFatMethod: "Manual",
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        let document = BodyMetricSpotlightDocument.make(for: metric, preferredSystem: .imperial)
+
+        XCTAssertEqual(document?.identifier, "body-metric-metric-spotlight")
+        XCTAssertEqual(document?.title, "Latest LogYourBody metrics")
+        XCTAssertEqual(document?.contentDescription, "180.0 lbs, 14.8% body fat on 1970-01-01")
+        XCTAssertEqual(
+            document?.keywords,
+            [
+                "LogYourBody",
+                "body metrics",
+                "weight",
+                "body composition",
+                "1970-01-01",
+                "latest weight",
+                "body fat"
+            ]
+        )
+    }
+
+    func testSpotlightDocumentSkipsEntriesWithoutSearchableMetrics() {
+        let metric = BodyMetrics(
+            id: "metric-empty",
+            userId: "user-1",
+            date: Date(timeIntervalSince1970: 0),
+            localDate: "1970-01-01",
+            weight: nil,
+            weightUnit: nil,
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertNil(BodyMetricSpotlightDocument.make(for: metric, preferredSystem: .imperial))
+    }
 }
 
 final class PhaseInsightPolicyTests: XCTestCase {


### PR DESCRIPTION
## Summary
- index newly logged body metrics into Core Spotlight from the existing local-first logging flow
- generate deterministic, searchable metric copy for weight/body-fat entries and skip empty metric records
- clear the LogYourBody Spotlight domain during logout so body metrics do not remain searchable after local auth state is cleared

## Scope
This is the safe Spotlight slice for JovieInc/Jovie#10364. It intentionally does not add a Widget Extension target, AppIntentConfiguration widget, or Control Center control because the current iOS project has no widget target and repo docs warn against re-adding widget refresh/scaffolding without a validated extension target and provisioning profile.

## Validation
- `swiftlint lint --strict --quiet`
- Build iOS Apps MCP focused tests: `LogYourBodyTests/BodyMetricLoggingServiceTests` + `LogYourBodyTests/OnboardingFlowViewModelTests/testLogoutSetsExitReasonUserInitiated` (6 passed)
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,name=iPhone 17' build-for-testing`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci` (29 web suites, 258 tests passed; package tests passed)

## Notes
- Local Node is v22.22.1 while package engines request node 20.x; pnpm commands passed with that existing warning.
- Focused iOS tests/build still report existing Swift 6 isolation/deprecation warnings outside this diff.
- Linear MCP currently requires reauthentication, so I am mirroring status through GitHub evidence/comments for now.