### PR TITLE
fix: allow ready App Store subscription products

### DIFF
--- a/.github/scripts/verify-app-store-subscriptions.rb
+++ b/.github/scripts/verify-app-store-subscriptions.rb
@@ -13,7 +13,7 @@ DEFAULT_REQUIRED_PRODUCTS = %w[
   com.logyourbody.app.pro1.annual.3daytrial
   com.logyourbody.app.pro1.monthly.3daytrial
 ].freeze
-DEFAULT_ALLOWED_STATES = %w[APPROVED].freeze
+DEFAULT_ALLOWED_STATES = %w[READY_TO_SUBMIT APPROVED].freeze
 
 def fail_with(message)
   warn "::error::#{message}"

--- a/apps/ios/docs/development/RELEASE_CHECKLIST.md
+++ b/apps/ios/docs/development/RELEASE_CHECKLIST.md
@@ -18,6 +18,11 @@ Use this checklist before sending a LogYourBody iOS build to TestFlight or App S
 - RevenueCat `Premium` entitlement matches `Constants.proEntitlementID`.
 - StoreKit/App Store products are attached to the active RevenueCat offering.
 - Release workflow verifies the RevenueCat current iOS offering exposes `$rc_annual` -> `com.logyourbody.app.pro1.annual.3daytrial` and `$rc_monthly` -> `com.logyourbody.app.pro1.monthly.3daytrial`.
+- Release workflow verifies App Store Connect contains those subscription
+  products in a releasable setup state: `READY_TO_SUBMIT` before first review
+  or `APPROVED` after Apple approval.
+- App Store Connect Paid Apps Agreement, tax, and banking must be active before
+  relying on sandbox/TestFlight in-app purchase tests.
 - Release workflow validates the actual release ref/SHA instead of the unrelated `preview` branch.
 - App Store release workflow is run from `main` with `release_type=app_store`,
   `submit_for_review=true`, `automatic_release=true`, and phased release


### PR DESCRIPTION
## Summary
- Allow App Store subscription products in `READY_TO_SUBMIT` or `APPROVED` state for the release preflight.
- Keep the separate App Store submission guard requiring `paywall_testflight_verified=true` before review submission.
- Document that Paid Apps Agreement, tax, and banking must be active before relying on sandbox/TestFlight IAP tests.

## Why
The merged guardrail correctly stopped App Store upload/deploy after RevenueCat passed but Apple subscription products were not `APPROVED`. The actual App Store Connect state is:

- `com.logyourbody.app.pro1.annual.3daytrial=READY_TO_SUBMIT`
- `com.logyourbody.app.pro1.monthly.3daytrial=READY_TO_SUBMIT`

For a first IAP review flow, `READY_TO_SUBMIT` is an expected pre-review state. Blocking TestFlight/release builds on `APPROVED` deadlocks the path to proving TestFlight purchase/restore before App Store submission.

## Validation
- `ruby -c .github/scripts/verify-app-store-subscriptions.rb`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`

## Release note
Do not run App Store submission with `paywall_testflight_verified=true` until a real TestFlight build loads subscription products and purchase plus restore are verified on-device.
