### PR TITLE
Perf: audit dashboard timeline responsiveness

### DIFF
--- a/apps/ios/LogYourBody/Services/TimelineDataProvider.swift
+++ b/apps/ios/LogYourBody/Services/TimelineDataProvider.swift
@@ -15,12 +15,27 @@ class TimelineDataProvider: ObservableObject {
 
     private let photoSearchWindow: TimeInterval = 7 * 24 * 60 * 60  // ±7 days
     private let metricSearchWindow: TimeInterval = 7 * 24 * 60 * 60  // ±7 days
+    private var metricsWithPhotos: [BodyMetrics] = []
+    private var metricsWithBodyData: [BodyMetrics] = []
+    private var metricsWithWeightOrBodyFat: [BodyMetrics] = []
+    private var dataDates: [Date] = []
+    private var metricsByLocalDate: [String: BodyMetrics] = [:]
 
     // MARK: - Data Loading
 
     /// Load all body metrics (would integrate with your existing data layer)
     func loadMetrics(_ metrics: [BodyMetrics]) {
-        self.bodyMetrics = metrics.sorted { $0.date < $1.date }
+        let sortedMetrics = metrics.sorted { $0.date < $1.date }
+        self.bodyMetrics = sortedMetrics
+        metricsWithPhotos = TimelinePhotoSampler.metricsWithPhotos(from: sortedMetrics)
+        metricsWithBodyData = TimelinePhotoSampler.metricsWithData(from: sortedMetrics)
+        metricsWithWeightOrBodyFat = sortedMetrics.filter {
+            $0.weight != nil || $0.bodyFatPercentage != nil
+        }
+        dataDates = metricsWithBodyData.map(\.date)
+        metricsByLocalDate = sortedMetrics.reduce(into: [:]) { lookup, metric in
+            lookup[metric.localDate] = metric
+        }
     }
 
     // MARK: - Photo Mode - Find Nearest Photo and Metrics
@@ -39,11 +54,6 @@ class TimelineDataProvider: ObservableObject {
     }
 
     private func findNearestPhoto(to date: Date, within window: TimeInterval) -> TimelineDataResult.PhotoResult? {
-        let metricsWithPhotos = bodyMetrics.filter { metric in
-            guard let photoUrl = metric.photoUrl else { return false }
-            return !photoUrl.isEmpty
-        }
-
         guard !metricsWithPhotos.isEmpty else { return nil }
 
         // Find nearest photo within window
@@ -69,10 +79,7 @@ class TimelineDataProvider: ObservableObject {
         var nearest: BodyMetrics?
         var smallestDiff: TimeInterval = window
 
-        for metric in bodyMetrics {
-            let hasData = metric.weight != nil || metric.bodyFatPercentage != nil
-            guard hasData else { continue }
-
+        for metric in metricsWithWeightOrBodyFat {
             let diff = abs(metric.date.timeIntervalSince(date))
             if diff <= window && diff < smallestDiff {
                 nearest = metric
@@ -100,36 +107,18 @@ class TimelineDataProvider: ObservableObject {
     /// Get all dates that have any data (weight OR BF% OR photo)
     /// Used for snap points in Avatar Mode
     func getAllDataDates() -> [Date] {
-        let metricsWithData = TimelinePhotoSampler.metricsWithData(from: bodyMetrics)
-        return metricsWithData.map { $0.date }.sorted()
+        dataDates
     }
 
     /// Find nearest data date for snapping in Avatar Mode
     func findNearestDataDate(to scrubDate: Date) -> Date? {
-        let dataDates = getAllDataDates()
-        guard !dataDates.isEmpty else { return nil }
-
-        var nearest: Date?
-        var smallestDiff: TimeInterval = .infinity
-
-        for date in dataDates {
-            let diff = abs(date.timeIntervalSince(scrubDate))
-            if diff < smallestDiff {
-                nearest = date
-                smallestDiff = diff
-            }
-        }
-
-        return nearest
+        nearestDate(in: dataDates, to: scrubDate)
     }
 
     /// Get metric for a specific date (exact match)
     func getMetric(for date: Date) -> BodyMetrics? {
-        // Find metric with matching date (within same day)
         let localDate = BodyMetricLocalDate.key(for: date)
-        return bodyMetrics.first { metric in
-            metric.localDate == localDate
-        }
+        return metricsByLocalDate[localDate]
     }
 
     // MARK: - Timeline Anchors Generation
@@ -139,9 +128,8 @@ class TimelineDataProvider: ObservableObject {
     func generateAnchors(mode: TimelineMode, zoomLevel: TimelineZoomLevel) -> [TimelineAnchor] {
         guard !bodyMetrics.isEmpty else { return [] }
 
-        let sortedMetrics = bodyMetrics.sorted { $0.date < $1.date }
-        guard let firstDate = sortedMetrics.first?.date,
-              let lastDate = sortedMetrics.last?.date else {
+        guard let firstDate = bodyMetrics.first?.date,
+              let lastDate = bodyMetrics.last?.date else {
             return []
         }
 
@@ -153,7 +141,7 @@ class TimelineDataProvider: ObservableObject {
         )
 
         // Distribute metrics to buckets
-        TimelineBucketCalculator.distributeToBuckets(metrics: sortedMetrics, buckets: &buckets)
+        TimelineBucketCalculator.distributeToBuckets(metrics: bodyMetrics, buckets: &buckets)
 
         // Sample based on mode
         let sampledMetrics: [BodyMetrics]
@@ -167,7 +155,7 @@ class TimelineDataProvider: ObservableObject {
             sampledMetrics = TimelinePhotoSampler.samplePhotos(
                 from: photoBuckets,
                 maxThumbnails: zoomLevel.maxVisibleThumbnails,
-                sortedMetrics: sortedMetrics
+                sortedMetrics: bodyMetrics
             )
         } else {
             // Avatar mode: show all data points (may need thinning for very dense data)
@@ -179,7 +167,7 @@ class TimelineDataProvider: ObservableObject {
             sampledMetrics = TimelinePhotoSampler.samplePhotos(
                 from: dataBuckets,
                 maxThumbnails: zoomLevel.maxVisibleThumbnails * 2,  // Allow more in avatar mode
-                sortedMetrics: sortedMetrics
+                sortedMetrics: bodyMetrics
             )
         }
 
@@ -260,6 +248,29 @@ class TimelineDataProvider: ObservableObject {
         } else {
             return .yearly
         }
+    }
+
+    private func nearestDate(in dates: [Date], to target: Date) -> Date? {
+        guard !dates.isEmpty else { return nil }
+
+        var low = 0
+        var high = dates.count
+
+        while low < high {
+            let mid = (low + high) / 2
+            if dates[mid] < target {
+                low = mid + 1
+            } else {
+                high = mid
+            }
+        }
+
+        if low == 0 { return dates[0] }
+        if low == dates.count { return dates[dates.count - 1] }
+
+        let before = dates[low - 1]
+        let after = dates[low]
+        return abs(before.timeIntervalSince(target)) <= abs(after.timeIntervalSince(target)) ? before : after
     }
 
     // MARK: - Date Conversion

--- a/apps/ios/LogYourBody/Views/OptimizedProgressPhotoView.swift
+++ b/apps/ios/LogYourBody/Views/OptimizedProgressPhotoView.swift
@@ -11,6 +11,7 @@ struct OptimizedProgressPhotoView: View {
     @State private var isLoading = true
     @State private var loadedImage: UIImage?
     @State private var loadError = false
+    @State private var loadTask: Task<Void, Never>?
 
     // Shared image cache
     private static let imageCache: NSCache<NSString, UIImage> = {
@@ -54,129 +55,120 @@ struct OptimizedProgressPhotoView: View {
             }
         }
         .onAppear {
-            loadImage()
+            startImageLoad()
         }
         .onChange(of: photoUrl) { _, _ in
-            loadImage()
+            startImageLoad()
+        }
+        .onDisappear {
+            loadTask?.cancel()
         }
     }
 
-    private func loadImage() {
+    private func startImageLoad() {
+        loadTask?.cancel()
+
         guard let photoUrl = photoUrl, !photoUrl.isEmpty else {
             isLoading = false
+            loadedImage = nil
+            loadError = false
             return
         }
 
-        // Check cache first
         let cacheKey = NSString(string: photoUrl)
         if let cachedImage = Self.imageCache.object(forKey: cacheKey) {
             self.loadedImage = cachedImage
             self.isLoading = false
+            self.loadError = false
             return
         }
 
-        // Load from network
-        Task {
-            await loadFromNetwork(urlString: photoUrl)
+        isLoading = true
+        loadError = false
+        loadedImage = nil
+
+        loadTask = Task {
+            do {
+                let processedImage = try await ProgressPhotoImagePipeline.loadImage(urlString: photoUrl)
+                guard !Task.isCancelled else { return }
+                guard self.photoUrl == photoUrl else { return }
+
+                let cost = ProgressPhotoImagePipeline.cacheCost(for: processedImage)
+                Self.imageCache.setObject(processedImage, forKey: cacheKey, cost: cost)
+
+                withAnimation(.easeInOut(duration: 0.22)) {
+                    self.loadedImage = processedImage
+                    self.isLoading = false
+                    self.loadError = false
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                guard self.photoUrl == photoUrl else { return }
+                isLoading = false
+                loadError = true
+                return
+            }
         }
     }
+}
 
-    @MainActor
-    private func loadFromNetwork(urlString: String) async {
+enum ProgressPhotoImagePipeline {
+    enum ImageLoadError: Error {
+        case invalidURL
+        case invalidResponse
+        case decodeFailed
+    }
+
+    private static let imageSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.urlCache = URLCache(
+            memoryCapacity: 50 * 1_024 * 1_024,
+            diskCapacity: 200 * 1_024 * 1_024,
+            diskPath: "progress_photos"
+        )
+        config.requestCachePolicy = .returnCacheDataElseLoad
+        return URLSession(configuration: config)
+    }()
+
+    static func loadImage(urlString: String) async throws -> UIImage {
         guard let url = URL(string: urlString) else {
-            isLoading = false
-            loadError = true
-            return
+            throw ImageLoadError.invalidURL
         }
 
-        // Check if it's a local file URL
+        let data: Data
         if url.isFileURL {
-            await loadLocalFile(url: url, urlString: urlString)
-            return
-        }
-
-        do {
-            // Configure URLSession for optimal image loading
-            let config = URLSessionConfiguration.default
-            config.urlCache = URLCache(
-                memoryCapacity: 50 * 1_024 * 1_024,  // 50MB memory cache
-                diskCapacity: 200 * 1_024 * 1_024,   // 200MB disk cache
-                diskPath: "progress_photos"
-            )
-            config.requestCachePolicy = .returnCacheDataElseLoad
-
-            let session = URLSession(configuration: config)
-            let (data, response) = try await session.data(from: url)
-
-            // Verify response
+            data = try await Task.detached(priority: .userInitiated) {
+                try Data(contentsOf: url)
+            }.value
+        } else {
+            let (responseData, response) = try await imageSession.data(from: url)
             guard let httpResponse = response as? HTTPURLResponse,
-                  (200...299).contains(httpResponse.statusCode),
-                  let image = UIImage(data: data) else {
-                isLoading = false
-                loadError = true
-                return
+                  (200...299).contains(httpResponse.statusCode) else {
+                throw ImageLoadError.invalidResponse
             }
-
-            // Process image on background queue
-            let processedImage = await Task.detached(priority: .userInitiated) {
-                return optimizeImage(image)
-            }.value
-
-            // Cache the processed image
-            let cost = processedImage.pngData()?.count ?? 0
-            Self.imageCache.setObject(processedImage, forKey: NSString(string: urlString), cost: cost)
-
-            // Update UI
-            withAnimation(.easeInOut(duration: 0.3)) {
-                self.loadedImage = processedImage
-                self.isLoading = false
-            }
-        } catch {
-            // print("❌ Failed to load progress photo: \(error)")
-            isLoading = false
-            loadError = true
+            data = responseData
         }
+
+        guard let image = await decodeAndOptimizeImage(from: data) else {
+            throw ImageLoadError.decodeFailed
+        }
+
+        return image
     }
 
-    @MainActor
-    private func loadLocalFile(url: URL, urlString: String) async {
-        do {
-            let data = try Data(contentsOf: url)
-            guard let image = UIImage(data: data) else {
-                isLoading = false
-                loadError = true
-                return
-            }
-
-            // Process image on background queue
-            let processedImage = await Task.detached(priority: .userInitiated) {
+    static func decodeAndOptimizeImage(from data: Data) async -> UIImage? {
+        await Task.detached(priority: .userInitiated) {
+            autoreleasepool {
+                guard let image = UIImage(data: data) else {
+                    return nil
+                }
                 return optimizeImage(image)
-            }.value
-
-            // Cache the processed image
-            let cost = processedImage.pngData()?.count ?? 0
-            Self.imageCache.setObject(processedImage, forKey: NSString(string: urlString), cost: cost)
-
-            // Update UI
-            withAnimation(.easeInOut(duration: 0.3)) {
-                self.loadedImage = processedImage
-                self.isLoading = false
             }
-        } catch {
-            // print("❌ Failed to load local photo: \(error)")
-            isLoading = false
-            loadError = true
-        }
+        }.value
     }
 
-    private func optimizeImage(_ image: UIImage) -> UIImage {
-        // First fix orientation if needed
+    static func optimizeImage(_ image: UIImage, maxDimension: CGFloat = 1_200.0) -> UIImage {
         let orientedImage = image.fixedOrientation()
-
-        // Optimize for display
-        // Use fixed dimensions for typical device screens to avoid UIScreen.main deprecation
-        // Assumes iPhone width ~390-430pt with 3x scale = ~1170-1290px
-        let maxDimension: CGFloat = 1_200.0
         let size = orientedImage.size
 
         guard size.width > maxDimension || size.height > maxDimension else {
@@ -195,6 +187,11 @@ struct OptimizedProgressPhotoView: View {
             orientedImage.draw(in: CGRect(origin: .zero, size: targetSize))
         }
     }
+
+    static func cacheCost(for image: UIImage) -> Int {
+        let scale = max(image.scale, 1)
+        return Int(image.size.width * scale * image.size.height * scale * 4)
+    }
 }
 
 // Extension to preload images for smooth scrolling
@@ -208,13 +205,9 @@ extension OptimizedProgressPhotoView {
                 continue
             }
 
-            // Load in background
             Task.detached(priority: .background) {
-                guard let url = URL(string: urlString),
-                      let (data, _) = try? await URLSession.shared.data(from: url),
-                      let image = UIImage(data: data) else { return }
-
-                let cost = data.count
+                guard let image = try? await ProgressPhotoImagePipeline.loadImage(urlString: urlString) else { return }
+                let cost = ProgressPhotoImagePipeline.cacheCost(for: image)
                 await MainActor.run {
                     imageCache.setObject(image, forKey: cacheKey, cost: cost)
                 }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -583,6 +583,119 @@ final class BodyScoreShareCardTests: XCTestCase {
     }
 }
 
+final class DashboardTimelineProviderPerformanceTests: XCTestCase {
+    func testLoadMetricsBuildsSortedTimelineIndexesOnce() {
+        let provider = TimelineDataProvider()
+        let baseDate = Date(timeIntervalSince1970: 1_800_000_000)
+        let oldest = makeMetric(id: "oldest", date: baseDate.addingTimeInterval(-86_400 * 2), weight: 181, bodyFat: nil)
+        let photo = makeMetric(
+            id: "photo",
+            date: baseDate.addingTimeInterval(-86_400),
+            weight: nil,
+            bodyFat: nil,
+            photoUrl: "https://example.com/photo.jpg"
+        )
+        let bodyData = makeMetric(id: "body-data", date: baseDate, weight: nil, bodyFat: 18.4)
+
+        provider.loadMetrics([bodyData, photo, oldest])
+
+        XCTAssertEqual(provider.bodyMetrics.map(\.id), ["oldest", "photo", "body-data"])
+        XCTAssertEqual(provider.getAllDataDates(), [oldest.date, photo.date, bodyData.date])
+        XCTAssertEqual(provider.findNearestDataDate(to: baseDate.addingTimeInterval(-3_600)), bodyData.date)
+    }
+
+    func testLocalDateLookupHandlesMultipleMetricsOnSameDay() throws {
+        let provider = TimelineDataProvider()
+        let calendar = Calendar(identifier: .gregorian)
+        let morningDate = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2_026,
+            month: 6,
+            day: 14,
+            hour: 8
+        )))
+        let eveningDate = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2_026,
+            month: 6,
+            day: 14,
+            hour: 16
+        )))
+        let morning = makeMetric(
+            id: "morning",
+            date: morningDate,
+            localDate: "2026-06-14",
+            weight: 181,
+            bodyFat: nil
+        )
+        let evening = makeMetric(
+            id: "evening",
+            date: eveningDate,
+            localDate: "2026-06-14",
+            weight: 180.5,
+            bodyFat: nil
+        )
+
+        provider.loadMetrics([evening, morning])
+
+        XCTAssertEqual(provider.getMetric(for: morning.date)?.id, "evening")
+    }
+
+    private func makeMetric(
+        id: String,
+        date: Date,
+        localDate: String? = nil,
+        weight: Double?,
+        bodyFat: Double?,
+        photoUrl: String? = nil
+    ) -> BodyMetrics {
+        BodyMetrics(
+            id: id,
+            userId: "timeline-performance-user",
+            date: date,
+            localDate: localDate,
+            weight: weight,
+            weightUnit: "lbs",
+            bodyFatPercentage: bodyFat,
+            bodyFatMethod: bodyFat == nil ? nil : "scale",
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: photoUrl,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+}
+
+@MainActor
+final class ProgressPhotoImagePipelineTests: XCTestCase {
+    func testOptimizeImageDownsamplesLargeImages() {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 2_400, height: 1_800), format: format).image { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 2_400, height: 1_800))
+        }
+
+        let optimized = ProgressPhotoImagePipeline.optimizeImage(image, maxDimension: 1_200)
+
+        XCTAssertLessThanOrEqual(max(optimized.size.width, optimized.size.height), 1_200)
+        XCTAssertEqual(optimized.size.width, 1_200, accuracy: 1)
+        XCTAssertEqual(optimized.size.height, 900, accuracy: 1)
+    }
+
+    func testCacheCostUsesPixelBytesWithoutEncodingImageData() {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 100, height: 50), format: format).image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 100, height: 50))
+        }
+
+        XCTAssertEqual(ProgressPhotoImagePipeline.cacheCost(for: image), 20_000)
+    }
+}
+
 final class DashboardDataVizPolicyTests: XCTestCase {
     func testMetricSummaryFootnoteKeepsOneGoalStatWhenGoalExists() {
         XCTAssertEqual(

--- a/docs/audits/jov-3184/performance-audit-2026-06-14.md
+++ b/docs/audits/jov-3184/performance-audit-2026-06-14.md
@@ -1,0 +1,36 @@
+# JOV-3184 iOS Performance Audit - 2026-06-14
+
+## Summary
+
+This pass targeted the dashboard timeline and progress-photo path because those were the highest-risk code-backed sources for janky swiping, slow timeline scrubbing, and heavy first render. The fixes landed here remove obvious main-thread image work and repeated timeline sorting/filtering. The run did not produce granular launch-time statistics from `xcresult`, so frame and hitch budgets still need an Instruments or ETTrace capture before this issue can be called fully done.
+
+## Findings
+
+1. Progress photo loading did decode and encode-adjacent work on the main actor.
+   - Symptom: timeline thumbnails and photo stages can hitch while images load.
+   - Evidence: `OptimizedProgressPhotoView` decoded `UIImage(data:)`, read local files, created per-load URL sessions, and used `pngData()` for cache cost inside the view-owned load path.
+   - Fix: moved URL/file loading, decode, orientation normalization, and downsample into `ProgressPhotoImagePipeline`; replaced `pngData()` cost calculation with pixel-byte estimation; reused one cached URL session.
+   - Validation: `ProgressPhotoImagePipelineTests` covers downsampling and cache-cost policy.
+
+2. Timeline scrub data was recomputed from raw metrics during interaction.
+   - Symptom: dragging the timeline can repeatedly sort/filter metric arrays and local-date scan collections.
+   - Evidence: `TimelineDataProvider` filtered photos/data and sorted metrics in lookup/generation methods.
+   - Fix: `loadMetrics` now builds sorted metrics, photo/data subsets, local-date lookup, and snap-point dates once per input change; nearest data-date lookup uses binary search.
+   - Validation: `DashboardTimelineProviderPerformanceTests` covers sorted indexes, nearest-date lookup, and duplicate same-day metrics.
+
+3. There was no repeatable local performance audit entrypoint.
+   - Symptom: launch-quality/performance checks were easy to skip or run differently across agents.
+   - Fix: added `pnpm ios:performance-audit`, which runs strict SwiftLint, the targeted performance unit tests, and `LogYourBodyUITests/testLaunchPerformance`, writing logs under ignored `apps/ios/test_results/performance-audit/`.
+   - Validation: `pnpm ios:performance-audit` passed on `LYB Golden iPhone 16`.
+
+## Metrics
+
+| Check                     | Result   | Notes                                                                          |
+| ------------------------- | -------- | ------------------------------------------------------------------------------ |
+| SwiftLint strict          | Passed   | `pnpm ios:performance-audit`                                                   |
+| Timeline/image unit tests | 4 passed | `DashboardTimelineProviderPerformanceTests`, `ProgressPhotoImagePipelineTests` |
+| Launch performance smoke  | Passed   | UI test duration 26.523s; `xcresult` statistics were empty                     |
+
+## Next Step
+
+Capture one focused dashboard timeline trace on a release-like build: open app to the post-MVP timeline, switch Avatar/Photo once, scrub the timeline for five seconds, and export Time Profiler plus SwiftUI/Animation Hitches evidence. Use that trace to set concrete budgets for launch time, scroll frame pacing, and hitches over 250ms.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "check": "pnpm --filter apps/web check",
     "format": "prettier --write .",
     "lint:swift": "cd apps/ios && swiftlint lint --strict",
-    "ios:launch-quality-audit": "bash scripts/ios/launch-quality-audit.sh"
+    "ios:launch-quality-audit": "bash scripts/ios/launch-quality-audit.sh",
+    "ios:performance-audit": "bash scripts/ios/performance-audit.sh"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",

--- a/scripts/ios/performance-audit.sh
+++ b/scripts/ios/performance-audit.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IOS_DIR="$ROOT_DIR/apps/ios"
+PROJECT="${PROJECT:-LogYourBody.xcodeproj}"
+SCHEME="${SCHEME:-LogYourBody}"
+DESTINATION="${DESTINATION:-platform=iOS Simulator,name=LYB Golden iPhone 16}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$IOS_DIR/test_results/performance-audit/$STAMP}"
+
+mkdir -p "$ARTIFACT_DIR"
+
+cd "$IOS_DIR"
+
+swiftlint lint --strict | tee "$ARTIFACT_DIR/swiftlint.log"
+
+xcodebuild \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -destination "$DESTINATION" \
+  -only-testing:LogYourBodyTests/DashboardTimelineProviderPerformanceTests \
+  -only-testing:LogYourBodyTests/ProgressPhotoImagePipelineTests \
+  test | tee "$ARTIFACT_DIR/performance-unit-tests.log"
+
+xcodebuild \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -destination "$DESTINATION" \
+  -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchPerformance \
+  test | tee "$ARTIFACT_DIR/launch-performance.log"
+
+cat > "$ARTIFACT_DIR/summary.md" <<SUMMARY
+# iOS Performance Audit
+
+- Destination: \`$DESTINATION\`
+- Unit coverage: dashboard timeline indexes, progress-photo image pipeline
+- Launch smoke: \`LogYourBodyUITests/testLaunchPerformance\`
+- Logs: \`$ARTIFACT_DIR\`
+SUMMARY
+
+echo "Performance audit logs written to $ARTIFACT_DIR"


### PR DESCRIPTION
## Summary
- move progress photo URL/file loading, decode, orientation fix, and downsampling into an async image pipeline
- cache timeline provider subsets and local-date/snap-point indexes once per metric load, with binary nearest-date lookup for avatar scrubbing
- add a repeatable `pnpm ios:performance-audit` command plus the JOV-3184 audit report

## Linear
- JOV-3184

## Validation
- `swiftlint lint --strict`
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/DashboardTimelineProviderPerformanceTests -only-testing:LogYourBodyTests/ProgressPhotoImagePipelineTests` (4/4 passed)
- `pnpm ios:performance-audit` (strict SwiftLint, targeted unit tests, `LogYourBodyUITests/testLaunchPerformance` passed; logs in ignored `apps/ios/test_results/performance-audit/20260614-131040`)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (32 suites / 286 tests)
- pre-push hook: filtered lint/typecheck/test passed

## Notes
- The launch performance smoke passes, but `xcresult` did not expose granular launch statistics in this local run. The next perf-budget step is a focused Instruments or ETTrace capture for dashboard timeline swiping and hitches.