### PR TITLE
docs: clarify widget extension provisioning plan

### DIFF
--- a/apps/ios/docs/setup/WIDGET_SETUP.md
+++ b/apps/ios/docs/setup/WIDGET_SETUP.md
@@ -7,3 +7,6 @@ widget refresh work even though no widget binary existed.
 Do not re-add `WidgetDataManager` or background widget refresh timers unless a
 new Widget Extension target is added to `LogYourBody.xcodeproj` and validated as
 part of the release plan.
+
+Use `docs/ios-widget-provisioning.md` as the preflight checklist before restoring
+widget or Control Center surfaces.

--- a/docs/ios-widget-provisioning.md
+++ b/docs/ios-widget-provisioning.md
@@ -1,47 +1,78 @@
-# iOS Widget Extension Provisioning
+# iOS Widget Extension Provisioning Plan
 
-The LogYourBody app includes a widget extension that requires its own provisioning profile.
+LogYourBody does not currently ship a Widget Extension target. The previous
+widget scaffolding was retired because it created signing and release risk while
+no widget binary was being shipped.
+
+This document is the preflight checklist for restoring widget and Control Center
+surfaces for Jovie issue #10364. Do not add WidgetKit source files, app-group
+refresh timers, or widget build phases until the provisioning items below are
+true.
 
 ## Current Status
 
-- Main app bundle ID: `LogYourBody.LogYourBody`
-- Widget bundle ID: `LogYourBody.LogYourBody.LogYourBodyWidget`
-- Current provisioning profile: `Github CI App Store` (only covers main app)
+- Main app bundle ID: `com.logyourbody.app`.
+- Main app team ID: `G24T327LXT`.
+- Main app App Group: `group.com.logyourbody.shared`.
+- Current release profile: `match AppStore com.logyourbody.app 1780400349`.
+- Widget Extension target: not present in `apps/ios/LogYourBody.xcodeproj`.
+- Widget refresh scaffolding: intentionally absent; see
+  `apps/ios/docs/setup/WIDGET_SETUP.md`.
+- Safe slice already landed: body metrics are indexed in Core Spotlight from the
+  app target.
 
-## Issue
+## Required Decisions
 
-The widget extension is causing build failures because it doesn't have a provisioning profile.
+Before adding a widget target, the release owner must choose and provision a
+stable widget bundle ID. The recommended value is:
 
-## Solutions
+```text
+com.logyourbody.app.widget
+```
 
-### Option 1: Create a Wildcard Profile (Recommended)
-1. Go to Apple Developer Portal
-2. Create a new App Store distribution profile
-3. Use bundle ID: `LogYourBody.LogYourBody.*`
-4. Name it: `Github CI App Store Wildcard`
-5. Download and add to GitHub secrets
+Use a specific widget App Store profile rather than a wildcard profile for the
+first restored release. A specific profile makes CI failures easier to diagnose
+and avoids accidentally broadening signing coverage for unrelated bundles.
 
-### Option 2: Create Specific Widget Profile
-1. Go to Apple Developer Portal
-2. Create a new App Store distribution profile
-3. Use bundle ID: `LogYourBody.LogYourBody.LogYourBodyWidget`
-4. Name it: `Github CI Widget`
-5. Update Fastfile to include both profiles
+## Provisioning Checklist
 
-### Option 3: Disable Widget (Temporary)
-Currently implemented as a temporary solution.
+1. Create the Widget Extension app identifier in Apple Developer Portal:
+   `com.logyourbody.app.widget`.
+2. Enable the same App Group on the widget identifier:
+   `group.com.logyourbody.shared`.
+3. Create or update the App Store distribution profile for the widget bundle.
+4. Install the profile through the existing release credential path.
+5. Add the widget profile name to CI secrets or Fastlane match configuration.
+6. Update the Xcode project with a real Widget Extension target.
+7. Verify archive signing includes both the main app and widget extension.
 
-## To Fix Properly
+## Implementation Boundaries
 
-1. Create the wildcard provisioning profile in Apple Developer Portal
-2. Download the new `.mobileprovision` file
-3. Base64 encode it: `base64 -i profile.mobileprovision | pbcopy`
-4. Update GitHub secret: `gh secret set IOS_PROVISIONING_PROFILE_BASE64`
-5. Revert the Fastfile changes to use `ENV["IOS_PROVISIONING_PROFILE_NAME"]`
+When the target exists and signs successfully, the product work can add:
 
-## GitHub Secrets Required
+- An `AppIntentConfiguration` widget for latest weight, body fat, or steps.
+- A Control Center control that opens the existing quick-log weight flow.
+- App Group data sharing for the latest local body metrics.
+- Device or simulator screenshots proving widget configuration and control
+  surfaces.
+
+Do not reintroduce `WidgetDataManager` background timers in the main app target.
+Widget state should be written only when the underlying body metric changes or
+when the app explicitly refreshes shared widget data.
+
+## Validation Before PR Merge
+
+Run from `apps/ios` after the widget target is added:
 
 ```bash
-# Set the correct profile name
-gh secret set IOS_PROVISIONING_PROFILE_NAME -b "Github CI App Store"
+swiftlint lint --strict
+xcodebuild -project LogYourBody.xcodeproj \
+  -scheme LogYourBody \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  build-for-testing
+bundle exec fastlane ios validate_release
 ```
+
+Release-ready evidence must include an archive or release-loop run that signs
+both targets, plus screenshots for widget configuration and the Control Center
+surface. Do not close #10364 until that evidence is attached.


### PR DESCRIPTION
## Summary

- Correct the stale widget provisioning doc so it reflects the current app state: no Widget Extension target is present in `LogYourBody.xcodeproj`.
- Record the preflight decisions and provisioning checklist required before restoring WidgetKit or Control Center surfaces for JovieInc/Jovie#10364.
- Link the iOS widget setup note back to the provisioning preflight checklist.

## Validation

- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`
- `git push` pre-push hook: turbo lint/typecheck/test for changes since `origin/main` ran and found no affected package tasks.

## Notes

Docs-only. This intentionally does not add a Widget Extension target, WidgetKit source, Control Center control, or signing changes. Those remain blocked on the validated bundle/profile/release plan in the updated doc.
