### PR TITLE
test: add body composition golden coverage

### DIFF
--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -38,6 +38,160 @@ final class LaunchSurfacePolicyTests: XCTestCase {
     }
 }
 
+final class BodyCompositionMathGoldenTests: XCTestCase {
+    private let calendar = Calendar.current
+
+    func testFFMILeanMassAndFatMassMatchGoldenValues() throws {
+        let ffmi = try XCTUnwrap(UnitConversion.calculateFFMI(
+            weightKg: 80,
+            bodyFatPercentage: 10,
+            heightCm: 177.8
+        ))
+        XCTAssertEqual(ffmi, 22.9, accuracy: 0.05)
+
+        let leanMassKg = try XCTUnwrap(UnitConversion.calculateLeanMass(
+            weightKg: 80,
+            bodyFatPercentage: 10,
+            useMetric: true
+        ))
+        XCTAssertEqual(leanMassKg, 72, accuracy: 0.001)
+
+        let leanMassLbs = try XCTUnwrap(UnitConversion.calculateLeanMass(
+            weightKg: 80,
+            bodyFatPercentage: 10,
+            useMetric: false
+        ))
+        XCTAssertEqual(leanMassLbs, 158.733, accuracy: 0.001)
+
+        let fatMassKg = try XCTUnwrap(UnitConversion.calculateFatMass(
+            weightKg: 80,
+            bodyFatPercentage: 10,
+            useMetric: true
+        ))
+        XCTAssertEqual(fatMassKg, 8, accuracy: 0.001)
+
+        let fatMassLbs = try XCTUnwrap(UnitConversion.calculateFatMass(
+            weightKg: 80,
+            bodyFatPercentage: 10,
+            useMetric: false
+        ))
+        XCTAssertEqual(fatMassLbs, 17.637, accuracy: 0.001)
+    }
+
+    func testBodyCompositionCalculationsRejectInvalidInputsAndKeepExtremeValuesFinite() throws {
+        XCTAssertNil(UnitConversion.calculateFFMI(weightKg: 0, bodyFatPercentage: 10, heightCm: 180))
+        XCTAssertNil(UnitConversion.calculateFFMI(weightKg: 80, bodyFatPercentage: 0, heightCm: 180))
+        XCTAssertNil(UnitConversion.calculateFFMI(weightKg: 80, bodyFatPercentage: 100, heightCm: 180))
+        XCTAssertNil(UnitConversion.calculateFFMI(weightKg: 80, bodyFatPercentage: 10, heightCm: 0))
+
+        let extremeFFMI = try XCTUnwrap(UnitConversion.calculateFFMI(
+            weightKg: 80,
+            bodyFatPercentage: 99.9,
+            heightCm: 180
+        ))
+        XCTAssertTrue(extremeFFMI.isFinite)
+        XCTAssertGreaterThan(extremeFFMI, 0)
+
+        let extremeLeanMass = try XCTUnwrap(UnitConversion.calculateLeanMass(
+            weightKg: 80,
+            bodyFatPercentage: 99.9,
+            useMetric: true
+        ))
+        XCTAssertTrue(extremeLeanMass.isFinite)
+        XCTAssertEqual(extremeLeanMass, 0.08, accuracy: 0.0001)
+    }
+
+    func testWeightConversionsRoundTripWithinHundredth() {
+        for weightKg in [20.0, 80.0, 123.45, 300.0] {
+            let roundTripped = UnitConversion.lbsToKg(UnitConversion.kgToLbs(weightKg))
+            XCTAssertEqual(roundTripped, weightKg, accuracy: 0.01)
+        }
+    }
+
+    func testTrendWeightUsesHandComputedEMAReference() throws {
+        let context = try makeWeightContext([
+            (dayOffset: 0, weight: 100),
+            (dayOffset: 1, weight: 104),
+            (dayOffset: 2, weight: 108)
+        ])
+
+        let dayTwoTrend = try XCTUnwrap(context.trendWeight(for: date(daysAfterStart: 2)))
+
+        XCTAssertEqual(dayTwoTrend.value, 102.8, accuracy: 0.001)
+        XCTAssertFalse(dayTwoTrend.isInterpolated)
+        XCTAssertFalse(dayTwoTrend.isLastKnown)
+        XCTAssertNil(dayTwoTrend.confidenceLevel)
+    }
+
+    func testTrendWeightConfidenceDegradesWithInterpolationGap() throws {
+        let cases: [(gapDays: Int, queryDay: Int, expected: InterpolatedMetric.ConfidenceLevel)] = [
+            (7, 3, .high),
+            (14, 7, .medium),
+            (30, 15, .low)
+        ]
+
+        for testCase in cases {
+            let context = try makeWeightContext([
+                (dayOffset: 0, weight: 100),
+                (dayOffset: testCase.gapDays, weight: 130)
+            ])
+
+            let trend = try XCTUnwrap(context.trendWeight(for: date(daysAfterStart: testCase.queryDay)))
+            XCTAssertTrue(trend.isInterpolated)
+            XCTAssertEqual(trend.confidenceLevel?.rawValue, testCase.expected.rawValue)
+        }
+    }
+
+    func testTrendWeightReturnsNilWhenInterpolationGapExceedsThirtyDays() throws {
+        let context = try makeWeightContext([
+            (dayOffset: 0, weight: 100),
+            (dayOffset: 31, weight: 131)
+        ])
+
+        XCTAssertNil(context.trendWeight(for: date(daysAfterStart: 15)))
+    }
+
+    private func makeWeightContext(
+        _ points: [(dayOffset: Int, weight: Double)]
+    ) throws -> MetricsInterpolationService.WeightInterpolationContext {
+        let metrics = points.map { point in
+            makeMetric(
+                date: date(daysAfterStart: point.dayOffset),
+                weight: point.weight
+            )
+        }
+        return try XCTUnwrap(MetricsInterpolationService.shared.makeWeightInterpolationContext(for: metrics))
+    }
+
+    private func makeMetric(date: Date, weight: Double) -> BodyMetrics {
+        BodyMetrics(
+            id: UUID().uuidString,
+            userId: "body-comp-golden-tests",
+            date: date,
+            weight: weight,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: "manual",
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+
+    private func date(daysAfterStart dayOffset: Int) -> Date {
+        let start = calendar.date(from: DateComponents(
+            year: 2_026,
+            month: 1,
+            day: 1
+        ))!
+        return calendar.date(byAdding: .day, value: dayOffset, to: start)!
+    }
+}
+
 @MainActor
 final class AccountDeletionCleanupServiceTests: XCTestCase {
     private enum TestError: Error, Equatable {


### PR DESCRIPTION
## Summary
- JOV-3157: add golden XCTest coverage for body-composition math values that drive FFMI, lean mass, fat mass, and display units.
- Cover invalid and extreme inputs so zero/100%/bad height/weight stay nil while 99.9% body fat remains finite.
- Add trend-weight EMA tests for hand-computed references, confidence degradation at 7/14/30-day interpolation gaps, and nil behavior beyond the 30-day gap.

## Validation
- `cd apps/ios && swiftlint lint --strict` passed: 0 violations in 261 files.
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/BodyCompositionMathGoldenTests` passed: 6 tests, 0 failures. xcresult: `/Users/timwhite/Library/Developer/XcodeBuildMCP/workspaces/LogYourBody-f25e48b4f67a/result-bundles/test_sim_2026-06-14T08-48-17-893Z_pid40762_5d6ceb5f.xcresult`.
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/BodyCompositionMathGoldenTests -only-testing:LogYourBodyTests/GlobalTimelineServiceTests` passed: 9 tests, 0 failures. xcresult: `/Users/timwhite/Library/Developer/XcodeBuildMCP/workspaces/LogYourBody-f25e48b4f67a/result-bundles/test_sim_2026-06-14T08-49-15-568Z_pid40762_db3b6912.xcresult`.
- `pnpm lint` passed with existing web lint warnings only.
- `pnpm typecheck` passed.
- `pnpm test` passed: 8 turbo tasks successful; web Jest 30 suites / 261 tests passed; shared-lib Vitest 18 tests passed.

## Notes
- Test-only change; no production behavior change and no feature gate needed.