### PR TITLE
Fix full-width dashboard avatar hero

### DIFF
--- a/apps/ios/LogYourBody/Components/AvatarBodyRenderer.swift
+++ b/apps/ios/LogYourBody/Components/AvatarBodyRenderer.swift
@@ -12,22 +12,36 @@ struct AvatarBodyRenderer: View {
     let gender: String?
     let height: CGFloat
     var padding: CGFloat = 12
+    var verticalPadding: CGFloat = 0
+    var horizontalFillScale: CGFloat = 1
     var alignment: Alignment = .center
 
     private var avatar: AvatarBodyFatCatalog.Match {
         AvatarBodyFatCatalog.match(bodyFatPercentage: bodyFatPercentage, gender: gender)
     }
 
+    private var clampedHorizontalFillScale: CGFloat {
+        max(horizontalFillScale, 1)
+    }
+
     var body: some View {
         GeometryReader { geometry in
+            let contentWidth = max(0, geometry.size.width - padding * 2)
+            let contentHeight = max(0, geometry.size.height - verticalPadding * 2)
+
             Image(avatar.assetName)
                 .resizable()
                 .interpolation(.high)
                 .scaledToFit()
                 .frame(
-                    width: max(0, geometry.size.width - padding * 2)
+                    width: contentWidth * clampedHorizontalFillScale,
+                    height: contentHeight,
+                    alignment: alignment
                 )
-                .padding(padding)
+                .frame(width: contentWidth, height: contentHeight, alignment: alignment)
+                .clipped()
+                .padding(.horizontal, padding)
+                .padding(.vertical, verticalPadding)
                 .frame(width: geometry.size.width, height: geometry.size.height, alignment: alignment)
                 .clipped()
                 .accessibilityHidden(true)

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -306,7 +306,9 @@ private struct DashboardHomeTimelineAvatarPlaceholder: View {
                 bodyFatPercentage: bodyFatPercentage,
                 gender: gender,
                 height: geometry.size.height,
-                padding: 18,
+                padding: 8,
+                verticalPadding: 0,
+                horizontalFillScale: 1.04,
                 alignment: .bottom
             )
             .frame(width: geometry.size.width, height: geometry.size.height, alignment: .bottom)


### PR DESCRIPTION
## Summary
- JOV-3145 follow-up polish for the dashboard avatar hero.
- Makes AvatarBodyRenderer fill the available 4:5 hero width with a small horizontal inset instead of rendering as a centered floating thumbnail.
- Keeps top/bottom padding at zero in the dashboard hero so the transparent avatar asset anchors as the main visual surface.

## Validation
- swiftlint lint --strict
- XcodeBuildMCP test_sim -only-testing:LogYourBodyTests/PhotoTimelineHUDPolicyTests (7 passed)
- XcodeBuildMCP build_run_sim on LYB Golden iPhone 16 with -lybUITestPhotoTimelineHUDFixture
- XcodeBuildMCP screenshot: /var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_bd945dc8-5653-4461-9060-52b2fbda2db0.jpg
- XcodeBuildMCP test_sim -only-testing:LogYourBodyUITests/LogYourBodyUITests/testPhotoHUDFixtureDefaultsToAvatarHeroWhenNoPhotoExists (1 passed)
- pnpm lint
- pnpm typecheck
- pnpm test

## Notes
- The existing avatar asset test still verifies every body-fat bucket image has transparent perimeter pixels, so this PR only changes SwiftUI framing/layout.
- A normal non-fixture launch still lands on the local placeholder auth/config error screen until real ignored config is present; fixture launch was used for dashboard visual proof.