### PR TITLE
fix: remove missing Vercel Analytics script

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { SpeedInsights } from '@vercel/speed-insights/next'
-import { Analytics } from '@vercel/analytics/react'
 import { Providers } from './providers'
 import { PWAInstallPrompt } from '@/components/PWAInstallPrompt'
 import { ServiceWorkerUpdater } from '@/components/ServiceWorkerUpdater'
@@ -135,7 +134,6 @@ export default function RootLayout({
           <ServiceWorkerUpdater />
         </Providers>
         <SpeedInsights />
-        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Remove the Vercel Analytics component from the root layout because production returns 404 for `/_vercel/insights/script.js`.
- Keep Vercel Speed Insights in place; `/_vercel/speed-insights/script.js` returns 200.

## Evidence
- `git diff --check`
- `pnpm --filter logyourbody lint`
- `pnpm --filter logyourbody typecheck`
- `pnpm --filter logyourbody test:ci` (30 suites, 261 tests)
- `pnpm --filter logyourbody build`
- pre-push hook passed `turbo run lint`, `turbo run typecheck`, `turbo run test` for the branch

## Production finding
- Public mobile browser smoke on `https://www.logyourbody.com/download/ios` reported one 404 console error: `https://www.logyourbody.com/_vercel/insights/script.js`.
- CTA layout was otherwise clean: 3 App Store redirect anchors, no horizontal overflow at 390px width.