### PR TITLE
Fix golden path release blockers

### DIFF
--- a/.github/scripts/release-approved-app-store-version.rb
+++ b/.github/scripts/release-approved-app-store-version.rb
@@ -41,6 +41,19 @@ TERMINAL_REVIEW_SUBMISSION_STATES = %w[
   RESOLVED
 ].freeze
 
+REJECTED_REVIEW_ITEM_STATES = %w[
+  DEVELOPER_REJECTED
+  METADATA_REJECTED
+  REJECTED
+].freeze
+
+REVIEW_SUBMISSION_ITEM_RELATIONSHIPS = %w[
+  appStoreVersion
+  appCustomProductPageVersion
+  appStoreVersionExperiment
+  appEvent
+].freeze
+
 def fail_with(message)
   warn "::error::#{message}"
   exit 1
@@ -48,6 +61,19 @@ end
 
 def warn_with(message)
   warn "::warning::#{message}"
+end
+
+def error_with(message)
+  warn "::error::#{message}"
+end
+
+def append_step_summary(lines)
+  summary_path = ENV["GITHUB_STEP_SUMMARY"].to_s
+  return if summary_path.empty?
+
+  File.open(summary_path, "a") do |file|
+    lines.each { |line| file.puts(line) }
+  end
 end
 
 def api_error_message(parsed)
@@ -230,8 +256,17 @@ def active_review_submission_for_version(token, app_id, app_store_version_id)
 end
 
 def review_submission_items(token, review_submission_id)
-  query = URI.encode_www_form("limit" => "50")
+  query = URI.encode_www_form(
+    "limit" => "50",
+    "fields[reviewSubmissionItems]" => (["state"] + REVIEW_SUBMISSION_ITEM_RELATIONSHIPS).join(","),
+    "include" => REVIEW_SUBMISSION_ITEM_RELATIONSHIPS.join(",")
+  )
   status, parsed = request(:get, "/v1/reviewSubmissions/#{review_submission_id}/items?#{query}", token)
+
+  if status == 400
+    fallback_query = URI.encode_www_form("limit" => "50")
+    status, parsed = request(:get, "/v1/reviewSubmissions/#{review_submission_id}/items?#{fallback_query}", token)
+  end
 
   unless status == 200
     warn_with("Unable to inspect App Review submission #{review_submission_id}: App Store Connect returned #{status_with_error(status, parsed)}.")
@@ -268,6 +303,34 @@ def review_submission_item_summary(items)
   end.join("; ")
 end
 
+def rejected_review_submission_items(items)
+  items.select do |item|
+    REJECTED_REVIEW_ITEM_STATES.include?(item.dig("attributes", "state").to_s)
+  end
+end
+
+def emit_review_submission_remediation(submission_id, review_state, item_summary, rejected_items)
+  return unless review_state.to_s == "UNRESOLVED_ISSUES" || rejected_items.any?
+
+  rejected_ids = rejected_items.map { |item| item.fetch("id") }.join(", ")
+  detail = rejected_ids.empty? ? "no rejected item IDs returned" : "rejected item IDs: #{rejected_ids}"
+  message = "App Review submission #{submission_id} has unresolved issues (#{review_state}; #{detail}). Resolve the rejected item in App Store Connect, then resubmit for review."
+
+  error_with(message)
+  append_step_summary(
+    [
+      "## App Review action required",
+      "",
+      message,
+      "",
+      "Submission item summary: `#{item_summary}`",
+      "",
+      "Open App Store Connect, choose the LogYourBody app, then use **View App Review Issues & Messages** to inspect and resolve the rejection before resubmitting."
+    ]
+  )
+  exit 1
+end
+
 token = bearer_token
 id = app_id(token)
 version = selected_version(app_store_versions(token, id))
@@ -295,8 +358,16 @@ when *FAILURE_STATES
 when "PREPARE_FOR_SUBMISSION"
   if active_review_submission
     review_state = active_review_submission.dig("attributes", "state")
+    submission_items = review_submission_items(token, active_review_submission.fetch("id"))
+    item_summary = review_submission_item_summary(submission_items)
     puts "App Store version #{version_string} has active App Review submission #{active_review_submission.fetch("id")} (#{review_state}); waiting for Apple review."
-    puts "App Review submission items: #{review_submission_item_summary(review_submission_items(token, active_review_submission.fetch("id")))}"
+    puts "App Review submission items: #{item_summary}"
+    emit_review_submission_remediation(
+      active_review_submission.fetch("id"),
+      review_state,
+      item_summary,
+      rejected_review_submission_items(submission_items)
+    )
   else
     puts "App Store version #{version_string} is #{state}; waiting for App Store Connect review state to update."
   end

--- a/apps/web/src/app/api/auth/delete-account/__tests__/route.node.test.ts
+++ b/apps/web/src/app/api/auth/delete-account/__tests__/route.node.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @jest-environment node
+ */
+import { DELETE } from '../route';
+import { auth, clerkClient } from '@clerk/nextjs/server';
+import { createClerkSupabaseClient } from '@/lib/supabase/clerk-client';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (data: unknown, init?: ResponseInit) => ({
+      json: async () => data,
+      status: init?.status ?? 200,
+    }),
+  },
+}));
+
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: jest.fn(),
+  clerkClient: jest.fn(),
+}));
+
+jest.mock('@/lib/supabase/clerk-client', () => ({
+  createClerkSupabaseClient: jest.fn(),
+}));
+
+class MockDeleteBuilder {
+  constructor(
+    private readonly table: string,
+    private readonly failures: ReadonlyMap<string, unknown>,
+    private readonly calls: string[],
+  ) {}
+
+  async eq(column: string, value: string) {
+    this.calls.push(`${this.table}.${column}=${value}`);
+    const error = this.failures.get(this.table);
+
+    return error ? { error } : { error: null };
+  }
+}
+
+function createMockSupabase(failures: Record<string, unknown> = {}) {
+  const calls: string[] = [];
+  const failureMap = new Map(Object.entries(failures));
+
+  return {
+    calls,
+    client: {
+      from(table: string) {
+        return {
+          delete() {
+            return new MockDeleteBuilder(table, failureMap, calls);
+          },
+        };
+      },
+    },
+  };
+}
+
+describe('DELETE /api/auth/delete-account', () => {
+  const deleteUser = jest.fn();
+  const getToken = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.example';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+
+    getToken.mockResolvedValue('clerk-token');
+    (auth as jest.Mock).mockResolvedValue({ userId: 'user_123', getToken });
+    (clerkClient as jest.Mock).mockResolvedValue({ users: { deleteUser } });
+    (global.fetch as jest.Mock | undefined) = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => '',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not delete the Clerk user when required data cleanup fails', async () => {
+    const supabase = createMockSupabase({
+      body_metrics: { message: 'permission denied for table body_metrics' },
+    });
+    (createClerkSupabaseClient as jest.Mock).mockResolvedValue(supabase.client);
+
+    const response = await DELETE();
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'Unable to delete all account data. Please try again or contact support.',
+    });
+    expect(response.status).toBe(502);
+    expect(deleteUser).not.toHaveBeenCalled();
+    expect(supabase.calls).toEqual([
+      'progress_photos.user_id=user_123',
+      'daily_metrics.user_id=user_123',
+      'body_metrics.user_id=user_123',
+    ]);
+  });
+
+  it('deletes the Clerk user only after asset and row cleanup succeeds', async () => {
+    const supabase = createMockSupabase();
+    (createClerkSupabaseClient as jest.Mock).mockResolvedValue(supabase.client);
+
+    const response = await DELETE();
+
+    await expect(response.json()).resolves.toEqual({
+      message: 'Account deleted successfully',
+    });
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://supabase.example/functions/v1/delete-user-assets',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer clerk-token',
+        }),
+      }),
+    );
+    expect(supabase.calls).toEqual([
+      'progress_photos.user_id=user_123',
+      'daily_metrics.user_id=user_123',
+      'body_metrics.user_id=user_123',
+      'user_goals.user_id=user_123',
+      'profiles.id=user_123',
+    ]);
+    expect(deleteUser).toHaveBeenCalledWith('user_123');
+  });
+
+  it('keeps the Clerk user when asset cleanup fails', async () => {
+    const supabase = createMockSupabase();
+    (createClerkSupabaseClient as jest.Mock).mockResolvedValue(supabase.client);
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'asset cleanup failed',
+    });
+
+    const response = await DELETE();
+
+    expect(response.status).toBe(502);
+    expect(supabase.calls).toEqual([]);
+    expect(deleteUser).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/auth/delete-account/route.ts
+++ b/apps/web/src/app/api/auth/delete-account/route.ts
@@ -1,111 +1,112 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { NextResponse } from 'next/server';
+import { auth, clerkClient } from '@clerk/nextjs/server';
+import { createClerkSupabaseClient } from '@/lib/supabase/clerk-client';
 
-export async function DELETE(request: NextRequest) {
+type DeleteTarget = {
+  table: string;
+  column: string;
+};
+
+const deleteTargets: DeleteTarget[] = [
+  { table: 'progress_photos', column: 'user_id' },
+  { table: 'daily_metrics', column: 'user_id' },
+  { table: 'body_metrics', column: 'user_id' },
+  { table: 'user_goals', column: 'user_id' },
+  { table: 'profiles', column: 'id' },
+];
+
+function describeDeletionError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const record = error as Record<string, unknown>;
+    const message = record.message ?? record.details ?? record.code;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return String(error);
+}
+
+function cleanupFailureResponse() {
+  return NextResponse.json(
+    { error: 'Unable to delete all account data. Please try again or contact support.' },
+    { status: 502 },
+  );
+}
+
+export async function DELETE() {
   try {
-    const authHeader = request.headers.get('authorization')
+    const { userId, getToken } = await auth();
 
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return NextResponse.json(
-        { error: 'Missing or invalid authorization header' },
-        { status: 401 }
-      )
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const token = authHeader.substring(7)
-    const supabase = await createClient()
+    const token = await getToken();
 
-    // Verify the token and get the user
-    const { data: { user }, error: authError } = await supabase.auth.getUser(token)
-
-    if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Invalid token' },
-        { status: 401 }
-      )
+    if (!token) {
+      return NextResponse.json({ error: 'Missing authentication token' }, { status: 401 });
     }
 
-    // Best-effort deletion of Supabase storage objects and Cloudinary assets
+    const supabase = await createClerkSupabaseClient(() => Promise.resolve(token));
+
     try {
-      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-      const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
       if (!supabaseUrl || !supabaseAnonKey) {
-        console.error('Missing Supabase environment variables for delete-user-assets function')
+        console.error('Missing Supabase environment variables for delete-user-assets function');
+        return cleanupFailureResponse();
       } else {
-        const response = await fetch(
-          `${supabaseUrl}/functions/v1/delete-user-assets`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              apikey: supabaseAnonKey,
-              Authorization: `Bearer ${token}`,
-            },
+        const response = await fetch(`${supabaseUrl}/functions/v1/delete-user-assets`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            apikey: supabaseAnonKey,
+            Authorization: `Bearer ${token}`,
           },
-        )
+        });
 
         if (!response.ok) {
-          const text = await response.text().catch(() => '')
+          const text = await response.text().catch(() => '');
           console.error('delete-user-assets function failed', {
             status: response.status,
             body: text,
-          })
+          });
+
+          return cleanupFailureResponse();
         }
       }
     } catch (error) {
-      console.error('Error calling delete-user-assets function', error)
+      console.error('Error calling delete-user-assets function', error);
+      return cleanupFailureResponse();
     }
 
-    // Delete user's data from various tables
-    // Note: Order matters due to foreign key constraints
+    for (const target of deleteTargets) {
+      const { error } = await supabase.from(target.table).delete().eq(target.column, userId);
 
-    // Delete body metrics
-    await supabase
-      .from('body_metrics')
-      .delete()
-      .eq('user_id', user.id)
+      if (error) {
+        console.error('Failed to delete account data before Clerk user deletion', {
+          table: target.table,
+          column: target.column,
+          error: describeDeletionError(error),
+        });
 
-    // Delete daily metrics
-    await supabase
-      .from('daily_metrics')
-      .delete()
-      .eq('user_id', user.id)
+        return cleanupFailureResponse();
+      }
+    }
 
-    // Delete progress photos
-    await supabase
-      .from('progress_photos')
-      .delete()
-      .eq('user_id', user.id)
+    const client = await clerkClient();
+    await client.users.deleteUser(userId);
 
-    // Delete user goals
-    await supabase
-      .from('user_goals')
-      .delete()
-      .eq('user_id', user.id)
-
-    // Delete profile
-    await supabase
-      .from('profiles')
-      .delete()
-      .eq('id', user.id)
-
-    // Sign out the user (this invalidates their session)
-    await supabase.auth.signOut()
-
-    // Note: Full user deletion from auth requires service role key
-    // For now, we've deleted all user data and invalidated their session
-    // You can implement a background job with service role key to fully delete auth records
-
-    return NextResponse.json(
-      { message: 'Account deleted successfully' },
-      { status: 200 }
-    )
+    return NextResponse.json({ message: 'Account deleted successfully' }, { status: 200 });
   } catch (error) {
-    console.error('Delete account error:', error)
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
+    console.error('Delete account error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/apps/web/src/app/download/ios/page.tsx
+++ b/apps/web/src/app/download/ios/page.tsx
@@ -1,11 +1,11 @@
-'use client'
+'use client';
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react';
 // import Image from 'next/image'
 // import Link from 'next/link'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
 import {
   Apple,
   Star,
@@ -22,26 +22,25 @@ import {
   Target,
   Heart,
   Sparkles,
-} from 'lucide-react'
-import { Header } from '@/components/Header'
-import { Footer } from '@/components/Footer'
+} from 'lucide-react';
+import { Header } from '@/components/Header';
+import { Footer } from '@/components/Footer';
 
 export default function IOSDownloadPage() {
-  const [isIOS, setIsIOS] = useState(false)
-  const [showAppStoreRedirect, setShowAppStoreRedirect] = useState(false)
+  const [isIOS, setIsIOS] = useState(false);
+  const [showAppStoreRedirect, setShowAppStoreRedirect] = useState(false);
+  const appStoreRedirectHref = '/api/app-store-redirect?platform=ios&source=landing';
 
   useEffect(() => {
     // Detect if user is on iOS
-    const userAgent = navigator.userAgent || navigator.vendor
-    const isIOSDevice = /iPad|iPhone|iPod/.test(userAgent) && !('MSStream' in window)
-    setIsIOS(isIOSDevice)
-  }, [])
+    const userAgent = navigator.userAgent || navigator.vendor;
+    const isIOSDevice = /iPad|iPhone|iPod/.test(userAgent) && !('MSStream' in window);
+    setIsIOS(isIOSDevice);
+  }, []);
 
   const handleDownload = () => {
-    setShowAppStoreRedirect(true)
-    // Track conversion event via API
-    window.open('/api/app-store-redirect?platform=ios&source=landing', '_blank')
-  }
+    setShowAppStoreRedirect(true);
+  };
 
   const coreFeatures = [
     {
@@ -62,14 +61,14 @@ export default function IOSDownloadPage() {
       description: 'Navy method calculations. Apple Health sync. Done before your coffee cools.',
       stat: '10x faster',
     },
-  ]
+  ];
 
   const trustSignals = [
     { value: '4.9★', label: 'App Store Rating' },
     { value: '10K+', label: 'Active Users' },
     { value: '500K+', label: 'Measurements Logged' },
     { value: '99.9%', label: 'Uptime' },
-  ]
+  ];
 
   const comparisonData = [
     { feature: 'FFMI Calculator', us: true, others: false },
@@ -80,74 +79,81 @@ export default function IOSDownloadPage() {
     { feature: 'No Ads Ever', us: true, others: false },
     { feature: 'Expert Support', us: true, others: false },
     { feature: 'Offline Mode', us: true, others: 'partial' },
-  ]
+  ];
 
   const testimonials = [
     {
       name: 'Dr. Sarah Chen',
       role: 'Sports Medicine',
-      content: 'Finally, an app that tracks what actually matters for body composition. I recommend it to all my patients.',
+      content:
+        'Finally, an app that tracks what actually matters for body composition. I recommend it to all my patients.',
       avatar: '👩‍⚕️',
     },
     {
       name: 'Mike Rodriguez',
       role: 'Natural Bodybuilder',
-      content: 'The FFMI tracking helped me understand my genetic limits. Game changer for natural athletes.',
+      content:
+        'The FFMI tracking helped me understand my genetic limits. Game changer for natural athletes.',
       avatar: '💪',
     },
     {
       name: 'Emma Wilson',
       role: 'Fitness Coach',
-      content: 'My clients love the progress photos feature. Seeing changes they miss in the mirror keeps them motivated.',
+      content:
+        'My clients love the progress photos feature. Seeing changes they miss in the mirror keeps them motivated.',
       avatar: '🏃‍♀️',
     },
-  ]
+  ];
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-50 to-white">
       <Header />
 
       {/* Hero Section - Apple-inspired */}
-      <section className="relative overflow-hidden pt-20 pb-32">
+      <section className="relative overflow-hidden pb-32 pt-20">
         <div className="container mx-auto px-4 sm:px-6">
           <div className="mx-auto max-w-4xl text-center">
             {/* App Store Badge */}
             <div className="mb-8 inline-flex items-center justify-center">
-              <Badge className="bg-blue-50 text-blue-700 border-blue-200 px-4 py-2">
-                <Apple className="h-4 w-4 mr-2" />
+              <Badge className="border-blue-200 bg-blue-50 px-4 py-2 text-blue-700">
+                <Apple className="mr-2 h-4 w-4" />
                 Exclusively on iPhone
               </Badge>
             </div>
 
             {/* Main Headline - Apple copywriting style */}
-            <h1 className="mb-6 text-5xl sm:text-6xl md:text-7xl font-bold tracking-tight text-gray-900">
-              Your body.<br />
+            <h1 className="mb-6 text-5xl font-bold tracking-tight text-gray-900 sm:text-6xl md:text-7xl">
+              Your body.
+              <br />
               <span className="bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
                 Decoded.
               </span>
             </h1>
 
-            <p className="mx-auto mb-10 max-w-2xl text-xl text-gray-600 leading-relaxed">
-              The only app that tracks FFMI, body fat percentage, and progress photos 
-              with scientific accuracy. Know exactly where you stand.
+            <p className="mx-auto mb-10 max-w-2xl text-xl leading-relaxed text-gray-600">
+              The only app that tracks FFMI, body fat percentage, and progress photos with
+              scientific accuracy. Know exactly where you stand.
             </p>
 
             {/* Primary CTA */}
             <div className="mb-8">
               <Button
-                onClick={handleDownload}
-                className="bg-black text-white px-10 py-6 text-lg font-medium rounded-2xl hover:bg-gray-900 transition-all duration-200 hover:scale-105 shadow-2xl"
+                asChild
+                className="w-full max-w-sm rounded-2xl bg-black px-4 py-6 text-base font-medium text-white shadow-2xl transition-all duration-200 hover:scale-105 hover:bg-gray-900 sm:w-auto sm:px-10 sm:text-lg"
               >
-                <Apple className="h-6 w-6 mr-3" />
-                Download on the App Store
-                <ArrowRight className="h-5 w-5 ml-3" />
+                <a
+                  href={appStoreRedirectHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={handleDownload}
+                >
+                  <Apple className="mr-3 h-6 w-6" />
+                  Download on the App Store
+                  <ArrowRight className="ml-3 h-5 w-5" />
+                </a>
               </Button>
-              
-              {isIOS && (
-                <p className="mt-4 text-sm text-gray-500">
-                  Opens in App Store
-                </p>
-              )}
+
+              {isIOS && <p className="mt-4 text-sm text-gray-500">Opens in App Store</p>}
             </div>
 
             {/* Trust Signals */}
@@ -172,174 +178,182 @@ export default function IOSDownloadPage() {
 
         {/* Background decoration */}
         <div className="absolute inset-0 -z-10">
-          <div className="absolute top-20 left-10 w-72 h-72 bg-blue-100 rounded-full filter blur-3xl opacity-20"></div>
-          <div className="absolute bottom-20 right-10 w-96 h-96 bg-purple-100 rounded-full filter blur-3xl opacity-20"></div>
+          <div className="absolute left-10 top-20 h-72 w-72 rounded-full bg-blue-100 opacity-20 blur-3xl filter"></div>
+          <div className="absolute bottom-20 right-10 h-96 w-96 rounded-full bg-purple-100 opacity-20 blur-3xl filter"></div>
         </div>
       </section>
 
       {/* Core Features - Linear.app style */}
-      <section className="py-20 bg-white">
+      <section className="bg-white py-20">
         <div className="container mx-auto px-4 sm:px-6">
           <div className="mb-16 text-center">
-            <h2 className="mb-4 text-3xl sm:text-4xl font-bold text-gray-900">
+            <h2 className="mb-4 text-3xl font-bold text-gray-900 sm:text-4xl">
               Built for serious athletes
             </h2>
-            <p className="text-xl text-gray-600 max-w-2xl mx-auto">
+            <p className="mx-auto max-w-2xl text-xl text-gray-600">
               Stop guessing. Start knowing. Track what actually matters.
             </p>
           </div>
 
-          <div className="grid gap-8 md:grid-cols-3 max-w-5xl mx-auto">
+          <div className="mx-auto grid max-w-5xl gap-8 md:grid-cols-3">
             {coreFeatures.map((feature, index) => {
-              const IconComponent = feature.icon
+              const IconComponent = feature.icon;
               return (
                 <div
                   key={index}
-                  className="group relative bg-gray-50 rounded-2xl p-8 hover:bg-white hover:shadow-xl transition-all duration-300 border border-gray-100"
+                  className="group relative rounded-2xl border border-gray-100 bg-gray-50 p-8 transition-all duration-300 hover:bg-white hover:shadow-xl"
                 >
                   <div className="mb-6">
                     <div className="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500 to-purple-500 text-white shadow-lg">
                       <IconComponent className="h-7 w-7" />
                     </div>
                   </div>
-                  
-                  <h3 className="mb-3 text-xl font-bold text-gray-900">
-                    {feature.title}
-                  </h3>
-                  
-                  <p className="mb-4 text-gray-600 leading-relaxed">
-                    {feature.description}
-                  </p>
-                  
+
+                  <h3 className="mb-3 text-xl font-bold text-gray-900">{feature.title}</h3>
+
+                  <p className="mb-4 leading-relaxed text-gray-600">{feature.description}</p>
+
                   <div className="flex items-center text-sm font-medium text-blue-600">
-                    <Sparkles className="h-4 w-4 mr-2" />
+                    <Sparkles className="mr-2 h-4 w-4" />
                     {feature.stat}
                   </div>
                 </div>
-              )
+              );
             })}
           </div>
         </div>
       </section>
 
       {/* iPhone Mockup Section */}
-      <section className="py-20 bg-gray-50">
+      <section className="bg-gray-50 py-20">
         <div className="container mx-auto px-4 sm:px-6">
-          <div className="grid lg:grid-cols-2 gap-12 items-center max-w-6xl mx-auto">
+          <div className="mx-auto grid max-w-6xl items-center gap-12 lg:grid-cols-2">
             {/* Content */}
             <div className="order-2 lg:order-1">
-              <Badge className="mb-6 bg-green-50 text-green-700 border-green-200">
-                <Zap className="h-3 w-3 mr-2" />
+              <Badge className="mb-6 border-green-200 bg-green-50 text-green-700">
+                <Zap className="mr-2 h-3 w-3" />
                 Lightning Fast
               </Badge>
-              
+
               <h2 className="mb-6 text-4xl font-bold text-gray-900">
-                Log in seconds.<br />
+                Log in seconds.
+                <br />
                 Track for life.
               </h2>
-              
-              <div className="space-y-4 mb-8">
+
+              <div className="mb-8 space-y-4">
                 <div className="flex items-start gap-3">
-                  <CheckCircle2 className="h-6 w-6 text-green-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle2 className="mt-0.5 h-6 w-6 flex-shrink-0 text-green-500" />
                   <div>
                     <h4 className="font-semibold text-gray-900">Smart Calculations</h4>
-                    <p className="text-gray-600">Navy method auto-calculates body fat percentage from measurements</p>
+                    <p className="text-gray-600">
+                      Navy method auto-calculates body fat percentage from measurements
+                    </p>
                   </div>
                 </div>
-                
+
                 <div className="flex items-start gap-3">
-                  <CheckCircle2 className="h-6 w-6 text-green-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle2 className="mt-0.5 h-6 w-6 flex-shrink-0 text-green-500" />
                   <div>
                     <h4 className="font-semibold text-gray-900">Apple Health Sync</h4>
-                    <p className="text-gray-600">Weight automatically pulled from your Apple Watch or smart scale</p>
+                    <p className="text-gray-600">
+                      Weight automatically pulled from your Apple Watch or smart scale
+                    </p>
                   </div>
                 </div>
-                
+
                 <div className="flex items-start gap-3">
-                  <CheckCircle2 className="h-6 w-6 text-green-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle2 className="mt-0.5 h-6 w-6 flex-shrink-0 text-green-500" />
                   <div>
                     <h4 className="font-semibold text-gray-900">Progress Photos</h4>
-                    <p className="text-gray-600">AI removes background for perfect before/after comparisons</p>
+                    <p className="text-gray-600">
+                      AI removes background for perfect before/after comparisons
+                    </p>
                   </div>
                 </div>
               </div>
-              
+
               <Button
-                onClick={handleDownload}
-                className="bg-black text-white px-8 py-4 rounded-xl hover:bg-gray-900 transition-all"
+                asChild
+                className="w-full max-w-xs rounded-xl bg-black px-4 py-4 text-white transition-all hover:bg-gray-900 sm:w-auto sm:px-8"
               >
-                Get Started Free
-                <ChevronRight className="h-5 w-5 ml-2" />
+                <a
+                  href={appStoreRedirectHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={handleDownload}
+                >
+                  Get Started Free
+                  <ChevronRight className="ml-2 h-5 w-5" />
+                </a>
               </Button>
             </div>
 
             {/* iPhone Mockup */}
-            <div className="order-1 lg:order-2 relative">
-              <div className="relative mx-auto w-80 h-[640px]">
+            <div className="relative order-1 lg:order-2">
+              <div className="relative mx-auto h-[640px] w-80">
                 {/* Phone Frame */}
-                <div className="absolute inset-0 bg-gray-900 rounded-[3rem] shadow-2xl"></div>
-                
+                <div className="absolute inset-0 rounded-[3rem] bg-gray-900 shadow-2xl"></div>
+
                 {/* Screen */}
-                <div className="absolute inset-3 bg-white rounded-[2.5rem] overflow-hidden">
+                <div className="absolute inset-3 overflow-hidden rounded-[2.5rem] bg-white">
                   {/* Status Bar */}
-                  <div className="h-14 bg-gray-50 flex items-center justify-between px-8 pt-2">
+                  <div className="flex h-14 items-center justify-between bg-gray-50 px-8 pt-2">
                     <span className="text-xs font-medium">9:41</span>
                     <div className="flex items-center gap-1">
-                      <div className="w-6 h-3 border border-gray-400 rounded-sm">
-                        <div className="w-4 h-full bg-gray-400 rounded-sm"></div>
+                      <div className="h-3 w-6 rounded-sm border border-gray-400">
+                        <div className="h-full w-4 rounded-sm bg-gray-400"></div>
                       </div>
                     </div>
                   </div>
-                  
+
                   {/* App UI */}
                   <div className="px-6 py-4">
-                    <h3 className="text-2xl font-bold text-gray-900 mb-6">Dashboard</h3>
-                    
+                    <h3 className="mb-6 text-2xl font-bold text-gray-900">Dashboard</h3>
+
                     {/* FFMI Card */}
-                    <div className="bg-gradient-to-r from-blue-500 to-purple-500 text-white rounded-2xl p-6 mb-4">
-                      <div className="flex justify-between items-start mb-4">
+                    <div className="mb-4 rounded-2xl bg-gradient-to-r from-blue-500 to-purple-500 p-6 text-white">
+                      <div className="mb-4 flex items-start justify-between">
                         <div>
-                          <p className="text-blue-100 text-sm mb-1">Fat-Free Mass Index</p>
+                          <p className="mb-1 text-sm text-blue-100">Fat-Free Mass Index</p>
                           <p className="text-4xl font-bold">21.4</p>
                         </div>
-                        <Badge className="bg-white/20 text-white border-white/30">
-                          Excellent
-                        </Badge>
+                        <Badge className="border-white/30 bg-white/20 text-white">Excellent</Badge>
                       </div>
                       <div className="text-sm text-blue-100">
                         87th percentile for natural athletes
                       </div>
                     </div>
-                    
+
                     {/* Stats Grid */}
-                    <div className="grid grid-cols-2 gap-3 mb-4">
-                      <div className="bg-gray-50 rounded-xl p-4">
-                        <p className="text-gray-500 text-xs mb-1">Body Fat</p>
+                    <div className="mb-4 grid grid-cols-2 gap-3">
+                      <div className="rounded-xl bg-gray-50 p-4">
+                        <p className="mb-1 text-xs text-gray-500">Body Fat</p>
                         <p className="text-2xl font-bold text-gray-900">12.3%</p>
                         <p className="text-xs text-green-600">↓ 0.5%</p>
                       </div>
-                      <div className="bg-gray-50 rounded-xl p-4">
-                        <p className="text-gray-500 text-xs mb-1">Weight</p>
+                      <div className="rounded-xl bg-gray-50 p-4">
+                        <p className="mb-1 text-xs text-gray-500">Weight</p>
                         <p className="text-2xl font-bold text-gray-900">180 lbs</p>
                         <p className="text-xs text-gray-500">→ 0.0</p>
                       </div>
                     </div>
-                    
+
                     {/* Action Button */}
-                    <Button className="w-full bg-gray-900 text-white rounded-xl py-4">
+                    <Button className="w-full rounded-xl bg-gray-900 py-4 text-white">
                       Log New Measurement
                     </Button>
                   </div>
                 </div>
-                
+
                 {/* Notch */}
-                <div className="absolute top-3 left-1/2 transform -translate-x-1/2 w-40 h-7 bg-gray-900 rounded-full"></div>
+                <div className="absolute left-1/2 top-3 h-7 w-40 -translate-x-1/2 transform rounded-full bg-gray-900"></div>
               </div>
-              
+
               {/* Floating elements */}
-              <div className="absolute -top-4 -right-4 bg-white rounded-2xl shadow-xl p-4 border border-gray-100">
+              <div className="absolute -right-4 -top-4 rounded-2xl border border-gray-100 bg-white p-4 shadow-xl">
                 <div className="flex items-center gap-3">
-                  <div className="h-10 w-10 bg-green-100 rounded-full flex items-center justify-center">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100">
                     <TrendingUp className="h-5 w-5 text-green-600" />
                   </div>
                   <div>
@@ -348,8 +362,8 @@ export default function IOSDownloadPage() {
                   </div>
                 </div>
               </div>
-              
-              <div className="absolute -bottom-4 -left-4 bg-white rounded-2xl shadow-xl p-4 border border-gray-100">
+
+              <div className="absolute -bottom-4 -left-4 rounded-2xl border border-gray-100 bg-white p-4 shadow-xl">
                 <div className="flex items-center gap-3">
                   <Award className="h-8 w-8 text-yellow-500" />
                   <div>
@@ -364,11 +378,11 @@ export default function IOSDownloadPage() {
       </section>
 
       {/* Comparison Table */}
-      <section className="py-20 bg-white">
+      <section className="bg-white py-20">
         <div className="container mx-auto px-4 sm:px-6">
-          <div className="max-w-4xl mx-auto">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
+          <div className="mx-auto max-w-4xl">
+            <div className="mb-12 text-center">
+              <h2 className="mb-4 text-3xl font-bold text-gray-900 sm:text-4xl">
                 Why professionals choose LogYourBody
               </h2>
               <p className="text-xl text-gray-600">
@@ -376,37 +390,37 @@ export default function IOSDownloadPage() {
               </p>
             </div>
 
-            <div className="bg-gray-50 rounded-2xl overflow-hidden">
+            <div className="overflow-hidden rounded-2xl bg-gray-50">
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-gray-200">
-                    <th className="text-left p-6 text-gray-600 font-medium">Feature</th>
-                    <th className="text-center p-6">
+                    <th className="p-6 text-left font-medium text-gray-600">Feature</th>
+                    <th className="p-6 text-center">
                       <div className="inline-flex items-center justify-center">
-                        <span className="text-blue-600 font-bold">LogYourBody</span>
+                        <span className="font-bold text-blue-600">LogYourBody</span>
                       </div>
                     </th>
-                    <th className="text-center p-6 text-gray-400">Others</th>
+                    <th className="p-6 text-center text-gray-400">Others</th>
                   </tr>
                 </thead>
                 <tbody>
                   {comparisonData.map((row, index) => (
                     <tr key={index} className="border-b border-gray-100">
                       <td className="p-6 text-gray-700">{row.feature}</td>
-                      <td className="text-center p-6">
+                      <td className="p-6 text-center">
                         {row.us === true ? (
-                          <CheckCircle2 className="h-6 w-6 text-green-500 mx-auto" />
+                          <CheckCircle2 className="mx-auto h-6 w-6 text-green-500" />
                         ) : (
                           <span className="text-gray-400">{row.us}</span>
                         )}
                       </td>
-                      <td className="text-center p-6">
+                      <td className="p-6 text-center">
                         {row.others === true ? (
-                          <CheckCircle2 className="h-6 w-6 text-green-500 mx-auto" />
+                          <CheckCircle2 className="mx-auto h-6 w-6 text-green-500" />
                         ) : row.others === false ? (
-                          <div className="h-6 w-6 mx-auto rounded-full bg-gray-200"></div>
+                          <div className="mx-auto h-6 w-6 rounded-full bg-gray-200"></div>
                         ) : (
-                          <span className="text-gray-400 text-sm">{row.others}</span>
+                          <span className="text-sm text-gray-400">{row.others}</span>
                         )}
                       </td>
                     </tr>
@@ -419,11 +433,11 @@ export default function IOSDownloadPage() {
       </section>
 
       {/* Social Proof */}
-      <section className="py-20 bg-gray-50">
+      <section className="bg-gray-50 py-20">
         <div className="container mx-auto px-4 sm:px-6">
-          <div className="max-w-5xl mx-auto">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
+          <div className="mx-auto max-w-5xl">
+            <div className="mb-12 text-center">
+              <h2 className="mb-4 text-3xl font-bold text-gray-900 sm:text-4xl">
                 Trusted by experts and athletes
               </h2>
               <p className="text-xl text-gray-600">
@@ -433,18 +447,18 @@ export default function IOSDownloadPage() {
 
             <div className="grid gap-6 md:grid-cols-3">
               {testimonials.map((testimonial, index) => (
-                <Card key={index} className="border-gray-200 hover:shadow-lg transition-shadow">
+                <Card key={index} className="border-gray-200 transition-shadow hover:shadow-lg">
                   <CardContent className="p-6">
-                    <div className="flex items-center gap-1 mb-4">
+                    <div className="mb-4 flex items-center gap-1">
                       {[...Array(5)].map((_, i) => (
                         <Star key={i} className="h-4 w-4 fill-yellow-400 text-yellow-400" />
                       ))}
                     </div>
-                    
-                    <p className="text-gray-700 mb-6 leading-relaxed">
+
+                    <p className="mb-6 leading-relaxed text-gray-700">
                       &quot;{testimonial.content}&quot;
                     </p>
-                    
+
                     <div className="flex items-center gap-3">
                       <div className="text-3xl">{testimonial.avatar}</div>
                       <div>
@@ -461,12 +475,12 @@ export default function IOSDownloadPage() {
       </section>
 
       {/* Stats Section */}
-      <section className="py-20 bg-gradient-to-r from-blue-600 to-purple-600 text-white">
+      <section className="bg-gradient-to-r from-blue-600 to-purple-600 py-20 text-white">
         <div className="container mx-auto px-4 sm:px-6">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-8 max-w-4xl mx-auto">
+          <div className="mx-auto grid max-w-4xl grid-cols-2 gap-8 md:grid-cols-4">
             {trustSignals.map((stat, index) => (
               <div key={index} className="text-center">
-                <div className="text-4xl font-bold mb-2">{stat.value}</div>
+                <div className="mb-2 text-4xl font-bold">{stat.value}</div>
                 <div className="text-blue-100">{stat.label}</div>
               </div>
             ))}
@@ -475,26 +489,33 @@ export default function IOSDownloadPage() {
       </section>
 
       {/* Final CTA */}
-      <section className="py-24 bg-white">
-        <div className="container mx-auto px-4 sm:px-6 text-center">
-          <div className="max-w-3xl mx-auto">
-            <h2 className="text-4xl sm:text-5xl font-bold text-gray-900 mb-6">
+      <section className="bg-white py-24">
+        <div className="container mx-auto px-4 text-center sm:px-6">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="mb-6 text-4xl font-bold text-gray-900 sm:text-5xl">
               Start tracking what matters
             </h2>
-            <p className="text-xl text-gray-600 mb-10">
-              Join thousands of athletes who&apos;ve stopped guessing and started knowing. 
-              Download LogYourBody and see your true progress.
+            <p className="mb-10 text-xl text-gray-600">
+              Join thousands of athletes who&apos;ve stopped guessing and started knowing. Download
+              LogYourBody and see your true progress.
             </p>
-            
+
             <Button
-              onClick={handleDownload}
-              className="bg-black text-white px-12 py-6 text-lg font-medium rounded-2xl hover:bg-gray-900 transition-all duration-200 hover:scale-105 shadow-2xl"
+              asChild
+              className="w-full max-w-sm rounded-2xl bg-black px-4 py-6 text-base font-medium text-white shadow-2xl transition-all duration-200 hover:scale-105 hover:bg-gray-900 sm:w-auto sm:px-12 sm:text-lg"
             >
-              <Apple className="h-6 w-6 mr-3" />
-              Download Free on App Store
-              <ArrowRight className="h-5 w-5 ml-3" />
+              <a
+                href={appStoreRedirectHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={handleDownload}
+              >
+                <Apple className="mr-3 h-6 w-6" />
+                Download Free on App Store
+                <ArrowRight className="ml-3 h-5 w-5" />
+              </a>
             </Button>
-            
+
             <div className="mt-8 flex items-center justify-center gap-8 text-sm text-gray-500">
               <div className="flex items-center gap-2">
                 <Heart className="h-4 w-4 text-red-500" />
@@ -517,16 +538,14 @@ export default function IOSDownloadPage() {
 
       {/* App Store Redirect Modal */}
       {showAppStoreRedirect && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-2xl p-8 max-w-md w-full">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-md rounded-2xl bg-white p-8">
             <div className="text-center">
-              <div className="h-16 w-16 bg-blue-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
+              <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-100">
                 <Apple className="h-8 w-8 text-blue-600" />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-2">
-                Opening App Store...
-              </h3>
-              <p className="text-gray-600 mb-6">
+              <h3 className="mb-2 text-2xl font-bold text-gray-900">Opening App Store...</h3>
+              <p className="mb-6 text-gray-600">
                 You&apos;re being redirected to download LogYourBody
               </p>
               <Button
@@ -541,5 +560,5 @@ export default function IOSDownloadPage() {
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,13 +1,13 @@
-import React from "react";
-import Link from "next/link";
-import { APP_CONFIG } from "@/constants/app";
+import React from 'react';
+import Link from 'next/link';
+import { APP_CONFIG } from '@/constants/app';
 
 export function Footer() {
   return (
     <footer className="relative overflow-hidden border-t border-gray-800/50 bg-black">
       {/* Gradient overlay for depth */}
       <div className="absolute inset-0 bg-gradient-to-b from-gray-900/5 to-black/50" />
-      
+
       <div className="relative">
         <div className="mx-auto max-w-7xl px-6 py-12 lg:px-8 lg:py-16">
           <div className="grid grid-cols-2 gap-8 md:grid-cols-4 lg:gap-x-12">
@@ -28,24 +28,28 @@ export function Footer() {
                     <path d="m19 9-5 5-4-4-3 3" />
                   </svg>
                 </div>
-                <span className="text-lg font-medium text-white">
-                  {APP_CONFIG.appName}
-                </span>
+                <span className="text-lg font-medium text-white">{APP_CONFIG.appName}</span>
               </Link>
               <p className="mt-4 text-sm leading-relaxed text-gray-400">
-                Track real progress.<br />Not just weight.
+                Track real progress.
+                <br />
+                Not just weight.
               </p>
-              
+
               {/* GitHub link */}
               <a
-                href="https://github.com/logyourbody"
+                href={APP_CONFIG.social.github}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="mt-6 inline-flex rounded-lg p-2 text-gray-400 transition hover:bg-white/5 hover:text-white"
                 aria-label="GitHub"
               >
                 <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-                  <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+                  <path
+                    fillRule="evenodd"
+                    d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                    clipRule="evenodd"
+                  />
                 </svg>
               </a>
             </div>
@@ -55,22 +59,34 @@ export function Footer() {
               <h3 className="text-sm font-medium text-white">Product</h3>
               <ul className="mt-4 space-y-3">
                 <li>
-                  <Link href="/#features" className="text-sm text-gray-400 transition hover:text-white">
+                  <Link
+                    href="/#features"
+                    className="text-sm text-gray-400 transition hover:text-white"
+                  >
                     Features
                   </Link>
                 </li>
                 <li>
-                  <Link href="/#pricing" className="text-sm text-gray-400 transition hover:text-white">
+                  <Link
+                    href="/#pricing"
+                    className="text-sm text-gray-400 transition hover:text-white"
+                  >
                     Pricing
                   </Link>
                 </li>
                 <li>
-                  <Link href="/download" className="text-sm text-gray-400 transition hover:text-white">
+                  <Link
+                    href="/download"
+                    className="text-sm text-gray-400 transition hover:text-white"
+                  >
                     Download
                   </Link>
                 </li>
                 <li>
-                  <Link href="/changelog" className="text-sm text-gray-400 transition hover:text-white">
+                  <Link
+                    href="/changelog"
+                    className="text-sm text-gray-400 transition hover:text-white"
+                  >
                     What's New
                   </Link>
                 </li>
@@ -87,14 +103,20 @@ export function Footer() {
               <h3 className="text-sm font-medium text-white">Support</h3>
               <ul className="mt-4 space-y-3">
                 <li>
-                  <Link href="/support" className="text-sm text-gray-400 transition hover:text-white">
+                  <Link
+                    href="/support"
+                    className="text-sm text-gray-400 transition hover:text-white"
+                  >
                     Help Center
                   </Link>
                 </li>
                 <li>
-                  <Link href="/contact" className="text-sm text-gray-400 transition hover:text-white">
+                  <a
+                    href={`mailto:${APP_CONFIG.contact.support}`}
+                    className="text-sm text-gray-400 transition hover:text-white"
+                  >
                     Contact Us
-                  </Link>
+                  </a>
                 </li>
                 <li>
                   <a
@@ -107,7 +129,10 @@ export function Footer() {
                   </a>
                 </li>
                 <li>
-                  <Link href="/security" className="text-sm text-gray-400 transition hover:text-white">
+                  <Link
+                    href="/security"
+                    className="text-sm text-gray-400 transition hover:text-white"
+                  >
                     Security
                   </Link>
                 </li>
@@ -119,7 +144,10 @@ export function Footer() {
               <h3 className="text-sm font-medium text-white">Legal</h3>
               <ul className="mt-4 space-y-3">
                 <li>
-                  <Link href="/privacy" className="text-sm text-gray-400 transition hover:text-white">
+                  <Link
+                    href="/privacy"
+                    className="text-sm text-gray-400 transition hover:text-white"
+                  >
                     Privacy Policy
                   </Link>
                 </li>
@@ -129,7 +157,10 @@ export function Footer() {
                   </Link>
                 </li>
                 <li>
-                  <Link href="/health-disclosure" className="text-sm text-gray-400 transition hover:text-white">
+                  <Link
+                    href="/health-disclosure"
+                    className="text-sm text-gray-400 transition hover:text-white"
+                  >
                     Health Disclosure
                   </Link>
                 </li>


### PR DESCRIPTION
## Summary
- turns unresolved App Review submissions with rejected items into a failing, actionable App Store monitor instead of a green-but-rejected run
- fixes golden-path web jank: App Store CTAs now have real href fallbacks, mobile CTA no longer overflows, footer Contact/GitHub links no longer point at dead targets
- hardens account deletion so Clerk user deletion only happens after asset cleanup and required Supabase row deletion succeed

## Validation
- `ruby -c .github/scripts/release-approved-app-store-version.rb`
- `git diff --check`
- `pnpm --filter logyourbody test:ci -- src/app/api/auth/delete-account/__tests__/route.node.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci` (30 suites, 261 tests)
- `pnpm build`
- pre-push hook: turbo lint/typecheck/test for changed web package passed
- Playwright fallback QA on `http://127.0.0.1:3016`:
  - `/download/ios` desktop and mobile: page rendered, no overlay, no console/page errors
  - 3 App Store CTA anchors point to `/api/app-store-redirect?platform=ios&source=landing` with `_blank`/`noopener noreferrer`
  - CTA click opened `https://apps.apple.com/us/app/logyourbody/id6755209876`
  - mobile CTA box was `x=16`, `width=358` in a 390px viewport; no overflow
  - `/support` footer Contact is `mailto:support@logyourbody.com`, GitHub is `https://github.com/JovieInc/LogYourBody`, and no `/contact` footer link remains
  - unauthenticated `DELETE /api/auth/delete-account` returns 401
  - `/api/app-store-redirect?platform=ios&source=landing` returns 307 to the App Store URL

## Remaining external blockers
- App Store public listing for `id6755209876` is still not live until Apple resolves the current review rejection/unresolved issues.
- Production currently needs real Clerk deployment env/secrets verified; the live deployment previously showed placeholder Clerk configuration. This PR does not edit workflow/env governance.
