### PR TITLE
JOV-3142: Align onboarding auth surfaces with System B

### DIFF
--- a/apps/ios/LogYourBody/DesignSystem/Atoms/BaseTextField.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Atoms/BaseTextField.swift
@@ -68,7 +68,7 @@ struct BaseTextField: View {
 
     private var effectiveBorderColor: Color {
         if hasError {
-            return .red
+            return .appError
         } else if isFocused {
             return .appPrimary
         } else {
@@ -141,7 +141,7 @@ struct BaseTextField: View {
                     if hasError {
                         Image(systemName: "exclamationmark.circle.fill")
                             .font(.system(size: 18))
-                            .foregroundColor(.red)
+                            .foregroundColor(.appError)
                     }
                 }
             }
@@ -156,7 +156,7 @@ struct BaseTextField: View {
             if let errorMessage = configuration.errorMessage {
                 Text(errorMessage)
                     .font(.caption)
-                    .foregroundColor(.red)
+                    .foregroundColor(.appError)
                     .padding(.horizontal, 4)
             } else if let helperText = configuration.helperText {
                 Text(helperText)

--- a/apps/ios/LogYourBody/DesignSystem/Atoms/DSAuthLink.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Atoms/DSAuthLink.swift
@@ -7,14 +7,17 @@ import SwiftUI
 // MARK: - DSAuthLink Atom
 
 struct DSAuthLink: View {
+    @Environment(\.theme)
+    private var theme
+
     let title: String
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: 15))
-                .foregroundColor(.appTextSecondary)
+                .font(theme.typography.labelMedium)
+                .foregroundColor(theme.colors.primary)
                 .underline()
         }
         .buttonStyle(PlainButtonStyle())
@@ -24,14 +27,17 @@ struct DSAuthLink: View {
 // MARK: - Navigation Link Variant
 
 struct DSAuthNavigationLink<Destination: View>: View {
+    @Environment(\.theme)
+    private var theme
+
     let title: String
     let destination: Destination
 
     var body: some View {
         NavigationLink(destination: destination) {
             Text(title)
-                .font(.system(size: 15))
-                .foregroundColor(.appTextSecondary)
+                .font(theme.typography.labelMedium)
+                .foregroundColor(theme.colors.primary)
                 .underline()
         }
         .buttonStyle(PlainButtonStyle())

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/AuthConsentCheckbox.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/AuthConsentCheckbox.swift
@@ -7,6 +7,9 @@ import SwiftUI
 // MARK: - AuthConsentCheckbox Molecule
 
 struct AuthConsentCheckbox: View {
+    @Environment(\.theme)
+    private var theme
+
     @Binding var isChecked: Bool
     let text: String
     let linkText: String
@@ -35,7 +38,7 @@ struct AuthConsentCheckbox: View {
             Button(action: { isChecked.toggle() }, label: {
                 Image(systemName: isChecked ? "checkmark.square.fill" : "square")
                     .font(.system(size: 20))
-                    .foregroundColor(isChecked ? .appPrimary : .appBorder)
+                    .foregroundColor(isChecked ? theme.colors.primary : theme.colors.border)
             })
             .buttonStyle(PlainButtonStyle())
 
@@ -43,13 +46,13 @@ struct AuthConsentCheckbox: View {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 4) {
                     Text("I agree to the")
-                        .font(.system(size: 14))
-                        .foregroundColor(.appTextSecondary)
+                        .font(theme.typography.bodySmall)
+                        .foregroundColor(theme.colors.textSecondary)
 
                     Button(action: handleLinkTap) {
                         Text(linkText)
-                            .font(.system(size: 14))
-                            .foregroundColor(.appPrimary)
+                            .font(theme.typography.labelMedium)
+                            .foregroundColor(theme.colors.primary)
                             .underline()
                     }
                     .buttonStyle(PlainButtonStyle())
@@ -57,8 +60,8 @@ struct AuthConsentCheckbox: View {
                 .multilineTextAlignment(.leading)
 
                 Text(text)
-                    .font(.system(size: 12))
-                    .foregroundColor(.appTextTertiary)
+                    .font(theme.typography.captionMedium)
+                    .foregroundColor(theme.colors.textTertiary)
                     .multilineTextAlignment(.leading)
             }
 

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/AuthFormField.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/AuthFormField.swift
@@ -7,6 +7,9 @@ import SwiftUI
 // MARK: - AuthFormField Molecule
 
 struct AuthFormField: View {
+    @Environment(\.theme)
+    private var theme
+
     let label: String
     @Binding var text: String
     var placeholder: String = ""
@@ -20,20 +23,29 @@ struct AuthFormField: View {
         VStack(alignment: .leading, spacing: 8) {
             // Label
             Text(label)
-                .font(.system(size: 14))
-                .foregroundColor(.appTextSecondary)
+                .font(theme.typography.captionLarge)
+                .foregroundColor(theme.colors.textSecondary)
 
             // Input Field
             BaseTextField(
                 text: $text,
                 placeholder: placeholder.isEmpty ? label : placeholder,
                 configuration: TextFieldConfiguration(
+                    style: .custom(background: .clear, border: nil),
                     isSecure: isSecure,
-                    showToggle: isSecure
+                    showToggle: isSecure,
+                    cornerRadius: theme.radius.input
                 ),
                 keyboardType: keyboardType,
                 textContentType: textContentType,
                 autocapitalization: autocapitalization
+            )
+            .systemBGlassSurface(
+                cornerRadius: theme.radius.input,
+                tint: theme.colors.text,
+                tintOpacity: 0.03,
+                borderColor: theme.colors.border,
+                borderOpacity: 0.65
             )
             .disabled(isDisabled)
         }

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/AuthHeader.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/AuthHeader.swift
@@ -7,6 +7,9 @@ import SwiftUI
 // MARK: - AuthHeader Molecule
 
 struct AuthHeader: View {
+    @Environment(\.theme)
+    private var theme
+
     let title: String
     let subtitle: String?
 
@@ -18,13 +21,13 @@ struct AuthHeader: View {
     var body: some View {
         VStack(spacing: 12) {
             Text(title)
-                .font(.system(size: 36, weight: .bold, design: .default))
-                .foregroundColor(.appText)
+                .font(theme.typography.displayMedium)
+                .foregroundColor(theme.colors.text)
 
             if let subtitle = subtitle {
                 Text(subtitle)
-                    .font(.system(size: 16))
-                    .foregroundColor(.appTextSecondary)
+                    .font(theme.typography.bodyMedium)
+                    .foregroundColor(theme.colors.textSecondary)
                     .multilineTextAlignment(.center)
             }
         }

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/DSAuthDivider.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/DSAuthDivider.swift
@@ -7,6 +7,9 @@ import SwiftUI
 // MARK: - DSAuthDivider Molecule
 
 struct DSAuthDivider: View {
+    @Environment(\.theme)
+    private var theme
+
     let text: String
 
     init(text: String = "or") {
@@ -16,15 +19,15 @@ struct DSAuthDivider: View {
     var body: some View {
         HStack(spacing: 16) {
             Rectangle()
-                .fill(Color.appBorder)
+                .fill(theme.colors.border)
                 .frame(height: 1)
 
             Text(text)
-                .font(.system(size: 14))
-                .foregroundColor(.appTextSecondary)
+                .font(theme.typography.captionLarge)
+                .foregroundColor(theme.colors.textSecondary)
 
             Rectangle()
-                .fill(Color.appBorder)
+                .fill(theme.colors.border)
                 .frame(height: 1)
         }
         .padding(.vertical, 20)

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/SocialLoginButton.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/SocialLoginButton.swift
@@ -7,6 +7,9 @@ import SwiftUI
 // MARK: - SocialLoginButton Molecule
 
 struct SocialLoginButton: View {
+    @Environment(\.theme)
+    private var theme
+
     enum Provider {
         case apple
         case google
@@ -36,12 +39,10 @@ struct SocialLoginButton: View {
 
         var backgroundColor: Color {
             switch self {
-            case .apple:
-                return Color.metricSurface
-            case .google:
-                return Color.metricSurface
+            case .apple, .google:
+                return .clear
             case .facebook:
-                return Color(red: 0.258, green: 0.406, blue: 0.697)
+                return .appPrimary
             }
         }
 
@@ -57,7 +58,7 @@ struct SocialLoginButton: View {
         var borderColor: Color {
             switch self {
             case .apple, .google:
-                return Color.white.opacity(0.14)
+                return Color.appBorder
             case .facebook:
                 return Color.clear
             }
@@ -103,9 +104,13 @@ struct SocialLoginButton: View {
             ),
             action: action
         )
-        .overlay(
-            RoundedRectangle(cornerRadius: 9_999, style: .continuous)
-                .stroke(provider.borderColor, lineWidth: provider.borderWidth)
+        .systemBGlassSurface(
+            cornerRadius: theme.radius.button,
+            tint: theme.colors.text,
+            tintOpacity: 0.035,
+            borderColor: provider.borderColor,
+            borderOpacity: 0.75,
+            borderWidth: provider.borderWidth
         )
     }
 }

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/LoginForm.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/LoginForm.swift
@@ -7,6 +7,9 @@ import SwiftUI
 // MARK: - LoginForm Organism
 
 struct LoginForm: View {
+    @Environment(\.theme)
+    private var theme
+
     @Binding var email: String
     @Binding var isLoading: Bool
 
@@ -42,14 +45,14 @@ struct LoginForm: View {
             }
 
             Text("We'll email you a one-time code to sign you in.")
-                .font(.system(size: 13))
-                .foregroundColor(.appTextSecondary)
+                .font(theme.typography.captionLarge)
+                .foregroundColor(theme.colors.textSecondary)
 
             // Login Button
             BaseButton(
                 "Email me a code",
                 configuration: ButtonConfiguration(
-                    style: .custom(background: .appCard, foreground: .appText),
+                    style: .custom(background: theme.colors.text, foreground: theme.colors.background),
                     isLoading: isLoading,
                     isEnabled: isFormValid,
                     fullWidth: true,

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/SignUpForm.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/SignUpForm.swift
@@ -7,6 +7,9 @@ import SwiftUI
 // MARK: - SignUpForm Organism
 
 struct SignUpForm: View {
+    @Environment(\.theme)
+    private var theme
+
     @Binding var email: String
     @Binding var isLoading: Bool
     @Binding var agreedToTerms: Bool
@@ -78,7 +81,7 @@ struct SignUpForm: View {
             BaseButton(
                 "Create Account",
                 configuration: ButtonConfiguration(
-                    style: .custom(background: .white, foreground: .black),
+                    style: .custom(background: theme.colors.text, foreground: theme.colors.background),
                     isLoading: isLoading,
                     isEnabled: isFormValid,
                     fullWidth: true

--- a/apps/ios/LogYourBody/DesignSystem/Theme.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Theme.swift
@@ -307,6 +307,32 @@ extension View {
     func surfaceStyle() -> some View {
         self.modifier(SurfaceStyleModifier())
     }
+
+    func systemBGlassSurface(
+        cornerRadius: CGFloat? = nil,
+        tint: Color = .white,
+        tintOpacity: Double = 0.035,
+        borderColor: Color? = nil,
+        borderOpacity: Double = 1,
+        borderWidth: CGFloat = 1,
+        shadowOpacity: Double = 0,
+        shadowRadius: CGFloat = 0,
+        shadowY: CGFloat = 0
+    ) -> some View {
+        modifier(
+            SystemBGlassSurfaceModifier(
+                cornerRadius: cornerRadius,
+                tint: tint,
+                tintOpacity: tintOpacity,
+                borderColor: borderColor,
+                borderOpacity: borderOpacity,
+                borderWidth: borderWidth,
+                shadowOpacity: shadowOpacity,
+                shadowRadius: shadowRadius,
+                shadowY: shadowY
+            )
+        )
+    }
 }
 
 // MARK: - Common View Modifiers
@@ -334,6 +360,49 @@ struct SurfaceStyleModifier: ViewModifier {
         content
             .background(theme.colors.surface)
             .cornerRadius(theme.radius.md)
+    }
+}
+
+private struct SystemBGlassSurfaceModifier: ViewModifier {
+    @Environment(\.theme)
+    private var theme
+
+    let cornerRadius: CGFloat?
+    let tint: Color
+    let tintOpacity: Double
+    let borderColor: Color?
+    let borderOpacity: Double
+    let borderWidth: CGFloat
+    let shadowOpacity: Double
+    let shadowRadius: CGFloat
+    let shadowY: CGFloat
+
+    func body(content: Content) -> some View {
+        let radius = cornerRadius ?? theme.radius.card
+        let shape = RoundedRectangle(cornerRadius: radius, style: .continuous)
+
+        content
+            .background(
+                shape
+                    .fill(theme.materials.glassUltraThin)
+                    .overlay(
+                        shape
+                            .fill(tint.opacity(tintOpacity))
+                    )
+            )
+            .overlay(
+                shape
+                    .stroke(
+                        (borderColor ?? theme.colors.border).opacity(borderOpacity),
+                        lineWidth: borderWidth
+                    )
+            )
+            .shadow(
+                color: Color.black.opacity(shadowOpacity),
+                radius: shadowRadius,
+                x: 0,
+                y: shadowY
+            )
     }
 }
 

--- a/apps/ios/LogYourBody/Extensions/Color+Theme.swift
+++ b/apps/ios/LogYourBody/Extensions/Color+Theme.swift
@@ -68,6 +68,10 @@ public extension Color {
     static let appTextTertiary = linearTextTertiary
     static let appDisabled = linearDisabled
     static let appDisabledText = linearDisabledText
+    static let appSuccess = success
+    static let appWarning = warning
+    static let appError = error
+    static let appInfo = appPrimary
 }
 
 // MARK: - Hex Color Extension

--- a/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingAtoms.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingAtoms.swift
@@ -3,45 +3,56 @@ import SwiftUI
 // MARK: - Typography Tokens
 
 enum OnboardingTypography {
-    static var title: Font { .system(.title2, design: .rounded).weight(.semibold) }
-    static var headline: Font { .system(.title3, design: .rounded).weight(.semibold) }
-    static var body: Font { .system(.body, design: .rounded) }
-    static var caption: Font { .system(.footnote, design: .rounded) }
+    private static let theme = DefaultTheme()
+
+    static var title: Font { theme.typography.headlineMedium }
+    static var headline: Font { theme.typography.headlineSmall }
+    static var body: Font { theme.typography.bodyMedium }
+    static var caption: Font { theme.typography.captionLarge }
 }
 
 struct OnboardingTitleText: View {
+    @Environment(\.theme)
+    private var theme
+
     let text: String
     var alignment: TextAlignment = .center
 
     var body: some View {
         Text(text)
-            .font(OnboardingTypography.title)
+            .font(theme.typography.headlineMedium)
             .multilineTextAlignment(alignment)
-            .foregroundStyle(Color.appText)
+            .foregroundStyle(theme.colors.text)
             .accessibilityAddTraits(.isHeader)
     }
 }
 
 struct OnboardingSubtitleText: View {
+    @Environment(\.theme)
+    private var theme
+
     let text: String
     var alignment: TextAlignment = .center
 
     var body: some View {
         Text(text)
-            .font(OnboardingTypography.body)
-            .foregroundStyle(Color.appTextSecondary)
+            .font(theme.typography.bodyMedium)
+            .foregroundStyle(theme.colors.textSecondary)
             .multilineTextAlignment(alignment)
     }
 }
 
 struct OnboardingCaptionText: View {
+    @Environment(\.theme)
+    private var theme
+
     let text: String
     var alignment: TextAlignment = .center
 
     var body: some View {
         Text(text)
-            .font(OnboardingTypography.caption)
-            .foregroundStyle(Color.appTextTertiary)
+            .font(theme.typography.captionLarge)
+            .foregroundStyle(theme.colors.textTertiary)
             .multilineTextAlignment(alignment)
     }
 }
@@ -49,25 +60,28 @@ struct OnboardingCaptionText: View {
 // MARK: - Buttons
 
 struct OnboardingPrimaryButtonStyle: ButtonStyle {
+    @Environment(\.theme)
+    private var theme
+
     @Environment(\.isEnabled) private var isEnabled
 
     func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
-            .font(.system(.headline, design: .rounded))
+            .font(theme.typography.labelLarge)
             .frame(maxWidth: .infinity)
             .frame(minHeight: 56)
             .padding(.vertical, 2)
-            .foregroundStyle(isEnabled ? Color.black : Color.black.opacity(0.55))
+            .foregroundStyle(isEnabled ? theme.colors.background : theme.colors.background.opacity(0.55))
             .background(
                 Capsule(style: .continuous)
-                    .fill(Color.white.opacity(buttonOpacity(isPressed: configuration.isPressed)))
+                    .fill(theme.colors.text.opacity(buttonOpacity(isPressed: configuration.isPressed)))
             )
             .overlay(
                 Capsule(style: .continuous)
-                    .stroke(Color.white.opacity(0.16))
+                    .stroke(theme.colors.text.opacity(0.16))
             )
             .opacity(configuration.isPressed ? 0.85 : 1)
-            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+            .animation(theme.animation.fast, value: configuration.isPressed)
     }
 
     private func buttonOpacity(isPressed: Bool) -> Double {
@@ -77,34 +91,38 @@ struct OnboardingPrimaryButtonStyle: ButtonStyle {
 }
 
 struct OnboardingSecondaryButtonStyle: ButtonStyle {
+    @Environment(\.theme)
+    private var theme
+
     func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
-            .font(.system(.body, design: .rounded))
+            .font(theme.typography.labelLarge)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 14)
-            .foregroundStyle(Color.appText)
-            .background(
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .opacity(configuration.isPressed ? 0.7 : 1)
+            .foregroundStyle(theme.colors.text)
+            .systemBGlassSurface(
+                cornerRadius: theme.radius.button,
+                tint: theme.colors.text,
+                tintOpacity: configuration.isPressed ? 0.05 : 0.035,
+                borderColor: theme.colors.border,
+                borderOpacity: 0.65
             )
-            .overlay(
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(Color.appBorder.opacity(0.5))
-            )
-            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+            .animation(theme.animation.fast, value: configuration.isPressed)
     }
 }
 
 struct OnboardingTextButton: View {
+    @Environment(\.theme)
+    private var theme
+
     let title: String
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(.footnote, design: .rounded).weight(.medium))
-                .foregroundStyle(Color.appPrimary)
+                .font(theme.typography.labelMedium)
+                .foregroundStyle(theme.colors.primary)
                 .padding(.vertical, 8)
         }
     }
@@ -119,22 +137,25 @@ struct OnboardingBulletItem: Identifiable, Hashable {
 }
 
 struct OnboardingIconBullet: View {
+    @Environment(\.theme)
+    private var theme
+
     let item: OnboardingBulletItem
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: item.iconName)
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(Color.appPrimary)
+                .foregroundStyle(theme.colors.primary)
                 .frame(width: 24, height: 24)
                 .background(
                     Circle()
-                        .fill(Color.appPrimary.opacity(0.15))
+                        .fill(theme.colors.primary.opacity(0.15))
                 )
 
             Text(item.text)
-                .font(OnboardingTypography.body)
-                .foregroundStyle(Color.appText)
+                .font(theme.typography.bodyMedium)
+                .foregroundStyle(theme.colors.text)
                 .multilineTextAlignment(.leading)
         }
         .padding(.vertical, 4)
@@ -142,22 +163,28 @@ struct OnboardingIconBullet: View {
 }
 
 struct OnboardingBadge: View {
+    @Environment(\.theme)
+    private var theme
+
     let text: String
 
     var body: some View {
         Text(text.uppercased())
-            .font(.system(.caption2, design: .rounded).weight(.medium))
-            .foregroundStyle(Color.appPrimary)
+            .font(theme.typography.labelSmall)
+            .foregroundStyle(theme.colors.primary)
             .padding(.horizontal, 10)
             .padding(.vertical, 4)
             .background(
                 Capsule(style: .continuous)
-                    .fill(Color.appPrimary.opacity(0.12))
+                    .fill(theme.colors.primary.opacity(0.12))
             )
     }
 }
 
 struct OnboardingCard<Content: View>: View {
+    @Environment(\.theme)
+    private var theme
+
     let content: Content
 
     init(@ViewBuilder content: () -> Content) {
@@ -167,14 +194,15 @@ struct OnboardingCard<Content: View>: View {
     var body: some View {
         content
             .padding(20)
-            .background(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .shadow(color: Color.black.opacity(0.18), radius: 14, x: 0, y: 8)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .stroke(Color.white.opacity(0.06))
+            .systemBGlassSurface(
+                cornerRadius: 20,
+                tint: theme.colors.text,
+                tintOpacity: 0.04,
+                borderColor: theme.colors.border,
+                borderOpacity: 0.7,
+                shadowOpacity: 0.18,
+                shadowRadius: 14,
+                shadowY: 8
             )
     }
 }
@@ -182,19 +210,22 @@ struct OnboardingCard<Content: View>: View {
 // MARK: - FFMI Helper
 
 struct FFMIInfoContent: View {
+    @Environment(\.theme)
+    private var theme
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("What's FFMI?")
-                .font(OnboardingTypography.headline)
-                .foregroundStyle(Color.appText)
+                .font(theme.typography.headlineSmall)
+                .foregroundStyle(theme.colors.text)
 
             Text("Fat-Free Mass Index compares your lean mass to your height, so bigger frames don’t get penalized.")
-                .font(OnboardingTypography.body)
-                .foregroundStyle(Color.appTextSecondary)
+                .font(theme.typography.bodyMedium)
+                .foregroundStyle(theme.colors.textSecondary)
 
             Text("We pair FFMI with body fat and percentile bands to surface your Body Score and coaching cues.")
-                .font(OnboardingTypography.body)
-                .foregroundStyle(Color.appTextSecondary)
+                .font(theme.typography.bodyMedium)
+                .foregroundStyle(theme.colors.textSecondary)
         }
     }
 }

--- a/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingMolecules.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingMolecules.swift
@@ -17,6 +17,9 @@ struct OnboardingBulletList: View {
 // MARK: - Option Buttons
 
 struct OnboardingOptionButton: View {
+    @Environment(\.theme)
+    private var theme
+
     let title: String
     let subtitle: String?
     let isSelected: Bool
@@ -28,7 +31,7 @@ struct OnboardingOptionButton: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(title)
                         .font(OnboardingTypography.headline)
-                        .foregroundStyle(Color.appText)
+                        .foregroundStyle(theme.colors.text)
                         .multilineTextAlignment(.leading)
                         .lineLimit(1)
                         .minimumScaleFactor(0.75)
@@ -38,7 +41,7 @@ struct OnboardingOptionButton: View {
                     if let subtitle {
                         Text(subtitle)
                             .font(OnboardingTypography.caption)
-                            .foregroundStyle(Color.appTextSecondary)
+                            .foregroundStyle(theme.colors.textSecondary)
                     }
                 }
 
@@ -46,16 +49,16 @@ struct OnboardingOptionButton: View {
 
                 Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
                     .font(.system(size: 22, weight: .semibold))
-                    .foregroundStyle(isSelected ? Color.appPrimary : Color.appTextSecondary.opacity(0.6))
+                    .foregroundStyle(isSelected ? theme.colors.primary : theme.colors.textSecondary.opacity(0.6))
             }
             .padding(20)
-            .background(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .fill(isSelected ? Color.appPrimary.opacity(0.18) : Color.appCard.opacity(0.7))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 20, style: .continuous)
-                            .stroke(isSelected ? Color.appPrimary : Color.appBorder.opacity(0.6), lineWidth: isSelected ? 2 : 1)
-                    )
+            .systemBGlassSurface(
+                cornerRadius: 20,
+                tint: isSelected ? theme.colors.primary : theme.colors.text,
+                tintOpacity: isSelected ? 0.16 : 0.035,
+                borderColor: isSelected ? theme.colors.primary : theme.colors.border,
+                borderOpacity: isSelected ? 0.85 : 0.65,
+                borderWidth: isSelected ? 2 : 1
             )
         })
         .buttonStyle(.plain)
@@ -65,6 +68,9 @@ struct OnboardingOptionButton: View {
 // MARK: - Segmented Control
 
 struct OnboardingSegmentedControl<Option: Hashable & CustomStringConvertible>: View {
+    @Environment(\.theme)
+    private var theme
+
     let options: [Option]
     @Binding var selection: Option
 
@@ -73,43 +79,48 @@ struct OnboardingSegmentedControl<Option: Hashable & CustomStringConvertible>: V
             ForEach(options, id: \.self) { option in
                 Button(action: { selection = option }, label: {
                     Text(option.description)
-                        .font(.system(.callout, design: .rounded).weight(.medium))
+                        .font(theme.typography.labelMedium)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 10)
-                        .foregroundStyle(selection == option ? Color.white : Color.appText)
-                        .background(
-                            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                .fill(selection == option ? Color.appPrimary : Color.appCard.opacity(0.7))
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                .stroke(selection == option ? Color.appPrimary : Color.appBorder.opacity(0.6))
+                        .foregroundStyle(selection == option ? theme.colors.text : theme.colors.textSecondary)
+                        .systemBGlassSurface(
+                            cornerRadius: 14,
+                            tint: selection == option ? theme.colors.primary : theme.colors.text,
+                            tintOpacity: selection == option ? 0.28 : 0.02,
+                            borderColor: selection == option ? theme.colors.primary : theme.colors.border,
+                            borderOpacity: selection == option ? 0.9 : 0.5
                         )
                 })
                 .buttonStyle(.plain)
             }
         }
         .padding(4)
-        .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(Color.appCard.opacity(0.4))
+        .systemBGlassSurface(
+            cornerRadius: 18,
+            tint: theme.colors.text,
+            tintOpacity: 0.02,
+            borderColor: theme.colors.border,
+            borderOpacity: 0.45
         )
     }
 }
 
 struct OnboardingInfoRow: View {
+    @Environment(\.theme)
+    private var theme
+
     let text: String
 
     var body: some View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: "questionmark.circle")
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(Color.appTextSecondary)
+                .foregroundStyle(theme.colors.textSecondary)
                 .padding(.top, 2)
 
             Text(text)
                 .font(OnboardingTypography.caption)
-                .foregroundStyle(Color.appTextSecondary)
+                .foregroundStyle(theme.colors.textSecondary)
                 .multilineTextAlignment(.leading)
         }
     }
@@ -118,6 +129,9 @@ struct OnboardingInfoRow: View {
 // MARK: - Input Rows
 
 struct OnboardingTextFieldRow: View {
+    @Environment(\.theme)
+    private var theme
+
     let title: String
     let placeholder: String
     @Binding var text: String
@@ -129,7 +143,7 @@ struct OnboardingTextFieldRow: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
                 .font(OnboardingTypography.caption)
-                .foregroundStyle(Color.appTextSecondary)
+                .foregroundStyle(theme.colors.textSecondary)
 
             TextField(placeholder, text: $text)
                 .keyboardType(keyboardType)
@@ -138,19 +152,21 @@ struct OnboardingTextFieldRow: View {
                 .focused($isFocused)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 12)
-                .background(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .fill(Color.appCard.opacity(0.6))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .stroke(isFocused ? Color.appPrimary : Color.appBorder.opacity(0.6), lineWidth: 1)
+                .systemBGlassSurface(
+                    cornerRadius: theme.radius.input,
+                    tint: isFocused ? theme.colors.primary : theme.colors.text,
+                    tintOpacity: isFocused ? 0.07 : 0.03,
+                    borderColor: isFocused ? theme.colors.primary : theme.colors.border,
+                    borderOpacity: isFocused ? 0.9 : 0.65
                 )
         }
     }
 }
 
 struct OnboardingValueRow: View {
+    @Environment(\.theme)
+    private var theme
+
     let label: String
     let value: String
     let helper: String?
@@ -161,17 +177,17 @@ struct OnboardingValueRow: View {
         HStack(alignment: .top, spacing: 16) {
             VStack(alignment: .leading, spacing: 6) {
                 Text(label.uppercased())
-                    .font(.system(.caption2, design: .rounded).weight(.medium))
-                    .foregroundStyle(Color.appTextSecondary)
+                    .font(theme.typography.labelSmall)
+                    .foregroundStyle(theme.colors.textSecondary)
 
                 Text(value)
-                    .font(.system(.title3, design: .rounded).weight(.semibold))
-                    .foregroundStyle(Color.appText)
+                    .font(theme.typography.headlineSmall)
+                    .foregroundStyle(theme.colors.text)
 
                 if let helper {
                     Text(helper)
                         .font(OnboardingTypography.caption)
-                        .foregroundStyle(Color.appTextTertiary)
+                        .foregroundStyle(theme.colors.textTertiary)
                 }
             }
 
@@ -180,20 +196,19 @@ struct OnboardingValueRow: View {
             if let actionTitle, let action {
                 Button(action: action, label: {
                     Text(actionTitle)
-                        .font(.system(.callout, design: .rounded).weight(.medium))
-                        .foregroundStyle(Color.appPrimary)
+                        .font(theme.typography.labelMedium)
+                        .foregroundStyle(theme.colors.primary)
                 })
                 .buttonStyle(.plain)
             }
         }
         .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(.ultraThinMaterial)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(Color.appBorder.opacity(0.4))
+        .systemBGlassSurface(
+            cornerRadius: 20,
+            tint: theme.colors.text,
+            tintOpacity: 0.035,
+            borderColor: theme.colors.border,
+            borderOpacity: 0.55
         )
     }
 }
@@ -201,6 +216,9 @@ struct OnboardingValueRow: View {
 // MARK: - Form Section Wrapper
 
 struct OnboardingFormSection<Content: View>: View {
+    @Environment(\.theme)
+    private var theme
+
     let title: String?
     let caption: String?
     let content: Content
@@ -216,26 +234,25 @@ struct OnboardingFormSection<Content: View>: View {
             if let title {
                 Text(title)
                     .font(OnboardingTypography.headline)
-                    .foregroundStyle(Color.appText)
+                    .foregroundStyle(theme.colors.text)
             }
 
             if let caption {
                 Text(caption)
                     .font(OnboardingTypography.caption)
-                    .foregroundStyle(Color.appTextSecondary)
+                    .foregroundStyle(theme.colors.textSecondary)
             }
 
             VStack(spacing: 16) {
                 content
             }
             .padding(20)
-            .background(
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .fill(.ultraThinMaterial)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .stroke(Color.white.opacity(0.08))
+            .systemBGlassSurface(
+                cornerRadius: 24,
+                tint: theme.colors.text,
+                tintOpacity: 0.035,
+                borderColor: theme.colors.border,
+                borderOpacity: 0.6
             )
         }
     }
@@ -244,21 +261,24 @@ struct OnboardingFormSection<Content: View>: View {
 // MARK: - Progress Indicator
 
 struct OnboardingProgressIndicator: View {
+    @Environment(\.theme)
+    private var theme
+
     let context: OnboardingFlowViewModel.ProgressContext
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Step \(context.currentIndex) of \(context.totalCount)")
-                .font(.system(.caption, design: .rounded).weight(.medium))
-                .foregroundStyle(Color.appTextSecondary)
+                .font(theme.typography.labelSmall)
+                .foregroundStyle(theme.colors.textSecondary)
 
             GeometryReader { geometry in
                 ZStack(alignment: .leading) {
                     Capsule()
-                        .fill(Color.appCard.opacity(0.45))
+                        .fill(theme.colors.surfaceTertiary.opacity(0.55))
 
                     Capsule()
-                        .fill(Color.appPrimary)
+                        .fill(theme.colors.primary)
                         .frame(
                             width: min(
                                 max(geometry.size.width * context.fractionComplete, 12),
@@ -275,6 +295,9 @@ struct OnboardingProgressIndicator: View {
 // MARK: - Page Template
 
 struct OnboardingScaffold<Content: View, CTA: View>: View {
+    @Environment(\.theme)
+    private var theme
+
     let showsCTA: Bool
     let content: Content
     let cta: CTA
@@ -291,7 +314,11 @@ struct OnboardingScaffold<Content: View, CTA: View>: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [Color.appBackground, Color.black], startPoint: .topLeading, endPoint: .bottomTrailing)
+            LinearGradient(
+                colors: [theme.colors.background, theme.colors.backgroundSecondary],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
                 .ignoresSafeArea()
 
             ScrollView {
@@ -314,7 +341,7 @@ struct OnboardingScaffold<Content: View, CTA: View>: View {
     private var ctaContainer: some View {
         VStack(spacing: 0) {
             Rectangle()
-                .fill(Color.white.opacity(0.08))
+                .fill(theme.colors.text.opacity(0.08))
                 .frame(height: 1)
 
             cta
@@ -323,7 +350,7 @@ struct OnboardingScaffold<Content: View, CTA: View>: View {
                 .padding(.bottom, 12)
         }
         .background(
-            Color.appBackground
+            theme.colors.background
                 .opacity(0.96)
                 .ignoresSafeArea(edges: .bottom)
         )
@@ -331,6 +358,9 @@ struct OnboardingScaffold<Content: View, CTA: View>: View {
 }
 
 struct OnboardingPageTemplate<Content: View, Footer: View>: View {
+    @Environment(\.theme)
+    private var theme
+
     let title: String
     let subtitle: String?
     var showsBackButton: Bool
@@ -384,11 +414,14 @@ struct OnboardingPageTemplate<Content: View, Footer: View>: View {
                 }, label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .semibold))
-                        .foregroundStyle(Color.appText)
+                        .foregroundStyle(theme.colors.text)
                         .padding(10)
-                        .background(
-                            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                .fill(Color.white.opacity(0.08))
+                        .systemBGlassSurface(
+                            cornerRadius: 14,
+                            tint: theme.colors.text,
+                            tintOpacity: 0.05,
+                            borderColor: theme.colors.border,
+                            borderOpacity: 0.5
                         )
                 })
                 .buttonStyle(.plain)

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreAccountCreationView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreAccountCreationView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct BodyScoreAccountCreationView: View {
+    @Environment(\.theme)
+    private var theme
+
     @EnvironmentObject var authManager: AuthManager
     @ObservedObject var viewModel: OnboardingFlowViewModel
 
@@ -28,11 +31,11 @@ struct BodyScoreAccountCreationView: View {
                     if viewModel.isCreatingAccount {
                         VStack(spacing: 8) {
                             ProgressView()
-                                .progressViewStyle(CircularProgressViewStyle(tint: .black))
+                                .progressViewStyle(CircularProgressViewStyle(tint: theme.colors.background))
                             if let status = viewModel.accountCreationStatusMessage {
                                 Text(status)
                                     .font(OnboardingTypography.caption)
-                                    .foregroundStyle(Color.black.opacity(0.65))
+                                    .foregroundStyle(theme.colors.background.opacity(0.65))
                             }
                         }
                     } else {
@@ -47,7 +50,7 @@ struct BodyScoreAccountCreationView: View {
                 if let error = viewModel.accountCreationError {
                     Text(error)
                         .font(OnboardingTypography.caption)
-                        .foregroundStyle(Color.red)
+                        .foregroundStyle(theme.colors.error)
                         .multilineTextAlignment(.center)
                         .padding(.top, 8)
                 }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatChoiceView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatChoiceView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct BodyScoreBodyFatChoiceView: View {
+    @Environment(\.theme)
+    private var theme
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
 
     private let options: [(title: String, subtitle: String, source: BodyFatInputSource, icon: String)] = [
@@ -43,13 +46,12 @@ struct BodyScoreBodyFatChoiceView: View {
                                     .foregroundStyle(Color.appTextSecondary)
                             }
                             .padding(20)
-                            .background(
-                                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                                    .fill(Color.appCard.opacity(0.6))
-                            )
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                                    .stroke(Color.appBorder.opacity(0.4))
+                            .systemBGlassSurface(
+                                cornerRadius: 24,
+                                tint: theme.colors.text,
+                                tintOpacity: 0.035,
+                                borderColor: theme.colors.border,
+                                borderOpacity: 0.6
                             )
                         }
                         .buttonStyle(.plain)
@@ -64,7 +66,7 @@ struct BodyScoreBodyFatChoiceView: View {
                     if let error = viewModel.errorMessage {
                         Text(error)
                             .font(OnboardingTypography.caption)
-                            .foregroundStyle(Color.red)
+                            .foregroundStyle(theme.colors.error)
                             .multilineTextAlignment(.center)
                             .frame(maxWidth: .infinity)
                     }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatNumericView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatNumericView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct BodyScoreBodyFatNumericView: View {
+    @Environment(\.theme)
+    private var theme
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @FocusState private var percentageFieldFocused: Bool
     @State private var bodyFatError: String?
@@ -34,19 +37,18 @@ struct BodyScoreBodyFatNumericView: View {
                         }
                         .padding(.horizontal, 20)
                         .padding(.vertical, 16)
-                        .background(
-                            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                .fill(Color.appCard.opacity(0.65))
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                .stroke(percentageFieldStrokeColor)
+                        .systemBGlassSurface(
+                            cornerRadius: 20,
+                            tint: percentageFieldFocused ? theme.colors.primary : theme.colors.text,
+                            tintOpacity: percentageFieldFocused ? 0.07 : 0.03,
+                            borderColor: percentageFieldStrokeColor,
+                            borderOpacity: 1
                         )
 
                         if let error = bodyFatError {
                             Text(error)
                                 .font(OnboardingTypography.caption)
-                                .foregroundStyle(Color.red)
+                                .foregroundStyle(theme.colors.error)
                         } else {
                             OnboardingCaptionText(
                                 text: "Most people fall between 4–60% body fat.",

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreEmailCaptureView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreEmailCaptureView.swift
@@ -32,7 +32,7 @@ struct BodyScoreEmailCaptureView: View {
                         if let error = emailError {
                             Text(error)
                                 .font(OnboardingTypography.caption)
-                                .foregroundStyle(Color.red)
+                                .foregroundStyle(Color.appError)
                         } else {
                             Button {
                                 withAnimation(.easeInOut(duration: 0.2)) {

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct BodyScoreFirstProgressPhotoView: View {
+    @Environment(\.theme)
+    private var theme
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @EnvironmentObject private var authManager: AuthManager
     @State private var isAttachSheetPresented = false
@@ -39,7 +42,7 @@ struct BodyScoreFirstProgressPhotoView: View {
         VStack(alignment: .leading, spacing: 16) {
             Image(systemName: "camera.metering.center.weighted")
                 .font(.system(size: 34, weight: .semibold))
-                .foregroundStyle(Color.white.opacity(0.82))
+                .foregroundStyle(theme.colors.text.opacity(0.82))
 
             VStack(alignment: .leading, spacing: 6) {
                 Text("Photos make the timeline useful.")
@@ -67,13 +70,15 @@ struct BodyScoreFirstProgressPhotoView: View {
         }
         .padding(20)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(Color.appCard.opacity(0.72))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .stroke(Color.appBorder.opacity(0.55), lineWidth: 1)
+        .systemBGlassSurface(
+            cornerRadius: 22,
+            tint: theme.colors.text,
+            tintOpacity: 0.04,
+            borderColor: theme.colors.border,
+            borderOpacity: 0.65,
+            shadowOpacity: 0.12,
+            shadowRadius: 12,
+            shadowY: 6
         )
         .accessibilityIdentifier("onboarding_first_photo_card")
     }
@@ -111,7 +116,7 @@ struct BodyScoreFirstProgressPhotoView: View {
             if let errorMessage = viewModel.firstPhotoErrorMessage {
                 Text(errorMessage)
                     .font(OnboardingTypography.caption)
-                    .foregroundStyle(Color.red)
+                    .foregroundStyle(theme.colors.error)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity)
             }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHealthConfirmationView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHealthConfirmationView.swift
@@ -49,7 +49,7 @@ struct BodyScoreHealthConfirmationView: View {
                                         .foregroundStyle(Color.appTextSecondary)
 
                                     Text(metric.value)
-                                        .font(.system(.title2, design: .rounded).weight(.semibold))
+                                        .font(OnboardingTypography.title)
                                         .foregroundStyle(Color.appText)
 
                                     Text(metric.subtitle)

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHealthConnectView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHealthConnectView.swift
@@ -104,7 +104,7 @@ struct BodyScoreHealthConnectView: View {
                                     .tint(.black)
                             }
                             Text(connectButtonTitle)
-                                .font(.system(.headline, design: .rounded))
+                                .font(OnboardingTypography.headline)
                         }
                     }
                     .buttonStyle(OnboardingPrimaryButtonStyle())

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHeightView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHeightView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct BodyScoreHeightView: View {
+    @Environment(\.theme)
+    private var theme
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @FocusState private var centimetersFocused: Bool
     @State private var heightError: String?
@@ -96,13 +99,12 @@ struct BodyScoreHeightView: View {
             }
             .padding(.horizontal, 18)
             .padding(.vertical, 14)
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(Color.appCard.opacity(0.7))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .stroke(centimetersFocused ? Color.appPrimary : Color.appBorder.opacity(0.5))
+            .systemBGlassSurface(
+                cornerRadius: theme.radius.input,
+                tint: centimetersFocused ? theme.colors.primary : theme.colors.text,
+                tintOpacity: centimetersFocused ? 0.07 : 0.03,
+                borderColor: centimetersFocused ? theme.colors.primary : theme.colors.border,
+                borderOpacity: centimetersFocused ? 0.9 : 0.65
             )
             .onAppear {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
@@ -113,7 +115,7 @@ struct BodyScoreHeightView: View {
             if let error = heightError {
                 Text(error)
                     .font(OnboardingTypography.caption)
-                    .foregroundStyle(Color.red)
+                    .foregroundStyle(theme.colors.error)
             } else {
                 Text("Most adults fall between 100–250 cm.")
                     .font(OnboardingTypography.caption)
@@ -154,13 +156,12 @@ struct BodyScoreHeightView: View {
                 }
             }
             .frame(height: 160)
-            .background(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .fill(Color.appCard.opacity(0.6))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .stroke(Color.appBorder.opacity(0.5))
+            .systemBGlassSurface(
+                cornerRadius: 20,
+                tint: theme.colors.text,
+                tintOpacity: 0.03,
+                borderColor: theme.colors.border,
+                borderOpacity: 0.65
             )
 
             Text("We’ll convert everything into centimeters automatically.")

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreLoadingView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreLoadingView.swift
@@ -1,16 +1,23 @@
 import SwiftUI
 
 struct BodyScoreLoadingView: View {
+    @Environment(\.theme)
+    private var theme
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [Color.appBackground, Color.black], startPoint: .topLeading, endPoint: .bottomTrailing)
+            LinearGradient(
+                colors: [theme.colors.background, theme.colors.backgroundSecondary],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
                 .ignoresSafeArea()
 
             VStack(spacing: 24) {
                 ProgressView()
-                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                    .progressViewStyle(CircularProgressViewStyle(tint: theme.colors.text))
                     .scaleEffect(1.3)
 
                 OnboardingTitleText(text: "Crunching your numbers…", alignment: .center)

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreManualWeightView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreManualWeightView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct BodyScoreManualWeightView: View {
+    @Environment(\.theme)
+    private var theme
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @FocusState private var weightFieldFocused: Bool
     @State private var weightError: String?
@@ -37,13 +40,12 @@ struct BodyScoreManualWeightView: View {
                             }
                             .padding(.horizontal, 18)
                             .padding(.vertical, 14)
-                            .background(
-                                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                    .fill(Color.appCard.opacity(0.6))
-                            )
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                    .stroke(weightFieldBorderColor)
+                            .systemBGlassSurface(
+                                cornerRadius: theme.radius.input,
+                                tint: weightFieldFocused ? theme.colors.primary : theme.colors.text,
+                                tintOpacity: weightFieldFocused ? 0.07 : 0.03,
+                                borderColor: weightFieldBorderColor,
+                                borderOpacity: 1
                             )
                             .overlay(
                                 HStack {
@@ -61,11 +63,14 @@ struct BodyScoreManualWeightView: View {
                                 } label: {
                                     Image(systemName: "minus")
                                         .font(.system(size: 14, weight: .medium))
-                                        .foregroundStyle(Color.appText)
+                                        .foregroundStyle(theme.colors.text)
                                         .frame(width: 32, height: 32)
-                                        .background(
-                                            Circle()
-                                                .fill(Color.appCard.opacity(0.6))
+                                        .systemBGlassSurface(
+                                            cornerRadius: 16,
+                                            tint: theme.colors.text,
+                                            tintOpacity: 0.03,
+                                            borderColor: theme.colors.border,
+                                            borderOpacity: 0.55
                                         )
                                 }
                                 .buttonStyle(.plain)
@@ -75,11 +80,14 @@ struct BodyScoreManualWeightView: View {
                                 } label: {
                                     Image(systemName: "plus")
                                         .font(.system(size: 14, weight: .medium))
-                                        .foregroundStyle(Color.appText)
+                                        .foregroundStyle(theme.colors.text)
                                         .frame(width: 32, height: 32)
-                                        .background(
-                                            Circle()
-                                                .fill(Color.appCard.opacity(0.8))
+                                        .systemBGlassSurface(
+                                            cornerRadius: 16,
+                                            tint: theme.colors.text,
+                                            tintOpacity: 0.05,
+                                            borderColor: theme.colors.border,
+                                            borderOpacity: 0.65
                                         )
                                 }
                                 .buttonStyle(.plain)
@@ -89,7 +97,7 @@ struct BodyScoreManualWeightView: View {
                         if let error = weightError {
                             Text(error)
                                 .font(OnboardingTypography.caption)
-                                .foregroundStyle(Color.red)
+                                .foregroundStyle(theme.colors.error)
                         }
 
                         Button {

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct BodyScoreProfileDetailsView: View {
+    @Environment(\.theme)
+    private var theme
+
     @EnvironmentObject var authManager: AuthManager
     @ObservedObject var viewModel: OnboardingFlowViewModel
 
@@ -184,7 +187,7 @@ struct BodyScoreProfileDetailsView: View {
                     if let errorMessage {
                         Text(errorMessage)
                             .font(OnboardingTypography.caption)
-                            .foregroundStyle(Color.red)
+                            .foregroundStyle(theme.colors.error)
                             .multilineTextAlignment(.center)
                     }
                 }
@@ -219,16 +222,12 @@ struct BodyScoreProfileDetailsView: View {
                         .focused($focusedNameField, equals: .firstName)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .fill(Color.appCard.opacity(0.6))
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .stroke(
-                                    focusedNameField == .firstName ? Color.appPrimary : Color.appBorder.opacity(0.6),
-                                    lineWidth: 1
-                                )
+                        .systemBGlassSurface(
+                            cornerRadius: theme.radius.input,
+                            tint: focusedNameField == .firstName ? theme.colors.primary : theme.colors.text,
+                            tintOpacity: focusedNameField == .firstName ? 0.07 : 0.03,
+                            borderColor: focusedNameField == .firstName ? theme.colors.primary : theme.colors.border,
+                            borderOpacity: focusedNameField == .firstName ? 0.9 : 0.65
                         )
                         .onSubmit {
                             handleFirstNameContinue()
@@ -256,16 +255,12 @@ struct BodyScoreProfileDetailsView: View {
                         .focused($focusedNameField, equals: .lastName)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .fill(Color.appCard.opacity(0.6))
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .stroke(
-                                    focusedNameField == .lastName ? Color.appPrimary : Color.appBorder.opacity(0.6),
-                                    lineWidth: 1
-                                )
+                        .systemBGlassSurface(
+                            cornerRadius: theme.radius.input,
+                            tint: focusedNameField == .lastName ? theme.colors.primary : theme.colors.text,
+                            tintOpacity: focusedNameField == .lastName ? 0.07 : 0.03,
+                            borderColor: focusedNameField == .lastName ? theme.colors.primary : theme.colors.border,
+                            borderOpacity: focusedNameField == .lastName ? 0.9 : 0.65
                         )
                         .onSubmit {
                             handleLastNameContinue()
@@ -326,17 +321,16 @@ struct BodyScoreProfileDetailsView: View {
                 case .centimeters:
                     TextField("178", text: $heightCentimetersText)
                         .keyboardType(.decimalPad)
-                        .font(.system(size: 40, weight: .bold, design: .rounded))
+                        .font(theme.typography.displayMedium)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .fill(Color.appCard.opacity(0.6))
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .stroke(Color.appBorder.opacity(0.6), lineWidth: 1)
+                        .systemBGlassSurface(
+                            cornerRadius: theme.radius.input,
+                            tint: theme.colors.text,
+                            tintOpacity: 0.03,
+                            borderColor: theme.colors.border,
+                            borderOpacity: 0.65
                         )
                         .accessibilityLabel("Height in centimeters")
 

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreRevealView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreRevealView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct BodyScoreRevealView: View {
+    @Environment(\.theme)
+    private var theme
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @State private var animateScore = false
     @State private var isSharePresented = false
@@ -85,12 +88,12 @@ struct BodyScoreRevealView: View {
     private func scoreHero(result: BodyScoreResult) -> some View {
         VStack(spacing: 8) {
             Text("\(result.score)")
-                .font(.system(size: 56, weight: .bold, design: .rounded))
-                .foregroundStyle(Color.appText)
+                .font(.system(size: 56, weight: .bold, design: .default))
+                .foregroundStyle(theme.colors.text)
 
             Text("Starting point")
-                .font(.system(.subheadline, design: .rounded).weight(.medium))
-                .foregroundStyle(Color.appTextSecondary)
+                .font(theme.typography.labelMedium)
+                .foregroundStyle(theme.colors.textSecondary)
 
             Text("Based on FFMI, body fat %, and trends.")
                 .font(OnboardingTypography.caption)
@@ -125,9 +128,12 @@ struct BodyScoreRevealView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(
-            Capsule(style: .continuous)
-                .fill(Color.appCard.opacity(0.6))
+        .systemBGlassSurface(
+            cornerRadius: theme.radius.full,
+            tint: theme.colors.text,
+            tintOpacity: 0.035,
+            borderColor: theme.colors.border,
+            borderOpacity: 0.55
         )
     }
 

--- a/apps/ios/LogYourBody/Views/LoginView.swift
+++ b/apps/ios/LogYourBody/Views/LoginView.swift
@@ -8,6 +8,9 @@ import SwiftUI
 import AuthenticationServices
 
 struct LoginView: View {
+    @Environment(\.theme)
+    private var theme
+
     @EnvironmentObject var authManager: AuthManager
     @State private var email = ""
     @State private var isLoading = false
@@ -35,7 +38,7 @@ struct LoginView: View {
 
     private var background: some View {
         // Atom: Background
-        Color.appBackground
+        theme.colors.background
             .ignoresSafeArea()
     }
 
@@ -80,8 +83,8 @@ struct LoginView: View {
                 // Molecule: Sign Up Link
                 HStack(spacing: 4) {
                     Text("Don't have an account?")
-                        .font(.system(size: 15))
-                        .foregroundColor(.appTextSecondary)
+                        .font(theme.typography.bodySmall)
+                        .foregroundColor(theme.colors.textSecondary)
 
                     DSAuthNavigationLink(
                         title: "Sign up",
@@ -118,23 +121,28 @@ struct LoginView: View {
     private var sessionStatusBanner: some View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: "exclamationmark.circle")
-                .foregroundColor(.appTextSecondary)
+                .foregroundColor(theme.colors.warning)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("Session expired")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.appText)
+                    .font(theme.typography.labelMedium)
+                    .foregroundColor(theme.colors.text)
 
                 Text("Your session ended. Please sign in again to continue.")
-                    .font(.system(size: 13))
-                    .foregroundColor(.appTextSecondary)
+                    .font(theme.typography.captionLarge)
+                    .foregroundColor(theme.colors.textSecondary)
             }
 
             Spacer(minLength: 0)
         }
         .padding(12)
-        .background(Color.black.opacity(0.25))
-        .cornerRadius(12)
+        .systemBGlassSurface(
+            cornerRadius: theme.radius.lg,
+            tint: theme.colors.warning,
+            tintOpacity: 0.06,
+            borderColor: theme.colors.warning,
+            borderOpacity: 0.24
+        )
     }
 
     // Clerk status banner
@@ -145,63 +153,67 @@ struct LoginView: View {
                 VStack(spacing: 8) {
                     HStack {
                         Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundColor(.red)
+                            .foregroundColor(theme.colors.error)
                         Text("Connection Error")
-                            .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(.appText)
+                            .font(theme.typography.labelMedium)
+                            .foregroundColor(theme.colors.text)
                         Spacer()
                     }
 
                     Text(error)
-                        .font(.system(size: 13))
-                        .foregroundColor(.appTextSecondary)
+                        .font(theme.typography.captionLarge)
+                        .foregroundColor(theme.colors.textSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                     Button(action: retryClerkInit) {
                         HStack {
                             if isRetrying {
                                 ProgressView()
-                                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                    .progressViewStyle(CircularProgressViewStyle(tint: theme.colors.background))
                                     .scaleEffect(0.8)
                             } else {
                                 Image(systemName: "arrow.clockwise")
                             }
                             Text(isRetrying ? "Retrying..." : "Retry Connection")
-                                .font(.system(size: 15, weight: .medium))
+                                .font(theme.typography.labelMedium)
                         }
-                        .foregroundColor(.white)
+                        .foregroundColor(theme.colors.background)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 12)
-                        .background(Color.blue)
-                        .cornerRadius(8)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(theme.colors.text)
+                        )
                     }
                     .disabled(isRetrying)
                 }
                 .padding(16)
-                .background(Color.red.opacity(0.1))
-                .cornerRadius(12)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.red.opacity(0.3), lineWidth: 1)
+                .systemBGlassSurface(
+                    cornerRadius: theme.radius.lg,
+                    tint: theme.colors.error,
+                    tintOpacity: 0.08,
+                    borderColor: theme.colors.error,
+                    borderOpacity: 0.32
                 )
             } else {
                 // Loading state
                 VStack(spacing: 8) {
                     HStack {
                         ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle())
+                            .progressViewStyle(CircularProgressViewStyle(tint: theme.colors.info))
                         Text("Connecting to authentication service...")
-                            .font(.system(size: 14))
-                            .foregroundColor(.appTextSecondary)
+                            .font(theme.typography.captionLarge)
+                            .foregroundColor(theme.colors.textSecondary)
                         Spacer()
                     }
                 }
                 .padding(16)
-                .background(Color.blue.opacity(0.1))
-                .cornerRadius(12)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.blue.opacity(0.3), lineWidth: 1)
+                .systemBGlassSurface(
+                    cornerRadius: theme.radius.lg,
+                    tint: theme.colors.info,
+                    tintOpacity: 0.08,
+                    borderColor: theme.colors.info,
+                    borderOpacity: 0.3
                 )
             }
         }

--- a/apps/ios/LogYourBody/Views/SignUpView.swift
+++ b/apps/ios/LogYourBody/Views/SignUpView.swift
@@ -8,6 +8,9 @@ import SwiftUI
 import AuthenticationServices
 
 struct SignUpView: View {
+    @Environment(\.theme)
+    private var theme
+
     @EnvironmentObject var authManager: AuthManager
     @Environment(\.dismiss) var dismiss
     @State private var email = ""
@@ -56,7 +59,7 @@ struct SignUpView: View {
 
     private var background: some View {
         // Atom: Background
-        Color.appBackground
+        theme.colors.background
             .ignoresSafeArea()
     }
 
@@ -109,14 +112,14 @@ struct SignUpView: View {
                 // Sign In Link
                 HStack(spacing: 4) {
                     Text("Already have an account?")
-                        .font(.system(size: 15))
-                        .foregroundColor(.appTextSecondary)
+                        .font(theme.typography.bodySmall)
+                        .foregroundColor(theme.colors.textSecondary)
 
                     Button("Sign in") {
                         dismiss()
                     }
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.appPrimary)
+                    .font(theme.typography.labelMedium)
+                    .foregroundColor(theme.colors.primary)
                 }
                 .padding(.top, 8)
 
@@ -142,9 +145,16 @@ struct SignUpView: View {
         HStack {
             Button(action: { dismiss() }, label: {
                 Image(systemName: "chevron.left")
-                    .font(.system(size: 20))
-                    .foregroundColor(.appText)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(theme.colors.text)
                     .frame(width: 44, height: 44)
+                    .systemBGlassSurface(
+                        cornerRadius: theme.radius.full,
+                        tint: theme.colors.text,
+                        tintOpacity: 0.045,
+                        borderColor: theme.colors.border,
+                        borderOpacity: 0.55
+                    )
             })
 
             Spacer()
@@ -161,63 +171,67 @@ struct SignUpView: View {
                 VStack(spacing: 8) {
                     HStack {
                         Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundColor(.red)
+                            .foregroundColor(theme.colors.error)
                         Text("Connection Error")
-                            .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(.appText)
+                            .font(theme.typography.labelMedium)
+                            .foregroundColor(theme.colors.text)
                         Spacer()
                     }
 
                     Text(error)
-                        .font(.system(size: 13))
-                        .foregroundColor(.appTextSecondary)
+                        .font(theme.typography.captionLarge)
+                        .foregroundColor(theme.colors.textSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                     Button(action: retryClerkInit) {
                         HStack {
                             if isRetrying {
                                 ProgressView()
-                                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                    .progressViewStyle(CircularProgressViewStyle(tint: theme.colors.background))
                                     .scaleEffect(0.8)
                             } else {
                                 Image(systemName: "arrow.clockwise")
                             }
                             Text(isRetrying ? "Retrying..." : "Retry Connection")
-                                .font(.system(size: 15, weight: .medium))
+                                .font(theme.typography.labelMedium)
                         }
-                        .foregroundColor(.white)
+                        .foregroundColor(theme.colors.background)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 12)
-                        .background(Color.blue)
-                        .cornerRadius(8)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(theme.colors.text)
+                        )
                     }
                     .disabled(isRetrying)
                 }
                 .padding(16)
-                .background(Color.red.opacity(0.1))
-                .cornerRadius(12)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.red.opacity(0.3), lineWidth: 1)
+                .systemBGlassSurface(
+                    cornerRadius: theme.radius.lg,
+                    tint: theme.colors.error,
+                    tintOpacity: 0.08,
+                    borderColor: theme.colors.error,
+                    borderOpacity: 0.32
                 )
             } else {
                 // Loading state
                 VStack(spacing: 8) {
                     HStack {
                         ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle())
+                            .progressViewStyle(CircularProgressViewStyle(tint: theme.colors.info))
                         Text("Connecting to authentication service...")
-                            .font(.system(size: 14))
-                            .foregroundColor(.appTextSecondary)
+                            .font(theme.typography.captionLarge)
+                            .foregroundColor(theme.colors.textSecondary)
                         Spacer()
                     }
                 }
                 .padding(16)
-                .background(Color.blue.opacity(0.1))
-                .cornerRadius(12)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.blue.opacity(0.3), lineWidth: 1)
+                .systemBGlassSurface(
+                    cornerRadius: theme.radius.lg,
+                    tint: theme.colors.info,
+                    tintOpacity: 0.08,
+                    borderColor: theme.colors.info,
+                    borderOpacity: 0.3
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Adds a reusable theme-backed System B glass surface modifier for onboarding/auth controls.
- Moves onboarding typography/buttons/cards/fields/progress/CTA shell onto theme tokens and shared glass treatment.
- Updates login/sign-up auth forms, status banners, links, dividers, and social buttons to semantic theme colors instead of bespoke blue/red/card styling.

## Linear
- JOV-3142

## Validation
- `swiftlint lint --strict`
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/OnboardingFlowViewModelTests` (22 passed)
- XcodeBuildMCP `build_run_sim -lybUITestBodyScoreOnboardingFixture`
- XcodeBuildMCP `build_run_sim -lybUITestSignedOutFixture`
- `git diff --check`
- targeted style scan for onboarding/auth hard-coded blue/red/card/material/rounded patterns: clean
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Simulator Evidence
- Body Score onboarding screenshot: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_9986092b-e2bd-403d-bae9-288bf4b50e8a.jpg`
- Signed-out auth screenshot: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_efe29b36-a097-4997-9f26-853fe978b729.jpg`