### PR TITLE
fix: handle active app store review submission

### DIFF
--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -871,22 +871,29 @@ platform :ios do
       notes: env_or_default.call("APP_REVIEW_NOTES", "LogYourBody lets users sign in, log their weight, sync their entries, export CSV data, and manage their subscription. No demo account is required; reviewers can create a test account in the app.")
     }.compact
 
-    # Upload to App Store Connect
-    upload_to_app_store(
-      ipa: options[:ipa_path],
-      force: true,
-      metadata_path: "fastlane/metadata",
-      screenshots_path: "fastlane/screenshots",
-      skip_metadata: false,
-      skip_screenshots: false,
-      submit_for_review: submit_for_review,
-      automatic_release: automatic_release,
-      phased_release: phased_release,
-      app_review_information: app_review_information,
-      run_precheck_before_submit: false,
-      app_identifier: ENV["APP_IDENTIFIER"] || "com.logyourbody.app",
-      team_id: ENV["APPLE_TEAM_ID"]
-    )
+    begin
+      upload_to_app_store(
+        ipa: options[:ipa_path],
+        force: true,
+        metadata_path: "fastlane/metadata",
+        screenshots_path: "fastlane/screenshots",
+        skip_metadata: false,
+        skip_screenshots: false,
+        submit_for_review: submit_for_review,
+        automatic_release: automatic_release,
+        phased_release: phased_release,
+        app_review_information: app_review_information,
+        run_precheck_before_submit: false,
+        app_identifier: ENV["APP_IDENTIFIER"] || "com.logyourbody.app",
+        team_id: ENV["APPLE_TEAM_ID"]
+      )
+    rescue => e
+      if submit_for_review && e.message.include?("A review submission is already in progress")
+        UI.success("App Store review submission is already in progress; treating as submitted.")
+      else
+        raise
+      end
+    end
   end
 
   desc "Deploy to App Store (build + upload)"


### PR DESCRIPTION
## Summary
- Treat App Store Connect's idempotent `A review submission is already in progress` response as a successful submitted state when `submit_for_review` is enabled.
- Keep all other App Store upload/submission errors fatal.

## Why
- The App Store release loop reached archive/export, pricing, precheck, and submission.
- Fastlane failed only because App Store Connect reported an existing active review submission.
- This makes the release workflow idempotent while Apple review is already in progress.

## Validation
- ruby -c apps/ios/fastlane/Fastfile
- swiftlint lint --strict
- pnpm lint
- pnpm typecheck
- pnpm test:ci
- pre-push affected turbo lint/typecheck/test since origin/main

## Evidence
- App Store release run 27459063632 failed at Submit to App Store with: Cannot submit for review - A review submission is already in progress.
- Post-submission approved-release monitor 27459475175 completed successfully and reported App Store version 1.2.0 is PREPARE_FOR_SUBMISSION; no release action taken.
