### PR TITLE
Fix LYB launch-quality sharing and HUD nav

### DIFF
--- a/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
+++ b/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
@@ -13,6 +13,12 @@ struct BodyScoreSharePayload {
     let weightValue: String
     let weightCaption: String
     let deltaText: String?
+    let bodyFatPercentage: Double?
+    let gender: String?
+
+    var avatarMatch: AvatarBodyFatCatalog.Match {
+        AvatarBodyFatCatalog.match(bodyFatPercentage: bodyFatPercentage, gender: gender)
+    }
 }
 
 enum BodyScoreShareAspect: String, CaseIterable, Identifiable {
@@ -50,59 +56,236 @@ struct BodyScoreShareCardView: View {
     let aspect: BodyScoreShareAspect
 
     var body: some View {
-        ZStack {
-            LinearGradient(
-                colors: [
-                    Color.black,
-                    Color.black.opacity(0.92)
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
+        GeometryReader { geometry in
+            let layout = ShareCardLayout(size: geometry.size, aspect: aspect)
 
-            VStack(spacing: 28) {
-                HStack(spacing: 12) {
-                    DSLogo(size: 44, textSize: 20)
+            ZStack {
+                Color.black
 
-                    Text("Body Score")
-                        .font(.system(size: 22, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white)
+                avatarStage(layout: layout)
+                    .frame(width: geometry.size.width, height: geometry.size.height, alignment: .top)
 
-                    Spacer()
+                LinearGradient(
+                    colors: [
+                        Color.black.opacity(0.62),
+                        Color.black.opacity(0.04),
+                        Color.black.opacity(0.94)
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+
+                VStack(spacing: 0) {
+                    shareHeader(layout: layout)
+
+                    Spacer(minLength: layout.bottomOverlayHeight * 0.08)
+
+                    shareSummary(layout: layout)
                 }
-
-                VStack(spacing: 20) {
-                    BodyScoreGaugeView(score: payload.score, scoreText: payload.scoreText)
-                        .scaleEffect(1.35)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 160)
-
-                    Text(payload.tagline)
-                        .font(.system(size: 20, weight: .semibold, design: .rounded))
-                        .foregroundColor(Color.white.opacity(0.82))
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: .infinity)
-                }
-
-                Spacer(minLength: 0)
-
-                Text("Shared from LogYourBody")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(Color.white.opacity(0.6))
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 16)
+                .padding(.horizontal, layout.horizontalPadding)
+                .padding(.top, layout.topPadding)
+                .padding(.bottom, layout.bottomPadding)
             }
-            .padding(.horizontal, 24)
-            .padding(.top, 32)
-            .padding(.bottom, 24)
         }
         .aspectRatio(aspectRatioValue, contentMode: .fit)
+        .clipped()
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("body_score_share_card")
     }
 
     private var aspectRatioValue: CGFloat {
         let size = aspect.pixelSize
         guard size.height > 0 else { return 1 }
         return size.width / size.height
+    }
+
+    private func avatarStage(layout: ShareCardLayout) -> some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: layout.visualTopOffset)
+
+            AvatarBodyRenderer(
+                bodyFatPercentage: payload.bodyFatPercentage,
+                gender: payload.gender,
+                height: layout.visualHeight,
+                padding: 0,
+                verticalPadding: 0,
+                horizontalFillScale: 1.04,
+                alignment: .bottom,
+                renderMode: .fillWidth
+            )
+            .frame(maxWidth: .infinity)
+            .accessibilityIdentifier("body_score_share_avatar_visual")
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func shareHeader(layout: ShareCardLayout) -> some View {
+        HStack(spacing: layout.headerSpacing) {
+            DSLogo(size: layout.logoSize, textSize: layout.logoTextSize)
+
+            VStack(alignment: .leading, spacing: layout.headerTextSpacing) {
+                Text("LogYourBody")
+                    .font(.system(size: layout.brandFontSize, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+
+                Text(payload.avatarMatch.badgeText)
+                    .font(.system(size: layout.badgeFontSize, weight: .medium))
+                    .foregroundColor(Color.white.opacity(0.62))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func shareSummary(layout: ShareCardLayout) -> some View {
+        VStack(alignment: .leading, spacing: layout.summarySpacing) {
+            HStack(alignment: .lastTextBaseline, spacing: layout.scoreSpacing) {
+                Text(payload.scoreText)
+                    .font(.system(size: layout.scoreFontSize, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.58)
+
+                VStack(alignment: .leading, spacing: layout.scoreLabelSpacing) {
+                    Text("Body Score")
+                        .font(.system(size: layout.scoreLabelFontSize, weight: .bold))
+                        .foregroundColor(Color.white.opacity(0.66))
+                        .textCase(.uppercase)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+
+                    Text(payload.tagline)
+                        .font(.system(size: layout.taglineFontSize, weight: .semibold, design: .rounded))
+                        .foregroundColor(Color.white.opacity(0.9))
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.7)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if let deltaText = payload.deltaText {
+                        Text(deltaText)
+                            .font(.system(size: layout.deltaFontSize, weight: .medium))
+                            .foregroundColor(Color.white.opacity(0.66))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.72)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            HStack(spacing: layout.metricSpacing) {
+                shareMetric("Weight", payload.weightValue, payload.weightCaption, layout: layout)
+                shareMetric("Body Fat", payload.bodyFatValue, payload.bodyFatCaption, layout: layout)
+                shareMetric("FFMI", payload.ffmiValue, payload.ffmiCaption, layout: layout)
+            }
+
+            Text("Shared from LogYourBody")
+                .font(.system(size: layout.footerFontSize, weight: .medium))
+                .foregroundColor(Color.white.opacity(0.58))
+                .lineLimit(1)
+                .minimumScaleFactor(0.74)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func shareMetric(
+        _ title: String,
+        _ value: String,
+        _ caption: String,
+        layout: ShareCardLayout
+    ) -> some View {
+        VStack(alignment: .leading, spacing: layout.metricTextSpacing) {
+            Text(title)
+                .font(.system(size: layout.metricTitleFontSize, weight: .bold))
+                .foregroundColor(Color.white.opacity(0.58))
+                .lineLimit(1)
+                .minimumScaleFactor(0.68)
+
+            Text(value)
+                .font(.system(size: layout.metricValueFontSize, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.58)
+
+            Text(caption)
+                .font(.system(size: layout.metricCaptionFontSize, weight: .medium))
+                .foregroundColor(Color.white.opacity(0.54))
+                .lineLimit(1)
+                .minimumScaleFactor(0.68)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct ShareCardLayout {
+    let size: CGSize
+    let aspect: BodyScoreShareAspect
+
+    private var scale: CGFloat {
+        min(max(size.width / 390, 0.86), 2.8)
+    }
+
+    var horizontalPadding: CGFloat { 28 * scale }
+    var topPadding: CGFloat { 30 * scale }
+    var bottomPadding: CGFloat { 26 * scale }
+    var headerSpacing: CGFloat { 12 * scale }
+    var headerTextSpacing: CGFloat { 2 * scale }
+    var logoSize: CGFloat { 36 * scale }
+    var logoTextSize: CGFloat { 16 * scale }
+    var brandFontSize: CGFloat { 16 * scale }
+    var badgeFontSize: CGFloat { 11 * scale }
+    var summarySpacing: CGFloat { 17 * scale }
+    var scoreSpacing: CGFloat { 13 * scale }
+    var scoreLabelSpacing: CGFloat { 4 * scale }
+    var scoreFontSize: CGFloat { 58 * scale }
+    var scoreLabelFontSize: CGFloat { 11 * scale }
+    var taglineFontSize: CGFloat { 15 * scale }
+    var deltaFontSize: CGFloat { 12 * scale }
+    var metricSpacing: CGFloat { 13 * scale }
+    var metricTextSpacing: CGFloat { 4 * scale }
+    var metricTitleFontSize: CGFloat { 10 * scale }
+    var metricValueFontSize: CGFloat { 20 * scale }
+    var metricCaptionFontSize: CGFloat { 10 * scale }
+    var footerFontSize: CGFloat { 11 * scale }
+
+    var visualTopOffset: CGFloat {
+        switch aspect {
+        case .square:
+            return size.height * 0.11
+        case .portrait:
+            return size.height * 0.10
+        case .story:
+            return size.height * 0.12
+        }
+    }
+
+    var visualHeight: CGFloat {
+        switch aspect {
+        case .square:
+            return size.height * 0.64
+        case .portrait:
+            return size.height * 0.66
+        case .story:
+            return size.height * 0.62
+        }
+    }
+
+    var bottomOverlayHeight: CGFloat {
+        switch aspect {
+        case .square:
+            return size.height * 0.36
+        case .portrait:
+            return size.height * 0.33
+        case .story:
+            return size.height * 0.28
+        }
     }
 }
 
@@ -142,10 +325,12 @@ struct BodyScoreShareSheet: View {
                     GlassPillButton(icon: "square.and.arrow.down", title: "Save") {
                         Task { await saveToPhotos() }
                     }
+                    .accessibilityIdentifier("body_score_share_save_button")
 
                     GlassPillButton(icon: "square.and.arrow.up", title: "Share") {
                         Task { await shareImage() }
                     }
+                    .accessibilityIdentifier("body_score_share_system_button")
                 }
                 .padding(.horizontal, 20)
                 .padding(.bottom, 16)
@@ -165,6 +350,7 @@ struct BodyScoreShareSheet: View {
             }
             .navigationTitle("Share Body Score")
             .navigationBarTitleDisplayMode(.inline)
+            .accessibilityIdentifier("body_score_share_sheet")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Close") {
@@ -205,8 +391,7 @@ struct BodyScoreShareSheet: View {
                 .frame(width: size.width, height: size.height)
                 .environment(\.colorScheme, .dark)
         )
-        // Use 3x scale for high quality images (suitable for sharing)
-        renderer.scale = 3.0
+        renderer.scale = 1.0
         renderedImage = renderer.uiImage
     }
 

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreRevealView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreRevealView.swift
@@ -177,7 +177,9 @@ struct BodyScoreRevealView: View {
             bodyFatCaption: "%",
             weightValue: weightValue,
             weightCaption: weightUnit,
-            deltaText: nil
+            deltaText: nil,
+            bodyFatPercentage: input.bodyFat.percentage,
+            gender: input.sex?.rawValue
         )
     }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -365,6 +365,7 @@ struct DashboardHomeTab<Header: View, SyncBanner: View, MetricContent: View, Qui
                 )
             }
             .coordinateSpace(name: "dashboardHomeScroll")
+            .scrollBounceBehavior(.basedOnSize)
             .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
                 scrollOffset = value
             }
@@ -432,6 +433,7 @@ struct DashboardPhotosTab<Header: View, SyncBanner: View, PhotosContent: View>: 
             }
             .padding(.top, 8)
         }
+        .scrollBounceBehavior(.basedOnSize)
         .refreshable {
             await onRefresh()
         }
@@ -464,6 +466,7 @@ struct DashboardMetricsTab<Header: View, SyncBanner: View, TitleBlock: View, Met
                 }
                 .padding(.top, 16)
             }
+            .scrollBounceBehavior(.basedOnSize)
             .refreshable {
                 await onRefresh()
             }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
@@ -547,7 +547,9 @@ extension DashboardViewLiquid {
             bodyFatCaption: bodyFatCaption,
             weightValue: weightValue,
             weightCaption: weightCaption,
-            deltaText: deltaText
+            deltaText: deltaText,
+            bodyFatPercentage: currentMetric?.bodyFatPercentage,
+            gender: authManager.currentUser?.profile?.gender
         )
     }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift
@@ -27,6 +27,7 @@ extension DashboardViewLiquid {
                 .padding(.top, 14)
                 .padding(.bottom, 32)
             }
+            .scrollBounceBehavior(.basedOnSize)
         }
     }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -33,13 +33,11 @@ extension DashboardViewLiquid {
                         .padding(.horizontal, 20)
                 }
 
-                hudStatsAction
-                    .padding(.horizontal, 20)
-
                 Spacer(minLength: 120)
             }
             .padding(.bottom, 24)
         }
+        .scrollBounceBehavior(.basedOnSize)
         .refreshable {
             await viewModel.refreshData(
                 authManager: authManager,
@@ -70,6 +68,7 @@ extension DashboardViewLiquid {
                 .accessibilityIdentifier("photo_timeline_root_page_analytics")
         }
         .tabViewStyle(.page(indexDisplayMode: .always))
+        .indexViewStyle(.page(backgroundDisplayMode: .interactive))
         .accessibilityIdentifier("photo_timeline_root_pager")
     }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineInsights.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineInsights.swift
@@ -134,54 +134,6 @@ extension DashboardViewLiquid {
         .accessibilityLabel("\(summary.title). \(summary.message). \(summary.actionTitle)")
     }
 
-    var hudStatsAction: some View {
-        Button {
-            HapticManager.shared.selection()
-            withAnimation(.easeInOut(duration: 0.25)) {
-                selectedPhotoTimelineRootPage = .analytics
-            }
-        } label: {
-            HStack(spacing: 12) {
-                Image(systemName: "chart.line.uptrend.xyaxis")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(Color.metricAccent)
-                    .frame(width: 32, height: 32)
-                    .background(
-                        Circle()
-                            .fill(Color.white.opacity(0.08))
-                    )
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Stats")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(Color.liquidTextPrimary)
-
-                    Text("Charts, sources, and history")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(Color.liquidTextPrimary.opacity(0.58))
-                }
-
-                Spacer()
-
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(Color.liquidTextPrimary.opacity(0.42))
-            }
-            .padding(14)
-            .background(
-                RoundedRectangle(cornerRadius: 18)
-                    .fill(Color.white.opacity(0.06))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 18)
-                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
-            )
-        }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("photo_timeline_hud_stats_button")
-        .accessibilityLabel("Open stats")
-    }
-
     var isPhaseInsightEnabled: Bool {
         _ = featureGateRefreshToken
 

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -6,6 +6,7 @@ import XCTest
 import AVFoundation
 import CoreData
 import RevenueCat
+import SwiftUI
 import UIKit
 @testable import LogYourBody
 
@@ -531,6 +532,54 @@ final class PhotoTimelineHUDPolicyTests: XCTestCase {
         let bytesPerPixel = 4
         let index = (y * width + x) * bytesPerPixel + 3
         return pixels[index]
+    }
+}
+
+@MainActor
+final class BodyScoreShareCardTests: XCTestCase {
+    func testSharePayloadUsesSameNearestAvatarBucketAsHomeHero() {
+        let payload = makePayload(bodyFatPercentage: 16.4, gender: "male")
+
+        XCTAssertEqual(payload.avatarMatch.assetName, "avatar_male_15")
+        XCTAssertEqual(payload.avatarMatch.badgeText, "Male 15% body fat")
+    }
+
+    func testShareCardRendersRequestedExportSize() throws {
+        let size = BodyScoreShareAspect.portrait.pixelSize
+        let renderer = ImageRenderer(
+            content: BodyScoreShareCardView(
+                payload: makePayload(bodyFatPercentage: 22.4, gender: "female"),
+                aspect: .portrait
+            )
+            .frame(width: size.width, height: size.height)
+            .environment(\.colorScheme, .dark)
+        )
+        renderer.scale = 1.0
+
+        let image = try XCTUnwrap(renderer.uiImage)
+
+        XCTAssertEqual(image.size.width, size.width, accuracy: 0.5)
+        XCTAssertEqual(image.size.height, size.height, accuracy: 0.5)
+    }
+
+    private func makePayload(
+        bodyFatPercentage: Double?,
+        gender: String?
+    ) -> BodyScoreSharePayload {
+        BodyScoreSharePayload(
+            score: 82,
+            scoreText: "82",
+            tagline: "Athletic and trending leaner",
+            ffmiValue: "21.8",
+            ffmiCaption: "Strong",
+            bodyFatValue: "16.4",
+            bodyFatCaption: "%",
+            weightValue: "181.0",
+            weightCaption: "lb",
+            deltaText: "+4 over 30 days",
+            bodyFatPercentage: bodyFatPercentage,
+            gender: gender
+        )
     }
 }
 

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -208,13 +208,16 @@ final class LogYourBodyUITests: XCTestCase {
 
         XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_pager"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.descendants(matching: .any)["dashboard_home_timeline_hero"].waitForExistence(timeout: 10))
-        let statsButton = app.descendants(matching: .any)["photo_timeline_hud_stats_button"]
-        scrollUntilHittable(statsButton, in: app)
-        XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
-        statsButton.tap()
+
+        XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_hud_stats_button"].exists)
+
+        let pager = app.collectionViews["photo_timeline_root_pager"]
+        XCTAssertTrue(pager.waitForExistence(timeout: 5))
+        pager.swipeLeft()
+
         XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].waitForExistence(timeout: 5))
         let presenceSummary = app.descendants(matching: .any)["photo_timeline_stats_presence_summary"]
-        XCTAssertTrue(presenceSummary.exists)
+        XCTAssertTrue(presenceSummary.waitForExistence(timeout: 5))
         XCTAssertTrue(presenceSummary.label.contains("Measured"))
         XCTAssertTrue(presenceSummary.label.contains("Interpolated"))
         XCTAssertFalse(app.staticTexts["Timeline states"].exists)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "prepare": "husky install",
     "check": "pnpm --filter apps/web check",
     "format": "prettier --write .",
-    "lint:swift": "cd apps/ios && swiftlint lint --strict"
+    "lint:swift": "cd apps/ios && swiftlint lint --strict",
+    "ios:launch-quality-audit": "bash scripts/ios/launch-quality-audit.sh"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",

--- a/scripts/ios/launch-quality-audit.sh
+++ b/scripts/ios/launch-quality-audit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IOS_DIR="$ROOT_DIR/apps/ios"
+PROJECT="${PROJECT:-LogYourBody.xcodeproj}"
+SCHEME="${SCHEME:-LogYourBody}"
+DESTINATION="${DESTINATION:-platform=iOS Simulator,name=LYB Golden iPhone 16}"
+
+cd "$IOS_DIR"
+
+swiftlint lint --strict
+
+xcodebuild \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -destination "$DESTINATION" \
+  -only-testing:LogYourBodyTests/PhotoTimelineHUDPolicyTests \
+  -only-testing:LogYourBodyTests/BodyScoreShareCardTests \
+  test
+
+xcodebuild \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -destination "$DESTINATION" \
+  -only-testing:LogYourBodyUITests/LogYourBodyUITests/testPhotoHUDFixtureRoutesToIntendedPostMVPDashboard \
+  test


### PR DESCRIPTION
## Summary
- Rebuilt Body Score sharing around the same avatar body-fat bucket used by the home hero, with constrained overlay text and export-size rendering.
- Removed the bottom stats-switch card from the photo timeline HUD; stats now remain reachable by native horizontal paging/swipe.
- Added `.scrollBounceBehavior(.basedOnSize)` to the dashboard scroll containers that were rubber-banding when content fit.
- Added `pnpm ios:launch-quality-audit` as a repeatable local launch-quality gate for the current regressions.

## Linear
- JOV-3181
- JOV-3182
- JOV-3183
- JOV-3185

## Validation
- `swiftlint lint --strict`
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/PhotoTimelineHUDPolicyTests -only-testing:LogYourBodyTests/BodyScoreShareCardTests` -> 9 passed
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyUITests/LogYourBodyUITests/testPhotoHUDFixtureRoutesToIntendedPostMVPDashboard` -> passed
- `pnpm ios:launch-quality-audit` -> passed
- XcodeBuildMCP `build_run_sim` with `-lybUITestPhotoTimelineHUDFixture` -> passed
- XcodeBuildMCP screenshot captured locally: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_7e5c1e74-d8e4-41a2-8434-72d9e4bd3dc5.jpg`
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchPerformance` -> passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Notes
- Local Node is v22.22.1 while the repo declares Node 20.x; pnpm emitted the existing engine warning but all commands passed.
- The launch-performance XCTest only gives a smoke signal in the captured summary. JOV-3184 should still own the deeper profiler pass and budget selection.
