### PR TITLE
JOV-3149 Polish iOS copy and inactive rows

### DIFF
--- a/apps/ios/LogYourBody/Components/DashboardSyncComponents.swift
+++ b/apps/ios/LogYourBody/Components/DashboardSyncComponents.swift
@@ -227,13 +227,13 @@ struct DashboardSyncDetailsSheet: View {
         case .offline:
             return "Offline"
         case .error:
-            return "Error"
+            return "Sync needs retry"
         case .success:
             return "Synced"
         case .syncing:
             return "Syncing…"
         case .idle:
-            return "Idle"
+            return syncManager.pendingSyncCount > 0 ? "Pending sync" : "Synced"
         }
     }
 }

--- a/apps/ios/LogYourBody/DashboardSyncComponents.swift
+++ b/apps/ios/LogYourBody/DashboardSyncComponents.swift
@@ -146,13 +146,13 @@ struct DashboardSyncDetailsSheet: View {
         case .offline:
             return "Offline"
         case .error:
-            return "Error"
+            return "Sync needs retry"
         case .success:
             return "Synced"
         case .syncing:
             return "Syncing…"
         case .idle:
-            return "Idle"
+            return syncManager.pendingSyncCount > 0 ? "Pending sync" : "Synced"
         }
     }
 }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHookView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHookView.swift
@@ -6,14 +6,14 @@ struct BodyScoreHookView: View {
 
     private let bulletItems: [OnboardingBulletItem] = [
         .init(iconName: "chart.xyaxis.line", text: "Track weight, body fat, and FFMI together."),
-        .init(iconName: "person.3", text: "See where you land vs similar men."),
+        .init(iconName: "person.3", text: "See where you land vs similar bodies."),
         .init(iconName: "arrow.triangle.2.circlepath", text: "Update your score anytime as you progress.")
     ]
 
     var body: some View {
         OnboardingPageTemplate(
             title: "Get your Body Score in 60 seconds.",
-            subtitle: "See your muscle, body fat, and FFMI vs similar men.",
+            subtitle: "See your muscle, body fat, and FFMI in one score.",
             showsBackButton: false,
             progress: viewModel.progress(for: .hook)
         ) {

--- a/apps/ios/LogYourBody/Services/ValidationService.swift
+++ b/apps/ios/LogYourBody/Services/ValidationService.swift
@@ -48,7 +48,7 @@ final class ValidationService {
             throw ValidationError.invalidBodyFat("Please enter a valid percentage")
         }
 
-        let range = 3.0...50.0
+        let range = 3.0...60.0
         guard range.contains(bodyFat) else {
             throw ValidationError.invalidBodyFat("Body fat must be between \(Int(range.lowerBound))-\(Int(range.upperBound))%")
         }

--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -439,7 +439,7 @@ struct AddEntrySheet: View {
                         .foregroundColor(.error)
                         .accessibilityLabel("Body fat validation error: \(error)")
                 } else {
-                    Text("Valid range: 3-50%")
+                    Text("Valid range: 3-60%")
                         .font(.appBodySmall)
                         .foregroundColor(.appTextTertiary)
                 }

--- a/apps/ios/LogYourBody/Views/BiometricLockView.swift
+++ b/apps/ios/LogYourBody/Views/BiometricLockView.swift
@@ -33,6 +33,32 @@ struct BiometricLockView: View {
         }
     }
 
+    private var biometricScanningText: String {
+        switch biometricType {
+        case .faceID:
+            return "Scanning your face…"
+        case .touchID:
+            return "Reading your fingerprint…"
+        }
+    }
+
+    private var biometricReadyText: String {
+        "\(biometricType.title) is ready"
+    }
+
+    private var biometricPromptText: String {
+        switch biometricType {
+        case .faceID:
+            return "Look at your iPhone to continue"
+        case .touchID:
+            return "Touch the sensor to continue"
+        }
+    }
+
+    private var biometricProtectionText: String {
+        "Your data stays encrypted on this device. \(biometricType.title) adds another lock on LogYourBody."
+    }
+
     var body: some View {
         ZStack {
             Color.liquidBg
@@ -154,11 +180,11 @@ struct BiometricLockView: View {
             }
 
             VStack(spacing: 6) {
-                Text(isAuthenticating ? "Scanning your face…" : "Face ID is ready")
+                Text(isAuthenticating ? biometricScanningText : biometricReadyText)
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundColor(.linearText)
 
-                Text("Look at your iPhone to continue")
+                Text(biometricPromptText)
                     .font(.system(size: 15))
                     .foregroundColor(.linearTextSecondary)
             }
@@ -178,7 +204,7 @@ struct BiometricLockView: View {
             }
             .opacity(isAuthenticating ? 1 : 0.4)
 
-            Text("Your data stays encrypted on this device. Face ID adds another lock on LogYourBody.")
+            Text(biometricProtectionText)
                 .font(.system(size: 14))
                 .multilineTextAlignment(.center)
                 .foregroundColor(.linearTextTertiary)
@@ -206,7 +232,7 @@ struct BiometricLockView: View {
                     Image(systemName: "lock.shield")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundColor(.linearTextSecondary)
-                    Text("Protected by Face ID")
+                    Text("Protected by \(biometricType.title)")
                         .font(.system(size: 14))
                         .foregroundColor(.linearTextSecondary)
                 }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeaderAndSync.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeaderAndSync.swift
@@ -119,8 +119,7 @@ extension DashboardViewLiquid {
         case .offline:
             return "Offline"
         case .error:
-            // Keep header copy neutral; red banner handles the explicit error messaging
-            return "Sync"
+            return "Sync needs retry"
         case .success, .idle:
             return "Synced"
         case .syncing:

--- a/apps/ios/LogYourBody/Views/EditEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/EditEntrySheet.swift
@@ -139,7 +139,7 @@ struct EditEntrySheet: View {
     }
 
     private var validationMessage: String? {
-        guard !primaryValue.isEmpty else { return "" }
+        guard !primaryValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
         guard let value = Double(primaryValue) else { return "Enter a valid number" }
 
         switch metricType {
@@ -150,7 +150,7 @@ struct EditEntrySheet: View {
             }
         case .bodyFat:
             if value < 3 || value > 60 {
-                return "Body fat must be between 3% and 60%"
+                return "Body fat must be between 3-60%"
             }
         default:
             break
@@ -159,7 +159,8 @@ struct EditEntrySheet: View {
     }
 
     private var canSave: Bool {
-        validationMessage?.isEmpty ?? false ? false : validationMessage == nil
+        guard !primaryValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        return validationMessage == nil
     }
 
     private var showsHealthBanner: Bool {

--- a/apps/ios/LogYourBody/Views/EnhancedOTPInputView.swift
+++ b/apps/ios/LogYourBody/Views/EnhancedOTPInputView.swift
@@ -260,17 +260,11 @@ struct EnhancedOTPInputView: View {
         // Check if it's a valid OTP code
         if numbers.count == numberOfDigits {
             clipboardCode = numbers
+            showPasteButton = true
 
-            // Only show paste button if clipboard changed recently (within 3 seconds)
-            if let changeTime = UIPasteboard.general.changeCount.description.data(using: .utf8),
-               let lastChange = try? JSONDecoder().decode(Date.self, from: changeTime),
-               Date().timeIntervalSince(lastChange) < 3 {
-                showPasteButton = true
-
-                // Hide paste button after 10 seconds
-                DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                    showPasteButton = false
-                }
+            // Hide paste affordance after a short grace period if the user ignores it.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                showPasteButton = false
             }
         } else {
             showPasteButton = false

--- a/apps/ios/LogYourBody/Views/IntegrationsView.swift
+++ b/apps/ios/LogYourBody/Views/IntegrationsView.swift
@@ -3,6 +3,7 @@
 // LogYourBody
 //
 import SwiftUI
+import UIKit
 
 struct IntegrationsView: View {
     @EnvironmentObject var authManager: AuthManager
@@ -26,7 +27,6 @@ struct IntegrationsView: View {
                     healthAndFitnessSection
                     photoImportSection
                     dataExportSection
-                    developerAccessSection
                 }
                 .padding(.horizontal, 20)
                 .padding(.top, 20)
@@ -35,15 +35,15 @@ struct IntegrationsView: View {
         }
         .navigationTitle("Integrations")
         .navigationBarTitleDisplayMode(.inline)
-        .sheet(isPresented: $showHealthKitConnect) {
-            // HealthKit authorization handled inline
-            Text("")
-                .onAppear {
-                    Task {
-                        _ = await healthKitManager.requestAuthorization()
-                        showHealthKitConnect = false
-                    }
+        .alert("Apple Health Permission Needed", isPresented: $showHealthKitConnect) {
+            Button("Open Settings") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
                 }
+            }
+            Button("Not Now", role: .cancel) {}
+        } message: {
+            Text("Enable Apple Health access in Settings to sync weight and body-composition data.")
         }
         .onAppear {
             // Check HealthKit authorization status
@@ -152,31 +152,9 @@ struct IntegrationsView: View {
                     )
                 }
 
-                Divider()
-
-                // Google Fit (Coming Soon)
-                HStack {
-                    Image(systemName: "figure.run")
-                        .foregroundColor(.green)
-                        .font(.system(size: SettingsDesign.iconSize))
-                        .frame(width: SettingsDesign.iconFrame)
-
-                    Text("Google Fit")
-                        .font(SettingsDesign.titleFont)
-
-                    Spacer()
-
-                    Text("Coming Soon")
-                        .font(SettingsDesign.valueFont)
-                        .foregroundColor(.appTextSecondary)
-                }
-                .padding(.horizontal, SettingsDesign.horizontalPadding)
-                .padding(.vertical, SettingsDesign.verticalPadding)
-                .opacity(0.6)
-
-                Divider()
-
                 if Constants.isBodySpecEnabled {
+                    Divider()
+
                     NavigationLink(
                         destination: BodySpecIntegrationView()
                             .environmentObject(authManager)
@@ -209,26 +187,6 @@ struct IntegrationsView: View {
                     }
                     .padding(.horizontal, SettingsDesign.horizontalPadding)
                     .padding(.vertical, SettingsDesign.verticalPadding)
-                } else {
-                    // BodySpec (Coming Soon)
-                    HStack {
-                        Image(systemName: "waveform.path.ecg")
-                            .foregroundColor(.blue)
-                            .font(.system(size: SettingsDesign.iconSize))
-                            .frame(width: SettingsDesign.iconFrame)
-
-                        Text("BodySpec")
-                            .font(SettingsDesign.titleFont)
-
-                        Spacer()
-
-                        Text("Coming Soon")
-                            .font(SettingsDesign.valueFont)
-                            .foregroundColor(.appTextSecondary)
-                    }
-                    .padding(.horizontal, SettingsDesign.horizontalPadding)
-                    .padding(.vertical, SettingsDesign.verticalPadding)
-                    .opacity(0.6)
                 }
             }
         }
@@ -268,66 +226,16 @@ struct IntegrationsView: View {
     private var dataExportSection: some View {
         SettingsSection(
             header: "Data Export",
-            footer: "Export your data to other platforms"
+            footer: "Export your data in available formats"
         ) {
-            VStack(spacing: 0) {
-                // CSV Export
-                NavigationLink(destination: ExportDataView()) {
-                    SettingsRow(
-                        icon: "doc.text",
-                        title: "Export as CSV",
-                        showChevron: true
-                    )
-                }
-
-                Divider()
-
-                // JSON Export (Coming Soon)
-                HStack {
-                    Image(systemName: "doc.badge.gearshape")
-                        .foregroundColor(.appTextSecondary)
-                        .font(.system(size: SettingsDesign.iconSize))
-                        .frame(width: SettingsDesign.iconFrame)
-
-                    Text("Export as JSON")
-                        .font(SettingsDesign.titleFont)
-
-                    Spacer()
-
-                    Text("Coming Soon")
-                        .font(SettingsDesign.valueFont)
-                        .foregroundColor(.appTextSecondary)
-                }
-                .padding(.horizontal, SettingsDesign.horizontalPadding)
-                .padding(.vertical, SettingsDesign.verticalPadding)
-                .opacity(0.6)
+            NavigationLink(destination: ExportDataView()) {
+                SettingsRow(
+                    icon: "doc.text",
+                    title: "Export Data",
+                    value: "CSV",
+                    showChevron: true
+                )
             }
-        }
-    }
-
-    private var developerAccessSection: some View {
-        SettingsSection(
-            header: "Developer Access",
-            footer: "API access for third-party developers will be available in the future"
-        ) {
-            HStack {
-                Image(systemName: "network")
-                    .foregroundColor(.appTextSecondary)
-                    .font(.system(size: SettingsDesign.iconSize))
-                    .frame(width: SettingsDesign.iconFrame)
-
-                Text("API Access")
-                    .font(SettingsDesign.titleFont)
-
-                Spacer()
-
-                Text("Coming Soon")
-                    .font(SettingsDesign.valueFont)
-                    .foregroundColor(.appTextSecondary)
-            }
-            .padding(.horizontal, SettingsDesign.horizontalPadding)
-            .padding(.vertical, SettingsDesign.verticalPadding)
-            .opacity(0.6)
         }
     }
 }

--- a/apps/ios/LogYourBody/Views/LegalView.swift
+++ b/apps/ios/LogYourBody/Views/LegalView.swift
@@ -108,16 +108,6 @@ extension LegalView {
                         isExternal: true
                     )
                 }
-
-                DSDivider().insetted(16)
-
-                // Mailing Address
-                SettingsRow(
-                    icon: "location",
-                    title: "Mailing Address",
-                    value: "View",
-                    showChevron: false
-                )
             }
         }
     }

--- a/apps/ios/LogYourBody/Views/MainTabView.swift
+++ b/apps/ios/LogYourBody/Views/MainTabView.swift
@@ -89,7 +89,7 @@ enum PaidWeightLoggerMVPPolicy {
     static func syncStatusText(status: RealtimeSyncManager.SyncStatus, pendingCount: Int) -> String {
         switch status {
         case .syncing:
-            return "Syncing now"
+            return "Syncing"
         case .success:
             return "Synced"
         case .error:
@@ -97,12 +97,12 @@ enum PaidWeightLoggerMVPPolicy {
         case .offline:
             return pendingCount > 0 ? "Saved offline" : "Offline"
         case .idle:
-            return pendingCount > 0 ? "Sync queued" : "Ready"
+            return pendingCount > 0 ? "Pending sync" : "Synced"
         }
     }
 
     static func savedConfirmationText(isOnline: Bool) -> String {
-        isOnline ? "Saved locally. Sync queued." : "Saved locally. Will sync when online."
+        isOnline ? "Saved locally. Pending sync." : "Saved locally. Will sync when online."
     }
 }
 

--- a/apps/ios/LogYourBody/Views/SyncStatusView.swift
+++ b/apps/ios/LogYourBody/Views/SyncStatusView.swift
@@ -77,16 +77,14 @@ struct SyncStatusView: View {
 
         switch syncManager.syncStatus {
         case .syncing:
-            return "Syncing..."
+            return "Syncing…"
         case .error:
-            return "Sync Error"
+            return "Sync needs retry"
         case .offline:
             return "Offline"
         default:
             if syncManager.pendingSyncCount > 0 {
-                return "\(syncManager.pendingSyncCount) pending"
-            } else if syncManager.realtimeConnected {
-                return "Live"
+                return "Pending sync"
             } else {
                 return "Synced"
             }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -990,7 +990,7 @@ final class PaidWeightLoggerMVPPolicyTests: XCTestCase {
     func testSyncStatusCopyAvoidsRawPendingState() {
         XCTAssertEqual(
             PaidWeightLoggerMVPPolicy.syncStatusText(status: .idle, pendingCount: 1),
-            "Sync queued"
+            "Pending sync"
         )
         XCTAssertEqual(
             PaidWeightLoggerMVPPolicy.syncStatusText(status: .offline, pendingCount: 1),
@@ -1034,15 +1034,15 @@ final class ValidationServiceTests: XCTestCase {
         let service = ValidationService.shared
 
         XCTAssertEqual(try service.validateBodyFat("3"), 3)
-        XCTAssertEqual(try service.validateBodyFat("50"), 50)
+        XCTAssertEqual(try service.validateBodyFat("60"), 60)
 
         assertValidationError(
             try service.validateBodyFat("2.9"),
-            expectedMessage: "Body fat must be between 3-50%"
+            expectedMessage: "Body fat must be between 3-60%"
         )
         assertValidationError(
-            try service.validateBodyFat("50.1"),
-            expectedMessage: "Body fat must be between 3-50%"
+            try service.validateBodyFat("60.1"),
+            expectedMessage: "Body fat must be between 3-60%"
         )
     }
 
@@ -1095,12 +1095,12 @@ final class LogWeightFormValidatorTests: XCTestCase {
     func testRejectsOutOfRangeBodyFatValues() {
         let tooLow = LogWeightFormValidator.validate(weight: "", bodyFat: "1", unit: "lbs")
         XCTAssertFalse(tooLow.isValid)
-        XCTAssertEqual(tooLow.bodyFatError, "Body fat must be between 3-50%")
+        XCTAssertEqual(tooLow.bodyFatError, "Body fat must be between 3-60%")
         XCTAssertNil(tooLow.bodyFatValue)
 
-        let tooHigh = LogWeightFormValidator.validate(weight: "", bodyFat: "60", unit: "lbs")
+        let tooHigh = LogWeightFormValidator.validate(weight: "", bodyFat: "60.1", unit: "lbs")
         XCTAssertFalse(tooHigh.isValid)
-        XCTAssertEqual(tooHigh.bodyFatError, "Body fat must be between 3-50%")
+        XCTAssertEqual(tooHigh.bodyFatError, "Body fat must be between 3-60%")
         XCTAssertNil(tooHigh.bodyFatValue)
     }
 
@@ -1138,7 +1138,7 @@ final class LogWeightFormValidatorTests: XCTestCase {
             _ = try ValidationService.shared.validateWeight("500.1", unit: "kg")
         }
         let expectedBodyFatError = validationErrorDescription {
-            _ = try ValidationService.shared.validateBodyFat("50.1")
+            _ = try ValidationService.shared.validateBodyFat("60.1")
         }
 
         XCTAssertEqual(
@@ -1146,7 +1146,7 @@ final class LogWeightFormValidatorTests: XCTestCase {
             expectedKgError
         )
         XCTAssertEqual(
-            LogWeightFormValidator.fieldError(for: "50.1", field: .bodyFat, unit: "kg"),
+            LogWeightFormValidator.fieldError(for: "60.1", field: .bodyFat, unit: "kg"),
             expectedBodyFatError
         )
     }

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -258,6 +258,10 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Locked"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["integrations_bulk_photo_import_link"].exists)
         XCTAssertFalse(app.staticTexts["Bulk Photo Import"].exists)
+        XCTAssertFalse(app.staticTexts["Google Fit"].exists)
+        XCTAssertFalse(app.staticTexts["Export as JSON"].exists)
+        XCTAssertFalse(app.staticTexts["API Access"].exists)
+        XCTAssertFalse(app.staticTexts["Coming Soon"].exists)
     }
 
     func testBulkPhotoImportGateOpensScannerEntry() throws {


### PR DESCRIPTION
## Summary
- Align iOS sync vocabulary around Synced, Pending sync, Syncing, and Sync needs retry.
- Make biometric lock copy adapt to Face ID vs Touch ID.
- Remove inactive Integrations and Legal rows, replace the blank HealthKit authorization sheet with a real alert, and keep Data Export honest as CSV-only.
- Expand the accepted body-fat range to 3-60% across validation and form copy.
- Fix the OTP paste affordance so valid clipboard codes actually show the paste button.

Linear: JOV-3149

## Validation
- GBrain: `gbrain doctor --fast --json` returned unhealthy health_score 65 with resolver/sync/manifest warnings only; not blocking this local iOS slice.
- `swiftlint lint --strict`
- XcodeBuildMCP `test_sim` focused tests: `ValidationServiceTests`, `LogWeightFormValidatorTests`, `PaidWeightLoggerMVPPolicyTests`, `LogYourBodyUITests/testBulkPhotoImportLockedByDefaultInIntegrations` (12 passed, 0 failed)
- XcodeBuildMCP `build_run_sim` with `-lybUITestWeightLoggerMVPFixture`
- Simulator screenshot: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_1cdddf18-b96f-4c09-b858-a9e00a4309e4.jpg`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Notes
- `Constants.isBodySpecEnabled` is true in this build, so BodySpec remains visible as an enabled integration. Disabled/coming-soon BodySpec copy is removed.
