### PR TITLE
feat: integrate photo-first MVP flow

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		ADA4B75D2ED1183900F4262A /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA4B75C2ED1183900F4262A /* DashboardViewModel.swift */; };
 		ADA600222ED2594300088042 /* DexaResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA600212ED2594200088042 /* DexaResult.swift */; };
 		ADA600242ED2596700088042 /* BodyScoreProfileDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA600232ED2596700088042 /* BodyScoreProfileDetailsView.swift */; };
+		ADA600502ED401000088042 /* BodyScoreFirstProgressPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA6004F2ED401000088042 /* BodyScoreFirstProgressPhotoView.swift */; };
 		ADA600262ED259A700088042 /* BodyScoreShareCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA600252ED259A700088042 /* BodyScoreShareCard.swift */; };
 		ADA600282ED259DB00088042 /* BodyScoreRecalculationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA600272ED259DB00088042 /* BodyScoreRecalculationService.swift */; };
 		ADA6002C2ED25F5600088042 /* DashboardViewLiquid+CoreAccessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA6002B2ED25F5600088042 /* DashboardViewLiquid+CoreAccessors.swift */; };
@@ -519,6 +520,7 @@
 		ADA4B75C2ED1183900F4262A /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 		ADA600212ED2594200088042 /* DexaResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DexaResult.swift; sourceTree = "<group>"; };
 		ADA600232ED2596700088042 /* BodyScoreProfileDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyScoreProfileDetailsView.swift; sourceTree = "<group>"; };
+		ADA6004F2ED401000088042 /* BodyScoreFirstProgressPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyScoreFirstProgressPhotoView.swift; sourceTree = "<group>"; };
 		ADA600252ED259A700088042 /* BodyScoreShareCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BodyScoreShareCard.swift; path = Components/BodyScoreShareCard.swift; sourceTree = "<group>"; };
 		ADA600272ED259DB00088042 /* BodyScoreRecalculationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyScoreRecalculationService.swift; sourceTree = "<group>"; };
 		ADA600292ED25F1F00088042 /* DashboardViewLiquid+HeroAndActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DashboardViewLiquid+HeroAndActions.swift"; sourceTree = "<group>"; };
@@ -1250,9 +1252,10 @@
 		ADBAF0492ECAD88A00A95F98 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				ADA600412ED35D8700088042 /* PreAuthBodyScoreOnboardingContainer.swift */,
-				ADA600422ED35D8700088042 /* ProfileCompletionGateView.swift */,
-				ADA600232ED2596700088042 /* BodyScoreProfileDetailsView.swift */,
+					ADA600412ED35D8700088042 /* PreAuthBodyScoreOnboardingContainer.swift */,
+					ADA600422ED35D8700088042 /* ProfileCompletionGateView.swift */,
+					ADA6004F2ED401000088042 /* BodyScoreFirstProgressPhotoView.swift */,
+					ADA600232ED2596700088042 /* BodyScoreProfileDetailsView.swift */,
 				ADBAF03D2ECAD88A00A95F98 /* BodyScoreAccountCreationView.swift */,
 				ADBAF03E2ECAD88A00A95F98 /* BodyScoreBasicsView.swift */,
 				ADA4B73A2ECE490A00F4262A /* BodyScoreHealthConfirmationView.swift */,
@@ -1656,10 +1659,11 @@
 				ADDC47EA2E2D89F3003C97E7 /* LogWeightView.swift in Sources */,
 				ADDC47EB2E2D89F3003C97E7 /* MainTabView.swift in Sources */,
 				AD8872352EB4061F0041C426 /* BackgroundTaskMonitor.swift in Sources */,
-				ADDC47EC2E2D89F3003C97E7 /* PreferencesView.swift in Sources */,
-				AD0B7BFB2EC6930D008B29E7 /* PeriodSelector.swift in Sources */,
-				ADA600242ED2596700088042 /* BodyScoreProfileDetailsView.swift in Sources */,
-				ADDC47EE2E2D89F3003C97E7 /* SignUpView.swift in Sources */,
+					ADDC47EC2E2D89F3003C97E7 /* PreferencesView.swift in Sources */,
+					AD0B7BFB2EC6930D008B29E7 /* PeriodSelector.swift in Sources */,
+					ADA600242ED2596700088042 /* BodyScoreProfileDetailsView.swift in Sources */,
+					ADA600502ED401000088042 /* BodyScoreFirstProgressPhotoView.swift in Sources */,
+					ADDC47EE2E2D89F3003C97E7 /* SignUpView.swift in Sources */,
 				ADDC47F22E2D89F3003C97E7 /* ContentView.swift in Sources */,
 				ADDC47F62E2D89F3003C97E7 /* LogYourBodyApp.swift in Sources */,
 				ADDC47F72E2D89F3003C97E7 /* AnimatedTabView.swift in Sources */,

--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -37,6 +37,7 @@ final class OnboardingFlowViewModel: ObservableObject {
         case emailCapture
         case account
         case profileDetails
+        case firstPhoto
         case paywall
     }
 
@@ -130,8 +131,12 @@ final class OnboardingFlowViewModel: ObservableObject {
     @Published var isCreatingAccount: Bool = false
     @Published var accountCreationError: String?
     @Published private(set) var accountCreationStage: AccountCreationStage = .idle
+    @Published private(set) var onboardingFirstPhotoMetric: BodyMetrics?
+    @Published private(set) var isPreparingFirstPhotoMetric = false
+    @Published var firstPhotoErrorMessage: String?
 
     let entryContext: EntryContext
+    let includesFirstPhotoStep: Bool
     private let healthKitManager: HealthKitManager
     private let calculator: BodyScoreCalculating
     private var hasMarkedOnboardingComplete = false
@@ -158,11 +163,21 @@ final class OnboardingFlowViewModel: ObservableObject {
     init(
         entryContext: EntryContext = .authenticated,
         healthKitManager: HealthKitManager = .shared,
-        calculator: BodyScoreCalculating = BodyScoreCalculator()
+        calculator: BodyScoreCalculating = BodyScoreCalculator(),
+        includesFirstPhotoStep: Bool? = nil
     ) {
         self.entryContext = entryContext
         self.healthKitManager = healthKitManager
         self.calculator = calculator
+        self.includesFirstPhotoStep = includesFirstPhotoStep
+            ?? (
+                entryContext == .authenticated &&
+                    PhotoTimelineHUDPolicy.shouldShowPhotoTimelineHUD(
+                        gateEnabled: AnalyticsService.shared.isFeatureEnabled(
+                            flagKey: Constants.photoTimelineHUDFlagKey
+                        )
+                    )
+            )
 
         configureMeasurementPreference()
         hydrateHeightFields()
@@ -217,8 +232,14 @@ final class OnboardingFlowViewModel: ObservableObject {
                 currentStep = .profileDetails
             }
         case .profileDetails:
-            completeOnboardingIfNeeded()
-            currentStep = .paywall
+            if includesFirstPhotoStep {
+                currentStep = .firstPhoto
+            } else {
+                completeOnboardingIfNeeded()
+                currentStep = .paywall
+            }
+        case .firstPhoto:
+            completeFirstPhotoStep()
         case .paywall:
             break
         }
@@ -253,7 +274,8 @@ final class OnboardingFlowViewModel: ObservableObject {
             currentStep = hasAuthenticatedAccountEmail ? .bodyScore : .emailCapture
         case .profileDetails:
             currentStep = hasAuthenticatedAccountEmail ? .bodyScore : .account
-        case .paywall: currentStep = .profileDetails
+        case .firstPhoto: currentStep = .profileDetails
+        case .paywall: currentStep = includesFirstPhotoStep ? .firstPhoto : .profileDetails
         }
     }
 
@@ -374,6 +396,8 @@ final class OnboardingFlowViewModel: ObservableObject {
         switch step {
         case .hook, .basics, .height, .healthConnect, .bodyScore, .profileDetails:
             return true
+        case .firstPhoto:
+            return includesFirstPhotoStep
         case .emailCapture, .account:
             return !hasAuthenticatedAccountEmail
         case .healthConfirmation:
@@ -740,6 +764,46 @@ final class OnboardingFlowViewModel: ObservableObject {
         }
     }
 
+    func completeFirstPhotoStep() {
+        completeOnboardingIfNeeded()
+        currentStep = .paywall
+    }
+
+    func prepareFirstPhotoBaselineMetric() async -> BodyMetrics? {
+        guard entryContext == .authenticated else { return nil }
+        if let onboardingFirstPhotoMetric {
+            return onboardingFirstPhotoMetric
+        }
+
+        guard let userId = AuthManager.shared.currentUser?.id else {
+            firstPhotoErrorMessage = "Sign in again to add a progress photo."
+            return nil
+        }
+
+        isPreparingFirstPhotoMetric = true
+        firstPhotoErrorMessage = nil
+        defer { isPreparingFirstPhotoMetric = false }
+
+        let metric = await PhotoMetadataService.shared.createOrUpdateMetrics(
+            for: Date(),
+            weight: bodyScoreInput.weight.inKilograms,
+            bodyFatPercentage: bodyScoreInput.bodyFat.percentage,
+            userId: userId,
+            dataSource: firstPhotoBaselineDataSource,
+            preserveExistingMeasurements: true
+        )
+        onboardingFirstPhotoMetric = metric
+        return metric
+    }
+
+    private var firstPhotoBaselineDataSource: String {
+        if didRequestHealthSync || bodyScoreInput.bodyFat.source == .healthKit {
+            return BodyMetricSource.healthKit.rawValue
+        }
+
+        return BodyMetricSource.manual.rawValue
+    }
+
     private func scheduleDeferredHealthSync() {
         Task.detached(priority: .background) { [weak self] in
             guard let self else { return }
@@ -1000,6 +1064,9 @@ final class OnboardingFlowViewModel: ObservableObject {
            currentStep == .emailCapture || currentStep == .account {
             currentStep = .profileDetails
         }
+        if currentStep == .firstPhoto, !includesFirstPhotoStep {
+            currentStep = .profileDetails
+        }
         isRestoringProgress = false
     }
 
@@ -1026,7 +1093,8 @@ private extension OnboardingFlowViewModel.Step {
             .bodyScore,
             .emailCapture,
             .account,
-            .profileDetails
+            .profileDetails,
+            .firstPhoto
         ]
     }
 
@@ -1043,6 +1111,7 @@ private extension OnboardingFlowViewModel.Step {
         case .emailCapture: return "Save Progress"
         case .account: return "Account"
         case .profileDetails: return "Profile"
+        case .firstPhoto: return "Photo"
         case .loading: return "Loading"
         case .paywall: return "Upgrade"
         }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+
+struct BodyScoreFirstProgressPhotoView: View {
+    @ObservedObject var viewModel: OnboardingFlowViewModel
+    @EnvironmentObject private var authManager: AuthManager
+    @State private var isAttachSheetPresented = false
+
+    var body: some View {
+        OnboardingPageTemplate(
+            title: "Start your visual timeline.",
+            subtitle: "Add a first progress photo now, or skip and add one from Home.",
+            onBack: { viewModel.goBack() },
+            progress: viewModel.progress(for: .firstPhoto),
+            content: {
+                VStack(alignment: .leading, spacing: 20) {
+                    previewCard
+                    actionStack
+                }
+            }
+        )
+        .task {
+            _ = await viewModel.prepareFirstPhotoBaselineMetric()
+        }
+        .sheet(isPresented: $isAttachSheetPresented) {
+            ProgressPhotoAttachSheet(
+                targetMetric: viewModel.onboardingFirstPhotoMetric,
+                fallbackDate: Date(),
+                onComplete: {
+                    await MainActor.run {
+                        viewModel.completeFirstPhotoStep()
+                    }
+                }
+            )
+            .environmentObject(authManager)
+        }
+    }
+
+    private var previewCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Image(systemName: "camera.metering.center.weighted")
+                .font(.system(size: 34, weight: .semibold))
+                .foregroundStyle(Color.white.opacity(0.82))
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Photos make the timeline useful.")
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundStyle(Color.appText)
+
+                Text(
+                    "We attach the photo to the baseline metrics you just entered, so Home opens with your first visual check-in."
+                )
+                    .font(OnboardingTypography.body)
+                    .foregroundStyle(Color.appTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "lock.shield")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.appPrimary)
+
+                Text("Camera and photo library access are optional. You can skip this and add a photo later.")
+                    .font(OnboardingTypography.caption)
+                    .foregroundStyle(Color.appTextTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(Color.appCard.opacity(0.72))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .stroke(Color.appBorder.opacity(0.55), lineWidth: 1)
+        )
+        .accessibilityIdentifier("onboarding_first_photo_card")
+    }
+
+    private var actionStack: some View {
+        VStack(spacing: 12) {
+            Button {
+                presentAttachSheet()
+            } label: {
+                if viewModel.isPreparingFirstPhotoMetric {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                } else {
+                    Label("Add first photo", systemImage: "camera.fill")
+                }
+            }
+            .buttonStyle(OnboardingPrimaryButtonStyle())
+            .disabled(viewModel.isPreparingFirstPhotoMetric)
+            .accessibilityIdentifier("onboarding_first_photo_add_button")
+
+            Button {
+                viewModel.completeFirstPhotoStep()
+            } label: {
+                Text("Continue")
+                    .font(.system(size: 18, weight: .semibold))
+            }
+            .buttonStyle(OnboardingSecondaryButtonStyle())
+            .accessibilityIdentifier("onboarding_first_photo_continue_button")
+
+            OnboardingTextButton(title: "Skip for now") {
+                viewModel.completeFirstPhotoStep()
+            }
+            .accessibilityIdentifier("onboarding_first_photo_skip_button")
+
+            if let errorMessage = viewModel.firstPhotoErrorMessage {
+                Text(errorMessage)
+                    .font(OnboardingTypography.caption)
+                    .foregroundStyle(Color.red)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    private func presentAttachSheet() {
+        Task {
+            guard await viewModel.prepareFirstPhotoBaselineMetric() != nil else { return }
+            await MainActor.run {
+                HapticManager.shared.selection()
+                isAttachSheetPresented = true
+            }
+        }
+    }
+}
+
+#Preview {
+    BodyScoreFirstProgressPhotoView(
+        viewModel: OnboardingFlowViewModel(includesFirstPhotoStep: true)
+    )
+    .environmentObject(AuthManager.shared)
+    .preferredColorScheme(.dark)
+}

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreOnboardingFlowView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreOnboardingFlowView.swift
@@ -45,6 +45,9 @@ struct BodyScoreOnboardingFlowView: View {
             case .profileDetails:
                 BodyScoreProfileDetailsView(viewModel: viewModel)
                     .environmentObject(authManager)
+            case .firstPhoto:
+                BodyScoreFirstProgressPhotoView(viewModel: viewModel)
+                    .environmentObject(authManager)
             case .paywall:
                 PaywallView()
                     .environmentObject(authManager)

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
@@ -421,6 +421,8 @@ struct BodyScoreProfileDetailsView: View {
         let trimmedFirst = trimmedFirstName
         let trimmedLast = trimmedLastName
         let fullName = "\(trimmedFirst) \(trimmedLast)".trimmingCharacters(in: .whitespacesAndNewlines)
+        let completesOnboardingNow = !viewModel.includesFirstPhotoStep ||
+            OnboardingStateManager.shared.hasCompletedCurrentVersion
 
         Task {
             do {
@@ -430,7 +432,7 @@ struct BodyScoreProfileDetailsView: View {
 
                 var updates: [String: Any] = [
                     "dateOfBirth": dateOfBirth,
-                    "onboardingCompleted": true
+                    "onboardingCompleted": completesOnboardingNow
                 ]
 
                 if let biologicalSex {
@@ -463,12 +465,12 @@ struct BodyScoreProfileDetailsView: View {
                             activityLevel: existingProfile?.activityLevel,
                             goalWeight: existingProfile?.goalWeight,
                             goalWeightUnit: existingProfile?.goalWeightUnit,
-                            onboardingCompleted: true
+                            onboardingCompleted: completesOnboardingNow
                         )
 
                         currentUser.name = fullName.isEmpty ? currentUser.name : fullName
                         currentUser.profile = updatedProfile
-                        currentUser.onboardingCompleted = true
+                        currentUser.onboardingCompleted = completesOnboardingNow
                         authManager.currentUser = currentUser
                     }
 

--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -194,15 +194,17 @@ struct LogYourBodyApp: App {
     private func applyPaidMVPUITestFixtureIfNeeded() async -> Bool {
         let arguments = ProcessInfo.processInfo.arguments
         let usesPaidFixture = arguments.contains("-lybUITestPaidMVPFixture")
+        let usesWeightLoggerFixture = arguments.contains("-lybUITestWeightLoggerMVPFixture")
         let usesPaywallFixture = arguments.contains("-lybUITestPaywallFixture")
         let usesFullDashboardFixture = arguments.contains("-lybUITestFullDashboardFixture")
         let usesPhotoTimelineHUDFixture = arguments.contains("-lybUITestPhotoTimelineHUDFixture")
 
-        guard usesPaidFixture || usesPaywallFixture || usesFullDashboardFixture || usesPhotoTimelineHUDFixture else {
+        guard usesPaidFixture || usesWeightLoggerFixture || usesPaywallFixture || usesFullDashboardFixture ||
+            usesPhotoTimelineHUDFixture else {
             return false
         }
 
-        let isSubscribed = usesPaidFixture || usesFullDashboardFixture || usesPhotoTimelineHUDFixture
+        let isSubscribed = usesPaidFixture || usesWeightLoggerFixture || usesFullDashboardFixture || usesPhotoTimelineHUDFixture
         let fixtureName: String
         let fixtureEmail: String
         let fixtureUsername: String
@@ -214,6 +216,10 @@ struct LogYourBodyApp: App {
             fixtureName = "Full Dashboard UI"
             fixtureEmail = "full-dashboard-ui@example.com"
             fixtureUsername = "full_dashboard_ui"
+        } else if usesWeightLoggerFixture {
+            fixtureName = "Weight Logger UI"
+            fixtureEmail = "weight-logger-ui@example.com"
+            fixtureUsername = "weight_logger_ui"
         } else if isSubscribed {
             fixtureName = "Paid MVP UI"
             fixtureEmail = "paid-mvp-ui@example.com"
@@ -228,6 +234,8 @@ struct LogYourBodyApp: App {
             fixtureSlug = "photo_hud"
         } else if usesFullDashboardFixture {
             fixtureSlug = "full_dashboard"
+        } else if usesWeightLoggerFixture {
+            fixtureSlug = "weight_logger"
         } else {
             fixtureSlug = isSubscribed ? "paid_mvp" : "paywall"
         }

--- a/apps/ios/LogYourBody/Services/PhotoMetadataService.swift
+++ b/apps/ios/LogYourBody/Services/PhotoMetadataService.swift
@@ -99,7 +99,9 @@ class PhotoMetadataService {
         photoUrl: String? = nil,
         weight: Double? = nil,
         bodyFatPercentage: Double? = nil,
-        userId: String
+        userId: String,
+        dataSource: String? = nil,
+        preserveExistingMeasurements: Bool = false
     ) async -> BodyMetrics {
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: date)
@@ -113,15 +115,20 @@ class PhotoMetadataService {
         .first?.toBodyMetrics()
 
         if let existing = existingMetrics {
+            let updatedWeight = preserveExistingMeasurements ? existing.weight ?? weight : weight ?? existing.weight
+            let updatedBodyFat = preserveExistingMeasurements
+                ? existing.bodyFatPercentage ?? bodyFatPercentage
+                : bodyFatPercentage ?? existing.bodyFatPercentage
+
             // Update existing metrics
             let updated = BodyMetrics(
                 id: existing.id,
                 userId: userId,
                 date: existing.date,
                 localDate: existing.localDate,
-                weight: weight ?? existing.weight,
+                weight: updatedWeight,
                 weightUnit: existing.weightUnit ?? "kg",
-                bodyFatPercentage: bodyFatPercentage ?? existing.bodyFatPercentage,
+                bodyFatPercentage: updatedBodyFat,
                 bodyFatMethod: existing.bodyFatMethod,
                 muscleMass: existing.muscleMass,
                 boneMass: existing.boneMass,
@@ -150,7 +157,7 @@ class PhotoMetadataService {
                 boneMass: nil,
                 notes: nil,
                 photoUrl: photoUrl,
-                dataSource: BodyMetricSource.photo.rawValue,
+                dataSource: dataSource ?? BodyMetricSource.photo.rawValue,
                 createdAt: Date(),
                 updatedAt: Date()
             )

--- a/apps/ios/LogYourBody/Utils/Constants.swift
+++ b/apps/ios/LogYourBody/Utils/Constants.swift
@@ -138,10 +138,10 @@ struct AuthSurfacePolicy {
 }
 
 enum PhotoTimelineHUDPolicy {
-    static let defaultShowsPhotoTimelineHUD = false
+    static let defaultShowsPhotoTimelineHUD = true
 
     static func shouldShowPhotoTimelineHUD(gateEnabled: Bool) -> Bool {
-        gateEnabled
+        defaultShowsPhotoTimelineHUD || gateEnabled
     }
 
     static func stateText(

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -77,6 +77,7 @@ struct DashboardViewLiquid: View {
     // Navigation state
     @State private var selectedTab: DashboardTab = .home
     @State private var isPhotosTabEnabled = true
+    @State private var selectedPhotoTimelineRootPage: PhotoTimelineRootPage = .timeline
     @State var isMetricDetailActive = false
     @State var selectedMetricType: MetricType = .weight
     @State private var isStatsDestinationActive = false
@@ -99,6 +100,11 @@ struct DashboardViewLiquid: View {
         case home
         case photos
         case metrics
+    }
+
+    enum PhotoTimelineRootPage: Hashable {
+        case timeline
+        case analytics
     }
 
     enum MetricType {
@@ -506,6 +512,26 @@ struct DashboardViewLiquid: View {
         .accessibilityIdentifier("photo_timeline_hud")
     }
 
+    private var photoTimelineRoot: some View {
+        TabView(selection: $selectedPhotoTimelineRootPage) {
+            Group {
+                if bodyMetrics.isEmpty {
+                    photoTimelineHUDEmptyState
+                } else {
+                    photoTimelineHUD
+                }
+            }
+            .tag(PhotoTimelineRootPage.timeline)
+            .accessibilityIdentifier("photo_timeline_root_page_timeline")
+
+            photoTimelineAnalyticsPage
+                .tag(PhotoTimelineRootPage.analytics)
+                .accessibilityIdentifier("photo_timeline_root_page_analytics")
+        }
+        .tabViewStyle(.page(indexDisplayMode: .always))
+        .accessibilityIdentifier("photo_timeline_root_pager")
+    }
+
     private var hudPhotoStage: some View {
         ZStack(alignment: .bottomLeading) {
             ProgressPhotoCarouselView(
@@ -833,7 +859,9 @@ struct DashboardViewLiquid: View {
     private var hudStatsAction: some View {
         Button {
             HapticManager.shared.selection()
-            isStatsDestinationActive = true
+            withAnimation(.easeInOut(duration: 0.25)) {
+                selectedPhotoTimelineRootPage = .analytics
+            }
         } label: {
             HStack(spacing: 12) {
                 Image(systemName: "chart.line.uptrend.xyaxis")
@@ -877,6 +905,13 @@ struct DashboardViewLiquid: View {
     }
 
     private var photoTimelineStatsDestination: some View {
+        photoTimelineAnalyticsPage
+            .navigationTitle("Stats")
+            .navigationBarTitleDisplayMode(.inline)
+            .accessibilityIdentifier("photo_timeline_stats_destination")
+    }
+
+    private var photoTimelineAnalyticsPage: some View {
         ZStack {
             Color.metricCanvas.ignoresSafeArea()
 
@@ -894,9 +929,6 @@ struct DashboardViewLiquid: View {
                 .padding(.bottom, 32)
             }
         }
-        .navigationTitle("Stats")
-        .navigationBarTitleDisplayMode(.inline)
-        .accessibilityIdentifier("photo_timeline_stats_destination")
     }
 
     private var photoTimelineStatsHeader: some View {
@@ -1469,12 +1501,10 @@ struct DashboardViewLiquid: View {
     private var dashboardContent: some View {
         if viewModel.bodyMetrics.isEmpty && !viewModel.hasLoadedInitialData {
             DashboardSkeleton()
-        } else if viewModel.bodyMetrics.isEmpty && layoutMode == .photoTimelineHUD {
-            photoTimelineHUDEmptyState
+        } else if layoutMode == .photoTimelineHUD {
+            photoTimelineRoot
         } else if viewModel.bodyMetrics.isEmpty {
             emptyState
-        } else if layoutMode == .photoTimelineHUD {
-            photoTimelineHUD
         } else {
             TabView(selection: $selectedTab) {
                 homeTab
@@ -1636,7 +1666,7 @@ struct ProgressPhotoAttachPolicy {
     }
 }
 
-private struct ProgressPhotoAttachSheet: View {
+struct ProgressPhotoAttachSheet: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var authManager: AuthManager
     @ObservedObject private var uploadManager = PhotoUploadManager.shared

--- a/apps/ios/LogYourBody/Views/MainTabView.swift
+++ b/apps/ios/LogYourBody/Views/MainTabView.swift
@@ -56,6 +56,12 @@ struct MainTabView: View {
     private func updateSelectedSurface() {
         #if DEBUG
         let arguments = ProcessInfo.processInfo.arguments
+        if arguments.contains("-lybUITestWeightLoggerMVPFixture") {
+            selectedSurface = .weightLoggerMVP
+            HealthSyncCoordinator.shared.bootstrapIfNeeded(syncEnabled: healthKitSyncEnabled)
+            return
+        }
+
         if arguments.contains("-lybUITestPhotoTimelineHUDFixture") {
             selectedSurface = .photoTimelineHUD
             HealthSyncCoordinator.shared.bootstrapIfNeeded(syncEnabled: healthKitSyncEnabled)

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -10,7 +10,7 @@ import CoreData
 // swiftlint:disable single_test_class
 
 final class LaunchSurfacePolicyTests: XCTestCase {
-    func testMVPDefaultSkipsBodyCompositionOnboardingAndProfileGate() {
+    func testGateOffWeightLoggerFallbackSkipsBodyCompositionOnboardingAndProfileGate() {
         XCTAssertFalse(
             LaunchSurfacePolicy.requiresBodyCompositionOnboarding(
                 hasCompletedOnboarding: false,
@@ -90,9 +90,9 @@ final class LaunchSurfacePolicyTests: XCTestCase {
 }
 
 final class PhotoTimelineHUDPolicyTests: XCTestCase {
-    func testPhotoTimelineHUDDefaultsOffBeforeGateLoads() {
-        XCTAssertFalse(PhotoTimelineHUDPolicy.defaultShowsPhotoTimelineHUD)
-        XCTAssertFalse(PhotoTimelineHUDPolicy.shouldShowPhotoTimelineHUD(gateEnabled: false))
+    func testPhotoTimelineHUDDefaultsOnForPhotoFirstMVP() {
+        XCTAssertTrue(PhotoTimelineHUDPolicy.defaultShowsPhotoTimelineHUD)
+        XCTAssertTrue(PhotoTimelineHUDPolicy.shouldShowPhotoTimelineHUD(gateEnabled: false))
         XCTAssertEqual(Constants.photoTimelineHUDFlagKey, "ios_photo_timeline_hud")
     }
 
@@ -121,6 +121,18 @@ final class PhotoTimelineHUDPolicyTests: XCTestCase {
                 legacyFullDashboardBetaEnabled: false
             ),
             .weightLoggerMVP
+        )
+    }
+
+    func testProductionDefaultRoutingUsesPhotoTimelineHUD() {
+        let defaultHUDEnabled = PhotoTimelineHUDPolicy.shouldShowPhotoTimelineHUD(gateEnabled: false)
+
+        XCTAssertEqual(
+            PaidAppSurfacePolicy.surface(
+                photoTimelineHUDEnabled: defaultHUDEnabled,
+                legacyFullDashboardBetaEnabled: false
+            ),
+            .photoTimelineHUD
         )
     }
 
@@ -668,6 +680,69 @@ final class ProgressPhotoAttachPolicyTests: XCTestCase {
     }
 }
 
+final class PhotoMetadataServiceTests: XCTestCase {
+    func testCreateOrUpdateMetricsPreservesExistingMeasurementsForFirstPhotoBaseline() async throws {
+        let userId = "photo_baseline_existing_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_764_000_000)
+        let existing = BodyMetrics(
+            id: UUID().uuidString,
+            userId: userId,
+            date: date,
+            weight: 80.0,
+            weightUnit: "kg",
+            bodyFatPercentage: 18.0,
+            bodyFatMethod: "HealthKit",
+            muscleMass: nil,
+            boneMass: nil,
+            waistCm: nil,
+            hipCm: nil,
+            waistUnit: nil,
+            notes: "Imported from HealthKit",
+            photoUrl: nil,
+            dataSource: BodyMetricSource.healthKit.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(existing, userId: userId)
+
+        let updated = await PhotoMetadataService.shared.createOrUpdateMetrics(
+            for: date,
+            photoUrl: "file:///first-photo.jpg",
+            weight: 77.0,
+            bodyFatPercentage: 14.0,
+            userId: userId,
+            dataSource: BodyMetricSource.manual.rawValue,
+            preserveExistingMeasurements: true
+        )
+
+        XCTAssertEqual(updated.id, existing.id)
+        XCTAssertEqual(updated.weight, 80.0)
+        XCTAssertEqual(updated.bodyFatPercentage, 18.0)
+        XCTAssertEqual(updated.bodyFatMethod, "HealthKit")
+        XCTAssertEqual(updated.dataSource, BodyMetricSource.healthKit.rawValue)
+        XCTAssertEqual(updated.photoUrl, "file:///first-photo.jpg")
+    }
+
+    func testCreateOrUpdateMetricsAssignsDataSourceForNewFirstPhotoBaseline() async {
+        let userId = "photo_baseline_new_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_000_000)
+
+        let created = await PhotoMetadataService.shared.createOrUpdateMetrics(
+            for: date,
+            weight: 79.5,
+            bodyFatPercentage: 16.5,
+            userId: userId,
+            dataSource: BodyMetricSource.manual.rawValue,
+            preserveExistingMeasurements: true
+        )
+
+        XCTAssertEqual(created.weight, 79.5)
+        XCTAssertEqual(created.bodyFatPercentage, 16.5)
+        XCTAssertEqual(created.dataSource, BodyMetricSource.manual.rawValue)
+        XCTAssertNil(created.photoUrl)
+    }
+}
+
 final class BulkProgressPhotoImportPolicyTests: XCTestCase {
     func testBulkProgressPhotoImportDefaultsLocked() {
         XCTAssertFalse(BulkProgressPhotoImportPolicy.defaultShowsBulkImport)
@@ -908,6 +983,16 @@ final class BodyMetricLocalDateContractTests: XCTestCase {
 
 @MainActor
 final class OnboardingFlowViewModelTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        OnboardingStateManager.shared.updateCompletionStatus(false)
+    }
+
+    override func tearDown() {
+        OnboardingStateManager.shared.updateCompletionStatus(false)
+        super.tearDown()
+    }
+
     func testAdvanceAfterHealthConfirmationSkipsToLoadingWhenMetricsExist() {
         let viewModel = OnboardingFlowViewModel()
         viewModel.bodyScoreInput.weight = WeightValue(value: 185, unit: .pounds)
@@ -961,6 +1046,56 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         viewModel.goToNextStep()
 
         XCTAssertEqual(viewModel.currentStep, .loading)
+    }
+
+    func testProfileDetailsAdvancesToFirstPhotoWhenEnabled() {
+        let viewModel = OnboardingFlowViewModel(includesFirstPhotoStep: true)
+        viewModel.currentStep = .profileDetails
+
+        viewModel.goToNextStep()
+
+        XCTAssertEqual(viewModel.currentStep, .firstPhoto)
+        XCTAssertFalse(OnboardingStateManager.shared.hasCompletedCurrentVersion)
+    }
+
+    func testProfileDetailsCompletesOnboardingWhenFirstPhotoDisabled() {
+        let viewModel = OnboardingFlowViewModel(includesFirstPhotoStep: false)
+        viewModel.currentStep = .profileDetails
+
+        viewModel.goToNextStep()
+
+        XCTAssertEqual(viewModel.currentStep, .paywall)
+        XCTAssertTrue(OnboardingStateManager.shared.hasCompletedCurrentVersion)
+    }
+
+    func testFirstPhotoStepCanCompleteToPaywall() {
+        let viewModel = OnboardingFlowViewModel(includesFirstPhotoStep: true)
+        viewModel.currentStep = .firstPhoto
+
+        viewModel.goToNextStep()
+
+        XCTAssertEqual(viewModel.currentStep, .paywall)
+        XCTAssertTrue(OnboardingStateManager.shared.hasCompletedCurrentVersion)
+    }
+
+    func testFirstPhotoBackNavigationAndPaywallBackNavigation() {
+        let viewModel = OnboardingFlowViewModel(includesFirstPhotoStep: true)
+        viewModel.currentStep = .firstPhoto
+
+        viewModel.goBack()
+        XCTAssertEqual(viewModel.currentStep, .profileDetails)
+
+        viewModel.currentStep = .paywall
+        viewModel.goBack()
+        XCTAssertEqual(viewModel.currentStep, .firstPhoto)
+    }
+
+    func testFirstPhotoProgressOnlyAppearsWhenEnabled() {
+        let enabledViewModel = OnboardingFlowViewModel(includesFirstPhotoStep: true)
+        let disabledViewModel = OnboardingFlowViewModel(includesFirstPhotoStep: false)
+
+        XCTAssertNotNil(enabledViewModel.progress(for: .firstPhoto))
+        XCTAssertNil(disabledViewModel.progress(for: .firstPhoto))
     }
 
     func testBuildOnboardingProfileUpdatesIncludesGenderDobAndHeight() {

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -48,7 +48,7 @@ final class LogYourBodyUITests: XCTestCase {
 
     func testPaidMVPWeightEntrySavesWithKeyboardOpen() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["-lybUITestPaidMVPFixture"]
+        app.launchArguments = ["-lybUITestWeightLoggerMVPFixture"]
         app.launch()
 
         XCTAssertTrue(app.staticTexts["Weight log"].waitForExistence(timeout: 10))
@@ -100,7 +100,7 @@ final class LogYourBodyUITests: XCTestCase {
 
     func testSubscribedMVPSettingsExposeSubscriptionEscapePaths() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["-lybUITestPaidMVPFixture"]
+        app.launchArguments = ["-lybUITestWeightLoggerMVPFixture"]
         app.launch()
 
         XCTAssertTrue(app.staticTexts["Weight log"].waitForExistence(timeout: 10))
@@ -129,8 +129,10 @@ final class LogYourBodyUITests: XCTestCase {
         app.launchArguments = ["-lybUITestPaidMVPFixture"]
         app.launch()
 
-        XCTAssertTrue(app.staticTexts["Weight log"].waitForExistence(timeout: 10))
-        XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_hud"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_pager"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_timeline"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_hud_empty_state"].exists)
+        XCTAssertFalse(app.staticTexts["Weight log"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["legacy_full_dashboard_beta"].exists)
     }
 
@@ -152,8 +154,14 @@ final class LogYourBodyUITests: XCTestCase {
         app.launchArguments = ["-lybUITestPhotoTimelineHUDFixture"]
         app.launch()
 
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_pager"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_hud"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_hud_stats_button"].exists)
+        let statsButton = app.descendants(matching: .any)["photo_timeline_hud_stats_button"]
+        scrollUntilHittable(statsButton, in: app)
+        XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
+        statsButton.tap()
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_stats_presence_summary"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_hud_phase_insight"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["legacy_full_dashboard_beta"].exists)
     }
@@ -208,7 +216,7 @@ final class LogYourBodyUITests: XCTestCase {
 
     func testBulkPhotoImportLockedByDefaultInIntegrations() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["-lybUITestPaidMVPFixture"]
+        app.launchArguments = ["-lybUITestWeightLoggerMVPFixture"]
         app.launch()
 
         try openIntegrations(in: app)
@@ -223,7 +231,7 @@ final class LogYourBodyUITests: XCTestCase {
     func testBulkPhotoImportGateOpensScannerEntry() throws {
         let app = XCUIApplication()
         app.launchArguments = [
-            "-lybUITestPaidMVPFixture",
+            "-lybUITestWeightLoggerMVPFixture",
             "-lybUITestBulkPhotoImportEnabledFixture"
         ]
         app.launch()

--- a/apps/ios/docs/development/RELEASE_CHECKLIST.md
+++ b/apps/ios/docs/development/RELEASE_CHECKLIST.md
@@ -33,10 +33,14 @@ Use this checklist before sending a LogYourBody iOS build to TestFlight or App S
   has physical-device proof.
 - Current JOV-2865 evidence keeps Apple Sign-In safely hidden; production
   enablement still requires physical Apple prompt and Clerk session proof.
-- `ios_full_body_composition_dashboard` stays off for the paid MVP App Store
-  launch unless the full dashboard has separate approval.
-- `ios_photo_timeline_hud` stays off until the photo-first HUD has separate
-  design, data, screenshot, and device proof.
+- `ios_full_body_composition_dashboard` stays off for the photo-first MVP App
+  Store launch; it remains a legacy/beta fallback only.
+- `ios_photo_timeline_hud` is the default paid MVP surface only after release
+  evidence proves HUD routing, progress-photo attach, metric/source states,
+  HealthKit-denied fallback, screenshot/device proof, and App Review notes.
+- `ios_phase_insight`, `ios_glp1_weekly_checkin`, and
+  `ios_bulk_progress_photo_import` stay off unless separately approved and
+  evidenced.
 
 ## Product Path
 
@@ -44,18 +48,23 @@ Use this checklist before sending a LogYourBody iOS build to TestFlight or App S
 - Apple Sign-In is hidden by default and appears only for users/cohorts covered
   by `ios_apple_sign_in_enabled`.
 - Unpaid authenticated user sees the paywall.
-- Purchase success unlocks the weight logger.
-- Restore success unlocks the weight logger.
-- Paid returning user opens directly to the weight logger after loading.
-- Paid user can log body weight without body-score onboarding or full profile completion.
-- Recent entries show the latest saved weight and history.
-- Paid user can prepare and share a weight-only CSV export.
+- Purchase success unlocks the photo-first HUD.
+- Restore success unlocks the photo-first HUD.
+- Paid returning user opens directly to the photo-first HUD after loading.
+- Paid user can add one progress photo, log or update weight/body-fat context,
+  scrub the timeline, and open Stats as a secondary surface.
+- Bulk progress-photo import remains locked or gated by
+  `ios_bulk_progress_photo_import`.
+- Paid user can export account data from Settings.
 - Signed-out user opens to auth.
 
 ## Data And Sync
 
-- User can save today's weight locally while online.
-- User can save today's weight locally while offline.
+- User can save today's weight/body-fat context locally while online.
+- User can save today's weight/body-fat context locally while offline.
+- User can attach a progress photo to an existing or newly created body metrics
+  timeline point.
+- HealthKit allow, deny, and skip paths all lead to a usable app state.
 - Sync retries after the device returns online.
 - Supabase rows use the Clerk user ID for `user_id` or profile `id`.
 - Sync failure shows recoverable UI and does not block local logging.
@@ -68,6 +77,9 @@ Use this checklist before sending a LogYourBody iOS build to TestFlight or App S
 - Native settings expose account deletion and data export paths, with support
   email fallback for export requests.
 - Camera, photo library, HealthKit, and Face ID usage strings are accurate for any enabled surfaces.
+- App Review notes explain the reviewer-accessible email OTP path, purchase
+  path, photo-first HUD, HealthKit skip/deny behavior, Restore Purchases, Export
+  Data, and Delete Account.
 - No secrets or local config files are committed.
 - Any credential previously exposed in setup docs or logs has been rotated
   before release.
@@ -100,11 +112,20 @@ xcodebuild -project LogYourBody.xcodeproj \
 
 ## PR Evidence
 
-- Include screenshots or a simulator recording for auth, paywall, purchase/restore, weight logging, recent history, and CSV export.
-- Include RevenueCat purchase and restore test results, or explicitly label
-  the account-owner sandbox/TestFlight credential blocker.
+- Include screenshots or a simulator recording for auth, paywall,
+  purchase/restore, photo-first HUD empty/populated states, add-photo
+  ready/permission/success states, timeline scrubber, Stats drilldown,
+  HealthKit allow/deny fallback, export, and account deletion.
+- Include real TestFlight purchase and restore proof: products loaded,
+  trial/purchase succeeds, Premium entitlement active, relaunch opens the HUD,
+  and restore works after logout/reinstall.
+- Include App Review login proof: email OTP path, terms/privacy/health
+  disclaimer acceptance, paywall, post-purchase HUD, Settings restore/export/delete.
 - Do not run App Store submission with `paywall_testflight_verified=true`
   until a real TestFlight build has loaded subscription products and completed
   purchase plus restore verification.
+- Include HealthKit/photo/analytics proof: `healthkit` and `photo` provenance,
+  photo upload/sync path, denied-permission fallback, Stats source-state quality,
+  and any Statsig/Sentry release events used as launch evidence.
 - Include Supabase sync test results.
 - Include validation command output and known risks.

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -868,7 +868,7 @@ platform :ios do
       last_name: env_or_default.call("APP_REVIEW_LAST_NAME", "Team"),
       email_address: env_or_default.call("APP_REVIEW_EMAIL_ADDRESS", "support@logyourbody.com"),
       phone_number: ENV["APP_REVIEW_PHONE_NUMBER"],
-      notes: env_or_default.call("APP_REVIEW_NOTES", "Review access: choose Create Account, enter an email address that can receive a one-time code, accept Terms, Privacy Policy, and Health Disclaimer, then enter the email code. On LogYourBody Pro, tap Start trial; subscriptions use Apple's sandbox review environment and include a 3-day trial. After purchase or trial activation, log a weight, review recent history, and export CSV from Settings. If email codes or subscription products do not load, contact support@logyourbody.com.")
+      notes: env_or_default.call("APP_REVIEW_NOTES", "Review access: choose Create Account, enter an email address that can receive a one-time code, accept Terms, Privacy Policy, and Health Disclaimer, then enter the email code. On LogYourBody Pro, tap Start trial; subscriptions use Apple's sandbox review environment and include a 3-day trial. After purchase or trial activation, the paid surface opens to the photo-first body-composition HUD. Add one progress photo, review the timeline and Stats view, optionally connect or skip HealthKit, then open Settings to test Restore Purchases, Manage Subscription, Export Data, and Delete Account. Apple Sign-In is hidden unless enabled for an internal cohort. If email codes, photos, HealthKit prompts, or subscription products do not load, contact support@logyourbody.com.")
     }.compact
 
     begin

--- a/apps/ios/fastlane/metadata/en-US/description.txt
+++ b/apps/ios/fastlane/metadata/en-US/description.txt
@@ -1,14 +1,15 @@
-LogYourBody is a focused body metrics tracker for people who want a simple, private weight log that can grow into deeper body composition tracking.
+LogYourBody is a focused body-composition tracker for people who want a private progress-photo timeline with weight, body-fat, and Apple Health context.
 
 Start with the essentials:
 
-- Log today's weight in pounds or kilograms
-- See your latest entry at a glance
-- Review recent weight history
+- Add progress photos to a swipeable body timeline
+- Log weight and body-fat context in pounds or kilograms
+- Review Stats for weight, body fat, FFMI, and steps
+- Optionally connect Apple Health for weight, body-fat, height, and step context
 - Sync entries to your account
-- Export your weight log as CSV
+- Export your account data
 - Keep access managed through LogYourBody Pro
 
-LogYourBody is built for consistent tracking without noisy coaching. Your entries stay available on device and sync to your account when you are signed in.
+LogYourBody is built for consistent body-composition tracking without noisy coaching. Your photos and entries stay available on device and sync to your account when you are signed in.
 
 LogYourBody is not a medical device and does not provide medical advice. Use it for personal fitness tracking and consult a qualified professional for medical decisions.

--- a/apps/ios/fastlane/metadata/en-US/keywords.txt
+++ b/apps/ios/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-weight,body metrics,fitness tracker,body composition,progress,health log
+progress photos,body composition,weight tracker,body fat,fitness tracker,health log

--- a/apps/ios/fastlane/metadata/en-US/promotional_text.txt
+++ b/apps/ios/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-Log weight, keep recent history, sync to your account, and export your data from a focused tracker.
+Track progress photos, weight, body fat, and Apple Health context from a private photo-first timeline.

--- a/apps/ios/fastlane/metadata/en-US/release_notes.txt
+++ b/apps/ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,1 +1,1 @@
-Initial App Store release with paid access, weight logging, recent history, account sync, and CSV export.
+Photo-first MVP release with paid access, progress-photo timeline, weight and body-fat logging, optional HealthKit context, account sync, restore purchases, data export, and account deletion.


### PR DESCRIPTION
## Summary
- make the paid iOS MVP default route the photo timeline HUD, with the full dashboard kept as the legacy beta path and a debug weight-logger fixture retained for tests
- wrap the HUD and analytics content in a page-style root with stable UI identifiers, and make the Stats control jump to the analytics page
- add authenticated onboarding first-photo step, reuse the progress-photo attach sheet, and preserve same-day HealthKit/manual baseline measurements when attaching the first photo
- update iOS release checklist, App Review notes, and App Store metadata for the photo-first MVP evidence bar

## GBrain / Subagent Evidence
- GBrain was retried first; the MCP transport returned `Transport closed`, so implementation used repo/GitHub/docs as the authoritative fallback
- subagent audits covered RevenueCat/App Review setup, iOS test coverage risks, and release copy updates; completed agents were closed

## Validation
- `pnpm lint` passed
- `pnpm typecheck` passed
- `pnpm test:ci` passed
- `swiftlint lint --strict` passed
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'id=7EB60D3E-3637-43EA-969D-167ADC72BAEC' -resultBundlePath /tmp/lyb-photo-first-build-for-testing-rerun.xcresult build-for-testing` passed
- Focused `xcodebuild ... test-without-building` did not execute tests locally because CoreSimulator/Xcode stuck at `waiting for workers to materialize` with unfinished simulator install/launch workers, then exited `TEST EXECUTE INTERRUPTED`; app and test bundle compilation succeeded in `build-for-testing`

## Release Hold
- Do not submit this build to App Store review until a new TestFlight build proves products load, purchase succeeds, restore succeeds, entitlement unlocks, onboarding completes, HealthKit allow/deny/skip paths work, photo capture/library attach works, analytics is one swipe/Stats tap away, and reviewer login proof is captured.