### PR TITLE
fix: persist onboarding profile details draft

### DIFF
--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 import Combine
 
+private func defaultProfileDateOfBirth() -> Date {
+    Calendar.current.date(byAdding: .year, value: -25, to: Date()) ?? Date()
+}
+
 @MainActor
 final class OnboardingFlowViewModel: ObservableObject {
     enum AccountCreationStage {
@@ -54,6 +58,14 @@ final class OnboardingFlowViewModel: ObservableObject {
                 return "pre_auth"
             }
         }
+    }
+
+    enum ProfileDetailsSubstep: String, Codable {
+        case firstName
+        case lastName
+        case dateOfBirth
+        case sex
+        case height
     }
 
     struct ProgressContext: Equatable {
@@ -141,6 +153,39 @@ final class OnboardingFlowViewModel: ObservableObject {
     @Published private(set) var onboardingFirstPhotoMetric: BodyMetrics?
     @Published private(set) var isPreparingFirstPhotoMetric = false
     @Published var firstPhotoErrorMessage: String?
+    @Published var profileFirstName: String = "" {
+        didSet { persistProgress() }
+    }
+    @Published var profileLastName: String = "" {
+        didSet { persistProgress() }
+    }
+    @Published var profileDateOfBirth: Date = defaultProfileDateOfBirth() {
+        didSet { persistProgress() }
+    }
+    @Published var profileBiologicalSex: BiologicalSex? {
+        didSet { persistProgress() }
+    }
+    @Published var profileHeightUnit: HeightUnit = .centimeters {
+        didSet { persistProgress() }
+    }
+    @Published var profileHeightCentimetersText: String = "" {
+        didSet { persistProgress() }
+    }
+    @Published var profileHeightFeet: Int = 5 {
+        didSet { persistProgress() }
+    }
+    @Published var profileHeightInches: Int = 10 {
+        didSet { persistProgress() }
+    }
+    @Published var profileDetailsActiveSubstep: ProfileDetailsSubstep = .firstName {
+        didSet { persistProgress() }
+    }
+    @Published var profileShouldAskSex: Bool = false {
+        didSet { persistProgress() }
+    }
+    @Published private(set) var hasHydratedProfileDetailsDraft = false {
+        didSet { persistProgress() }
+    }
 
     let entryContext: EntryContext
     let includesFirstPhotoStep: Bool
@@ -766,6 +811,57 @@ final class OnboardingFlowViewModel: ObservableObject {
         accountCreationStage.statusMessage
     }
 
+    func hydrateProfileDetailsDraftIfNeeded(from user: User?) {
+        guard !hasHydratedProfileDetailsDraft else { return }
+
+        isRestoringProgress = true
+
+        guard let user else {
+            if profileBiologicalSex == nil {
+                profileBiologicalSex = bodyScoreInput.sex
+            }
+
+            profileShouldAskSex = profileBiologicalSex == nil
+            recomputeProfileDetailsActiveSubstep()
+            isRestoringProgress = false
+            persistProgress()
+            return
+        }
+
+        hydrateProfileName(from: user)
+
+        if let existingDob = user.profile?.dateOfBirth {
+            profileDateOfBirth = existingDob
+        }
+
+        if let existingGender = user.profile?.gender {
+            profileBiologicalSex = Self.biologicalSex(from: existingGender)
+        }
+
+        if let existingHeight = user.profile?.height, existingHeight > 0 {
+            hydrateProfileHeight(
+                centimeters: existingHeight,
+                storedUnit: user.profile?.heightUnit
+            )
+        }
+
+        if profileBiologicalSex == nil {
+            profileBiologicalSex = bodyScoreInput.sex
+        }
+
+        profileShouldAskSex = profileBiologicalSex == nil
+        recomputeProfileDetailsActiveSubstep()
+        hasHydratedProfileDetailsDraft = true
+
+        isRestoringProgress = false
+        persistProgress()
+    }
+
+    func updateProfileBiologicalSex(_ sex: BiologicalSex) {
+        profileBiologicalSex = sex
+        updateSex(sex)
+    }
+
     func completeOnboardingIfNeeded() {
         guard entryContext == .authenticated else { return }
         guard !hasMarkedOnboardingComplete else { return }
@@ -839,10 +935,27 @@ final class OnboardingFlowViewModel: ObservableObject {
     }
 
     func buildOnboardingProfileUpdates() -> [String: Any] {
-        OnboardingProfileUpdateBuilder.buildUpdates(
+        var updates = OnboardingProfileUpdateBuilder.buildUpdates(
             bodyScoreInput: bodyScoreInput,
             heightUnit: heightUnit
         )
+
+        guard hasHydratedProfileDetailsDraft else {
+            return updates
+        }
+
+        if let profileBiologicalSex {
+            updates["gender"] = profileBiologicalSex.description
+        }
+
+        updates["dateOfBirth"] = profileDateOfBirth
+
+        if let profileHeightInCentimeters {
+            updates["height"] = profileHeightInCentimeters
+            updates["heightUnit"] = profileHeightUnitStorageValue
+        }
+
+        return updates
     }
 
     var weightFieldTitle: String {
@@ -941,6 +1054,78 @@ final class OnboardingFlowViewModel: ObservableObject {
 
     private static func formatHeight(_ centimeters: Double) -> String {
         String(format: "%.1f", centimeters)
+    }
+
+    private static func biologicalSex(from gender: String) -> BiologicalSex? {
+        let normalized = gender.lowercased()
+        if normalized.contains("female") || normalized.contains("woman") {
+            return .female
+        }
+        if normalized.contains("male") || normalized.contains("man") {
+            return .male
+        }
+        return nil
+    }
+
+    private func hydrateProfileName(from user: User) {
+        let baseName = user.profile?.fullName ?? user.name ?? ""
+        let components = baseName.split(separator: " ")
+        guard !components.isEmpty else { return }
+
+        profileFirstName = String(components.first ?? "")
+        if components.count > 1 {
+            profileLastName = components.dropFirst().joined(separator: " ")
+        }
+    }
+
+    private func hydrateProfileHeight(centimeters: Double, storedUnit: String?) {
+        if storedUnit?.lowercased() == "in" {
+            profileHeightUnit = .inches
+            let totalInches = Int((centimeters / 2.54).rounded())
+            profileHeightFeet = max(3, min(8, totalInches / 12))
+            profileHeightInches = max(0, min(11, totalInches % 12))
+        } else {
+            profileHeightUnit = .centimeters
+        }
+
+        profileHeightCentimetersText = String(format: "%.0f", centimeters)
+    }
+
+    private var profileHeightInCentimeters: Double? {
+        switch profileHeightUnit {
+        case .centimeters:
+            return Double(profileHeightCentimetersText)
+        case .inches:
+            let totalInches = Double((profileHeightFeet * 12) + profileHeightInches)
+            return totalInches > 0 ? totalInches * 2.54 : nil
+        }
+    }
+
+    private var profileHeightUnitStorageValue: String {
+        switch profileHeightUnit {
+        case .centimeters:
+            return "cm"
+        case .inches:
+            return "in"
+        }
+    }
+
+    private func recomputeProfileDetailsActiveSubstep() {
+        let trimmedFirstName = profileFirstName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedLastName = profileLastName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let age = Calendar.current.dateComponents([.year], from: profileDateOfBirth, to: Date()).year
+
+        if trimmedFirstName.isEmpty {
+            profileDetailsActiveSubstep = .firstName
+        } else if trimmedLastName.isEmpty {
+            profileDetailsActiveSubstep = .lastName
+        } else if (age ?? 0) < 16 || (age ?? 0) > 80 {
+            profileDetailsActiveSubstep = .dateOfBirth
+        } else if profileShouldAskSex && profileBiologicalSex == nil {
+            profileDetailsActiveSubstep = .sex
+        } else {
+            profileDetailsActiveSubstep = .height
+        }
     }
 
     private func applyMeasurementSystem(_ system: MeasurementSystem, skipHeight: Bool = false, skipWeight: Bool = false) {
@@ -1045,6 +1230,17 @@ final class OnboardingFlowViewModel: ObservableObject {
             defaultHomeMode: defaultHomeMode,
             didRequestHealthSync: didRequestHealthSync,
             emailAddress: emailAddress,
+            profileFirstName: profileFirstName,
+            profileLastName: profileLastName,
+            profileDateOfBirth: profileDateOfBirth,
+            profileBiologicalSex: profileBiologicalSex,
+            profileHeightUnit: profileHeightUnit,
+            profileHeightCentimetersText: profileHeightCentimetersText,
+            profileHeightFeet: profileHeightFeet,
+            profileHeightInches: profileHeightInches,
+            profileDetailsActiveSubstep: profileDetailsActiveSubstep,
+            profileShouldAskSex: profileShouldAskSex,
+            hasHydratedProfileDetailsDraft: hasHydratedProfileDetailsDraft,
             lastUpdated: Date()
         )
 
@@ -1082,6 +1278,17 @@ final class OnboardingFlowViewModel: ObservableObject {
         defaultHomeMode = snapshot.defaultHomeMode
         didRequestHealthSync = snapshot.didRequestHealthSync
         emailAddress = snapshot.emailAddress
+        profileFirstName = snapshot.profileFirstName
+        profileLastName = snapshot.profileLastName
+        profileDateOfBirth = snapshot.profileDateOfBirth
+        profileBiologicalSex = snapshot.profileBiologicalSex
+        profileHeightUnit = snapshot.profileHeightUnit
+        profileHeightCentimetersText = snapshot.profileHeightCentimetersText
+        profileHeightFeet = snapshot.profileHeightFeet
+        profileHeightInches = snapshot.profileHeightInches
+        profileDetailsActiveSubstep = snapshot.profileDetailsActiveSubstep
+        profileShouldAskSex = snapshot.profileShouldAskSex
+        hasHydratedProfileDetailsDraft = snapshot.hasHydratedProfileDetailsDraft
         if hasAuthenticatedAccountEmail,
            currentStep == .emailCapture || currentStep == .account {
             currentStep = .profileDetails
@@ -1176,6 +1383,17 @@ private struct OnboardingProgressSnapshot: Codable {
     let defaultHomeMode: DefaultHomeMode
     let didRequestHealthSync: Bool
     let emailAddress: String
+    let profileFirstName: String
+    let profileLastName: String
+    let profileDateOfBirth: Date
+    let profileBiologicalSex: BiologicalSex?
+    let profileHeightUnit: HeightUnit
+    let profileHeightCentimetersText: String
+    let profileHeightFeet: Int
+    let profileHeightInches: Int
+    let profileDetailsActiveSubstep: OnboardingFlowViewModel.ProfileDetailsSubstep
+    let profileShouldAskSex: Bool
+    let hasHydratedProfileDetailsDraft: Bool
     let lastUpdated: Date
 }
 
@@ -1195,6 +1413,17 @@ private extension OnboardingProgressSnapshot {
         case defaultHomeMode
         case didRequestHealthSync
         case emailAddress
+        case profileFirstName
+        case profileLastName
+        case profileDateOfBirth
+        case profileBiologicalSex
+        case profileHeightUnit
+        case profileHeightCentimetersText
+        case profileHeightFeet
+        case profileHeightInches
+        case profileDetailsActiveSubstep
+        case profileShouldAskSex
+        case hasHydratedProfileDetailsDraft
         case lastUpdated
     }
 
@@ -1214,6 +1443,27 @@ private extension OnboardingProgressSnapshot {
         defaultHomeMode = try container.decodeIfPresent(DefaultHomeMode.self, forKey: .defaultHomeMode) ?? .default
         didRequestHealthSync = try container.decode(Bool.self, forKey: .didRequestHealthSync)
         emailAddress = try container.decode(String.self, forKey: .emailAddress)
+        profileFirstName = try container.decodeIfPresent(String.self, forKey: .profileFirstName) ?? ""
+        profileLastName = try container.decodeIfPresent(String.self, forKey: .profileLastName) ?? ""
+        profileDateOfBirth = try container.decodeIfPresent(Date.self, forKey: .profileDateOfBirth)
+            ?? defaultProfileDateOfBirth()
+        profileBiologicalSex = try container.decodeIfPresent(BiologicalSex.self, forKey: .profileBiologicalSex)
+        profileHeightUnit = try container.decodeIfPresent(HeightUnit.self, forKey: .profileHeightUnit) ?? .centimeters
+        profileHeightCentimetersText = try container.decodeIfPresent(
+            String.self,
+            forKey: .profileHeightCentimetersText
+        ) ?? ""
+        profileHeightFeet = try container.decodeIfPresent(Int.self, forKey: .profileHeightFeet) ?? 5
+        profileHeightInches = try container.decodeIfPresent(Int.self, forKey: .profileHeightInches) ?? 10
+        profileDetailsActiveSubstep = try container.decodeIfPresent(
+            OnboardingFlowViewModel.ProfileDetailsSubstep.self,
+            forKey: .profileDetailsActiveSubstep
+        ) ?? .firstName
+        profileShouldAskSex = try container.decodeIfPresent(Bool.self, forKey: .profileShouldAskSex) ?? false
+        hasHydratedProfileDetailsDraft = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .hasHydratedProfileDetailsDraft
+        ) ?? false
         lastUpdated = try container.decode(Date.self, forKey: .lastUpdated)
     }
 
@@ -1233,6 +1483,17 @@ private extension OnboardingProgressSnapshot {
         try container.encode(defaultHomeMode, forKey: .defaultHomeMode)
         try container.encode(didRequestHealthSync, forKey: .didRequestHealthSync)
         try container.encode(emailAddress, forKey: .emailAddress)
+        try container.encode(profileFirstName, forKey: .profileFirstName)
+        try container.encode(profileLastName, forKey: .profileLastName)
+        try container.encode(profileDateOfBirth, forKey: .profileDateOfBirth)
+        try container.encodeIfPresent(profileBiologicalSex, forKey: .profileBiologicalSex)
+        try container.encode(profileHeightUnit, forKey: .profileHeightUnit)
+        try container.encode(profileHeightCentimetersText, forKey: .profileHeightCentimetersText)
+        try container.encode(profileHeightFeet, forKey: .profileHeightFeet)
+        try container.encode(profileHeightInches, forKey: .profileHeightInches)
+        try container.encode(profileDetailsActiveSubstep, forKey: .profileDetailsActiveSubstep)
+        try container.encode(profileShouldAskSex, forKey: .profileShouldAskSex)
+        try container.encode(hasHydratedProfileDetailsDraft, forKey: .hasHydratedProfileDetailsDraft)
         try container.encode(lastUpdated, forKey: .lastUpdated)
     }
 }
@@ -1305,11 +1566,32 @@ final class OnboardingProgressStore {
     #if DEBUG
     func snapshotForTesting(for userId: String) -> (
         currentStep: OnboardingFlowViewModel.Step,
-        defaultHomeMode: DefaultHomeMode
+        defaultHomeMode: DefaultHomeMode,
+        profileFirstName: String,
+        profileLastName: String,
+        profileDateOfBirth: Date,
+        profileBiologicalSex: BiologicalSex?,
+        profileHeightUnit: HeightUnit,
+        profileHeightCentimetersText: String,
+        profileHeightFeet: Int,
+        profileHeightInches: Int,
+        profileDetailsActiveSubstep: OnboardingFlowViewModel.ProfileDetailsSubstep
     )? {
         queue.sync {
             guard let snapshot = snapshots[userId], snapshot.version == Self.snapshotVersion else { return nil }
-            return (snapshot.currentStep, snapshot.defaultHomeMode)
+            return (
+                snapshot.currentStep,
+                snapshot.defaultHomeMode,
+                snapshot.profileFirstName,
+                snapshot.profileLastName,
+                snapshot.profileDateOfBirth,
+                snapshot.profileBiologicalSex,
+                snapshot.profileHeightUnit,
+                snapshot.profileHeightCentimetersText,
+                snapshot.profileHeightFeet,
+                snapshot.profileHeightInches,
+                snapshot.profileDetailsActiveSubstep
+            )
         }
     }
     #endif

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
@@ -7,26 +7,16 @@ struct BodyScoreProfileDetailsView: View {
     @EnvironmentObject var authManager: AuthManager
     @ObservedObject var viewModel: OnboardingFlowViewModel
 
-    @State private var firstName: String = ""
-    @State private var lastName: String = ""
-    @State private var dateOfBirth: Date = Calendar.current.date(byAdding: .year, value: -25, to: Date()) ?? Date()
-    @State private var biologicalSex: BiologicalSex?
-    @State private var heightUnit: HeightUnit = .centimeters
-    @State private var heightCentimetersText: String = ""
-    @State private var heightFeet: Int = 5
-    @State private var heightInches: Int = 10
     @State private var isSaving: Bool = false
     @State private var errorMessage: String?
-    @State private var activeSubstep: ProfileSubstep = .firstName
-    @State private var shouldAskSexInProfile: Bool = false
     @FocusState private var focusedNameField: NameField?
 
     private var trimmedFirstName: String {
-        firstName.trimmingCharacters(in: .whitespacesAndNewlines)
+        viewModel.profileFirstName.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private var trimmedLastName: String {
-        lastName.trimmingCharacters(in: .whitespacesAndNewlines)
+        viewModel.profileLastName.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private var isFirstNameValid: Bool {
@@ -38,7 +28,7 @@ struct BodyScoreProfileDetailsView: View {
     }
 
     private var canContinue: Bool {
-        switch activeSubstep {
+        switch viewModel.profileDetailsActiveSubstep {
         case .firstName:
             return isFirstNameValid
         case .lastName:
@@ -46,7 +36,7 @@ struct BodyScoreProfileDetailsView: View {
         case .dateOfBirth:
             return isFirstNameValid && isLastNameValid && isDateOfBirthWithinValidRange
         case .sex:
-            return biologicalSex != nil
+            return viewModel.profileBiologicalSex != nil
         case .height:
             return isHeightValid
         }
@@ -54,34 +44,34 @@ struct BodyScoreProfileDetailsView: View {
 
     private var isDateOfBirthWithinValidRange: Bool {
         let calendar = Calendar.current
-        let components = calendar.dateComponents([.year], from: dateOfBirth, to: Date())
+        let components = calendar.dateComponents([.year], from: viewModel.profileDateOfBirth, to: Date())
         guard let age = components.year else { return false }
         return age >= 16 && age <= 80
     }
 
     private var heightInCentimeters: Double? {
-        switch heightUnit {
+        switch viewModel.profileHeightUnit {
         case .centimeters:
-            return Double(heightCentimetersText)
+            return Double(viewModel.profileHeightCentimetersText)
         case .inches:
-            let totalInches = Double((heightFeet * 12) + heightInches)
+            let totalInches = Double((viewModel.profileHeightFeet * 12) + viewModel.profileHeightInches)
             return totalInches > 0 ? totalInches * 2.54 : nil
         }
     }
 
     private var isHeightValid: Bool {
-        switch heightUnit {
+        switch viewModel.profileHeightUnit {
         case .centimeters:
-            let value = Double(heightCentimetersText) ?? 0
+            let value = Double(viewModel.profileHeightCentimetersText) ?? 0
             return value >= 100 && value <= 250
         case .inches:
-            let totalInches = (heightFeet * 12) + heightInches
+            let totalInches = (viewModel.profileHeightFeet * 12) + viewModel.profileHeightInches
             return totalInches >= 48 && totalInches <= 96
         }
     }
 
     private var heightUnitStorageValue: String {
-        switch heightUnit {
+        switch viewModel.profileHeightUnit {
         case .centimeters:
             return "cm"
         case .inches:
@@ -90,7 +80,7 @@ struct BodyScoreProfileDetailsView: View {
     }
 
     private var currentTitle: String {
-        switch activeSubstep {
+        switch viewModel.profileDetailsActiveSubstep {
         case .firstName:
             return "What's your first name?"
         case .lastName:
@@ -105,7 +95,7 @@ struct BodyScoreProfileDetailsView: View {
     }
 
     private var currentSubtitle: String {
-        switch activeSubstep {
+        switch viewModel.profileDetailsActiveSubstep {
         case .firstName:
             return "We'll use this to personalize your experience."
         case .lastName:
@@ -120,7 +110,7 @@ struct BodyScoreProfileDetailsView: View {
     }
 
     private var primaryButtonTitle: String {
-        switch activeSubstep {
+        switch viewModel.profileDetailsActiveSubstep {
         case .firstName, .lastName, .dateOfBirth, .sex:
             return "Continue"
         case .height:
@@ -133,31 +123,31 @@ struct BodyScoreProfileDetailsView: View {
             title: currentTitle,
             subtitle: currentSubtitle,
             onBack: {
-                switch activeSubstep {
+                switch viewModel.profileDetailsActiveSubstep {
                 case .firstName:
                     viewModel.goBack()
                 case .lastName:
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                        activeSubstep = .firstName
+                        viewModel.profileDetailsActiveSubstep = .firstName
                     }
                 case .dateOfBirth:
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                        activeSubstep = .lastName
+                        viewModel.profileDetailsActiveSubstep = .lastName
                     }
                 case .sex:
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                        activeSubstep = .dateOfBirth
+                        viewModel.profileDetailsActiveSubstep = .dateOfBirth
                     }
                 case .height:
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                        activeSubstep = shouldAskSexInProfile ? .sex : .dateOfBirth
+                        viewModel.profileDetailsActiveSubstep = viewModel.profileShouldAskSex ? .sex : .dateOfBirth
                     }
                 }
             },
             progress: viewModel.progress(for: .profileDetails),
             content: {
                 VStack(spacing: 24) {
-                    switch activeSubstep {
+                    switch viewModel.profileDetailsActiveSubstep {
                     case .firstName, .lastName:
                         nameSection
                     case .dateOfBirth:
@@ -194,12 +184,12 @@ struct BodyScoreProfileDetailsView: View {
             }
         )
         .onAppear {
-            hydrateFromCurrentUser()
+            viewModel.hydrateProfileDetailsDraftIfNeeded(from: authManager.currentUser)
             DispatchQueue.main.async {
                 focusNameFieldIfNeeded()
             }
         }
-        .onChange(of: activeSubstep) { _, newValue in
+        .onChange(of: viewModel.profileDetailsActiveSubstep) { _, newValue in
             DispatchQueue.main.async {
                 focusNameFieldIfNeeded(newValue)
             }
@@ -209,13 +199,13 @@ struct BodyScoreProfileDetailsView: View {
     private var nameSection: some View {
         OnboardingFormSection(title: "Name", caption: "We use this to personalize your experience.") {
             VStack(alignment: .leading, spacing: 16) {
-                switch activeSubstep {
+                switch viewModel.profileDetailsActiveSubstep {
                 case .firstName:
                     Text("First name")
                         .font(OnboardingTypography.caption)
                         .foregroundStyle(Color.appTextSecondary)
 
-                    TextField("First name", text: $firstName)
+                    TextField("First name", text: $viewModel.profileFirstName)
                         .textInputAutocapitalization(.words)
                         .autocorrectionDisabled(true)
                         .submitLabel(.next)
@@ -248,7 +238,7 @@ struct BodyScoreProfileDetailsView: View {
                         .font(OnboardingTypography.headline)
                         .foregroundStyle(Color.appText)
 
-                    TextField("Last name", text: $lastName)
+                    TextField("Last name", text: $viewModel.profileLastName)
                         .textInputAutocapitalization(.words)
                         .autocorrectionDisabled(true)
                         .submitLabel(.next)
@@ -277,7 +267,7 @@ struct BodyScoreProfileDetailsView: View {
         OnboardingFormSection(title: nil, caption: nil) {
             DatePicker(
                 "Date of Birth",
-                selection: $dateOfBirth,
+                selection: $viewModel.profileDateOfBirth,
                 displayedComponents: .date
             )
             .datePickerStyle(.wheel)
@@ -292,10 +282,9 @@ struct BodyScoreProfileDetailsView: View {
                     OnboardingOptionButton(
                         title: sex.description,
                         subtitle: nil,
-                        isSelected: biologicalSex == sex,
+                        isSelected: viewModel.profileBiologicalSex == sex,
                         action: {
-                            biologicalSex = sex
-                            viewModel.updateSex(sex)
+                            viewModel.updateProfileBiologicalSex(sex)
                             HapticManager.shared.selection()
                         }
                     )
@@ -307,19 +296,19 @@ struct BodyScoreProfileDetailsView: View {
     private var heightSection: some View {
         OnboardingFormSection(title: nil, caption: "You can update this later in Settings.") {
             VStack(alignment: .leading, spacing: 18) {
-                Picker("Height unit", selection: $heightUnit) {
+                Picker("Height unit", selection: $viewModel.profileHeightUnit) {
                     ForEach(HeightUnit.allCases, id: \.self) { unit in
                         Text(unit.description).tag(unit)
                     }
                 }
                 .pickerStyle(.segmented)
-                .onChange(of: heightUnit) { oldValue, newValue in
+                .onChange(of: viewModel.profileHeightUnit) { oldValue, newValue in
                     convertHeightFields(from: oldValue, to: newValue)
                 }
 
-                switch heightUnit {
+                switch viewModel.profileHeightUnit {
                 case .centimeters:
-                    TextField("178", text: $heightCentimetersText)
+                    TextField("178", text: $viewModel.profileHeightCentimetersText)
                         .keyboardType(.decimalPad)
                         .font(theme.typography.displayMedium)
                         .multilineTextAlignment(.center)
@@ -340,7 +329,7 @@ struct BodyScoreProfileDetailsView: View {
 
                 case .inches:
                     HStack(spacing: 12) {
-                        Picker("Feet", selection: $heightFeet) {
+                        Picker("Feet", selection: $viewModel.profileHeightFeet) {
                             ForEach(3...8, id: \.self) { feet in
                                 Text("\(feet) ft").tag(feet)
                             }
@@ -350,7 +339,7 @@ struct BodyScoreProfileDetailsView: View {
                         .frame(height: 150)
                         .clipped()
 
-                        Picker("Inches", selection: $heightInches) {
+                        Picker("Inches", selection: $viewModel.profileHeightInches) {
                             ForEach(0...11, id: \.self) { inches in
                                 Text("\(inches) in").tag(inches)
                             }
@@ -367,53 +356,6 @@ struct BodyScoreProfileDetailsView: View {
                 }
             }
         }
-    }
-
-    private func hydrateFromCurrentUser() {
-        guard let user = authManager.currentUser else {
-            biologicalSex = viewModel.bodyScoreInput.sex
-            shouldAskSexInProfile = biologicalSex == nil
-            recomputeActiveSubstep()
-            return
-        }
-
-        let baseName = user.profile?.fullName ?? user.name ?? ""
-        let components = baseName.split(separator: " ")
-        if !components.isEmpty {
-            firstName = String(components.first ?? "")
-            if components.count > 1 {
-                lastName = components.dropFirst().joined(separator: " ")
-            }
-        }
-
-        if let existingDob = user.profile?.dateOfBirth {
-            dateOfBirth = existingDob
-        }
-
-        if let existingGender = user.profile?.gender {
-            biologicalSex = Self.biologicalSex(from: existingGender)
-        }
-
-        if biologicalSex == nil {
-            biologicalSex = viewModel.bodyScoreInput.sex
-        }
-
-        shouldAskSexInProfile = biologicalSex == nil
-
-        if let existingHeight = user.profile?.height, existingHeight > 0 {
-            if user.profile?.heightUnit?.lowercased() == "in" {
-                heightUnit = .inches
-                let totalInches = Int((existingHeight / 2.54).rounded())
-                heightFeet = max(3, min(8, totalInches / 12))
-                heightInches = max(0, min(11, totalInches % 12))
-            } else {
-                heightUnit = .centimeters
-            }
-
-            heightCentimetersText = String(format: "%.0f", existingHeight)
-        }
-
-        recomputeActiveSubstep()
     }
 
     private func submit() {
@@ -434,11 +376,11 @@ struct BodyScoreProfileDetailsView: View {
                 }
 
                 var updates: [String: Any] = [
-                    "dateOfBirth": dateOfBirth,
+                    "dateOfBirth": viewModel.profileDateOfBirth,
                     "onboardingCompleted": completesOnboardingNow
                 ]
 
-                if let biologicalSex {
+                if let biologicalSex = viewModel.profileBiologicalSex {
                     updates["gender"] = biologicalSex.description
                 }
 
@@ -461,10 +403,10 @@ struct BodyScoreProfileDetailsView: View {
                             email: existingProfile?.email ?? currentUser.email,
                             username: existingProfile?.username,
                             fullName: fullName.isEmpty ? existingProfile?.fullName ?? currentUser.name : fullName,
-                            dateOfBirth: dateOfBirth,
+                            dateOfBirth: viewModel.profileDateOfBirth,
                             height: heightInCentimeters ?? existingProfile?.height,
                             heightUnit: heightInCentimeters == nil ? existingProfile?.heightUnit : heightUnitStorageValue,
-                            gender: biologicalSex?.description ?? existingProfile?.gender,
+                            gender: viewModel.profileBiologicalSex?.description ?? existingProfile?.gender,
                             activityLevel: existingProfile?.activityLevel,
                             goalWeight: existingProfile?.goalWeight,
                             goalWeightUnit: existingProfile?.goalWeightUnit,
@@ -493,18 +435,18 @@ struct BodyScoreProfileDetailsView: View {
 
 private extension BodyScoreProfileDetailsView {
     func handlePrimaryAction() {
-        switch activeSubstep {
+        switch viewModel.profileDetailsActiveSubstep {
         case .firstName:
             handleFirstNameContinue()
         case .lastName:
             handleLastNameContinue()
         case .dateOfBirth:
             withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                activeSubstep = shouldAskSexInProfile ? .sex : .height
+                viewModel.profileDetailsActiveSubstep = viewModel.profileShouldAskSex ? .sex : .height
             }
         case .sex:
             withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                activeSubstep = .height
+                viewModel.profileDetailsActiveSubstep = .height
             }
         case .height:
             submit()
@@ -515,7 +457,7 @@ private extension BodyScoreProfileDetailsView {
         guard isFirstNameValid else { return }
         HapticManager.shared.selection()
         withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-            activeSubstep = .lastName
+            viewModel.profileDetailsActiveSubstep = .lastName
         }
     }
 
@@ -523,28 +465,12 @@ private extension BodyScoreProfileDetailsView {
         guard isLastNameValid else { return }
         HapticManager.shared.selection()
         withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-            activeSubstep = .dateOfBirth
+            viewModel.profileDetailsActiveSubstep = .dateOfBirth
         }
     }
 
-    func recomputeActiveSubstep() {
-        if !isFirstNameValid {
-            activeSubstep = .firstName
-        } else if !isLastNameValid {
-            activeSubstep = .lastName
-        } else if !isDateOfBirthWithinValidRange {
-            activeSubstep = .dateOfBirth
-        } else if shouldAskSexInProfile && biologicalSex == nil {
-            activeSubstep = .sex
-        } else if !isHeightValid {
-            activeSubstep = .height
-        } else {
-            activeSubstep = .height
-        }
-    }
-
-    func focusNameFieldIfNeeded(_ step: ProfileSubstep? = nil) {
-        switch step ?? activeSubstep {
+    func focusNameFieldIfNeeded(_ step: OnboardingFlowViewModel.ProfileDetailsSubstep? = nil) {
+        switch step ?? viewModel.profileDetailsActiveSubstep {
         case .firstName:
             focusedNameField = .firstName
         case .lastName:
@@ -559,39 +485,20 @@ private extension BodyScoreProfileDetailsView {
 
         switch (oldUnit, newUnit) {
         case (.centimeters, .inches):
-            guard let centimeters = Double(heightCentimetersText) else { return }
+            guard let centimeters = Double(viewModel.profileHeightCentimetersText) else { return }
             let totalInches = Int((centimeters / 2.54).rounded())
-            heightFeet = max(3, min(8, totalInches / 12))
-            heightInches = max(0, min(11, totalInches % 12))
+            viewModel.profileHeightFeet = max(3, min(8, totalInches / 12))
+            viewModel.profileHeightInches = max(0, min(11, totalInches % 12))
         case (.inches, .centimeters):
-            let totalInches = Double((heightFeet * 12) + heightInches)
-            heightCentimetersText = String(format: "%.0f", totalInches * 2.54)
+            let totalInches = Double((viewModel.profileHeightFeet * 12) + viewModel.profileHeightInches)
+            viewModel.profileHeightCentimetersText = String(format: "%.0f", totalInches * 2.54)
         default:
             break
         }
     }
-
-    static func biologicalSex(from gender: String) -> BiologicalSex? {
-        let normalized = gender.lowercased()
-        if normalized.contains("female") || normalized.contains("woman") {
-            return .female
-        }
-        if normalized.contains("male") || normalized.contains("man") {
-            return .male
-        }
-        return nil
-    }
 }
 
 // MARK: - Local Types
-
-private enum ProfileSubstep {
-    case firstName
-    case lastName
-    case dateOfBirth
-    case sex
-    case height
-}
 
 private enum NameField: Hashable {
     case firstName

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -892,6 +892,7 @@ struct DashboardViewLiquid: View {
         )
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("photo_timeline_hud_phase_insight")
+        .accessibilityLabel(phaseInsightAccessibilityLabel(for: insight))
     }
 
     private var hudGlp1WeeklyCheckIn: some View {
@@ -1314,6 +1315,16 @@ struct DashboardViewLiquid: View {
         case .insufficientData:
             return Color.metricTextTertiary
         }
+    }
+
+    private func phaseInsightAccessibilityLabel(for insight: PhaseInsight) -> String {
+        [
+            insight.title,
+            insight.message,
+            insight.detail
+        ]
+        .compactMap { $0 }
+        .joined(separator: ". ")
     }
 
     private func glp1WeeklyCheckInColor(for status: Glp1WeeklyCheckInStatus) -> Color {

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -1672,6 +1672,77 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         XCTAssertNil(PreAuthOnboardingStore.shared.load())
     }
 
+    func testPersistedProgressRestoresProfileDetailsDraft() throws {
+        let userId = "onboarding-profile-draft-\(UUID().uuidString)"
+        let previousUser = AuthManager.shared.currentUser
+        let previousAuthenticationState = AuthManager.shared.isAuthenticated
+        let dateOfBirth = try XCTUnwrap(
+            Calendar.current.date(from: DateComponents(year: 1_992, month: 7, day: 4))
+        )
+
+        defer {
+            AuthManager.shared.currentUser = previousUser
+            AuthManager.shared.isAuthenticated = previousAuthenticationState
+            OnboardingProgressStore.shared.clearProgress(for: userId)
+        }
+
+        let initialUser = User(
+            id: userId,
+            email: "profile-draft@example.com",
+            name: "Seed User"
+        )
+        AuthManager.shared.currentUser = initialUser
+        AuthManager.shared.isAuthenticated = true
+
+        let viewModel = OnboardingFlowViewModel()
+        viewModel.currentStep = .profileDetails
+        viewModel.hydrateProfileDetailsDraftIfNeeded(from: initialUser)
+        viewModel.profileFirstName = "Avery"
+        viewModel.profileLastName = "Stone"
+        viewModel.profileDateOfBirth = dateOfBirth
+        viewModel.updateProfileBiologicalSex(.female)
+        viewModel.profileHeightUnit = .inches
+        viewModel.profileHeightFeet = 5
+        viewModel.profileHeightInches = 7
+        viewModel.profileHeightCentimetersText = "170"
+        viewModel.profileDetailsActiveSubstep = .height
+
+        let savedSnapshot = OnboardingProgressStore.shared.snapshotForTesting(for: userId)
+        XCTAssertEqual(savedSnapshot?.currentStep, .profileDetails)
+        XCTAssertEqual(savedSnapshot?.profileFirstName, "Avery")
+        XCTAssertEqual(savedSnapshot?.profileLastName, "Stone")
+        XCTAssertEqual(savedSnapshot?.profileDateOfBirth, dateOfBirth)
+        XCTAssertEqual(savedSnapshot?.profileBiologicalSex, .female)
+        XCTAssertEqual(savedSnapshot?.profileHeightUnit, .inches)
+        XCTAssertEqual(savedSnapshot?.profileHeightFeet, 5)
+        XCTAssertEqual(savedSnapshot?.profileHeightInches, 7)
+        XCTAssertEqual(savedSnapshot?.profileDetailsActiveSubstep, .height)
+
+        let restoredViewModel = OnboardingFlowViewModel()
+
+        XCTAssertEqual(restoredViewModel.currentStep, .profileDetails)
+        XCTAssertEqual(restoredViewModel.profileFirstName, "Avery")
+        XCTAssertEqual(restoredViewModel.profileLastName, "Stone")
+        XCTAssertEqual(restoredViewModel.profileDateOfBirth, dateOfBirth)
+        XCTAssertEqual(restoredViewModel.profileBiologicalSex, .female)
+        XCTAssertEqual(restoredViewModel.profileHeightUnit, .inches)
+        XCTAssertEqual(restoredViewModel.profileHeightFeet, 5)
+        XCTAssertEqual(restoredViewModel.profileHeightInches, 7)
+        XCTAssertEqual(restoredViewModel.profileHeightCentimetersText, "170")
+        XCTAssertEqual(restoredViewModel.profileDetailsActiveSubstep, .height)
+
+        let laterUserSnapshot = User(
+            id: userId,
+            email: "profile-draft@example.com",
+            name: "Server Override"
+        )
+        restoredViewModel.hydrateProfileDetailsDraftIfNeeded(from: laterUserSnapshot)
+
+        XCTAssertEqual(restoredViewModel.profileFirstName, "Avery")
+        XCTAssertEqual(restoredViewModel.profileLastName, "Stone")
+        XCTAssertEqual(restoredViewModel.profileDetailsActiveSubstep, .height)
+    }
+
     func testAdvanceAfterHealthConfirmationRequestsBodyFatWhenMissing() {
         let viewModel = OnboardingFlowViewModel()
         viewModel.bodyScoreInput.weight = WeightValue(value: 185, unit: .pounds)
@@ -1811,6 +1882,57 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         }
 
         XCTAssertEqual(updates["heightUnit"] as? String, "in")
+    }
+
+    func testBuildOnboardingProfileUpdatesPrefersPersistedProfileDetailsDraft() throws {
+        let userId = "onboarding-profile-update-draft-\(UUID().uuidString)"
+        let previousUser = AuthManager.shared.currentUser
+        let previousAuthenticationState = AuthManager.shared.isAuthenticated
+        let profileDateOfBirth = try XCTUnwrap(
+            Calendar.current.date(from: DateComponents(year: 1_991, month: 3, day: 22))
+        )
+
+        defer {
+            AuthManager.shared.currentUser = previousUser
+            AuthManager.shared.isAuthenticated = previousAuthenticationState
+            OnboardingProgressStore.shared.clearProgress(for: userId)
+        }
+
+        let user = User(
+            id: userId,
+            email: "profile-update-draft@example.com",
+            name: "Profile Draft"
+        )
+        AuthManager.shared.currentUser = user
+        AuthManager.shared.isAuthenticated = true
+
+        let viewModel = OnboardingFlowViewModel()
+        viewModel.updateSex(.male)
+        viewModel.updateBirthYear(1_979)
+        viewModel.bodyScoreInput.height = HeightValue(value: 180, unit: .centimeters)
+        viewModel.setHeightUnit(.centimeters)
+        viewModel.hydrateProfileDetailsDraftIfNeeded(from: user)
+        viewModel.updateProfileBiologicalSex(.female)
+        viewModel.profileDateOfBirth = profileDateOfBirth
+        viewModel.profileHeightUnit = .inches
+        viewModel.profileHeightFeet = 5
+        viewModel.profileHeightInches = 7
+
+        let updates = viewModel.buildOnboardingProfileUpdates()
+
+        XCTAssertEqual(updates["gender"] as? String, "Female")
+
+        let dateOfBirth = updates["dateOfBirth"] as? Date
+        XCTAssertEqual(dateOfBirth, profileDateOfBirth)
+
+        let height = updates["height"] as? Double
+        XCTAssertNotNil(height)
+        if let height {
+            XCTAssertEqual(height, 67 * 2.54, accuracy: 0.01)
+        }
+
+        XCTAssertEqual(updates["heightUnit"] as? String, "in")
+        XCTAssertEqual(updates["onboardingCompleted"] as? Bool, true)
     }
 
     func testBuildOnboardingProfileUpdatesAlwaysMarksOnboardingCompleted() {

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -180,7 +180,7 @@ final class LogYourBodyUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_pager"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_hud"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.descendants(matching: .any)["dashboard_home_timeline_hero"].waitForExistence(timeout: 10))
         let statsButton = app.descendants(matching: .any)["photo_timeline_hud_stats_button"]
         scrollUntilHittable(statsButton, in: app)
         XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
@@ -209,19 +209,18 @@ final class LogYourBodyUITests: XCTestCase {
         ]
         app.launch()
 
-        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_hud"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.descendants(matching: .any)["dashboard_home_timeline_hero"].waitForExistence(timeout: 10))
 
         let insight = app.descendants(matching: .any)["photo_timeline_hud_phase_insight"]
-        if !insight.waitForExistence(timeout: 2) {
-            app.scrollViews["photo_timeline_hud"].swipeUp()
-        }
+        scrollUntilExists(insight, in: app)
         XCTAssertTrue(insight.waitForExistence(timeout: 8))
-        XCTAssertTrue(app.staticTexts["Cutting"].exists)
-
-        let trendMessage = app.staticTexts.matching(
-            NSPredicate(format: "label CONTAINS %@", "Weight is trending down")
-        ).firstMatch
-        XCTAssertTrue(trendMessage.exists)
+        let expectedInsight = NSPredicate(
+            format: "label CONTAINS %@ AND label CONTAINS %@",
+            "Cutting",
+            "Weight is trending down"
+        )
+        expectation(for: expectedInsight, evaluatedWith: insight)
+        waitForExpectations(timeout: 5)
     }
 
     func testGlp1WeeklyCheckInFixtureShowsPromptAndOpensDoseFlow() throws {
@@ -232,12 +231,10 @@ final class LogYourBodyUITests: XCTestCase {
         ]
         app.launch()
 
-        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_hud"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.descendants(matching: .any)["dashboard_home_timeline_hero"].waitForExistence(timeout: 10))
 
         let prompt = app.buttons["photo_timeline_hud_glp1_weekly_checkin"]
-        if !prompt.waitForExistence(timeout: 2) {
-            app.scrollViews["photo_timeline_hud"].swipeUp()
-        }
+        scrollUntilExists(prompt, in: app)
         XCTAssertTrue(prompt.waitForExistence(timeout: 8))
 
         scrollUntilHittable(prompt, in: app)
@@ -304,6 +301,18 @@ final class LogYourBodyUITests: XCTestCase {
     ) {
         var remainingSwipes = maxSwipes
         while !element.isHittable && remainingSwipes > 0 {
+            app.swipeUp()
+            remainingSwipes -= 1
+        }
+    }
+
+    private func scrollUntilExists(
+        _ element: XCUIElement,
+        in app: XCUIApplication,
+        maxSwipes: Int = 8
+    ) {
+        var remainingSwipes = maxSwipes
+        while !element.exists && remainingSwipes > 0 {
             app.swipeUp()
             remainingSwipes -= 1
         }


### PR DESCRIPTION
## Summary
- Persist Body Score profile-details draft fields in the authenticated onboarding progress snapshot: name, DOB, biological sex, height unit/value, active substep, and sex prompt state.
- Bind `BodyScoreProfileDetailsView` directly to the persisted view-model draft so restarts preserve in-progress profile details.
- Prefer the persisted profile-details draft when final onboarding completion writes profile updates, avoiding DOB/height/sex overwrite from earlier Body Score inputs.
- Stabilize Photo HUD UI fixture tests after the full-width avatar layout by anchoring on visible hero content and exposing a deterministic Phase Insight accessibility label.

## Linear
- JOV-3175

## Validation
- `swiftlint lint --strict` from `apps/ios` passed.
- `git diff --check` passed.
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/OnboardingFlowViewModelTests` passed: 24 passed, 0 failed.
- XcodeBuildMCP `build_run_sim` with `-lybUITestBodyScoreOnboardingFixture` passed on `LYB Golden iPhone 16`.
- Onboarding fixture screenshot captured: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_fab412a2-709d-4657-aacc-8375ffe8fe75.jpg`.
- `pnpm lint` passed.
- `pnpm typecheck` passed.
- `pnpm test` passed: web Jest 30 suites / 261 tests; workspace test tasks all successful.
- XcodeBuildMCP rerun for previously failing HUD UI fixtures passed: 3 passed, 0 failed.
- Full XcodeBuildMCP `test_sim` passed after polling the underlying run to completion: 167 total tests, 167 passed, 0 failed.

## Notes
- The first full iOS run exposed stale HUD UI-test anchors unrelated to onboarding persistence. This PR includes the small fixture/test accessibility stabilization so full local iOS validation is green.
