### PR TITLE
JOV-3146 Simplify dashboard data viz

### DIFF
--- a/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
+++ b/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
@@ -72,13 +72,15 @@ struct BodyScoreShareCardView: View {
                 }
 
                 VStack(spacing: 20) {
-                    BodyScoreGaugeView(score: payload.score)
+                    BodyScoreGaugeView(score: payload.score, scoreText: payload.scoreText)
+                        .scaleEffect(1.35)
                         .frame(maxWidth: .infinity)
+                        .frame(height: 160)
 
-                    Text(payload.scoreText)
-                        .font(.system(size: 72, weight: .bold, design: .rounded))
-                        .foregroundColor(.white)
-                        .monospacedDigit()
+                    Text(payload.tagline)
+                        .font(.system(size: 20, weight: .semibold, design: .rounded))
+                        .foregroundColor(Color.white.opacity(0.82))
+                        .multilineTextAlignment(.center)
                         .frame(maxWidth: .infinity)
                 }
 

--- a/apps/ios/LogYourBody/Components/DashboardBodyScoreHeroCard.swift
+++ b/apps/ios/LogYourBody/Components/DashboardBodyScoreHeroCard.swift
@@ -2,63 +2,49 @@ import SwiftUI
 
 struct BodyScoreGaugeView: View {
     let score: Int
+    let scoreText: String
 
     var body: some View {
-        GeometryReader { geometry in
-            let width = geometry.size.width
-            let radius = width * 0.45
-            let lineWidth: CGFloat = 10
-            let progress = max(0, min(Double(score) / 100.0, 1.0))
+        let progress = max(0, min(Double(score) / 100.0, 1.0))
 
-            ZStack {
-                Circle()
-                    .trim(from: 0, to: 0.5)
-                    .stroke(
-                        Color.white.opacity(0.15),
-                        style: StrokeStyle(
-                            lineWidth: lineWidth,
-                            lineCap: .round,
-                            lineJoin: .round
-                        )
-                    )
-                    .frame(width: radius * 2, height: radius * 2)
+        ZStack {
+            Circle()
+                .stroke(
+                    Color.white.opacity(0.14),
+                    style: StrokeStyle(lineWidth: 10, lineCap: .round)
+                )
 
-                Circle()
-                    .trim(from: 0, to: 0.5 * progress)
-                    .stroke(
-                        AngularGradient(
-                            gradient: Gradient(colors: [
-                                Color.metricAccent,
-                                Color.metricAccent.opacity(0.6),
-                                Color.metricAccent
-                            ]),
-                            center: .center,
-                            startAngle: .degrees(180),
-                            endAngle: .degrees(360)
-                        ),
-                        style: StrokeStyle(
-                            lineWidth: lineWidth + 2,
-                            lineCap: .round,
-                            lineJoin: .round,
-                            dash: [10, 10]
-                        )
-                    )
-                    .frame(width: radius * 2, height: radius * 2)
-                    .shadow(
-                        color: Color.metricAccent.opacity(0.4),
-                        radius: 8,
-                        x: 0,
-                        y: 0
-                    )
-                    .animation(
-                        .spring(response: 0.8, dampingFraction: 0.8),
-                        value: score
-                    )
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(
+                    AngularGradient(
+                        gradient: Gradient(colors: [
+                            Color.metricAccent,
+                            Color.metricAccent.opacity(0.58),
+                            Color.metricAccent
+                        ]),
+                        center: .center
+                    ),
+                    style: StrokeStyle(lineWidth: 12, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .shadow(color: Color.metricAccent.opacity(0.35), radius: 8, x: 0, y: 0)
+                .animation(.spring(response: 0.8, dampingFraction: 0.8), value: score)
+
+            VStack(spacing: 0) {
+                Text(scoreText)
+                    .font(.system(size: 42, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.65)
+
+                Text("/100")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(Color.white.opacity(0.45))
             }
-            .rotationEffect(.degrees(180))
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
-        .frame(height: 120)
+        .frame(width: 118, height: 118)
+        .accessibilityLabel("Body Score \(scoreText)")
     }
 }
 
@@ -67,11 +53,8 @@ struct DashboardBodyScoreHeroCard: View {
     let scoreText: String
     let tagline: String
     let ffmiValue: String
-    let ffmiCaption: String
     let bodyFatValue: String
-    let bodyFatCaption: String
     let weightValue: String
-    let weightCaption: String
     let deltaText: String?
     let onTapBodyScore: (() -> Void)?
     let onTapFFMI: (() -> Void)?
@@ -80,161 +63,97 @@ struct DashboardBodyScoreHeroCard: View {
 
     var body: some View {
         HeroGlassCard {
-            VStack(alignment: .leading, spacing: 20) {
-                header
-
+            VStack(alignment: .leading, spacing: 22) {
                 gaugeAndSummary
 
-                HStack(spacing: 18) {
+                HStack(spacing: 12) {
                     tappableHeroStatTile(
                         title: "FFMI",
                         value: ffmiValue,
-                        caption: ffmiCaption,
                         onTap: onTapFFMI
                     )
                     tappableHeroStatTile(
                         title: "Body Fat",
                         value: bodyFatValue,
-                        caption: bodyFatCaption,
                         onTap: onTapBodyFat
                     )
                     tappableHeroStatTile(
                         title: "Weight",
                         value: weightValue,
-                        caption: weightCaption,
                         onTap: onTapWeight
                     )
                 }
+                .accessibilityIdentifier("dashboard_body_score_hero_stats")
             }
-            .padding(28)
+            .padding(24)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-    }
-
-    private var header: some View {
-        HStack(alignment: .center, spacing: 12) {
-            Text("Body Score")
-                .font(.system(size: 14, weight: .medium))
-                .foregroundColor(Color.white.opacity(0.65))
-
-            Spacer()
-
-            if let deltaText {
-                GlassChip(
-                    icon: deltaIcon(for: deltaText),
-                    text: deltaText,
-                    color: deltaColor(for: deltaText)
-                )
-            }
-        }
+        .accessibilityIdentifier("dashboard_body_score_hero")
     }
 
     private var gaugeAndSummary: some View {
-        VStack(spacing: 16) {
-            BodyScoreGaugeView(score: score)
+        HStack(alignment: .center, spacing: 18) {
+            BodyScoreGaugeView(score: score, scoreText: scoreText)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    onTapBodyScore?()
+                }
 
-            VStack(spacing: 6) {
-                Text(scoreText)
-                    .font(.system(size: 72, weight: .bold, design: .rounded))
-                    .foregroundColor(.white)
-                    .monospacedDigit()
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Body Score")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(Color.white.opacity(0.62))
 
                 Text(tagline)
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(Color.white.opacity(0.7))
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: .infinity)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(.white)
+                    .fixedSize(horizontal: false, vertical: true)
 
-                Text(projectionText)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(Color.white.opacity(0.6))
+                if let deltaText {
+                    GlassChip(
+                        icon: deltaIcon(for: deltaText),
+                        text: deltaText,
+                        color: deltaColor(for: deltaText)
+                    )
+                }
             }
             .frame(maxWidth: .infinity)
         }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            onTapBodyScore?()
-        }
-    }
-
-    private var projectionText: String {
-        guard let deltaText,
-              let deltaValue = parsedDelta(from: deltaText) else {
-            return "Stable over 30 days."
-        }
-
-        let absoluteDelta = abs(deltaValue)
-
-        // Treat very small changes as effectively flat
-        if absoluteDelta < 0.5 {
-            return "Stable over 30 days."
-        }
-
-        let projectedScore = max(0, min(100, Double(score) + deltaValue))
-        let projectedScoreText = String(format: "%.0f", projectedScore)
-        let formattedDelta = formatDelta(deltaValue)
-
-        return "On pace for \(projectedScoreText) (\(formattedDelta)) in 30d"
-    }
-
-    private func parsedDelta(from text: String) -> Double? {
-        let trimmed = text.trimmingCharacters(in: .whitespaces)
-        guard let firstToken = trimmed.split(separator: " ").first else {
-            return nil
-        }
-
-        var numericString = String(firstToken)
-        numericString = numericString.replacingOccurrences(of: "+", with: "")
-        numericString = numericString.replacingOccurrences(of: "\u{2013}", with: "-")
-
-        return Double(numericString)
-    }
-
-    private func formatDelta(_ value: Double) -> String {
-        let sign = value >= 0 ? "+" : "\u{2013}"
-        let magnitude = abs(value)
-        let rounded = (magnitude * 10).rounded() / 10
-
-        if rounded == rounded.rounded() {
-            return "\(sign)\(Int(rounded))"
-        }
-
-        return String(format: "%@%.1f", sign, rounded)
     }
 
     private func tappableHeroStatTile(
         title: String,
         value: String,
-        caption: String,
         onTap: (() -> Void)?
     ) -> some View {
         Group {
             if let onTap {
                 Button(action: onTap) {
-                    heroStatTile(title: title, value: value, caption: caption)
+                    heroStatTile(title: title, value: value)
                 }
                 .buttonStyle(PlainButtonStyle())
             } else {
-                heroStatTile(title: title, value: value, caption: caption)
+                heroStatTile(title: title, value: value)
             }
         }
     }
 
-    private func heroStatTile(title: String, value: String, caption: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+    private func heroStatTile(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
             Text(title.uppercased())
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundColor(Color.liquidTextPrimary.opacity(0.6))
+                .lineLimit(1)
 
             Text(value)
-                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .font(.system(size: 19, weight: .bold, design: .rounded))
                 .foregroundColor(Color.liquidTextPrimary)
-
-            Text(caption)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundColor(Color.liquidTextPrimary.opacity(0.55))
+                .lineLimit(1)
+                .minimumScaleFactor(0.68)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title) \(value)")
     }
 
     private func deltaIcon(for deltaText: String) -> String {

--- a/apps/ios/LogYourBody/Components/DashboardFFMITile.swift
+++ b/apps/ios/LogYourBody/Components/DashboardFFMITile.swift
@@ -67,31 +67,20 @@ struct DashboardFFMITile: View {
         // Human FFMI range: 10 (very low) to 30 (elite bodybuilder)
         let minFFMI: Double = 10
         let maxFFMI: Double = 30
-        let range = maxFFMI - minFFMI
 
-        // Calculate positions (0.0 to 1.0)
-        let currentPosition = max(0, min(1, (current - minFFMI) / range))
-        let goalPosition = max(0, min(1, (goal - minFFMI) / range))
-
-        return VStack(spacing: 0) {
-            ZStack(alignment: .leading) {
-                // Background track
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(Color.white.opacity(0.15))
-                    .frame(height: 4)
-
-                // Progress fill (from min to current value)
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(Color(hex: "#6EE7F0"))
-                    .frame(width: max(0, currentPosition * 60), height: 4)  // 60pt total width
-
-                // Goal indicator tick
-                Rectangle()
-                    .fill(Color.white.opacity(0.90))
-                    .frame(width: 2, height: 8)
-                    .offset(x: goalPosition * 60 - 1)  // Center the tick on goal position
-            }
-            .frame(width: 60, height: 8)  // Container for the bar
+        return Gauge(value: max(minFFMI, min(current, maxFFMI)), in: minFFMI...maxFFMI) {
+            Text("FFMI progress")
+        } currentValueLabel: {
+            Text(String(format: "%.1f", current))
+        } minimumValueLabel: {
+            Text("")
+        } maximumValueLabel: {
+            Text(String(format: "Target %.1f", goal))
         }
+        .gaugeStyle(.accessoryLinearCapacity)
+        .tint(Color.metricAccentFFMI)
+        .labelsHidden()
+        .frame(width: 88, height: 8)
+        .accessibilityLabel("FFMI \(String(format: "%.1f", current)), target \(String(format: "%.1f", goal))")
     }
 }

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/MetricSummaryCard.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/MetricSummaryCard.swift
@@ -259,6 +259,9 @@ public struct MetricSummaryCard: View {
                     .foregroundStyle(
                         colorScheme == .dark ? Color.metricTextSecondary : secondaryTextColor
                     )
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.85)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/apps/ios/LogYourBody/Helpers/DashboardMetricFormatting.swift
+++ b/apps/ios/LogYourBody/Helpers/DashboardMetricFormatting.swift
@@ -117,6 +117,18 @@ func formatAverageFootnote(value: Double, unit: String) -> String {
     return "\(formatted) \(unit) average"
 }
 
+func metricSummaryFootnote(averageText: String?, goalText: String?) -> String? {
+    if let goalText, !goalText.isEmpty {
+        return goalText
+    }
+
+    if let averageText, !averageText.isEmpty {
+        return averageText
+    }
+
+    return nil
+}
+
 extension TimeRange {
     var shortRelativeLabel: String {
         switch self {

--- a/apps/ios/LogYourBody/Views/DashboardMetricsSection.swift
+++ b/apps/ios/LogYourBody/Views/DashboardMetricsSection.swift
@@ -131,7 +131,7 @@ struct DashboardMetricsSection: View {
                         chartAccessibilityLabel: "Weight trend for the past week",
                         chartAccessibilityValue: "Latest value \(formatTrendWeightHeadline(currentMetric, weightUsesTrend)) \(weightUnit)",
                         trend: stats.flatMap { makeTrend($0.delta, weightUnit, selectedRange) },
-                        footnote: combinedAverageAndGoal(averageText, weightGoalText)
+                        footnote: metricSummaryFootnote(averageText: averageText, goalText: weightGoalText)
                     )),
                     isButtonContext: true
                 )
@@ -163,7 +163,7 @@ struct DashboardMetricsSection: View {
                         chartAccessibilityLabel: "Body fat percentage trend for the past week",
                         chartAccessibilityValue: "Latest value \(formatBodyFatValue(currentMetric.bodyFatPercentage))%",
                         trend: stats.flatMap { makeTrend($0.delta, "%", selectedRange) },
-                        footnote: combinedAverageAndGoal(averageText, bodyFatGoalText)
+                        footnote: metricSummaryFootnote(averageText: averageText, goalText: bodyFatGoalText)
                     )),
                     isButtonContext: true
                 )
@@ -195,25 +195,12 @@ struct DashboardMetricsSection: View {
                         chartAccessibilityLabel: "FFMI trend for the past week",
                         chartAccessibilityValue: "Latest value \(formatFFMIValue(currentMetric))",
                         trend: stats.flatMap { makeTrend($0.delta, "", selectedRange) },
-                        footnote: combinedAverageAndGoal(averageText, ffmiGoalText)
+                        footnote: metricSummaryFootnote(averageText: averageText, goalText: ffmiGoalText)
                     )),
                     isButtonContext: true
                 )
             }
             .buttonStyle(MetricCardButtonStyle())
         }
-    }
-}
-
-private func combinedAverageAndGoal(_ averageText: String?, _ goalText: String?) -> String? {
-    switch (averageText, goalText) {
-    case let (avg?, goal?):
-        return "\(avg) · \(goal)"
-    case let (avg?, nil):
-        return avg
-    case let (nil, goal?):
-        return goal
-    default:
-        return nil
     }
 }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
@@ -10,11 +10,8 @@ extension DashboardViewLiquid {
             scoreText: bodyScore.scoreText,
             tagline: bodyScore.tagline,
             ffmiValue: heroFFMIValue(),
-            ffmiCaption: heroFFMICaption(),
             bodyFatValue: heroBodyFatValue(),
-            bodyFatCaption: heroBodyFatCaption(),
             weightValue: heroWeightValue(),
-            weightCaption: heroWeightCaption(),
             deltaText: heroBodyScoreDeltaText(),
             onTapBodyScore: bodyScore.score > 0 ? {
                 selectedMetricType = .bodyScore
@@ -422,59 +419,35 @@ extension DashboardViewLiquid {
 
     func stepsProgressBar(steps: Int, goal: Int) -> some View {
         let clampedGoal = max(goal, 1)
-        let progress = max(0, min(Double(steps) / Double(clampedGoal), 1))
+        let progress = min(Double(steps), Double(clampedGoal))
 
-        return GeometryReader { geometry in
-            ZStack(alignment: .leading) {
-                RoundedRectangle(cornerRadius: 999)
-                    .fill(Color.white.opacity(0.15))
-
-                RoundedRectangle(cornerRadius: 999)
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color(hex: "#6EE7F0"),
-                                Color(hex: "#22C1C3")
-                            ],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .frame(width: geometry.size.width * CGFloat(progress))
-            }
+        return Gauge(value: progress, in: 0...Double(clampedGoal)) {
+            Text("Steps progress")
         }
+        .gaugeStyle(.accessoryLinearCapacity)
+        .tint(Color.metricAccentSteps)
+        .labelsHidden()
+        .accessibilityHidden(true)
     }
 
     func bodyFatProgressBar(current: Double, goal: Double) -> some View {
         // Body fat range: 0% to 40% (human range)
         let minBF: Double = 0
         let maxBF: Double = 40
-        let range = maxBF - minBF
 
-        // Calculate positions (0.0 to 1.0)
-        let currentPosition = max(0, min(1, (current - minBF) / range))
-        let goalPosition = max(0, min(1, (goal - minBF) / range))
-
-        return VStack(spacing: 0) {
-            ZStack(alignment: .leading) {
-                // Background track
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(Color.white.opacity(0.15))
-                    .frame(height: 4)
-
-                // Progress fill (from min to current value)
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(Color(hex: "#6EE7F0"))
-                    .frame(width: max(0, currentPosition * 60), height: 4)
-
-                // Goal indicator tick
-                Rectangle()
-                    .fill(Color.white.opacity(0.90))
-                    .frame(width: 2, height: 8)
-                    .offset(x: goalPosition * 60 - 1)
-            }
-            .frame(width: 60, height: 8)
+        return Gauge(value: max(minBF, min(current, maxBF)), in: minBF...maxBF) {
+            Text("Body fat progress")
+        } currentValueLabel: {
+            Text(String(format: "%.1f%%", current))
+        } minimumValueLabel: {
+            Text("0%")
+        } maximumValueLabel: {
+            Text(String(format: "Target %.1f%%", goal))
         }
+        .gaugeStyle(.accessoryLinearCapacity)
+        .tint(Color.metricAccentBodyFat)
+        .labelsHidden()
+        .accessibilityLabel("Body fat \(String(format: "%.1f%%", current)), target \(String(format: "%.1f%%", goal))")
     }
 
     func weightProgressBar(current: Double, goal: Double?, unit: String) -> some View {
@@ -484,31 +457,22 @@ extension DashboardViewLiquid {
             let minWeight = goal - (range / 2)
             let maxWeight = goal + (range / 2)
 
-            // Calculate positions (0.0 to 1.0)
-            let currentPosition = max(0, min(1, (current - minWeight) / (maxWeight - minWeight)))
-            let goalPosition: Double = 0.5  // Goal is always in the middle
-
             return AnyView(
-                VStack(spacing: 0) {
-                    ZStack(alignment: .leading) {
-                        // Background track
-                        RoundedRectangle(cornerRadius: 2)
-                            .fill(Color.white.opacity(0.15))
-                            .frame(height: 4)
-
-                        // Progress fill (from min to current value)
-                        RoundedRectangle(cornerRadius: 2)
-                            .fill(Color(hex: "#6EE7F0"))
-                            .frame(width: max(0, currentPosition * 60), height: 4)
-
-                        // Goal indicator tick
-                        Rectangle()
-                            .fill(Color.white.opacity(0.90))
-                            .frame(width: 2, height: 8)
-                            .offset(x: goalPosition * 60 - 1)
-                    }
-                    .frame(width: 60, height: 8)
+                Gauge(value: max(minWeight, min(current, maxWeight)), in: minWeight...maxWeight) {
+                    Text("Weight progress")
+                } currentValueLabel: {
+                    Text(String(format: "%.1f %@", current, unit))
+                } minimumValueLabel: {
+                    Text("")
+                } maximumValueLabel: {
+                    Text(String(format: "Target %.1f %@", goal, unit))
                 }
+                .gaugeStyle(.accessoryLinearCapacity)
+                .tint(Color.metricAccentWeight)
+                .labelsHidden()
+                .accessibilityLabel(
+                    "Weight \(String(format: "%.1f %@", current, unit)), target \(String(format: "%.1f %@", goal, unit))"
+                )
             )
         } else {
             // No goal set - show "Tap to set" placeholder
@@ -522,7 +486,7 @@ extension DashboardViewLiquid {
                         .font(.system(size: 11, weight: .medium))
                         .foregroundColor(Color.liquidTextPrimary.opacity(0.40))
                 }
-                .frame(width: 60, height: 8)
+                .frame(maxWidth: .infinity, minHeight: 8, alignment: .leading)
             )
         }
     }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift
@@ -43,9 +43,9 @@ extension DashboardViewLiquid {
     }
 
     var photoTimelinePresenceSummary: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 8) {
             HStack {
-                Text("Timeline states")
+                Text("Timeline data")
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundColor(.white)
 
@@ -56,21 +56,13 @@ extension DashboardViewLiquid {
                     .foregroundColor(Color.metricTextTertiary)
             }
 
-            LazyVGrid(
-                columns: [
-                    GridItem(.flexible(), spacing: 8),
-                    GridItem(.flexible(), spacing: 8)
-                ],
-                spacing: 8
-            ) {
-                ForEach(MetricPresence.allCases, id: \.rawValue) { presence in
-                    photoTimelinePresenceChip(
-                        title: photoTimelinePresenceLabel(for: presence),
-                        count: timelinePresenceCounts[presence] ?? 0,
-                        color: photoTimelinePresenceColor(for: presence)
-                    )
-                }
-            }
+            Text(photoTimelinePresenceLegendText)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(Color.metricTextSecondary)
+                .lineLimit(2)
+                .minimumScaleFactor(0.85)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("photo_timeline_stats_presence_legend")
         }
         .padding(14)
         .background(
@@ -81,35 +73,17 @@ extension DashboardViewLiquid {
             RoundedRectangle(cornerRadius: 18)
                 .stroke(Color.white.opacity(0.08), lineWidth: 1)
         )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Timeline data. \(photoTimelinePresenceLegendText). \(timelinePresenceValueCount) values.")
         .accessibilityIdentifier("photo_timeline_stats_presence_summary")
     }
 
-    func photoTimelinePresenceChip(
-        title: String,
-        count: Int,
-        color: Color
-    ) -> some View {
-        HStack(spacing: 8) {
-            Circle()
-                .fill(color)
-                .frame(width: 8, height: 8)
-
-            Text(title)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(Color.metricTextSecondary)
-
-            Spacer(minLength: 4)
-
-            Text("\(count)")
-                .font(.system(size: 12, weight: .bold))
-                .foregroundColor(.white)
+    var photoTimelinePresenceLegendText: String {
+        MetricPresence.allCases.map { presence in
+            let label = photoTimelinePresenceLabel(for: presence)
+            let count = timelinePresenceCounts[presence] ?? 0
+            return "\(label) \(count)"
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 9)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(Color.white.opacity(0.055))
-        )
-        .accessibilityLabel("\(title), \(count) timeline values")
+        .joined(separator: " • ")
     }
 }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineInsights.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineInsights.swift
@@ -291,17 +291,4 @@ extension DashboardViewLiquid {
             return "Missing"
         }
     }
-
-    func photoTimelinePresenceColor(for presence: MetricPresence) -> Color {
-        switch presence {
-        case .present:
-            return Color.metricChartLine
-        case .interpolated:
-            return Color.metricAccentBodyFat
-        case .lastKnown:
-            return Color.metricAccentFFMI
-        case .missing:
-            return Color.metricTextTertiary
-        }
-    }
 }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -534,6 +534,37 @@ final class PhotoTimelineHUDPolicyTests: XCTestCase {
     }
 }
 
+final class DashboardDataVizPolicyTests: XCTestCase {
+    func testMetricSummaryFootnoteKeepsOneGoalStatWhenGoalExists() {
+        XCTAssertEqual(
+            metricSummaryFootnote(
+                averageText: "181.4 lb average",
+                goalText: "Target 180.0 lb"
+            ),
+            "Target 180.0 lb"
+        )
+    }
+
+    func testMetricSummaryFootnoteFallsBackToOneAverageStat() {
+        XCTAssertEqual(
+            metricSummaryFootnote(
+                averageText: "18.2 average",
+                goalText: nil
+            ),
+            "18.2 average"
+        )
+    }
+
+    func testMetricSummaryFootnoteOmitsEmptyStats() {
+        XCTAssertNil(
+            metricSummaryFootnote(
+                averageText: "",
+                goalText: ""
+            )
+        )
+    }
+}
+
 final class PreferenceGoalValidatorTests: XCTestCase {
     func testAcceptsValidGoalValuesAtBoundaries() {
         XCTAssertEqual(

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -213,7 +213,11 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
         statsButton.tap()
         XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_stats_presence_summary"].exists)
+        let presenceSummary = app.descendants(matching: .any)["photo_timeline_stats_presence_summary"]
+        XCTAssertTrue(presenceSummary.exists)
+        XCTAssertTrue(presenceSummary.label.contains("Measured"))
+        XCTAssertTrue(presenceSummary.label.contains("Interpolated"))
+        XCTAssertFalse(app.staticTexts["Timeline states"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_hud_phase_insight"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["legacy_full_dashboard_beta"].exists)
     }


### PR DESCRIPTION
## Summary
- Simplifies the Body Score hero to a score ring plus three compact stats, removing duplicate per-tile captions and projection copy.
- Replaces fixed-width hand-drawn goal/progress bars with native SwiftUI `Gauge` surfaces for steps, weight, body fat, and FFMI helper UI.
- Collapses the photo timeline presence summary from a 2x2 state grid into a single compact legend line.
- Keeps metric-card footnotes to one stat and lets footnote text wrap instead of truncating.

## Linear
- JOV-3146

## Validation
- `swiftlint lint --strict` from `apps/ios` passed across 279 Swift files.
- `xcodebuildmcp test_sim -only-testing:LogYourBodyTests/DashboardDataVizPolicyTests` passed: 3 tests.
- `xcodebuildmcp test_sim -only-testing:LogYourBodyUITests/LogYourBodyUITests/testPhotoHUDFixtureRoutesToIntendedPostMVPDashboard` passed: 1 UI test.
- `xcodebuildmcp build_run_sim` passed with `-lybUITestPhotoTimelineHUDFixture`.
- `xcodebuildmcp build_run_sim` passed with `-lybUITestFullDashboardFixture`.
- `pnpm lint` passed.
- `pnpm typecheck` passed.
- `pnpm test` passed: 32 Jest suites / 286 tests plus cached package tests.

## Screenshots
- Photo timeline avatar/home fixture: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_e4ec5272-b3d9-458a-8110-1d47ac518262.jpg`
- Full-dashboard fixture route smoke: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_e34e8d48-167c-4694-b83f-e33150ba1dcf.jpg`

## Notes
- The unfiltered XcodeBuildMCP simulator suite exceeded the 120s tool timeout. It continued into the broader unit set and showed the new dashboard tests passing, then stalled with repeated Xcode `DebuggerVersionStore.StoreError` / `no debugger version` messages. I terminated only that timed-out runner. Focused simulator unit/UI tests and simulator launches are green.
- Root pnpm commands warn that this local shell is Node 22 while the repo wants Node 20; commands still passed.
