### PR TITLE
fix: block App Store submit before paywall proof

### DIFF
--- a/.github/scripts/verify-app-store-subscriptions.rb
+++ b/.github/scripts/verify-app-store-subscriptions.rb
@@ -1,0 +1,173 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "jwt"
+require "net/http"
+require "openssl"
+require "uri"
+
+API_BASE = "https://api.appstoreconnect.apple.com"
+PLATFORM = ENV.fetch("APP_STORE_PLATFORM", "IOS")
+DEFAULT_REQUIRED_PRODUCTS = %w[
+  com.logyourbody.app.pro1.annual.3daytrial
+  com.logyourbody.app.pro1.monthly.3daytrial
+].freeze
+DEFAULT_ALLOWED_STATES = %w[APPROVED].freeze
+
+def fail_with(message)
+  warn "::error::#{message}"
+  exit 1
+end
+
+def warn_with(message)
+  warn "::warning::#{message}"
+end
+
+def api_key
+  path = ENV.fetch("APP_STORE_CONNECT_API_KEY_PATH", "fastlane/api_key.json")
+  JSON.parse(File.read(path))
+rescue KeyError
+  fail_with("APP_STORE_CONNECT_API_KEY_PATH is required")
+rescue Errno::ENOENT
+  fail_with("App Store Connect API key file not found")
+rescue JSON::ParserError => e
+  fail_with("App Store Connect API key file is invalid JSON: #{e.message}")
+end
+
+def bearer_token
+  key = api_key
+  private_key = OpenSSL::PKey::EC.new(key.fetch("key"))
+  payload = {
+    iss: key.fetch("issuer_id"),
+    exp: Time.now.to_i + key.fetch("duration", 1200).to_i,
+    aud: "appstoreconnect-v1"
+  }
+  headers = {
+    kid: key.fetch("key_id"),
+    typ: "JWT"
+  }
+
+  JWT.encode(payload, private_key, "ES256", headers)
+rescue KeyError => e
+  fail_with("App Store Connect API key is missing #{e.key}")
+rescue OpenSSL::PKey::ECError => e
+  fail_with("App Store Connect private key is invalid: #{e.message}")
+end
+
+def request(method, path, token)
+  uri = URI("#{API_BASE}#{path}")
+  request_class = { get: Net::HTTP::Get }.fetch(method)
+  req = request_class.new(uri)
+  req["Authorization"] = "Bearer #{token}"
+  req["Content-Type"] = "application/json"
+
+  response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+    http.request(req)
+  end
+
+  [response.code.to_i, response.body.empty? ? {} : JSON.parse(response.body)]
+rescue JSON::ParserError => e
+  fail_with("App Store Connect returned invalid JSON for #{path}: #{e.message}")
+end
+
+def expect(method, path, token, expected: [200])
+  status, parsed = request(method, path, token)
+  return parsed if expected.include?(status)
+
+  fail_with("App Store Connect #{method.upcase} #{path} returned #{status}: #{JSON.pretty_generate(parsed)}")
+end
+
+def app_by_bundle_id(token)
+  bundle_id = ENV.fetch("APP_IDENTIFIER", "com.logyourbody.app")
+  query = URI.encode_www_form("filter[bundleId]" => bundle_id, "limit" => "1")
+  response = expect(:get, "/v1/apps?#{query}", token)
+  app = response.fetch("data", []).first
+  fail_with("No App Store Connect app found for bundle ID #{bundle_id}") unless app
+
+  [app.fetch("id"), bundle_id]
+end
+
+def app_id(token)
+  configured = ENV["APP_STORE_APP_ID"].to_s.strip
+  unless configured.empty?
+    query = URI.encode_www_form("fields[apps]" => "bundleId")
+    status, parsed = request(:get, "/v1/apps/#{configured}?#{query}", token)
+    return configured if status == 200
+
+    unless status == 404
+      fail_with("App Store Connect GET /v1/apps/#{configured} returned #{status}: #{JSON.pretty_generate(parsed)}")
+    end
+
+    resolved_id, bundle_id = app_by_bundle_id(token)
+    warn_with("Configured APP_STORE_APP_ID #{configured} was not found in App Store Connect; using app #{resolved_id} resolved from bundle ID #{bundle_id}.")
+    return resolved_id
+  end
+
+  app_by_bundle_id(token).first
+end
+
+def required_products
+  configured = ENV["APP_STORE_REQUIRED_SUBSCRIPTION_PRODUCTS"].to_s
+  products = configured.split(",").map(&:strip).reject(&:empty?)
+  products.empty? ? DEFAULT_REQUIRED_PRODUCTS : products
+end
+
+def allowed_states
+  configured = ENV["APP_STORE_SUBSCRIPTION_ALLOWED_STATES"].to_s
+  states = configured.split(",").map(&:strip).reject(&:empty?)
+  states.empty? ? DEFAULT_ALLOWED_STATES : states
+end
+
+def subscription_groups(token, app_id)
+  query = URI.encode_www_form(
+    "fields[subscriptionGroups]" => "referenceName",
+    "limit" => "200"
+  )
+  expect(:get, "/v1/apps/#{app_id}/subscriptionGroups?#{query}", token).fetch("data", [])
+end
+
+def subscriptions_for_group(token, group_id)
+  query = URI.encode_www_form(
+    "fields[subscriptions]" => "name,productId,state",
+    "limit" => "200"
+  )
+  expect(:get, "/v1/subscriptionGroups/#{group_id}/subscriptions?#{query}", token).fetch("data", [])
+end
+
+def subscription_product_records(token, app_id)
+  subscription_groups(token, app_id).flat_map do |group|
+    subscriptions_for_group(token, group.fetch("id"))
+  end
+end
+
+token = bearer_token
+id = app_id(token)
+required = required_products
+allowed = allowed_states
+records = subscription_product_records(token, id)
+
+by_product_id = records.to_h do |record|
+  attributes = record.fetch("attributes", {})
+  [attributes["productId"].to_s, attributes]
+end
+
+missing = required.reject { |product_id| by_product_id.key?(product_id) }
+unless missing.empty?
+  available = by_product_id.keys.reject(&:empty?).sort
+  fail_with("App Store Connect is missing required subscription products for app #{id}: #{missing.join(", ")}. Available products: #{available.join(", ")}")
+end
+
+invalid = required.filter_map do |product_id|
+  attributes = by_product_id.fetch(product_id)
+  state = attributes["state"].to_s
+  next if allowed.include?(state)
+
+  "#{product_id}=#{state.empty? ? "UNKNOWN" : state}"
+end
+
+unless invalid.empty?
+  fail_with("App Store Connect subscription products are not in allowed states #{allowed.join(", ")}: #{invalid.join(", ")}")
+end
+
+puts "Verified App Store subscription products for app #{id}: #{required.map { |product_id| "#{product_id}=#{by_product_id.fetch(product_id)["state"]}" }.join(", ")}."

--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: boolean
         default: true
+      paywall_testflight_verified:
+        description: 'Required for App Store submission after a real TestFlight paywall purchase/restore passes'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
 
 concurrency:
@@ -181,6 +186,14 @@ jobs:
 
           # Set API key path for subsequent steps
           echo "APP_STORE_CONNECT_API_KEY_PATH=$(pwd)/fastlane/api_key.json" >> "$GITHUB_ENV"
+
+      - name: Verify App Store subscription products
+        run: |
+          cd apps/ios
+          bundle exec ruby ../../.github/scripts/verify-app-store-subscriptions.rb
+        env:
+          APP_STORE_APP_ID: ${{ env.LOGYOURBODY_APP_STORE_APP_ID }}
+          APP_IDENTIFIER: ${{ env.LOGYOURBODY_APP_IDENTIFIER }}
 
       - name: Sync Certificates with Match
         uses: ./.github/actions/sync-match
@@ -344,6 +357,12 @@ jobs:
           SUBMIT_FOR_REVIEW="${{ github.event.inputs.submit_for_review || 'true' }}"
           AUTOMATIC_RELEASE="${{ github.event.inputs.automatic_release || 'true' }}"
           PHASED_RELEASE="${{ github.event.inputs.phased_release || 'true' }}"
+          PAYWALL_TESTFLIGHT_VERIFIED="${{ github.event.inputs.paywall_testflight_verified || 'false' }}"
+
+          if [ "$SUBMIT_FOR_REVIEW" = "true" ] && [ "$PAYWALL_TESTFLIGHT_VERIFIED" != "true" ]; then
+            echo "::error::App Store submission is blocked until a real TestFlight paywall purchase and restore have been verified. Re-run with paywall_testflight_verified=true only after that proof exists."
+            exit 1
+          fi
 
           IPA_PATH="$(find "$GITHUB_WORKSPACE/apps/ios/build" -name "*.ipa" -type f -print -quit)"
           if [ -z "$IPA_PATH" ]; then

--- a/apps/ios/docs/development/RELEASE_CHECKLIST.md
+++ b/apps/ios/docs/development/RELEASE_CHECKLIST.md
@@ -98,5 +98,8 @@ xcodebuild -project LogYourBody.xcodeproj \
 - Include screenshots or a simulator recording for auth, paywall, purchase/restore, weight logging, recent history, and CSV export.
 - Include RevenueCat purchase and restore test results, or explicitly label
   the account-owner sandbox/TestFlight credential blocker.
+- Do not run App Store submission with `paywall_testflight_verified=true`
+  until a real TestFlight build has loaded subscription products and completed
+  purchase plus restore verification.
 - Include Supabase sync test results.
 - Include validation command output and known risks.

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -868,7 +868,7 @@ platform :ios do
       last_name: env_or_default.call("APP_REVIEW_LAST_NAME", "Team"),
       email_address: env_or_default.call("APP_REVIEW_EMAIL_ADDRESS", "support@logyourbody.com"),
       phone_number: ENV["APP_REVIEW_PHONE_NUMBER"],
-      notes: env_or_default.call("APP_REVIEW_NOTES", "LogYourBody lets users sign in, log their weight, sync their entries, export CSV data, and manage their subscription. No demo account is required; reviewers can create a test account in the app.")
+      notes: env_or_default.call("APP_REVIEW_NOTES", "Review access: choose Create Account, enter an email address that can receive a one-time code, accept Terms, Privacy Policy, and Health Disclaimer, then enter the email code. On LogYourBody Pro, tap Start trial; subscriptions use Apple's sandbox review environment and include a 3-day trial. After purchase or trial activation, log a weight, review recent history, and export CSV from Settings. If email codes or subscription products do not load, contact support@logyourbody.com.")
     }.compact
 
     begin


### PR DESCRIPTION
## Summary
- Add an App Store Connect subscription-product preflight to the iOS release loop so TestFlight/App Store releases verify the required subscription products for app `6755209876` before signing/build release proceeds.
- Add a hard App Store submission gate: `paywall_testflight_verified=true` is required before `submit_for_review=true` can run.
- Replace the default App Review note that claimed no demo path was required with reviewer instructions that match the email-code signup plus sandbox subscription flow.
- Document that TestFlight paywall purchase + restore proof is required before enabling the App Store submission flag.

## Context
The latest TestFlight build uploaded successfully, but the real device paywall shows "Subscription plans are unavailable." RevenueCat's SDK offering endpoint still returns `$rc_annual` and `$rc_monthly` mapped to the expected `pro1` product IDs, so the likely remaining blocker is App Store Connect/TestFlight IAP product availability after the App Store app id was moved to `6755209876`.

This PR intentionally does not submit to App Review. The previously dispatched App Store run `27472455252` was canceled before deploy/submission.

## Validation
- `actionlint .github/workflows/ios-release-loop.yml`
- `ruby -c .github/scripts/verify-app-store-subscriptions.rb`
- `ruby -c apps/ios/fastlane/Fastfile`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-release-loop.yml")'`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`

## Release note
Do not rerun App Store submission until a new TestFlight build loads subscription products and completes purchase + restore verification on-device. After that proof exists, run the App Store workflow with `paywall_testflight_verified=true`.
