### PR TITLE
fix: stabilize landing timeline dates

### DIFF
--- a/apps/web/src/components/LandingTimelineDemo.tsx
+++ b/apps/web/src/components/LandingTimelineDemo.tsx
@@ -19,7 +19,8 @@ const demoData: DemoEntry[] = [
 ];
 
 function formatDate(dateStr: string, opts?: Intl.DateTimeFormatOptions) {
-  const date = new Date(dateStr);
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const date = new Date(year, month - 1, day, 12);
   return date.toLocaleDateString("en-US", opts);
 }
 


### PR DESCRIPTION
## Summary
- Parse landing demo date-only strings as local calendar dates before formatting
- Prevent server/browser timezone drift from rendering different timeline labels during hydration

## Evidence
- Date proof: old `new Date("2024-03-25")` formats as March 25 in UTC but March 24 in America/Los_Angeles; new local-noon parser formats March 25 in both
- `git diff --check origin/main..HEAD`
- `pnpm --filter logyourbody lint`
- `pnpm --filter logyourbody typecheck`
- `pnpm --filter logyourbody test:ci` (30 suites, 261 tests)
- `pnpm --filter logyourbody build`
- Pre-push hook repeated Turbo lint/typecheck/build/test for affected package

## Notes
- Production Browser check previously confirmed React hydration error #418 on the homepage before this fix.
- No workflow, branch protection, or gate changes.