### PR TITLE
fix: preserve pre-auth onboarding home mode

### DIFF
--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -296,7 +296,11 @@ final class OnboardingFlowViewModel: ObservableObject {
 
         if entryContext == .preAuth {
             if let result = bodyScoreResult {
-                PreAuthOnboardingStore.shared.save(input: bodyScoreInput, result: result)
+                PreAuthOnboardingStore.shared.save(
+                    input: bodyScoreInput,
+                    result: result,
+                    defaultHomeMode: defaultHomeMode
+                )
             }
             currentStep = .emailCapture
         } else {
@@ -767,11 +771,13 @@ final class OnboardingFlowViewModel: ObservableObject {
         guard !hasMarkedOnboardingComplete else { return }
         hasMarkedOnboardingComplete = true
         OnboardingStateManager.shared.markCompleted()
+        UserDefaults.standard.set(defaultHomeMode.rawValue, forKey: Constants.defaultHomeModeKey)
         let updates = buildOnboardingProfileUpdates()
         Task {
             await AuthManager.shared.updateProfile(updates)
         }
         clearPersistedProgress()
+        PreAuthOnboardingStore.shared.clear()
 
         if didRequestHealthSync, UserDefaults.standard.bool(forKey: "healthKitSyncEnabled") {
             scheduleDeferredHealthSync()
@@ -1052,10 +1058,16 @@ final class OnboardingFlowViewModel: ObservableObject {
             progressStore.clearProgress(for: userId)
             return
         }
-        guard let snapshot = progressStore.loadProgress(for: userId), snapshot.currentStep != .paywall else {
+
+        if let snapshot = progressStore.loadProgress(for: userId), snapshot.currentStep != .paywall {
+            restore(snapshot)
             return
         }
 
+        restorePreAuthSnapshotIfNeeded(for: userId)
+    }
+
+    private func restore(_ snapshot: OnboardingProgressSnapshot) {
         isRestoringProgress = true
         currentStep = snapshot.currentStep
         bodyScoreInput = snapshot.bodyScoreInput
@@ -1078,6 +1090,24 @@ final class OnboardingFlowViewModel: ObservableObject {
             currentStep = .profileDetails
         }
         isRestoringProgress = false
+    }
+
+    private func restorePreAuthSnapshotIfNeeded(for userId: String) {
+        guard let snapshot = PreAuthOnboardingStore.shared.load() else { return }
+
+        isRestoringProgress = true
+        bodyScoreInput = snapshot.input
+        bodyScoreResult = snapshot.result
+        defaultHomeMode = snapshot.defaultHomeMode
+        if emailAddress.isEmpty {
+            emailAddress = AuthManager.shared.currentUser?.email ?? ""
+        }
+        currentStep = hasAuthenticatedAccountEmail ? .profileDetails : .emailCapture
+        isRestoringProgress = false
+
+        BodyScoreCache.shared.store(snapshot.result, for: userId)
+        persistProgress()
+        PreAuthOnboardingStore.shared.clear()
     }
 
     private func clearPersistedProgress() {

--- a/apps/ios/LogYourBody/Services/PreAuthOnboardingStore.swift
+++ b/apps/ios/LogYourBody/Services/PreAuthOnboardingStore.swift
@@ -11,34 +11,47 @@ final class PreAuthOnboardingStore {
         self.userDefaults = userDefaults
     }
 
-    func save(input: BodyScoreInput, result: BodyScoreResult) {
+    struct StoredSnapshot: Equatable {
+        let input: BodyScoreInput
+        let result: BodyScoreResult
+        let defaultHomeMode: DefaultHomeMode
+    }
+
+    func save(
+        input: BodyScoreInput,
+        result: BodyScoreResult,
+        defaultHomeMode: DefaultHomeMode = .default
+    ) {
         let snapshot = Snapshot(
             input: input,
             result: PreAuthBodyScoreResultCodable(result: result),
+            defaultHomeMode: defaultHomeMode,
             lastUpdated: Date()
         )
 
-        queue.async { [weak self] in
-            guard let self else { return }
+        queue.sync {
             let encoder = JSONEncoder()
             if let data = try? encoder.encode(snapshot) {
-                self.userDefaults.set(data, forKey: self.storageKey)
+                userDefaults.set(data, forKey: storageKey)
             }
         }
     }
 
-    func load() -> (BodyScoreInput, BodyScoreResult)? {
+    func load() -> StoredSnapshot? {
         queue.sync {
             guard let data = userDefaults.data(forKey: storageKey) else { return nil }
             let decoder = JSONDecoder()
             guard let snapshot = try? decoder.decode(Snapshot.self, from: data) else { return nil }
-            return (snapshot.input, snapshot.result.result)
+            return StoredSnapshot(
+                input: snapshot.input,
+                result: snapshot.result.result,
+                defaultHomeMode: snapshot.defaultHomeMode
+            )
         }
     }
 
     func clear() {
-        queue.async { [weak self] in
-            guard let self else { return }
+        queue.sync {
             userDefaults.removeObject(forKey: storageKey)
         }
     }
@@ -46,7 +59,35 @@ final class PreAuthOnboardingStore {
     private struct Snapshot: Codable {
         let input: BodyScoreInput
         let result: PreAuthBodyScoreResultCodable
+        let defaultHomeMode: DefaultHomeMode
         let lastUpdated: Date
+
+        private enum CodingKeys: String, CodingKey {
+            case input
+            case result
+            case defaultHomeMode
+            case lastUpdated
+        }
+
+        init(
+            input: BodyScoreInput,
+            result: PreAuthBodyScoreResultCodable,
+            defaultHomeMode: DefaultHomeMode,
+            lastUpdated: Date
+        ) {
+            self.input = input
+            self.result = result
+            self.defaultHomeMode = defaultHomeMode
+            self.lastUpdated = lastUpdated
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            input = try container.decode(BodyScoreInput.self, forKey: .input)
+            result = try container.decode(PreAuthBodyScoreResultCodable.self, forKey: .result)
+            defaultHomeMode = try container.decodeIfPresent(DefaultHomeMode.self, forKey: .defaultHomeMode) ?? .default
+            lastUpdated = try container.decode(Date.self, forKey: .lastUpdated)
+        }
     }
 }
 

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -1554,6 +1554,69 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         XCTAssertEqual(restoredViewModel.defaultHomeMode, .photo)
     }
 
+    func testAuthenticatedFlowConsumesPreAuthDefaultHomeModeChoice() {
+        let userId = "preauth-default-mode-\(UUID().uuidString)"
+        let previousUser = AuthManager.shared.currentUser
+        let previousAuthenticationState = AuthManager.shared.isAuthenticated
+        let previousDefaultHomeMode = UserDefaults.standard.string(forKey: Constants.defaultHomeModeKey)
+
+        defer {
+            AuthManager.shared.currentUser = previousUser
+            AuthManager.shared.isAuthenticated = previousAuthenticationState
+            if let previousDefaultHomeMode {
+                UserDefaults.standard.set(previousDefaultHomeMode, forKey: Constants.defaultHomeModeKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Constants.defaultHomeModeKey)
+            }
+            OnboardingProgressStore.shared.clearProgress(for: userId)
+            PreAuthOnboardingStore.shared.clear()
+        }
+
+        PreAuthOnboardingStore.shared.clear()
+        AuthManager.shared.currentUser = User(
+            id: userId,
+            email: "preauth-default-mode@example.com",
+            name: "Pre Auth"
+        )
+        AuthManager.shared.isAuthenticated = true
+        UserDefaults.standard.set(DefaultHomeMode.avatar.rawValue, forKey: Constants.defaultHomeModeKey)
+
+        let input = BodyScoreInput(
+            sex: .male,
+            birthYear: 1_990,
+            height: HeightValue(value: 70, unit: .inches),
+            weight: WeightValue(value: 185, unit: .pounds),
+            bodyFat: BodyFatValue(percentage: 18, source: .manualValue)
+        )
+        let result = BodyScoreResult(
+            score: 82,
+            ffmi: 21.4,
+            leanPercentile: 0.72,
+            ffmiStatus: "Strong",
+            targetBodyFat: .init(lowerBound: 10, upperBound: 15, label: "Athletic"),
+            statusTagline: "Strong base"
+        )
+
+        PreAuthOnboardingStore.shared.save(
+            input: input,
+            result: result,
+            defaultHomeMode: .photo
+        )
+
+        let viewModel = OnboardingFlowViewModel()
+
+        XCTAssertEqual(viewModel.currentStep, .profileDetails)
+        XCTAssertEqual(viewModel.bodyScoreInput, input)
+        XCTAssertEqual(viewModel.bodyScoreResult, result)
+        XCTAssertEqual(viewModel.defaultHomeMode, .photo)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: Constants.defaultHomeModeKey), DefaultHomeMode.photo.rawValue)
+
+        let savedSnapshot = OnboardingProgressStore.shared.snapshotForTesting(for: userId)
+        XCTAssertEqual(savedSnapshot?.currentStep, .profileDetails)
+        XCTAssertEqual(savedSnapshot?.defaultHomeMode, .photo)
+        XCTAssertNil(PreAuthOnboardingStore.shared.load())
+    }
+
     func testAdvanceAfterHealthConfirmationRequestsBodyFatWhenMissing() {
         let viewModel = OnboardingFlowViewModel()
         viewModel.bodyScoreInput.weight = WeightValue(value: 185, unit: .pounds)


### PR DESCRIPTION
## Summary

Fixes JOV-3174.

- Carries the selected `defaultHomeMode` through `PreAuthOnboardingStore`.
- Makes pre-auth save/clear synchronous so account creation cannot race the snapshot write.
- Consumes the pre-auth snapshot after authentication, stores the Body Score result for the user, writes the default home mode to `UserDefaults`, and creates a user-specific onboarding progress snapshot for resume.
- Clears the pre-auth snapshot once consumed or when authenticated onboarding completes.

## Validation

- `swiftlint lint --strict`
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/OnboardingFlowViewModelTests` on `LYB Golden iPhone 16`: 22 passed
- XcodeBuildMCP `build_run_sim` on `LYB Golden iPhone 16` with `-lybUITestBodyScoreOnboardingFixture`
- Screenshot evidence: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_c06f08be-07d7-4b08-9354-cacfd040d161.jpg`
- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Notes

This is a regression follow-up to JOV-3162/JOV-3164 from TestFlight validation. The fix is local persistence and handoff only; no feature gates are involved.
