### PR TITLE
JOV-2855 Remove v1 launch feature gates

### DIFF
--- a/apps/ios/LogYourBody/Models/GlobalTimelineModels.swift
+++ b/apps/ios/LogYourBody/Models/GlobalTimelineModels.swift
@@ -109,7 +109,7 @@ struct PhaseInsight: Equatable {
 }
 
 enum PhaseInsightPolicy {
-    static let defaultShowsPhaseInsight = false
+    static let defaultShowsPhaseInsight = true
 
     private static let trendWindowDays: Double = 42
     private static let minimumTrendDays: Double = 14
@@ -117,8 +117,8 @@ enum PhaseInsightPolicy {
     private static let weightChangeThresholdPercentPerWeek = 0.25
     private static let bodyFatChangeThresholdPercentagePoints = 0.3
 
-    static func shouldShowPhaseInsight(gateEnabled: Bool) -> Bool {
-        gateEnabled
+    static func shouldShowPhaseInsight() -> Bool {
+        true
     }
 
     static func insight(for metrics: [BodyMetrics]) -> PhaseInsight {

--- a/apps/ios/LogYourBody/Models/Glp1Medication.swift
+++ b/apps/ios/LogYourBody/Models/Glp1Medication.swift
@@ -60,12 +60,12 @@ struct Glp1WeeklyCheckInSummary: Equatable {
 }
 
 enum Glp1WeeklyCheckInPolicy {
-    static let defaultShowsWeeklyCheckIn = false
+    static let defaultShowsWeeklyCheckIn = true
 
     private static let weeklyDueDays = 6
 
-    static func shouldShowWeeklyCheckIn(gateEnabled: Bool) -> Bool {
-        gateEnabled
+    static func shouldShowWeeklyCheckIn() -> Bool {
+        true
     }
 
     static func summary(

--- a/apps/ios/LogYourBody/Services/BugReportManager.swift
+++ b/apps/ios/LogYourBody/Services/BugReportManager.swift
@@ -44,12 +44,6 @@ final class BugReportManager: ObservableObject {
     }
 
     func handleShakeGesture() {
-        #if canImport(Statsig)
-        if !AnalyticsService.shared.isFeatureEnabled(flagKey: "bug_report_shake_v1") {
-            return
-        }
-        #endif
-
         guard isShakeToReportEnabled else { return }
         guard !isPromptPresented, !isFormPresented else { return }
         guard !isCapturingScreenshot else { return }

--- a/apps/ios/LogYourBody/Utils/Constants.swift
+++ b/apps/ios/LogYourBody/Utils/Constants.swift
@@ -16,13 +16,8 @@ struct Constants {
     static let appVersion = "1.0.0"
     static let buildNumber = "1"
 
-    // MARK: - Feature Flags
+    // MARK: - Product Capabilities
     static let isBodySpecEnabled = true
-    static let appleSignInEnabledFlagKey = "ios_apple_sign_in_enabled"
-    static let phaseInsightFlagKey = "ios_phase_insight"
-    static let glp1WeeklyCheckInFlagKey = "ios_glp1_weekly_checkin"
-    static let bulkProgressPhotoImportFlagKey = "ios_bulk_progress_photo_import"
-    static let photosTabFlagKey = "photos_tab"
 
     // MARK: - API Configuration (from Config.xcconfig via Info.plist)
     static var baseURL: String {
@@ -131,11 +126,11 @@ struct Constants {
 }
 
 struct AuthSurfacePolicy {
-    static let defaultShowsAppleSignIn = false
+    static let defaultShowsAppleSignIn = true
     static let primarySignInMethod = "email_otp"
 
-    static func shouldShowAppleSignIn(gateEnabled: Bool) -> Bool {
-        gateEnabled
+    static func shouldShowAppleSignIn() -> Bool {
+        true
     }
 }
 
@@ -177,11 +172,8 @@ enum BulkProgressPhotoImportPolicy {
     static let defaultShowsBulkImport = false
     static let activationProgressPhotoCount = 2
 
-    static func shouldShowBulkImport(
-        gateEnabled: Bool,
-        existingProgressPhotoCount: Int
-    ) -> Bool {
-        gateEnabled || existingProgressPhotoCount >= activationProgressPhotoCount
+    static func shouldShowBulkImport(existingProgressPhotoCount: Int) -> Bool {
+        existingProgressPhotoCount >= activationProgressPhotoCount
     }
 
     static func footerText(

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineInsights.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineInsights.swift
@@ -191,11 +191,7 @@ extension DashboardViewLiquid {
         }
         #endif
 
-        return PhaseInsightPolicy.shouldShowPhaseInsight(
-            gateEnabled: AnalyticsService.shared.isFeatureEnabled(
-                flagKey: Constants.phaseInsightFlagKey
-            )
-        )
+        return PhaseInsightPolicy.shouldShowPhaseInsight()
     }
 
     var isGlp1WeeklyCheckInEnabled: Bool {
@@ -207,11 +203,7 @@ extension DashboardViewLiquid {
         }
         #endif
 
-        return Glp1WeeklyCheckInPolicy.shouldShowWeeklyCheckIn(
-            gateEnabled: AnalyticsService.shared.isFeatureEnabled(
-                flagKey: Constants.glp1WeeklyCheckInFlagKey
-            )
-        )
+        return Glp1WeeklyCheckInPolicy.shouldShowWeeklyCheckIn()
     }
 
     func loadGlp1WeeklyCheckInDataIfNeeded() {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -321,15 +321,7 @@ struct DashboardViewLiquid: View {
         previousSyncStatus = realtimeSyncManager.syncStatus
         handleSyncStatusChange(from: realtimeSyncManager.syncStatus, to: realtimeSyncManager.syncStatus)
 
-        #if DEBUG
-        if ProcessInfo.processInfo.arguments.contains("-lybUITestFullDashboardFixture") {
-            isPhotosTabEnabled = true
-        } else {
-            isPhotosTabEnabled = AnalyticsService.shared.isFeatureEnabled(flagKey: Constants.photosTabFlagKey)
-        }
-        #else
-        isPhotosTabEnabled = AnalyticsService.shared.isFeatureEnabled(flagKey: Constants.photosTabFlagKey)
-        #endif
+        isPhotosTabEnabled = true
 
         loadGlp1WeeklyCheckInDataIfNeeded()
     }

--- a/apps/ios/LogYourBody/Views/IntegrationsView.swift
+++ b/apps/ios/LogYourBody/Views/IntegrationsView.swift
@@ -260,9 +260,6 @@ extension IntegrationsView {
         #endif
 
         return BulkProgressPhotoImportPolicy.shouldShowBulkImport(
-            gateEnabled: AnalyticsService.shared.isFeatureEnabled(
-                flagKey: Constants.bulkProgressPhotoImportFlagKey
-            ),
             existingProgressPhotoCount: progressPhotoCount
         )
     }

--- a/apps/ios/LogYourBody/Views/LoginView.swift
+++ b/apps/ios/LogYourBody/Views/LoginView.swift
@@ -112,10 +112,7 @@ struct LoginView: View {
     }
 
     private func refreshAppleSignInVisibility() {
-        let gateEnabled = AnalyticsService.shared.isFeatureEnabled(
-            flagKey: Constants.appleSignInEnabledFlagKey
-        )
-        showsAppleSignIn = AuthSurfacePolicy.shouldShowAppleSignIn(gateEnabled: gateEnabled)
+        showsAppleSignIn = AuthSurfacePolicy.shouldShowAppleSignIn()
     }
 
     private var sessionStatusBanner: some View {

--- a/apps/ios/LogYourBody/Views/SignUpView.swift
+++ b/apps/ios/LogYourBody/Views/SignUpView.swift
@@ -134,10 +134,7 @@ struct SignUpView: View {
     }
 
     private func refreshAppleSignInVisibility() {
-        let gateEnabled = AnalyticsService.shared.isFeatureEnabled(
-            flagKey: Constants.appleSignInEnabledFlagKey
-        )
-        showsAppleSignIn = AuthSurfacePolicy.shouldShowAppleSignIn(gateEnabled: gateEnabled)
+        showsAppleSignIn = AuthSurfacePolicy.shouldShowAppleSignIn()
     }
 
     private var navigationBar: some View {

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -779,11 +779,9 @@ final class PhaseInsightPolicyTests: XCTestCase {
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
     }
 
-    func testPhaseInsightDefaultsOffBeforeGateLoads() {
-        XCTAssertFalse(PhaseInsightPolicy.defaultShowsPhaseInsight)
-        XCTAssertFalse(PhaseInsightPolicy.shouldShowPhaseInsight(gateEnabled: false))
-        XCTAssertTrue(PhaseInsightPolicy.shouldShowPhaseInsight(gateEnabled: true))
-        XCTAssertEqual(Constants.phaseInsightFlagKey, "ios_phase_insight")
+    func testPhaseInsightShowsByDefaultForV1Launch() {
+        XCTAssertTrue(PhaseInsightPolicy.defaultShowsPhaseInsight)
+        XCTAssertTrue(PhaseInsightPolicy.shouldShowPhaseInsight())
     }
 
     func testClassifiesCuttingWithBodyFatContext() {
@@ -902,11 +900,9 @@ final class Glp1WeeklyCheckInPolicyTests: XCTestCase {
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
     }
 
-    func testWeeklyCheckInDefaultsOffBeforeGateLoads() {
-        XCTAssertFalse(Glp1WeeklyCheckInPolicy.defaultShowsWeeklyCheckIn)
-        XCTAssertFalse(Glp1WeeklyCheckInPolicy.shouldShowWeeklyCheckIn(gateEnabled: false))
-        XCTAssertTrue(Glp1WeeklyCheckInPolicy.shouldShowWeeklyCheckIn(gateEnabled: true))
-        XCTAssertEqual(Constants.glp1WeeklyCheckInFlagKey, "ios_glp1_weekly_checkin")
+    func testWeeklyCheckInShowsByDefaultForV1Launch() {
+        XCTAssertTrue(Glp1WeeklyCheckInPolicy.defaultShowsWeeklyCheckIn)
+        XCTAssertTrue(Glp1WeeklyCheckInPolicy.shouldShowWeeklyCheckIn())
     }
 
     func testSetupStateWhenNoDoseExists() {
@@ -1016,18 +1012,13 @@ final class Glp1WeeklyCheckInPolicyTests: XCTestCase {
 }
 
 final class AuthSurfacePolicyTests: XCTestCase {
-    func testAppleSignInDefaultsHiddenBeforeFeatureGateLoads() {
-        XCTAssertFalse(AuthSurfacePolicy.defaultShowsAppleSignIn)
-        XCTAssertFalse(AuthSurfacePolicy.shouldShowAppleSignIn(gateEnabled: false))
-    }
-
-    func testAppleSignInCanBeEnabledByFeatureGate() {
-        XCTAssertTrue(AuthSurfacePolicy.shouldShowAppleSignIn(gateEnabled: true))
+    func testAppleSignInShowsByDefaultForV1Launch() {
+        XCTAssertTrue(AuthSurfacePolicy.defaultShowsAppleSignIn)
+        XCTAssertTrue(AuthSurfacePolicy.shouldShowAppleSignIn())
     }
 
     func testEmailOTPRemainsPrimaryLaunchMethod() {
         XCTAssertEqual(AuthSurfacePolicy.primarySignInMethod, "email_otp")
-        XCTAssertEqual(Constants.appleSignInEnabledFlagKey, "ios_apple_sign_in_enabled")
     }
 }
 
@@ -1363,21 +1354,10 @@ final class PhotoMetadataServiceTests: XCTestCase {
 }
 
 final class BulkProgressPhotoImportPolicyTests: XCTestCase {
-    func testBulkProgressPhotoImportDefaultsLocked() {
+    func testBulkProgressPhotoImportRequiresActivationEvidence() {
         XCTAssertFalse(BulkProgressPhotoImportPolicy.defaultShowsBulkImport)
-        XCTAssertEqual(Constants.bulkProgressPhotoImportFlagKey, "ios_bulk_progress_photo_import")
         XCTAssertFalse(
             BulkProgressPhotoImportPolicy.shouldShowBulkImport(
-                gateEnabled: false,
-                existingProgressPhotoCount: 0
-            )
-        )
-    }
-
-    func testBulkProgressPhotoImportUnlocksForMigrationGate() {
-        XCTAssertTrue(
-            BulkProgressPhotoImportPolicy.shouldShowBulkImport(
-                gateEnabled: true,
                 existingProgressPhotoCount: 0
             )
         )
@@ -1386,13 +1366,11 @@ final class BulkProgressPhotoImportPolicyTests: XCTestCase {
     func testBulkProgressPhotoImportUnlocksAfterActivationEvidence() {
         XCTAssertFalse(
             BulkProgressPhotoImportPolicy.shouldShowBulkImport(
-                gateEnabled: false,
                 existingProgressPhotoCount: BulkProgressPhotoImportPolicy.activationProgressPhotoCount - 1
             )
         )
         XCTAssertTrue(
             BulkProgressPhotoImportPolicy.shouldShowBulkImport(
-                gateEnabled: false,
                 existingProgressPhotoCount: BulkProgressPhotoImportPolicy.activationProgressPhotoCount
             )
         )

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -18,7 +18,7 @@ final class LogYourBodyUITests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testSignedOutAppleSignInHiddenByDefault() throws {
+    func testSignedOutAppleSignInVisibleByDefault() throws {
         let app = XCUIApplication()
         app.launchArguments = ["-lybUITestSignedOutFixture"]
         app.launch()
@@ -26,7 +26,7 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["LogYourBody"].waitForExistence(timeout: 8))
         XCTAssertTrue(app.descendants(matching: .any)["login_email_field"].exists)
         XCTAssertTrue(app.buttons["login_email_code_button"].exists)
-        XCTAssertFalse(app.buttons["Continue with Apple"].exists)
+        XCTAssertTrue(app.buttons["Continue with Apple"].exists)
     }
 
     func testEmailVerificationFixtureShowsOTPReadyState() throws {
@@ -218,7 +218,6 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(presenceSummary.label.contains("Measured"))
         XCTAssertTrue(presenceSummary.label.contains("Interpolated"))
         XCTAssertFalse(app.staticTexts["Timeline states"].exists)
-        XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_hud_phase_insight"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["legacy_full_dashboard_beta"].exists)
     }
 
@@ -295,7 +294,7 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts["Coming Soon"].exists)
     }
 
-    func testBulkPhotoImportGateOpensScannerEntry() throws {
+    func testBulkPhotoImportActivationOpensScannerEntry() throws {
         let app = XCUIApplication()
         app.launchArguments = [
             "-lybUITestWeightLoggerMVPFixture",


### PR DESCRIPTION
## Summary
- removes Statsig-driven visibility gates from built v1 launch surfaces
- shows Apple Sign-In, Photos tab, phase insight, GLP-1 weekly check-in, and shake bug reporting by default
- keeps bulk progress photo import behind local activation evidence instead of a remote flag
- removes dead iOS flag-key constants and updates unit/UI tests to protect the new default-visible behavior

## Validation
- swiftlint lint --strict --quiet <touched Swift files>
- swiftlint lint --strict (apps/ios, 279 files)
- XcodeBuildMCP test_sim: AuthSurfacePolicyTests, PhaseInsightPolicyTests, Glp1WeeklyCheckInPolicyTests, BulkProgressPhotoImportPolicyTests (15 passed)
- XcodeBuildMCP test_sim: testSignedOutAppleSignInVisibleByDefault, testPhotoHUDFixtureRoutesToIntendedPostMVPDashboard, testBulkPhotoImportLockedByDefaultInIntegrations, testBulkPhotoImportActivationOpensScannerEntry (4 passed)
- XcodeBuildMCP build_run_sim -lybUITestPhotoTimelineHUDFixture passed
- Avatar screenshot inspected locally: /tmp/lyb-screenshots/kill-gates-avatar-home.png
- pnpm lint
- pnpm typecheck
- pnpm test

## Notes
- Statsig remains initialized for analytics/future experiments; this PR removes launch-surface visibility dependence on gates.
- Existing local warnings remain: Node 22 is outside the repo's Node 20 engine, and web tests emit existing PDF/parser console noise.

Refs JOV-2855.