### PR TITLE
feat: add daily weigh-in reminders

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		AD1036332F00000100ABCDEF /* BodyMetricAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1036322F00000100ABCDEF /* BodyMetricAppIntents.swift */; };
 		AD1036352F00000100ABCDEF /* BodyMetricLoggingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1036342F00000100ABCDEF /* BodyMetricLoggingService.swift */; };
 		AD1036372F00000200ABCDEF /* BodyMetricSpotlightIndexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1036362F00000200ABCDEF /* BodyMetricSpotlightIndexer.swift */; };
+		AD3134012F01313400D134A1 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3134002F01313400D134A1 /* NotificationManager.swift */; };
+		AD3134032F01313400D134A1 /* DailyWeighInReminderPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3134022F01313400D134A1 /* DailyWeighInReminderPromptView.swift */; };
 		AD0B7BF52EC552FA008B29E7 /* LogYourBody.storekit in Resources */ = {isa = PBXBuildFile; fileRef = AD0B7BF42EC552FA008B29E7 /* LogYourBody.storekit */; };
 		AD0B7BF72EC692ED008B29E7 /* MetricChartDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0B7BF62EC692ED008B29E7 /* MetricChartDataHelper.swift */; };
 		AD0B7BFB2EC6930D008B29E7 /* PeriodSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0B7BFA2EC6930D008B29E7 /* PeriodSelector.swift */; };
@@ -377,6 +379,8 @@
 		AD1036322F00000100ABCDEF /* BodyMetricAppIntents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyMetricAppIntents.swift; sourceTree = "<group>"; };
 		AD1036342F00000100ABCDEF /* BodyMetricLoggingService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyMetricLoggingService.swift; sourceTree = "<group>"; };
 		AD1036362F00000200ABCDEF /* BodyMetricSpotlightIndexer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyMetricSpotlightIndexer.swift; sourceTree = "<group>"; };
+		AD3134002F01313400D134A1 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		AD3134022F01313400D134A1 /* DailyWeighInReminderPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyWeighInReminderPromptView.swift; sourceTree = "<group>"; };
 		AD723AE82E15FA5C002376C6 /* LoadingManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingManager.swift; sourceTree = "<group>"; };
 		AD723AEA2E15FA5C002376C6 /* SupabaseDataClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupabaseDataClient.swift; sourceTree = "<group>"; };
 		AD723AEE2E15FA5C002376C6 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
@@ -906,6 +910,7 @@
 				AD1036322F00000100ABCDEF /* BodyMetricAppIntents.swift */,
 				AD1036342F00000100ABCDEF /* BodyMetricLoggingService.swift */,
 				AD1036362F00000200ABCDEF /* BodyMetricSpotlightIndexer.swift */,
+				AD3134002F01313400D134A1 /* NotificationManager.swift */,
 				ADA4B7382ECD44C800F4262A /* BodyScoreCache.swift */,
 				ADA4B7362ECC3A7A00F4262A /* EntryVisibilityManager.swift */,
 				AD050C482EC12E390082A313 /* RevenueCatManager.swift */,
@@ -1002,6 +1007,7 @@
 				AD723AFF2E15FA5C002376C6 /* EmailVerificationView.swift */,
 				ADF5C1B12E1CD2FD00E3FB4D /* AddEntrySheet.swift */,
 				AD723B002E15FA5C002376C6 /* ExportDataView.swift */,
+				AD3134022F01313400D134A1 /* DailyWeighInReminderPromptView.swift */,
 				AD723B012E15FA5C002376C6 /* HealthKitPromptView.swift */,
 				AD723B022E15FA5C002376C6 /* LoadingView.swift */,
 				AD723B032E15FA5C002376C6 /* LoginView.swift */,
@@ -1565,6 +1571,7 @@
 				AD1036332F00000100ABCDEF /* BodyMetricAppIntents.swift in Sources */,
 				AD1036352F00000100ABCDEF /* BodyMetricLoggingService.swift in Sources */,
 				AD1036372F00000200ABCDEF /* BodyMetricSpotlightIndexer.swift in Sources */,
+				AD3134012F01313400D134A1 /* NotificationManager.swift in Sources */,
 				AD8872452EB87F480041C426 /* LiquidGlassCard.swift in Sources */,
 				ADDC47AD2E2D89F3003C97E7 /* User.swift in Sources */,
 				ADDC487C2E2D8A6B003C97E7 /* ProgressPhotoCarouselView.swift in Sources */,
@@ -1651,6 +1658,7 @@
 				ADDC47E42E2D89F3003C97E7 /* EmailVerificationView.swift in Sources */,
 				ADDC47E52E2D89F3003C97E7 /* AddEntrySheet.swift in Sources */,
 				ADDC47E62E2D89F3003C97E7 /* ExportDataView.swift in Sources */,
+				AD3134032F01313400D134A1 /* DailyWeighInReminderPromptView.swift in Sources */,
 				ADDC47E72E2D89F3003C97E7 /* HealthKitPromptView.swift in Sources */,
 				ADDC47E82E2D89F3003C97E7 /* LoadingView.swift in Sources */,
 				ADDC47E92E2D89F3003C97E7 /* LoginView.swift in Sources */,

--- a/apps/ios/LogYourBody/ContentView.swift
+++ b/apps/ios/LogYourBody/ContentView.swift
@@ -32,6 +32,7 @@ struct ContentView: View {
     @EnvironmentObject var revenueCatManager: RevenueCatManager
     @EnvironmentObject var bugReportManager: BugReportManager
     @StateObject private var loadingManager: LoadingManager
+    @StateObject private var notificationManager = NotificationManager.shared
     private let onboardingStateManager = OnboardingStateManager.shared
     @State private var currentUserId: String?
     @State private var hasCompletedOnboarding = OnboardingStateManager.shared.hasCompletedCurrentVersion
@@ -108,6 +109,27 @@ struct ContentView: View {
             mvpLoggerFallbackEnabled: AnalyticsService.shared.isFeatureEnabled(
                 flagKey: Constants.mvpLoggerFallbackFlagKey
             )
+        )
+    }
+
+    private var isDailyWeighInReminderGateEnabled: Bool {
+        _ = featureGateRefreshToken
+
+        #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("-lybUITestDailyReminderPromptFixture") {
+            return true
+        }
+        #endif
+
+        return AnalyticsService.shared.isFeatureEnabled(
+            flagKey: Constants.dailyWeighInReminderFlagKey
+        )
+    }
+
+    private var shouldShowDailyReminderPrompt: Bool {
+        notificationManager.shouldShowPostPaywallPrompt(
+            featureEnabled: isDailyWeighInReminderGateEnabled,
+            isSubscribed: revenueCatManager.isSubscribed
         )
     }
 
@@ -227,6 +249,8 @@ struct ContentView: View {
                 PaywallView()
                     .environmentObject(authManager)
                     .environmentObject(revenueCatManager)
+            } else if shouldShowDailyReminderPrompt {
+                DailyWeighInReminderPromptView(notificationManager: notificationManager)
             } else {
                 MainTabView()
                     .onAppear {

--- a/apps/ios/LogYourBody/Services/NotificationManager.swift
+++ b/apps/ios/LogYourBody/Services/NotificationManager.swift
@@ -1,0 +1,244 @@
+import Foundation
+import UserNotifications
+
+enum NotificationReminderKind: String, CaseIterable {
+    case dailyWeighIn = "daily_weigh_in"
+
+    var requestIdentifier: String {
+        "lyb.notification.\(rawValue)"
+    }
+}
+
+enum DailyReminderPolicy {
+    static let defaultHour = 7
+    static let defaultMinute = 0
+
+    static func shouldShowPostPaywallPrompt(
+        featureEnabled: Bool,
+        isSubscribed: Bool,
+        hasCompletedPrompt: Bool
+    ) -> Bool {
+        featureEnabled && isSubscribed && !hasCompletedPrompt
+    }
+
+    static func normalizedTime(hour: Int, minute: Int) -> (hour: Int, minute: Int) {
+        (
+            hour: min(max(hour, 0), 23),
+            minute: min(max(minute, 0), 59)
+        )
+    }
+
+    static func triggerDateComponents(hour: Int, minute: Int) -> DateComponents {
+        let normalized = normalizedTime(hour: hour, minute: minute)
+        var components = DateComponents()
+        components.hour = normalized.hour
+        components.minute = normalized.minute
+        return components
+    }
+
+    static func displayTime(hour: Int, minute: Int, calendar: Calendar = .current) -> String {
+        let normalized = normalizedTime(hour: hour, minute: minute)
+        var components = DateComponents()
+        components.hour = normalized.hour
+        components.minute = normalized.minute
+
+        guard let date = calendar.date(from: components) else {
+            return String(format: "%02d:%02d", normalized.hour, normalized.minute)
+        }
+
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return formatter.string(from: date)
+    }
+}
+
+protocol NotificationSchedulingClient {
+    func notificationSettings() async -> UNNotificationSettings
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool
+    func add(_ request: UNNotificationRequest) async throws
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String])
+}
+
+extension UNUserNotificationCenter: NotificationSchedulingClient {}
+
+@MainActor
+final class NotificationManager: ObservableObject {
+    static let shared = NotificationManager()
+
+    @Published private(set) var authorizationStatus: UNAuthorizationStatus = .notDetermined
+    @Published private(set) var isDailyWeighInReminderEnabled: Bool
+    @Published private(set) var dailyWeighInHour: Int
+    @Published private(set) var dailyWeighInMinute: Int
+    @Published private(set) var hasCompletedDailyWeighInPrompt: Bool
+
+    private let center: NotificationSchedulingClient
+    private let defaults: UserDefaults
+
+    init(
+        center: NotificationSchedulingClient = UNUserNotificationCenter.current(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.center = center
+        self.defaults = defaults
+
+        isDailyWeighInReminderEnabled = defaults.bool(forKey: Constants.dailyWeighInReminderEnabledKey)
+        dailyWeighInHour = defaults.object(forKey: Constants.dailyWeighInReminderHourKey) as? Int
+            ?? DailyReminderPolicy.defaultHour
+        dailyWeighInMinute = defaults.object(forKey: Constants.dailyWeighInReminderMinuteKey) as? Int
+            ?? DailyReminderPolicy.defaultMinute
+        hasCompletedDailyWeighInPrompt = defaults.bool(forKey: Constants.dailyWeighInReminderPromptCompletedKey)
+
+        let normalized = DailyReminderPolicy.normalizedTime(hour: dailyWeighInHour, minute: dailyWeighInMinute)
+        dailyWeighInHour = normalized.hour
+        dailyWeighInMinute = normalized.minute
+    }
+
+    var dailyWeighInDisplayTime: String {
+        DailyReminderPolicy.displayTime(hour: dailyWeighInHour, minute: dailyWeighInMinute)
+    }
+
+    var dailyWeighInReminderDate: Date {
+        let components = DailyReminderPolicy.triggerDateComponents(
+            hour: dailyWeighInHour,
+            minute: dailyWeighInMinute
+        )
+        return Calendar.current.date(from: components) ?? Date()
+    }
+
+    func shouldShowPostPaywallPrompt(featureEnabled: Bool, isSubscribed: Bool) -> Bool {
+        DailyReminderPolicy.shouldShowPostPaywallPrompt(
+            featureEnabled: featureEnabled,
+            isSubscribed: isSubscribed,
+            hasCompletedPrompt: hasCompletedDailyWeighInPrompt
+        )
+    }
+
+    func refreshAuthorizationStatus() async {
+        let settings = await center.notificationSettings()
+        authorizationStatus = settings.authorizationStatus
+
+        if settings.authorizationStatus == .denied, isDailyWeighInReminderEnabled {
+            setDailyWeighInReminder(enabled: false)
+        }
+    }
+
+    @discardableResult
+    func requestDailyWeighInReminder(at date: Date) async -> Bool {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        return await requestDailyWeighInReminder(
+            hour: components.hour ?? DailyReminderPolicy.defaultHour,
+            minute: components.minute ?? DailyReminderPolicy.defaultMinute
+        )
+    }
+
+    @discardableResult
+    func requestDailyWeighInReminder(hour: Int, minute: Int) async -> Bool {
+        markDailyWeighInPromptCompleted()
+
+        do {
+            let granted = try await center.requestAuthorization(options: [.alert, .badge, .sound])
+            await refreshAuthorizationStatus()
+
+            guard granted else {
+                setDailyWeighInReminder(enabled: false)
+                return false
+            }
+
+            let normalized = DailyReminderPolicy.normalizedTime(hour: hour, minute: minute)
+            setDailyWeighInReminder(enabled: true, hour: normalized.hour, minute: normalized.minute)
+            try await scheduleDailyWeighInReminder(hour: normalized.hour, minute: normalized.minute)
+
+            AnalyticsService.shared.track(
+                event: "notification_permission_granted",
+                properties: ["notification_type": NotificationReminderKind.dailyWeighIn.rawValue]
+            )
+            return true
+        } catch {
+            setDailyWeighInReminder(enabled: false)
+            return false
+        }
+    }
+
+    @discardableResult
+    func setDailyWeighInReminderEnabled(_ isEnabled: Bool) async -> Bool {
+        if isEnabled {
+            return await requestDailyWeighInReminder(
+                hour: dailyWeighInHour,
+                minute: dailyWeighInMinute
+            )
+        }
+
+        markDailyWeighInPromptCompleted()
+        setDailyWeighInReminder(enabled: false)
+        center.removePendingNotificationRequests(
+            withIdentifiers: [NotificationReminderKind.dailyWeighIn.requestIdentifier]
+        )
+        return true
+    }
+
+    func updateDailyWeighInReminderTime(to date: Date) async {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        let normalized = DailyReminderPolicy.normalizedTime(
+            hour: components.hour ?? DailyReminderPolicy.defaultHour,
+            minute: components.minute ?? DailyReminderPolicy.defaultMinute
+        )
+        setDailyWeighInReminder(
+            enabled: isDailyWeighInReminderEnabled,
+            hour: normalized.hour,
+            minute: normalized.minute
+        )
+
+        guard isDailyWeighInReminderEnabled else { return }
+        try? await scheduleDailyWeighInReminder(hour: normalized.hour, minute: normalized.minute)
+    }
+
+    func skipDailyWeighInPrompt() {
+        markDailyWeighInPromptCompleted()
+        setDailyWeighInReminder(enabled: false)
+    }
+
+    private func scheduleDailyWeighInReminder(hour: Int, minute: Int) async throws {
+        center.removePendingNotificationRequests(
+            withIdentifiers: [NotificationReminderKind.dailyWeighIn.requestIdentifier]
+        )
+
+        let content = UNMutableNotificationContent()
+        content.title = "Log today's weight"
+        content.body = "A quick weigh-in keeps your body trend current."
+        content.sound = .default
+        content.categoryIdentifier = NotificationReminderKind.dailyWeighIn.rawValue
+
+        let trigger = UNCalendarNotificationTrigger(
+            dateMatching: DailyReminderPolicy.triggerDateComponents(hour: hour, minute: minute),
+            repeats: true
+        )
+        let request = UNNotificationRequest(
+            identifier: NotificationReminderKind.dailyWeighIn.requestIdentifier,
+            content: content,
+            trigger: trigger
+        )
+
+        try await center.add(request)
+    }
+
+    private func markDailyWeighInPromptCompleted() {
+        hasCompletedDailyWeighInPrompt = true
+        defaults.set(true, forKey: Constants.dailyWeighInReminderPromptCompletedKey)
+    }
+
+    private func setDailyWeighInReminder(enabled: Bool, hour: Int? = nil, minute: Int? = nil) {
+        let normalized = DailyReminderPolicy.normalizedTime(
+            hour: hour ?? dailyWeighInHour,
+            minute: minute ?? dailyWeighInMinute
+        )
+
+        isDailyWeighInReminderEnabled = enabled
+        dailyWeighInHour = normalized.hour
+        dailyWeighInMinute = normalized.minute
+
+        defaults.set(enabled, forKey: Constants.dailyWeighInReminderEnabledKey)
+        defaults.set(normalized.hour, forKey: Constants.dailyWeighInReminderHourKey)
+        defaults.set(normalized.minute, forKey: Constants.dailyWeighInReminderMinuteKey)
+    }
+}

--- a/apps/ios/LogYourBody/Utils/Constants.swift
+++ b/apps/ios/LogYourBody/Utils/Constants.swift
@@ -27,6 +27,7 @@ struct Constants {
     static let glp1WeeklyCheckInFlagKey = "ios_glp1_weekly_checkin"
     static let bulkProgressPhotoImportFlagKey = "ios_bulk_progress_photo_import"
     static let photosTabFlagKey = "photos_tab"
+    static let dailyWeighInReminderFlagKey = "ios_daily_weigh_in_reminders"
 
     // MARK: - API Configuration (from Config.xcconfig via Info.plist)
     static var baseURL: String {
@@ -77,6 +78,10 @@ struct Constants {
     static let defaultHomeModeKey = "defaultHomeMode"
     static let hasCompletedOnboardingKey = "hasCompletedOnboarding"
     static let onboardingCompletedVersionKey = "onboardingCompletedVersion"
+    static let dailyWeighInReminderEnabledKey = "dailyWeighInReminderEnabled"
+    static let dailyWeighInReminderHourKey = "dailyWeighInReminderHour"
+    static let dailyWeighInReminderMinuteKey = "dailyWeighInReminderMinute"
+    static let dailyWeighInReminderPromptCompletedKey = "dailyWeighInReminderPromptCompleted"
 
     // Goal Keys
     static let goalBodyFatPercentageKey = "goalBodyFatPercentage"

--- a/apps/ios/LogYourBody/Views/DailyWeighInReminderPromptView.swift
+++ b/apps/ios/LogYourBody/Views/DailyWeighInReminderPromptView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+struct DailyWeighInReminderPromptView: View {
+    @ObservedObject private var notificationManager: NotificationManager
+    @State private var reminderTime: Date
+    @State private var isRequesting = false
+
+    let onComplete: () -> Void
+
+    init(
+        notificationManager: NotificationManager,
+        onComplete: @escaping () -> Void = {}
+    ) {
+        self.notificationManager = notificationManager
+        self.onComplete = onComplete
+        _reminderTime = State(initialValue: notificationManager.dailyWeighInReminderDate)
+    }
+
+    @MainActor
+    init(onComplete: @escaping () -> Void = {}) {
+        self.init(notificationManager: NotificationManager.shared, onComplete: onComplete)
+    }
+
+    var body: some View {
+        OnboardingPageTemplate(
+            title: "Want a daily nudge at 7am?",
+            subtitle: "Log your weight once a day so your trend stays useful.",
+            showsBackButton: false,
+            content: {
+                VStack(alignment: .leading, spacing: 18) {
+                    reminderIcon
+
+                    DatePicker(
+                        "Reminder time",
+                        selection: $reminderTime,
+                        displayedComponents: .hourAndMinute
+                    )
+                    .datePickerStyle(.wheel)
+                    .labelsHidden()
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            .fill(Color.appCard.opacity(0.55))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            .stroke(Color.appBorder.opacity(0.45))
+                    )
+                    .accessibilityIdentifier("daily_reminder_time_picker")
+
+                    OnboardingBulletList(
+                        items: [
+                            OnboardingBulletItem(
+                                iconName: "clock.fill",
+                                text: "One reminder per day at your chosen time."
+                            ),
+                            OnboardingBulletItem(
+                                iconName: "slider.horizontal.3",
+                                text: "Change or turn it off anytime in Settings."
+                            )
+                        ]
+                    )
+                }
+            },
+            footer: {
+                VStack(spacing: 12) {
+                    Button {
+                        requestReminder()
+                    } label: {
+                        if isRequesting {
+                            ProgressView()
+                                .tint(.black)
+                        } else {
+                            Text("Enable reminder")
+                        }
+                    }
+                    .buttonStyle(OnboardingPrimaryButtonStyle())
+                    .disabled(isRequesting)
+                    .accessibilityIdentifier("daily_reminder_enable_button")
+
+                    Button("Not now") {
+                        notificationManager.skipDailyWeighInPrompt()
+                        onComplete()
+                    }
+                    .buttonStyle(OnboardingSecondaryButtonStyle())
+                    .disabled(isRequesting)
+                    .accessibilityIdentifier("daily_reminder_skip_button")
+                }
+            }
+        )
+        .task {
+            await notificationManager.refreshAuthorizationStatus()
+        }
+    }
+
+    private var reminderIcon: some View {
+        ZStack {
+            Circle()
+                .fill(Color.appPrimary.opacity(0.16))
+                .frame(width: 76, height: 76)
+
+            Image(systemName: "bell.badge.fill")
+                .font(.system(size: 32, weight: .semibold))
+                .foregroundStyle(Color.appPrimary)
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityHidden(true)
+    }
+
+    private func requestReminder() {
+        guard !isRequesting else { return }
+        isRequesting = true
+
+        Task {
+            _ = await notificationManager.requestDailyWeighInReminder(at: reminderTime)
+            await MainActor.run {
+                isRequesting = false
+                onComplete()
+            }
+        }
+    }
+}
+
+#Preview {
+    DailyWeighInReminderPromptView()
+}

--- a/apps/ios/LogYourBody/Views/PreferencesView.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView.swift
@@ -11,6 +11,7 @@ import UIKit
 struct PreferencesView: View {
     @EnvironmentObject var authManager: AuthManager
     @StateObject private var revenueCatManager = RevenueCatManager.shared
+    @StateObject private var notificationManager = NotificationManager.shared
     @AppStorage(Constants.preferredMeasurementSystemKey) private var measurementSystem = PreferencesView.defaultMeasurementSystem
     @AppStorage("biometricLockEnabled") private var biometricLockEnabled = false
     @AppStorage("healthKitSyncEnabled") private var healthKitSyncEnabled = true
@@ -45,6 +46,8 @@ struct PreferencesView: View {
     @State private var showingLogoutConfirmation = false
     @State private var isTriggeringHealthResync = false
     @State private var isHealthSyncSetupInProgress = false
+    @State private var dailyReminderDate = Date()
+    @State private var featureGateRefreshToken = UUID()
 
     // Cached computed properties for performance
     @State private var cachedUserGender: String = ""
@@ -96,6 +99,20 @@ struct PreferencesView: View {
 
     private var currentFFMIGoal: Double {
         customFFMIGoal ?? defaultFFMIGoal
+    }
+
+    private var isDailyWeighInReminderGateEnabled: Bool {
+        _ = featureGateRefreshToken
+
+        #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("-lybUITestDailyReminderPromptFixture") {
+            return true
+        }
+        #endif
+
+        return AnalyticsService.shared.isFeatureEnabled(
+            flagKey: Constants.dailyWeighInReminderFlagKey
+        )
     }
 
     // Update cached values when user profile changes
@@ -157,6 +174,9 @@ struct PreferencesView: View {
                     accountSection
                     profileSection
                     trackingGoalsSection
+                    if isDailyWeighInReminderGateEnabled {
+                        remindersSection
+                    }
                     integrationsSection
                     securitySection
                     subscriptionSection
@@ -222,6 +242,13 @@ struct PreferencesView: View {
         .onAppear {
             checkBiometricAvailability()
             updateCachedValues() // Cache computed properties for performance
+            dailyReminderDate = notificationManager.dailyWeighInReminderDate
+            Task {
+                await notificationManager.refreshAuthorizationStatus()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .featureGatesDidChange)) { _ in
+            featureGateRefreshToken = UUID()
         }
     }
 
@@ -604,6 +631,72 @@ struct PreferencesView: View {
                 IntegrationsView()
             }
         }
+    }
+
+    private var remindersSection: some View {
+        SettingsSection(header: "Reminders") {
+            VStack(spacing: 0) {
+                SettingsToggleRow(
+                    icon: "bell.badge.fill",
+                    title: "Daily weigh-in",
+                    isOn: dailyWeighInReminderBinding,
+                    tintColor: .appText,
+                    subtitle: dailyReminderSubtitle
+                )
+                .accessibilityIdentifier("settings_daily_weigh_in_reminder_toggle")
+
+                if notificationManager.isDailyWeighInReminderEnabled {
+                    DSDivider().insetted(16)
+
+                    DatePicker(
+                        "Reminder time",
+                        selection: $dailyReminderDate,
+                        displayedComponents: .hourAndMinute
+                    )
+                    .datePickerStyle(.compact)
+                    .padding(.horizontal, SettingsDesign.horizontalPadding)
+                    .padding(.vertical, SettingsDesign.verticalPadding)
+                    .onChange(of: dailyReminderDate) { _, newValue in
+                        Task {
+                            await notificationManager.updateDailyWeighInReminderTime(to: newValue)
+                        }
+                    }
+                    .accessibilityIdentifier("settings_daily_weigh_in_reminder_time_picker")
+                }
+            }
+        }
+    }
+
+    private var dailyReminderSubtitle: String {
+        if notificationManager.isDailyWeighInReminderEnabled {
+            return "On at \(notificationManager.dailyWeighInDisplayTime)"
+        }
+
+        if notificationManager.authorizationStatus == .denied {
+            return "Off. Enable notifications in iOS Settings."
+        }
+
+        return "Off"
+    }
+
+    private var dailyWeighInReminderBinding: Binding<Bool> {
+        Binding(
+            get: {
+                notificationManager.isDailyWeighInReminderEnabled
+            },
+            set: { isEnabled in
+                HapticManager.shared.selection()
+                Task {
+                    let didApply = await notificationManager.setDailyWeighInReminderEnabled(isEnabled)
+                    await MainActor.run {
+                        dailyReminderDate = notificationManager.dailyWeighInReminderDate
+                        if isEnabled && !didApply {
+                            HapticManager.shared.notification(type: .warning)
+                        }
+                    }
+                }
+            }
+        )
     }
 
     private var securitySection: some View {

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -237,6 +237,68 @@ final class PhotoTimelineHUDPolicyTests: XCTestCase {
     }
 }
 
+final class DailyReminderPolicyTests: XCTestCase {
+    func testPromptRequiresGateSubscriptionAndIncompletePrompt() {
+        XCTAssertTrue(
+            DailyReminderPolicy.shouldShowPostPaywallPrompt(
+                featureEnabled: true,
+                isSubscribed: true,
+                hasCompletedPrompt: false
+            )
+        )
+        XCTAssertFalse(
+            DailyReminderPolicy.shouldShowPostPaywallPrompt(
+                featureEnabled: false,
+                isSubscribed: true,
+                hasCompletedPrompt: false
+            )
+        )
+        XCTAssertFalse(
+            DailyReminderPolicy.shouldShowPostPaywallPrompt(
+                featureEnabled: true,
+                isSubscribed: false,
+                hasCompletedPrompt: false
+            )
+        )
+        XCTAssertFalse(
+            DailyReminderPolicy.shouldShowPostPaywallPrompt(
+                featureEnabled: true,
+                isSubscribed: true,
+                hasCompletedPrompt: true
+            )
+        )
+    }
+
+    func testDailyWeighInReminderDefaultsToSevenAM() {
+        XCTAssertEqual(Constants.dailyWeighInReminderFlagKey, "ios_daily_weigh_in_reminders")
+        XCTAssertEqual(DailyReminderPolicy.defaultHour, 7)
+        XCTAssertEqual(DailyReminderPolicy.defaultMinute, 0)
+        XCTAssertEqual(
+            NotificationReminderKind.dailyWeighIn.requestIdentifier,
+            "lyb.notification.daily_weigh_in"
+        )
+    }
+
+    func testReminderTimeNormalizationClampsInvalidValues() {
+        let low = DailyReminderPolicy.normalizedTime(hour: -2, minute: -10)
+        XCTAssertEqual(low.hour, 0)
+        XCTAssertEqual(low.minute, 0)
+
+        let high = DailyReminderPolicy.normalizedTime(hour: 30, minute: 91)
+        XCTAssertEqual(high.hour, 23)
+        XCTAssertEqual(high.minute, 59)
+    }
+
+    func testTriggerComponentsUseNormalizedHourAndMinuteOnly() {
+        let components = DailyReminderPolicy.triggerDateComponents(hour: 26, minute: 75)
+
+        XCTAssertEqual(components.hour, 23)
+        XCTAssertEqual(components.minute, 59)
+        XCTAssertNil(components.day)
+        XCTAssertNil(components.month)
+    }
+}
+
 final class BodyMetricLoggingServiceTests: XCTestCase {
     func testStoredWeightConvertsPoundsToKilograms() {
         let stored = BodyMetricLoggingService.storedWeightInKilograms(


### PR DESCRIPTION
## Linear
- JOV-3134

## Summary
- Add a local notification manager for a daily weigh-in reminder with persisted time, enabled state, and prompt completion.
- Add a gated post-paywall reminder prompt with a time picker and native notification authorization request.
- Add a gated Settings > Reminders row to enable/disable the reminder, adjust the time, and show the iOS Settings fallback after denial.
- Track `notification_permission_granted` with `notification_type=daily_weigh_in` only after authorization is granted.

## Validation
- `swiftlint lint --strict`
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,name=LYB Golden iPhone 16' -only-testing:LogYourBodyTests/DailyReminderPolicyTests test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- XcodeBuildMCP `build_run_sim` on `LYB Golden iPhone 16` with `-lybUITestPaidMVPFixture -lybUITestDailyReminderPromptFixture`
- Simulator prompt screenshot: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_d5d1618c-9ed5-4438-9978-3e5b157f0c48.jpg`
- Native permission alert screenshot: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_7a6b47d0-c8d0-4381-b1e8-d587e6d3ce82.jpg`
- Denied-permission Settings fallback screenshot: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_62057924-c7f8-418a-b3c4-038d9720afb7.jpg`

## Scope Notes
- User-visible surfaces are gated by `ios_daily_weigh_in_reminders`.
- The simulator-only fixture arg is DEBUG-only and only used to exercise the gated flow locally.
- Real TestFlight/App Store notification proof follows the normal post-merge iOS release loop.