### PR TITLE
fix: resolve App Store app id by bundle

### DIFF
--- a/.github/scripts/ensure-app-store-free-pricing.rb
+++ b/.github/scripts/ensure-app-store-free-pricing.rb
@@ -16,6 +16,10 @@ def fail_with(message)
   exit 1
 end
 
+def warn_with(message)
+  warn "::warning::#{message}"
+end
+
 def api_key
   path = ENV.fetch("APP_STORE_CONNECT_API_KEY_PATH", "fastlane/api_key.json")
   JSON.parse(File.read(path))
@@ -75,17 +79,33 @@ def expect(method, path, token, body: nil, expected: [200])
   fail_with("App Store Connect #{method.upcase} #{path} returned #{status}: #{JSON.pretty_generate(parsed)}")
 end
 
-def app_id(token)
-  configured = ENV["APP_STORE_APP_ID"].to_s.strip
-  return configured unless configured.empty?
-
+def app_by_bundle_id(token)
   bundle_id = ENV.fetch("APP_IDENTIFIER", "com.logyourbody.app")
   query = URI.encode_www_form("filter[bundleId]" => bundle_id, "limit" => "1")
   response = expect(:get, "/v1/apps?#{query}", token)
   app = response.fetch("data", []).first
   fail_with("No App Store Connect app found for bundle ID #{bundle_id}") unless app
 
-  app.fetch("id")
+  [app.fetch("id"), bundle_id]
+end
+
+def app_id(token)
+  configured = ENV["APP_STORE_APP_ID"].to_s.strip
+  unless configured.empty?
+    query = URI.encode_www_form("fields[apps]" => "bundleId")
+    status, parsed = request(:get, "/v1/apps/#{configured}?#{query}", token)
+    return configured if status == 200
+
+    unless status == 404
+      fail_with("App Store Connect GET /v1/apps/#{configured} returned #{status}: #{JSON.pretty_generate(parsed)}")
+    end
+
+    resolved_id, bundle_id = app_by_bundle_id(token)
+    warn_with("Configured APP_STORE_APP_ID #{configured} was not found in App Store Connect; using app #{resolved_id} resolved from bundle ID #{bundle_id}.")
+    return resolved_id
+  end
+
+  app_by_bundle_id(token).first
 end
 
 def pricing_configured?(token, app_id)

--- a/.github/scripts/release-approved-app-store-version.rb
+++ b/.github/scripts/release-approved-app-store-version.rb
@@ -99,17 +99,33 @@ def expect(method, path, token, body: nil, expected: [200])
   fail_with("App Store Connect #{method.upcase} #{path} returned #{status}: #{JSON.pretty_generate(parsed)}")
 end
 
-def app_id(token)
-  configured = ENV["APP_STORE_APP_ID"].to_s.strip
-  return configured unless configured.empty?
-
+def app_by_bundle_id(token)
   bundle_id = ENV.fetch("APP_IDENTIFIER", "com.logyourbody.app")
   query = URI.encode_www_form("filter[bundleId]" => bundle_id, "limit" => "1")
   response = expect(:get, "/v1/apps?#{query}", token)
   app = response.fetch("data", []).first
   fail_with("No App Store Connect app found for bundle ID #{bundle_id}") unless app
 
-  app.fetch("id")
+  [app.fetch("id"), bundle_id]
+end
+
+def app_id(token)
+  configured = ENV["APP_STORE_APP_ID"].to_s.strip
+  unless configured.empty?
+    query = URI.encode_www_form("fields[apps]" => "bundleId")
+    status, parsed = request(:get, "/v1/apps/#{configured}?#{query}", token)
+    return configured if status == 200
+
+    unless status == 404
+      fail_with("App Store Connect GET /v1/apps/#{configured} returned #{status}: #{JSON.pretty_generate(parsed)}")
+    end
+
+    resolved_id, bundle_id = app_by_bundle_id(token)
+    warn_with("Configured APP_STORE_APP_ID #{configured} was not found in App Store Connect; using app #{resolved_id} resolved from bundle ID #{bundle_id}.")
+    return resolved_id
+  end
+
+  app_by_bundle_id(token).first
 end
 
 def app_store_versions(token, app_id)


### PR DESCRIPTION
## Summary
- Validate the configured App Store Connect app id before using it in release monitor scripts
- Fall back to resolving the app by bundle id when App Store Connect returns 404 for the configured id
- Apply the same resolution path to approved-version release and App Store free-pricing setup

## Evidence
- ruby -c .github/scripts/release-approved-app-store-version.rb
- ruby -c .github/scripts/ensure-app-store-free-pricing.rb
- node .github/scripts/verify-workflow-concurrency.mjs
- pnpm lint
- pnpm typecheck
- pnpm test:ci

## Release context
Latest TestFlight upload still fails on an external App Store Connect agreement blocker: FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED. This PR removes the misleading approved-release monitor 404 so the release lane can progress to the real external gate after merge.