### PR TITLE
Fix onboarding default view persistence

### DIFF
--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -149,9 +149,6 @@ final class OnboardingFlowViewModel: ObservableObject {
     private var hasMarkedOnboardingComplete = false
     private let progressStore = OnboardingProgressStore.shared
     private var isRestoringProgress = false
-    private var progressPersistenceWorkItem: DispatchWorkItem?
-    private let persistenceQueue = DispatchQueue(label: "com.logyourbody.onboarding.progressPersistence", qos: .utility)
-    private let persistenceDebounceInterval: TimeInterval = 0.4
 
     private var hasWeightEntry: Bool {
         bodyScoreInput.weight.value != nil
@@ -179,10 +176,12 @@ final class OnboardingFlowViewModel: ObservableObject {
         self.includesFirstPhotoStep = includesFirstPhotoStep
             ?? (entryContext == .authenticated && PhotoTimelineHUDPolicy.shouldShowPhotoTimelineHUD())
 
+        isRestoringProgress = true
         configureMeasurementPreference()
         hydrateHeightFields()
         hydrateWeightFields()
         hydrateDefaultHomeMode()
+        isRestoringProgress = false
 
         if let bodyFat = bodyScoreInput.bodyFat.percentage {
             bodyFatPercentageText = Self.formatNumber(bodyFat)
@@ -1020,7 +1019,6 @@ final class OnboardingFlowViewModel: ObservableObject {
         guard entryContext == .authenticated else { return }
         guard !isRestoringProgress else { return }
         guard !OnboardingStateManager.shared.hasCompletedCurrentVersion else {
-            progressPersistenceWorkItem?.cancel()
             clearPersistedProgress()
             return
         }
@@ -1038,22 +1036,13 @@ final class OnboardingFlowViewModel: ObservableObject {
             manualWeightText: manualWeightText,
             bodyFatPercentageText: bodyFatPercentageText,
             selectedVisualBodyFat: selectedVisualBodyFat,
+            defaultHomeMode: defaultHomeMode,
             didRequestHealthSync: didRequestHealthSync,
             emailAddress: emailAddress,
             lastUpdated: Date()
         )
 
-        progressPersistenceWorkItem?.cancel()
-
-        let pendingWorkItem = DispatchWorkItem { [progressStore] in
-            progressStore.save(snapshot, for: userId)
-        }
-        progressPersistenceWorkItem = pendingWorkItem
-
-        persistenceQueue.asyncAfter(
-            deadline: .now() + persistenceDebounceInterval,
-            execute: pendingWorkItem
-        )
+        progressStore.save(snapshot, for: userId)
     }
 
     private func restorePersistedProgressIfNeeded() {
@@ -1078,6 +1067,7 @@ final class OnboardingFlowViewModel: ObservableObject {
         manualWeightText = snapshot.manualWeightText
         bodyFatPercentageText = snapshot.bodyFatPercentageText
         selectedVisualBodyFat = snapshot.selectedVisualBodyFat
+        defaultHomeMode = snapshot.defaultHomeMode
         didRequestHealthSync = snapshot.didRequestHealthSync
         emailAddress = snapshot.emailAddress
         if hasAuthenticatedAccountEmail,
@@ -1092,7 +1082,6 @@ final class OnboardingFlowViewModel: ObservableObject {
 
     private func clearPersistedProgress() {
         guard entryContext == .authenticated else { return }
-        progressPersistenceWorkItem?.cancel()
         guard let userId = AuthManager.shared.currentUser?.id else { return }
         progressStore.clearProgress(for: userId)
     }
@@ -1154,9 +1143,68 @@ private struct OnboardingProgressSnapshot: Codable {
     let manualWeightText: String
     let bodyFatPercentageText: String
     let selectedVisualBodyFat: Double?
+    let defaultHomeMode: DefaultHomeMode
     let didRequestHealthSync: Bool
     let emailAddress: String
     let lastUpdated: Date
+}
+
+private extension OnboardingProgressSnapshot {
+    enum CodingKeys: String, CodingKey {
+        case version
+        case currentStep
+        case bodyScoreInput
+        case heightUnit
+        case weightUnit
+        case heightCentimetersText
+        case heightFeet
+        case heightInches
+        case manualWeightText
+        case bodyFatPercentageText
+        case selectedVisualBodyFat
+        case defaultHomeMode
+        case didRequestHealthSync
+        case emailAddress
+        case lastUpdated
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decode(Int.self, forKey: .version)
+        currentStep = try container.decode(OnboardingFlowViewModel.Step.self, forKey: .currentStep)
+        bodyScoreInput = try container.decode(BodyScoreInput.self, forKey: .bodyScoreInput)
+        heightUnit = try container.decode(HeightUnit.self, forKey: .heightUnit)
+        weightUnit = try container.decode(WeightUnit.self, forKey: .weightUnit)
+        heightCentimetersText = try container.decode(String.self, forKey: .heightCentimetersText)
+        heightFeet = try container.decode(Int.self, forKey: .heightFeet)
+        heightInches = try container.decode(Int.self, forKey: .heightInches)
+        manualWeightText = try container.decode(String.self, forKey: .manualWeightText)
+        bodyFatPercentageText = try container.decode(String.self, forKey: .bodyFatPercentageText)
+        selectedVisualBodyFat = try container.decodeIfPresent(Double.self, forKey: .selectedVisualBodyFat)
+        defaultHomeMode = try container.decodeIfPresent(DefaultHomeMode.self, forKey: .defaultHomeMode) ?? .default
+        didRequestHealthSync = try container.decode(Bool.self, forKey: .didRequestHealthSync)
+        emailAddress = try container.decode(String.self, forKey: .emailAddress)
+        lastUpdated = try container.decode(Date.self, forKey: .lastUpdated)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        try container.encode(currentStep, forKey: .currentStep)
+        try container.encode(bodyScoreInput, forKey: .bodyScoreInput)
+        try container.encode(heightUnit, forKey: .heightUnit)
+        try container.encode(weightUnit, forKey: .weightUnit)
+        try container.encode(heightCentimetersText, forKey: .heightCentimetersText)
+        try container.encode(heightFeet, forKey: .heightFeet)
+        try container.encode(heightInches, forKey: .heightInches)
+        try container.encode(manualWeightText, forKey: .manualWeightText)
+        try container.encode(bodyFatPercentageText, forKey: .bodyFatPercentageText)
+        try container.encodeIfPresent(selectedVisualBodyFat, forKey: .selectedVisualBodyFat)
+        try container.encode(defaultHomeMode, forKey: .defaultHomeMode)
+        try container.encode(didRequestHealthSync, forKey: .didRequestHealthSync)
+        try container.encode(emailAddress, forKey: .emailAddress)
+        try container.encode(lastUpdated, forKey: .lastUpdated)
+    }
 }
 
 struct OnboardingProfileUpdateBuilder {
@@ -1210,11 +1258,10 @@ final class OnboardingProgressStore {
     }
 
     fileprivate func save(_ snapshot: OnboardingProgressSnapshot, for userId: String) {
-        queue.async { [weak self] in
-            guard let self else { return }
+        queue.sync {
             guard snapshot.version == Self.snapshotVersion else { return }
-            self.snapshots[userId] = snapshot
-            self.persistToDiskLocked()
+            snapshots[userId] = snapshot
+            persistToDiskLocked()
         }
     }
 
@@ -1225,11 +1272,22 @@ final class OnboardingProgressStore {
         }
     }
 
+    #if DEBUG
+    func snapshotForTesting(for userId: String) -> (
+        currentStep: OnboardingFlowViewModel.Step,
+        defaultHomeMode: DefaultHomeMode
+    )? {
+        queue.sync {
+            guard let snapshot = snapshots[userId], snapshot.version == Self.snapshotVersion else { return nil }
+            return (snapshot.currentStep, snapshot.defaultHomeMode)
+        }
+    }
+    #endif
+
     func clearProgress(for userId: String) {
-        queue.async { [weak self] in
-            guard let self else { return }
-            guard self.snapshots.removeValue(forKey: userId) != nil else { return }
-            self.persistToDiskLocked()
+        queue.sync {
+            guard snapshots.removeValue(forKey: userId) != nil else { return }
+            persistToDiskLocked()
         }
     }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -291,73 +291,28 @@ private struct DashboardHomeTimelineAvatarPlaceholder: View {
         AvatarBodyFatCatalog.match(bodyFatPercentage: bodyFatPercentage, gender: gender)
     }
 
-    var body: some View {
-        GeometryReader { geometry in
-            ZStack {
-                Color.black
-
-                LinearGradient(
-                    colors: [
-                        Color.metricAccent.opacity(0.22),
-                        Color.black.opacity(0.15),
-                        Color.metricAccentBodyFat.opacity(0.18)
-                    ],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-
-                timelineGrid
-
-                Image(avatar.assetName)
-                    .resizable()
-                    .interpolation(.high)
-                    .scaledToFit()
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 18)
-                    .frame(width: geometry.size.width, height: geometry.size.height)
-                    .shadow(color: Color.metricAccent.opacity(0.42), radius: 24)
-                    .accessibilityHidden(true)
-
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(mode == .avatar ? "Avatar" : "Avatar fallback")
-                        .font(.system(size: 13, weight: .bold))
-                        .foregroundColor(Color.white.opacity(0.9))
-                        .textCase(.uppercase)
-
-                    Text(avatar.badgeText)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(Color.white.opacity(0.76))
-                }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .background(Color.black.opacity(0.58))
-                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
-                .padding(.leading, 20)
-                .padding(.bottom, 18)
-            }
-        }
-        .accessibilityLabel(avatar.accessibilityLabel)
+    private var accessibilityText: String {
+        mode == .avatar ? avatar.accessibilityLabel : "\(avatar.accessibilityLabel), photo fallback"
     }
 
-    private var timelineGrid: some View {
+    var body: some View {
         GeometryReader { geometry in
-            Path { path in
-                let horizontalSpacing: CGFloat = 34
-                let verticalSpacing: CGFloat = 40
-
-                stride(from: CGFloat(0), through: geometry.size.width, by: horizontalSpacing).forEach { x in
-                    path.move(to: CGPoint(x: x, y: 0))
-                    path.addLine(to: CGPoint(x: x, y: geometry.size.height))
-                }
-
-                stride(from: CGFloat(0), through: geometry.size.height, by: verticalSpacing).forEach { y in
-                    path.move(to: CGPoint(x: 0, y: y))
-                    path.addLine(to: CGPoint(x: geometry.size.width, y: y))
-                }
-            }
-            .stroke(Color.white.opacity(0.045), lineWidth: 1)
+            Image(avatar.assetName)
+                .resizable()
+                .interpolation(.high)
+                .scaledToFill()
+                .frame(
+                    width: max(0, geometry.size.width - 24),
+                    height: max(0, geometry.size.height - 56)
+                )
+                .padding(.top, 42)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 14)
+                .frame(width: geometry.size.width, height: geometry.size.height)
+                .clipped()
+                .accessibilityHidden(true)
         }
+        .accessibilityLabel(accessibilityText)
     }
 }
 

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -1155,6 +1155,46 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentStep, .loading)
     }
 
+    func testPersistedProgressRestoresDefaultHomeModeChoice() {
+        let userId = "onboarding-default-mode-\(UUID().uuidString)"
+        let previousUser = AuthManager.shared.currentUser
+        let previousAuthenticationState = AuthManager.shared.isAuthenticated
+        let previousDefaultHomeMode = UserDefaults.standard.string(forKey: Constants.defaultHomeModeKey)
+
+        defer {
+            AuthManager.shared.currentUser = previousUser
+            AuthManager.shared.isAuthenticated = previousAuthenticationState
+            if let previousDefaultHomeMode {
+                UserDefaults.standard.set(previousDefaultHomeMode, forKey: Constants.defaultHomeModeKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Constants.defaultHomeModeKey)
+            }
+            OnboardingProgressStore.shared.clearProgress(for: userId)
+        }
+
+        AuthManager.shared.currentUser = User(
+            id: userId,
+            email: "default-mode@example.com",
+            name: "Default Mode"
+        )
+        AuthManager.shared.isAuthenticated = true
+        UserDefaults.standard.set(DefaultHomeMode.avatar.rawValue, forKey: Constants.defaultHomeModeKey)
+
+        let viewModel = OnboardingFlowViewModel()
+        viewModel.currentStep = .defaultHomeMode
+        viewModel.updateDefaultHomeMode(.photo)
+
+        let savedSnapshot = OnboardingProgressStore.shared.snapshotForTesting(for: userId)
+        XCTAssertEqual(savedSnapshot?.currentStep, .defaultHomeMode)
+        XCTAssertEqual(savedSnapshot?.defaultHomeMode, .photo)
+
+        UserDefaults.standard.set(DefaultHomeMode.avatar.rawValue, forKey: Constants.defaultHomeModeKey)
+        let restoredViewModel = OnboardingFlowViewModel()
+
+        XCTAssertEqual(restoredViewModel.currentStep, .defaultHomeMode)
+        XCTAssertEqual(restoredViewModel.defaultHomeMode, .photo)
+    }
+
     func testAdvanceAfterHealthConfirmationRequestsBodyFatWhenMissing() {
         let viewModel = OnboardingFlowViewModel()
         viewModel.bodyScoreInput.weight = WeightValue(value: 185, unit: .pounds)


### PR DESCRIPTION
## Summary
- Persist and restore the onboarding default home mode in the resumable onboarding snapshot.
- Suppress initial hydration writes so a fresh view model cannot overwrite saved onboarding progress with the hook step before restore.
- Render the avatar placeholder as a full-width alpha image in the timeline hero, removing the floating label/grid/card treatment.

## Validation
- swiftlint lint --strict
- xcodebuildmcp test_sim -only-testing:LogYourBodyTests/OnboardingFlowViewModelTests -only-testing:LogYourBodyTests/PhotoTimelineHUDPolicyTests (27 passed)
- xcodebuildmcp build_run_sim -lybUITestPhotoTimelineHUDFixture
- xcodebuildmcp screenshot: /var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_a7b027c5-522c-49bd-b10a-b23973672e09.jpg
- pnpm lint
- pnpm typecheck
- pnpm test