### PR TITLE
Fix onboarding completion and share launch quality

### DIFF
--- a/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
+++ b/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
@@ -2,7 +2,8 @@ import SwiftUI
 import UIKit
 import Photos
 
-struct BodyScoreSharePayload {
+struct BodyScoreSharePayload: Identifiable {
+    let id = UUID()
     let score: Int
     let scoreText: String
     let tagline: String
@@ -293,11 +294,17 @@ struct BodyScoreShareSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let payload: BodyScoreSharePayload
+    let onClose: (() -> Void)?
 
     @State private var selectedAspect: BodyScoreShareAspect = .square
     @State private var renderedImage: UIImage?
     @State private var isRendering = false
     @State private var showSystemShareSheet = false
+
+    init(payload: BodyScoreSharePayload, onClose: (() -> Void)? = nil) {
+        self.payload = payload
+        self.onClose = onClose
+    }
 
     var body: some View {
         NavigationView {
@@ -315,11 +322,9 @@ struct BodyScoreShareSheet: View {
 
                     BodyScoreShareCardView(payload: payload, aspect: selectedAspect)
                         .frame(width: size.width, height: size.height)
-                        .cornerRadius(24)
-                        .shadow(color: Color.black.opacity(0.4), radius: 24, x: 0, y: 12)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
                 }
-                .padding(.horizontal, 20)
+                .frame(maxWidth: .infinity)
 
                 HStack(spacing: 12) {
                     GlassPillButton(icon: "square.and.arrow.down", title: "Save") {
@@ -350,11 +355,14 @@ struct BodyScoreShareSheet: View {
             }
             .navigationTitle("Share Body Score")
             .navigationBarTitleDisplayMode(.inline)
-            .accessibilityIdentifier("body_score_share_sheet")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Close") {
-                        dismiss()
+                        if let onClose {
+                            onClose()
+                        } else {
+                            dismiss()
+                        }
                     }
                 }
             }

--- a/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
+++ b/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
@@ -15,13 +15,12 @@ struct ProgressTimelineView: View {
     @Binding var selectedIndex: Int
     @Binding var mode: TimelineMode
 
-    @StateObject private var dataProvider = TimelineDataProvider()
+    @State private var dataProvider = TimelineDataProvider()
     @State private var anchors: [TimelineAnchor] = []
     @State private var zoomLevel: TimelineZoomLevel = .month
     @State private var isDragging: Bool = false
     @State private var dragPosition: Double = 0.5
     @State private var currentDateLabel: String = ""
-    @State private var timelineSetupTask: Task<Void, Never>?
 
     private let timelineHeight: CGFloat = 50
     private let scrubberHandleSize: CGFloat = 44
@@ -69,9 +68,6 @@ struct ProgressTimelineView: View {
         }
         .onChange(of: selectedIndex) { _, _ in
             scheduleTimelineSetup()
-        }
-        .onDisappear {
-            timelineSetupTask?.cancel()
         }
     }
 
@@ -200,10 +196,13 @@ struct ProgressTimelineView: View {
         let modeSnapshot = mode
         let selectedIndexSnapshot = selectedIndex
 
-        timelineSetupTask?.cancel()
-        timelineSetupTask = Task { @MainActor in
+        Task { @MainActor in
             await Task.yield()
-            guard !Task.isCancelled else { return }
+            guard mode == modeSnapshot,
+                  selectedIndex == selectedIndexSnapshot,
+                  bodyMetrics.map(\.id) == metricsSnapshot.map(\.id) else {
+                return
+            }
             setupTimeline(
                 metrics: metricsSnapshot,
                 mode: modeSnapshot,

--- a/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
+++ b/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
@@ -21,6 +21,7 @@ struct ProgressTimelineView: View {
     @State private var isDragging: Bool = false
     @State private var dragPosition: Double = 0.5
     @State private var currentDateLabel: String = ""
+    @State private var timelineSetupTask: Task<Void, Never>?
 
     private let timelineHeight: CGFloat = 50
     private let scrubberHandleSize: CGFloat = 44
@@ -58,13 +59,19 @@ struct ProgressTimelineView: View {
             .frame(height: timelineHeight)
         }
         .onAppear {
-            setupTimeline()
+            scheduleTimelineSetup()
         }
         .onChange(of: bodyMetrics) { _, _ in
-            setupTimeline()
+            scheduleTimelineSetup()
         }
         .onChange(of: mode) { _, _ in
-            setupTimeline()
+            scheduleTimelineSetup()
+        }
+        .onChange(of: selectedIndex) { _, _ in
+            scheduleTimelineSetup()
+        }
+        .onDisappear {
+            timelineSetupTask?.cancel()
         }
     }
 
@@ -188,15 +195,32 @@ struct ProgressTimelineView: View {
 
     // MARK: - Logic
 
-    private func setupTimeline() {
-        dataProvider.loadMetrics(bodyMetrics)
+    private func scheduleTimelineSetup() {
+        let metricsSnapshot = bodyMetrics
+        let modeSnapshot = mode
+        let selectedIndexSnapshot = selectedIndex
 
-        guard !bodyMetrics.isEmpty else {
+        timelineSetupTask?.cancel()
+        timelineSetupTask = Task { @MainActor in
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+            setupTimeline(
+                metrics: metricsSnapshot,
+                mode: modeSnapshot,
+                selectedIndex: selectedIndexSnapshot
+            )
+        }
+    }
+
+    private func setupTimeline(metrics: [BodyMetrics], mode: TimelineMode, selectedIndex: Int) {
+        dataProvider.loadMetrics(metrics)
+
+        guard !metrics.isEmpty else {
             anchors = []
             return
         }
 
-        let sortedMetrics = bodyMetrics.sorted { $0.date < $1.date }
+        let sortedMetrics = metrics.sorted { $0.date < $1.date }
         guard let firstDate = sortedMetrics.first?.date,
               let lastDate = sortedMetrics.last?.date else {
             return
@@ -209,17 +233,17 @@ struct ProgressTimelineView: View {
         anchors = dataProvider.generateAnchors(mode: mode, zoomLevel: zoomLevel)
 
         // Set initial position
-        updateDragPosition(for: selectedIndex)
+        updateDragPosition(for: selectedIndex, in: metrics, using: anchors)
     }
 
-    private func updateDragPosition(for index: Int) {
-        guard index >= 0, index < bodyMetrics.count else { return }
-        let metric = bodyMetrics[index]
+    private func updateDragPosition(for index: Int, in metrics: [BodyMetrics], using anchors: [TimelineAnchor]) {
+        guard index >= 0, index < metrics.count else { return }
+        let metric = metrics[index]
 
         guard let anchor = anchors.first(where: { $0.bodyMetrics.id == metric.id }) else {
             // If not an anchor, calculate position manually
-            guard let firstDate = bodyMetrics.first?.date,
-                  let lastDate = bodyMetrics.last?.date else {
+            guard let firstDate = metrics.first?.date,
+                  let lastDate = metrics.last?.date else {
                 return
             }
             let midpointDate = dataProvider.dateFromPosition(0.5, from: firstDate, to: lastDate)

--- a/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
+++ b/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
@@ -15,9 +15,6 @@ struct ProgressTimelineView: View {
     @Binding var selectedIndex: Int
     @Binding var mode: TimelineMode
 
-    @State private var dataProvider = TimelineDataProvider()
-    @State private var anchors: [TimelineAnchor] = []
-    @State private var zoomLevel: TimelineZoomLevel = .month
     @State private var isDragging: Bool = false
     @State private var dragPosition: Double = 0.5
     @State private var currentDateLabel: String = ""
@@ -28,6 +25,12 @@ struct ProgressTimelineView: View {
     // MARK: - Body
 
     var body: some View {
+        let renderData = makeRenderData(metrics: bodyMetrics, mode: mode)
+        let handlePosition = isDragging ? dragPosition : selectedPosition(
+            in: renderData,
+            selectedIndex: selectedIndex
+        )
+
         VStack(spacing: 0) {
             // Date label (shows when dragging)
             if isDragging {
@@ -42,32 +45,26 @@ struct ProgressTimelineView: View {
                     timelineTrack
 
                     // Anchors (photos/metrics)
-                    anchorsView(width: geometry.size.width)
+                    anchorsView(
+                        width: geometry.size.width,
+                        anchors: renderData.anchors,
+                        zoomLevel: renderData.zoomLevel
+                    )
 
                     // Scrubber handle
                     scrubberHandle
-                        .offset(x: dragPosition * geometry.size.width - scrubberHandleSize / 2)
+                        .offset(x: handlePosition * geometry.size.width - scrubberHandleSize / 2)
                         .gesture(
                             DragGesture(minimumDistance: 0)
-                                .onChanged { handleDrag($0, width: geometry.size.width) }
+                                .onChanged {
+                                    handleDrag($0, width: geometry.size.width, renderData: renderData)
+                                }
                                 .onEnded { _ in handleDragEnd() }
                         )
                 }
                 .frame(height: timelineHeight)
             }
             .frame(height: timelineHeight)
-        }
-        .onAppear {
-            scheduleTimelineSetup()
-        }
-        .onChange(of: bodyMetrics) { _, _ in
-            scheduleTimelineSetup()
-        }
-        .onChange(of: mode) { _, _ in
-            scheduleTimelineSetup()
-        }
-        .onChange(of: selectedIndex) { _, _ in
-            scheduleTimelineSetup()
         }
     }
 
@@ -101,9 +98,13 @@ struct ProgressTimelineView: View {
             .padding(.vertical, (timelineHeight - 6) / 2)
     }
 
-    private func anchorsView(width: CGFloat) -> some View {
+    private func anchorsView(
+        width: CGFloat,
+        anchors: [TimelineAnchor],
+        zoomLevel: TimelineZoomLevel
+    ) -> some View {
         ForEach(anchors) { anchor in
-            anchorView(for: anchor)
+            anchorView(for: anchor, zoomLevel: zoomLevel)
                 .position(
                     x: anchor.position * width,
                     y: timelineHeight / 2
@@ -112,16 +113,16 @@ struct ProgressTimelineView: View {
     }
 
     @ViewBuilder
-    private func anchorView(for anchor: TimelineAnchor) -> some View {
+    private func anchorView(for anchor: TimelineAnchor, zoomLevel: TimelineZoomLevel) -> some View {
         switch mode {
         case .photo:
-            photoModeAnchor(for: anchor)
+            photoModeAnchor(for: anchor, zoomLevel: zoomLevel)
         case .avatar:
             avatarModeAnchor(for: anchor)
         }
     }
 
-    private func photoModeAnchor(for anchor: TimelineAnchor) -> some View {
+    private func photoModeAnchor(for anchor: TimelineAnchor, zoomLevel: TimelineZoomLevel) -> some View {
         Group {
             if anchor.anchorType == .photo || anchor.anchorType == .photoWithMetrics {
                 if let photoUrl = anchor.bodyMetrics.photoUrl,
@@ -138,7 +139,7 @@ struct ProgressTimelineView: View {
                             .stroke(Color.white.opacity(0.5), lineWidth: 2)
                     )
                 } else {
-                    photoPlaceholder
+                    photoPlaceholder(zoomLevel: zoomLevel)
                 }
             } else if zoomLevel.showMetricTicks {
                 Circle()
@@ -150,7 +151,7 @@ struct ProgressTimelineView: View {
         }
     }
 
-    private var photoPlaceholder: some View {
+    private func photoPlaceholder(zoomLevel: TimelineZoomLevel) -> some View {
         Circle()
             .fill(Color.white.opacity(0.2))
             .frame(width: zoomLevel.thumbnailSize, height: zoomLevel.thumbnailSize)
@@ -191,69 +192,49 @@ struct ProgressTimelineView: View {
 
     // MARK: - Logic
 
-    private func scheduleTimelineSetup() {
-        let metricsSnapshot = bodyMetrics
-        let modeSnapshot = mode
-        let selectedIndexSnapshot = selectedIndex
-
-        Task { @MainActor in
-            await Task.yield()
-            guard mode == modeSnapshot,
-                  selectedIndex == selectedIndexSnapshot,
-                  bodyMetrics.map(\.id) == metricsSnapshot.map(\.id) else {
-                return
-            }
-            setupTimeline(
-                metrics: metricsSnapshot,
-                mode: modeSnapshot,
-                selectedIndex: selectedIndexSnapshot
+    private func makeRenderData(metrics: [BodyMetrics], mode: TimelineMode) -> TimelineRenderData {
+        let provider = TimelineDataProvider()
+        provider.loadMetrics(metrics)
+        guard !metrics.isEmpty else {
+            return TimelineRenderData(
+                metrics: [],
+                provider: provider,
+                anchors: [],
+                zoomLevel: .month
             )
         }
-    }
 
-    private func setupTimeline(metrics: [BodyMetrics], mode: TimelineMode, selectedIndex: Int) {
-        dataProvider.loadMetrics(metrics)
-
-        guard !metrics.isEmpty else {
-            anchors = []
-            return
+        guard let firstDate = provider.bodyMetrics.first?.date,
+              let lastDate = provider.bodyMetrics.last?.date else {
+            return TimelineRenderData(
+                metrics: [],
+                provider: provider,
+                anchors: [],
+                zoomLevel: .month
+            )
         }
 
-        let sortedMetrics = metrics.sorted { $0.date < $1.date }
-        guard let firstDate = sortedMetrics.first?.date,
-              let lastDate = sortedMetrics.last?.date else {
-            return
-        }
+        let zoomLevel = TimelineZoomLevel.calculate(from: firstDate, to: lastDate)
+        let anchors = provider.generateAnchors(mode: mode, zoomLevel: zoomLevel)
 
-        // Calculate zoom level
-        zoomLevel = TimelineZoomLevel.calculate(from: firstDate, to: lastDate)
-
-        // Generate anchors
-        anchors = dataProvider.generateAnchors(mode: mode, zoomLevel: zoomLevel)
-
-        // Set initial position
-        updateDragPosition(for: selectedIndex, in: metrics, using: anchors)
+        return TimelineRenderData(
+            metrics: provider.bodyMetrics,
+            provider: provider,
+            anchors: anchors,
+            zoomLevel: zoomLevel
+        )
     }
 
-    private func updateDragPosition(for index: Int, in metrics: [BodyMetrics], using anchors: [TimelineAnchor]) {
-        guard index >= 0, index < metrics.count else { return }
-        let metric = metrics[index]
-
-        guard let anchor = anchors.first(where: { $0.bodyMetrics.id == metric.id }) else {
-            // If not an anchor, calculate position manually
-            guard let firstDate = metrics.first?.date,
-                  let lastDate = metrics.last?.date else {
-                return
-            }
-            let midpointDate = dataProvider.dateFromPosition(0.5, from: firstDate, to: lastDate)
-            dragPosition = midpointDate.timeIntervalSince1970 / metric.date.timeIntervalSince1970
-            return
+    private func selectedPosition(in renderData: TimelineRenderData, selectedIndex: Int) -> Double {
+        guard selectedIndex >= 0, selectedIndex < bodyMetrics.count else {
+            return dragPosition
         }
 
-        dragPosition = anchor.position
+        let metric = bodyMetrics[selectedIndex]
+        return renderData.anchors.first(where: { $0.bodyMetrics.id == metric.id })?.position ?? dragPosition
     }
 
-    private func handleDrag(_ value: DragGesture.Value, width: CGFloat) {
+    private func handleDrag(_ value: DragGesture.Value, width: CGFloat, renderData: TimelineRenderData) {
         isDragging = true
 
         // Calculate position (0.0 to 1.0)
@@ -261,26 +242,26 @@ struct ProgressTimelineView: View {
         dragPosition = position
 
         // Convert position to date
-        guard !bodyMetrics.isEmpty,
-              let firstDate = bodyMetrics.first?.date,
-              let lastDate = bodyMetrics.last?.date else {
+        guard !renderData.metrics.isEmpty,
+              let firstDate = renderData.metrics.first?.date,
+              let lastDate = renderData.metrics.last?.date else {
             return
         }
 
-        let scrubDate = dataProvider.dateFromPosition(position, from: firstDate, to: lastDate)
+        let scrubDate = renderData.provider.dateFromPosition(position, from: firstDate, to: lastDate)
 
         // Update based on mode
         switch mode {
         case .photo:
-            handlePhotoModeScrub(scrubDate: scrubDate)
+            handlePhotoModeScrub(scrubDate: scrubDate, provider: renderData.provider)
         case .avatar:
-            handleAvatarModeScrub(scrubDate: scrubDate)
+            handleAvatarModeScrub(scrubDate: scrubDate, provider: renderData.provider)
         }
     }
 
-    private func handlePhotoModeScrub(scrubDate: Date) {
+    private func handlePhotoModeScrub(scrubDate: Date, provider: TimelineDataProvider) {
         // Find data for photo mode (continuous time-based)
-        let result = dataProvider.findDataForPhotoMode(scrubDate: scrubDate)
+        let result = provider.findDataForPhotoMode(scrubDate: scrubDate)
         currentDateLabel = result.formattedDateLabel()
 
         // Update selected index to nearest entry
@@ -295,9 +276,9 @@ struct ProgressTimelineView: View {
         }
     }
 
-    private func handleAvatarModeScrub(scrubDate: Date) {
+    private func handleAvatarModeScrub(scrubDate: Date, provider: TimelineDataProvider) {
         // Snap to nearest data date
-        guard let nearestDate = dataProvider.findNearestDataDate(to: scrubDate) else {
+        guard let nearestDate = provider.findNearestDataDate(to: scrubDate) else {
             return
         }
 
@@ -307,7 +288,7 @@ struct ProgressTimelineView: View {
         currentDateLabel = formatter.string(from: nearestDate)
 
         // Update selected index
-        if let metric = dataProvider.getMetric(for: nearestDate),
+        if let metric = provider.getMetric(for: nearestDate),
            let index = bodyMetrics.firstIndex(where: { $0.id == metric.id }) {
             selectedIndex = index
         }
@@ -322,6 +303,13 @@ struct ProgressTimelineView: View {
         let impact = UIImpactFeedbackGenerator(style: .light)
         impact.impactOccurred()
     }
+}
+
+private struct TimelineRenderData {
+    let metrics: [BodyMetrics]
+    let provider: TimelineDataProvider
+    let anchors: [TimelineAnchor]
+    let zoomLevel: TimelineZoomLevel
 }
 
 // MARK: - Preview

--- a/apps/ios/LogYourBody/DesignSystem/Atoms/DSCircularProgress.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Atoms/DSCircularProgress.swift
@@ -17,8 +17,6 @@ struct DSCircularProgress: View {
     var showPercentage: Bool = false
     var percentageFontSize: CGFloat = 14
 
-    @State private var animatedProgress: Double = 0
-
     private var normalizedProgress: Double {
         min(1.0, max(0.0, progress))
     }
@@ -32,7 +30,7 @@ struct DSCircularProgress: View {
 
             // Progress arc
             Circle()
-                .trim(from: 0, to: animatedProgress)
+                .trim(from: 0, to: normalizedProgress)
                 .stroke(
                     foregroundColor,
                     style: StrokeStyle(
@@ -44,21 +42,15 @@ struct DSCircularProgress: View {
                 .rotationEffect(.degrees(-90))
                 .animation(
                     .spring(response: animationDuration, dampingFraction: 0.8),
-                    value: animatedProgress
+                    value: normalizedProgress
                 )
 
             // Optional percentage display
             if showPercentage {
-                Text("\(Int(animatedProgress * 100))%")
+                Text("\(Int(normalizedProgress * 100))%")
                     .font(.system(size: percentageFontSize, weight: .semibold))
                     .foregroundColor(foregroundColor)
             }
-        }
-        .onAppear {
-            animatedProgress = normalizedProgress
-        }
-        .onChange(of: normalizedProgress) { newValue in
-            animatedProgress = newValue
         }
     }
 }

--- a/apps/ios/LogYourBody/DesignSystem/Atoms/DSLogo.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Atoms/DSLogo.swift
@@ -55,9 +55,12 @@ struct DSLogoAnimated: View {
         .scaleEffect(logoScale)
         .opacity(logoOpacity)
         .onAppear {
-            withAnimation(.easeOut(duration: animationDuration)) {
-                logoScale = 1.0
-                logoOpacity = 1.0
+            Task { @MainActor in
+                await Task.yield()
+                withAnimation(.easeOut(duration: animationDuration)) {
+                    logoScale = 1.0
+                    logoOpacity = 1.0
+                }
             }
         }
     }

--- a/apps/ios/LogYourBody/DesignSystem/Atoms/DSProgressBar.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Atoms/DSProgressBar.swift
@@ -15,8 +15,6 @@ struct DSProgressBar: View {
     var cornerRadius: CGFloat = 4
     var animationDuration: Double = 0.4
 
-    @State private var animatedProgress: Double = 0
-
     private var normalizedProgress: Double {
         min(1.0, max(0.0, progress))
     }
@@ -32,20 +30,14 @@ struct DSProgressBar: View {
                 // Progress
                 RoundedRectangle(cornerRadius: cornerRadius)
                     .fill(foregroundColor)
-                    .frame(width: geometry.size.width * animatedProgress, height: height)
+                    .frame(width: geometry.size.width * normalizedProgress, height: height)
                     .animation(
                         .spring(response: animationDuration, dampingFraction: 0.8),
-                        value: animatedProgress
+                        value: normalizedProgress
                     )
             }
         }
         .frame(height: height)
-        .onAppear {
-            animatedProgress = normalizedProgress
-        }
-        .onChange(of: normalizedProgress) { newValue in
-            animatedProgress = newValue
-        }
     }
 }
 

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/LoadingScreen.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/LoadingScreen.swift
@@ -14,6 +14,9 @@ struct LoadingScreen: View {
 
     var backgroundColor = Color("LaunchScreenBackground")
     var showPercentage: Bool = true
+    private var clampedProgress: Double {
+        min(max(progress, 0), 1)
+    }
 
     var body: some View {
         ZStack {
@@ -42,12 +45,14 @@ struct LoadingScreen: View {
                         style: .footnote,
                         color: .white.opacity(0.7)
                     )
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+                    .multilineTextAlignment(.center)
                     .frame(minHeight: 20)
-                    .animation(.easeInOut(duration: 0.3), value: loadingStatus)
 
                     // Progress bar
                     DSProgressBar(
-                        progress: progress,
+                        progress: clampedProgress,
                         height: 8,
                         backgroundColor: .white.opacity(0.2),
                         foregroundColor: .white,
@@ -58,7 +63,7 @@ struct LoadingScreen: View {
                     // Percentage
                     if showPercentage {
                         DSText(
-                            "\(Int(progress * 100))%",
+                            "\(Int(clampedProgress * 100))%",
                             style: .caption,
                             weight: .medium,
                             color: .white.opacity(0.5)
@@ -77,7 +82,7 @@ struct LoadingScreen: View {
     }
 
     private func checkCompletion() {
-        if progress >= 1.0 {
+        if clampedProgress >= 1.0 {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 onComplete()
             }

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/LoadingScreen.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/LoadingScreen.swift
@@ -11,6 +11,7 @@ struct LoadingScreen: View {
     @Binding var progress: Double
     @Binding var loadingStatus: String
     let onComplete: () -> Void
+    @State private var didScheduleCompletion = false
 
     var backgroundColor = Color("LaunchScreenBackground")
     var showPercentage: Bool = true
@@ -76,16 +77,24 @@ struct LoadingScreen: View {
         .onAppear {
             checkCompletion()
         }
-        .onChange(of: progress) { _ in
+        .onChange(of: clampedProgress) { _ in
             checkCompletion()
         }
     }
 
     private func checkCompletion() {
-        if clampedProgress >= 1.0 {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                onComplete()
+        guard clampedProgress >= 1.0, !didScheduleCompletion else {
+            return
+        }
+
+        Task { @MainActor in
+            await Task.yield()
+            guard clampedProgress >= 1.0, !didScheduleCompletion else {
+                return
             }
+            didScheduleCompletion = true
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            onComplete()
         }
     }
 }

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/LoadingScreen.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/LoadingScreen.swift
@@ -77,7 +77,7 @@ struct LoadingScreen: View {
         .onAppear {
             checkCompletion()
         }
-        .onChange(of: clampedProgress) { _ in
+        .onChange(of: clampedProgress) { _, _ in
             checkCompletion()
         }
     }

--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -152,6 +152,7 @@ final class OnboardingFlowViewModel: ObservableObject {
     @Published private(set) var accountCreationStage: AccountCreationStage = .idle
     @Published private(set) var onboardingFirstPhotoMetric: BodyMetrics?
     @Published private(set) var isPreparingFirstPhotoMetric = false
+    @Published private(set) var isCompletingOnboarding = false
     @Published var firstPhotoErrorMessage: String?
     @Published var profileFirstName: String = "" {
         didSet { persistProgress() }
@@ -235,6 +236,8 @@ final class OnboardingFlowViewModel: ObservableObject {
         if entryContext == .authenticated {
             restorePersistedProgressIfNeeded()
         }
+
+        applyFirstPhotoUITestFixtureIfNeeded()
     }
 
     func goToNextStep() {
@@ -282,11 +285,16 @@ final class OnboardingFlowViewModel: ObservableObject {
             if includesFirstPhotoStep {
                 currentStep = .firstPhoto
             } else {
-                completeOnboardingIfNeeded()
-                currentStep = .paywall
+                Task {
+                    await finishOnboardingAndShowPaywall(from: previousStep)
+                }
+                return
             }
         case .firstPhoto:
-            completeFirstPhotoStep()
+            Task {
+                await finishOnboardingAndShowPaywall(from: previousStep)
+            }
+            return
         case .paywall:
             break
         }
@@ -862,16 +870,53 @@ final class OnboardingFlowViewModel: ObservableObject {
         updateSex(sex)
     }
 
-    func completeOnboardingIfNeeded() {
+    private func applyFirstPhotoUITestFixtureIfNeeded() {
+        guard entryContext == .authenticated else { return }
+        guard ProcessInfo.processInfo.arguments.contains("-lybUITestBodyScoreFirstPhotoFixture") else { return }
+
+        isRestoringProgress = true
+        bodyScoreInput = BodyScoreInput(
+            sex: .male,
+            birthYear: 1_990,
+            height: HeightValue(value: 178, unit: .centimeters),
+            weight: WeightValue(value: 185, unit: .pounds),
+            bodyFat: BodyFatValue(percentage: 18, source: .manualValue)
+        )
+        bodyScoreResult = BodyScoreResult(
+            score: 82,
+            ffmi: 21.4,
+            leanPercentile: 0.72,
+            ffmiStatus: "Strong",
+            targetBodyFat: .init(lowerBound: 10, upperBound: 15, label: "Athletic"),
+            statusTagline: "Strong base"
+        )
+        defaultHomeMode = .photo
+        profileFirstName = "Onboarding"
+        profileLastName = "UI"
+        profileDateOfBirth = Calendar.current.date(from: DateComponents(year: 1_990, month: 1, day: 1))
+            ?? defaultProfileDateOfBirth()
+        profileBiologicalSex = .male
+        profileHeightUnit = .centimeters
+        profileHeightCentimetersText = "178"
+        profileShouldAskSex = false
+        hasHydratedProfileDetailsDraft = true
+        currentStep = .firstPhoto
+        isRestoringProgress = false
+        persistProgress()
+    }
+
+    func completeOnboardingIfNeeded() async {
         guard entryContext == .authenticated else { return }
         guard !hasMarkedOnboardingComplete else { return }
         hasMarkedOnboardingComplete = true
+        isCompletingOnboarding = true
+        defer { isCompletingOnboarding = false }
+
+        let updates = buildOnboardingProfileUpdates()
+        await AuthManager.shared.updateProfile(updates)
+        applyCompletedOnboardingLocally(with: updates)
         OnboardingStateManager.shared.markCompleted()
         UserDefaults.standard.set(defaultHomeMode.rawValue, forKey: Constants.defaultHomeModeKey)
-        let updates = buildOnboardingProfileUpdates()
-        Task {
-            await AuthManager.shared.updateProfile(updates)
-        }
         clearPersistedProgress()
         PreAuthOnboardingStore.shared.clear()
 
@@ -880,9 +925,42 @@ final class OnboardingFlowViewModel: ObservableObject {
         }
     }
 
-    func completeFirstPhotoStep() {
-        completeOnboardingIfNeeded()
+    func completeFirstPhotoStep() async {
+        await finishOnboardingAndShowPaywall(from: currentStep)
+    }
+
+    func finishOnboardingAndShowPaywall() async {
+        await finishOnboardingAndShowPaywall(from: currentStep)
+    }
+
+    private func finishOnboardingAndShowPaywall(from previousStep: Step) async {
+        await completeOnboardingIfNeeded()
         currentStep = .paywall
+        trackStepTransition(from: previousStep, to: currentStep)
+    }
+
+    private func applyCompletedOnboardingLocally(with updates: [String: Any]) {
+        guard var currentUser = AuthManager.shared.currentUser else { return }
+
+        let existingProfile = currentUser.profile
+        let updatedProfile = UserProfile(
+            id: existingProfile?.id ?? currentUser.id,
+            email: existingProfile?.email ?? currentUser.email,
+            username: existingProfile?.username,
+            fullName: existingProfile?.fullName ?? currentUser.name,
+            dateOfBirth: updates["dateOfBirth"] as? Date ?? existingProfile?.dateOfBirth,
+            height: updates["height"] as? Double ?? existingProfile?.height,
+            heightUnit: updates["heightUnit"] as? String ?? existingProfile?.heightUnit,
+            gender: updates["gender"] as? String ?? existingProfile?.gender,
+            activityLevel: existingProfile?.activityLevel,
+            goalWeight: existingProfile?.goalWeight,
+            goalWeightUnit: existingProfile?.goalWeightUnit,
+            onboardingCompleted: true
+        )
+
+        currentUser.profile = updatedProfile
+        currentUser.onboardingCompleted = true
+        AuthManager.shared.currentUser = currentUser
     }
 
     func prepareFirstPhotoBaselineMetric() async -> BodyMetrics? {

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
@@ -29,9 +29,7 @@ struct BodyScoreFirstProgressPhotoView: View {
                 targetMetric: viewModel.onboardingFirstPhotoMetric,
                 fallbackDate: Date(),
                 onComplete: {
-                    await MainActor.run {
-                        viewModel.completeFirstPhotoStep()
-                    }
+                    await viewModel.completeFirstPhotoStep()
                 }
             )
             .environmentObject(authManager)
@@ -88,7 +86,7 @@ struct BodyScoreFirstProgressPhotoView: View {
             Button {
                 presentAttachSheet()
             } label: {
-                if viewModel.isPreparingFirstPhotoMetric {
+                if viewModel.isPreparingFirstPhotoMetric || viewModel.isCompletingOnboarding {
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle(tint: .white))
                 } else {
@@ -96,22 +94,30 @@ struct BodyScoreFirstProgressPhotoView: View {
                 }
             }
             .buttonStyle(OnboardingPrimaryButtonStyle())
-            .disabled(viewModel.isPreparingFirstPhotoMetric)
+            .disabled(viewModel.isPreparingFirstPhotoMetric || viewModel.isCompletingOnboarding)
             .accessibilityIdentifier("onboarding_first_photo_add_button")
 
             Button {
-                viewModel.completeFirstPhotoStep()
+                Task {
+                    await viewModel.completeFirstPhotoStep()
+                }
             } label: {
-                Text("Continue")
-                    .font(.system(size: 18, weight: .semibold))
+                if viewModel.isCompletingOnboarding {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: Color.appTextSecondary))
+                } else {
+                    Text("Skip for now")
+                }
             }
             .buttonStyle(OnboardingSecondaryButtonStyle())
-            .accessibilityIdentifier("onboarding_first_photo_continue_button")
-
-            OnboardingTextButton(title: "Skip for now") {
-                viewModel.completeFirstPhotoStep()
-            }
+            .disabled(viewModel.isCompletingOnboarding)
             .accessibilityIdentifier("onboarding_first_photo_skip_button")
+
+            Text("You can add progress photos later from Home.")
+                .font(OnboardingTypography.caption)
+                .foregroundStyle(Color.appTextTertiary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
 
             if let errorMessage = viewModel.firstPhotoErrorMessage {
                 Text(errorMessage)

--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -195,7 +195,8 @@ struct LogYourBodyApp: App {
         let usesPaywallPlansFixture = arguments.contains("-lybUITestPaywallPlansFixture")
         let usesFullDashboardFixture = arguments.contains("-lybUITestFullDashboardFixture")
         let usesPhotoTimelineHUDFixture = arguments.contains("-lybUITestPhotoTimelineHUDFixture")
-        let usesBodyScoreOnboardingFixture = arguments.contains("-lybUITestBodyScoreOnboardingFixture")
+        let usesBodyScoreOnboardingFixture = arguments.contains("-lybUITestBodyScoreOnboardingFixture") ||
+            arguments.contains("-lybUITestBodyScoreFirstPhotoFixture")
         let usesDailyReminderPromptFixture = arguments.contains("-lybUITestDailyReminderPromptFixture")
 
         guard usesPaidFixture || usesWeightLoggerFixture || usesPaywallFixture || usesPaywallPlansFixture ||

--- a/apps/ios/LogYourBody/Services/LoadingManager.swift
+++ b/apps/ios/LogYourBody/Services/LoadingManager.swift
@@ -225,10 +225,7 @@ class LoadingManager: ObservableObject {
         let stepProgress = step.weight * partial
         completedWeight = min(max(completedWeight + stepProgress, 0), 1.0)
 
-        // Animate progress update
-        withAnimation(.easeInOut(duration: 0.2)) { // Faster animation
-            progress = min(max(completedWeight, 0), 0.99) // Keep at 99% until truly complete
-        }
+        progress = min(max(completedWeight, 0), 0.99) // Keep at 99% until truly complete
 
         // Minimal delay only for UI responsiveness
         try? await Task.sleep(nanoseconds: 10_000_000) // 0.01s

--- a/apps/ios/LogYourBody/Services/LoadingManager.swift
+++ b/apps/ios/LogYourBody/Services/LoadingManager.swift
@@ -62,6 +62,8 @@ class LoadingManager: ObservableObject {
             || arguments.contains("-lybUITestPaywallPlansFixture")
             || arguments.contains("-lybUITestFullDashboardFixture")
             || arguments.contains("-lybUITestPhotoTimelineHUDFixture")
+            || arguments.contains("-lybUITestBodyScoreOnboardingFixture")
+            || arguments.contains("-lybUITestBodyScoreFirstPhotoFixture")
     }
     #endif
 
@@ -221,11 +223,11 @@ class LoadingManager: ObservableObject {
         loadingStatus = step.status
 
         let stepProgress = step.weight * partial
-        completedWeight += stepProgress
+        completedWeight = min(max(completedWeight + stepProgress, 0), 1.0)
 
         // Animate progress update
         withAnimation(.easeInOut(duration: 0.2)) { // Faster animation
-            progress = min(completedWeight, 0.99) // Keep at 99% until truly complete
+            progress = min(max(completedWeight, 0), 0.99) // Keep at 99% until truly complete
         }
 
         // Minimal delay only for UI responsiveness

--- a/apps/ios/LogYourBody/Services/OnboardingStateManager.swift
+++ b/apps/ios/LogYourBody/Services/OnboardingStateManager.swift
@@ -45,7 +45,14 @@ final class OnboardingStateManager {
     }
 
     func syncCompletionFlagFromProfile(_ isCompleted: Bool) {
-        defaults.set(isCompleted, forKey: Constants.hasCompletedOnboardingKey)
+        if isCompleted {
+            defaults.set(true, forKey: Constants.hasCompletedOnboardingKey)
+            defaults.set(currentOnboardingVersion, forKey: Constants.onboardingCompletedVersionKey)
+        } else {
+            defaults.set(false, forKey: Constants.hasCompletedOnboardingKey)
+            defaults.removeObject(forKey: Constants.onboardingCompletedVersionKey)
+        }
+        notifyChange()
     }
 
     func resetForNextVersion(newVersion: Int) {

--- a/apps/ios/LogYourBody/Services/TimelineDataProvider.swift
+++ b/apps/ios/LogYourBody/Services/TimelineDataProvider.swift
@@ -6,12 +6,11 @@
 //
 
 import Foundation
-import Combine
 
 /// Provides data for the timeline with intelligent caching and nearest-match logic
-class TimelineDataProvider: ObservableObject {
-    @Published private(set) var bodyMetrics: [BodyMetrics] = []
-    @Published private(set) var isLoading: Bool = false
+final class TimelineDataProvider {
+    private(set) var bodyMetrics: [BodyMetrics] = []
+    private(set) var isLoading: Bool = false
 
     private let photoSearchWindow: TimeInterval = 7 * 24 * 60 * 60  // ±7 days
     private let metricSearchWindow: TimeInterval = 7 * 24 * 60 * 60  // ±7 days

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -384,7 +384,7 @@ struct DashboardHomeTab<Header: View, SyncBanner: View, MetricContent: View, Qui
             .coordinateSpace(name: "dashboardHomeScroll")
             .scrollBounceBehavior(.basedOnSize)
             .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
-                scrollOffset = value
+                updateScrollOffset(value)
             }
             .refreshable {
                 await onRefresh()
@@ -402,10 +402,10 @@ struct DashboardHomeTab<Header: View, SyncBanner: View, MetricContent: View, Qui
                 GeometryReader { geo in
                     Color.clear
                         .onAppear {
-                            headerStackHeight = geo.size.height
+                            updateHeaderStackHeight(geo.size.height)
                         }
                         .onChange(of: geo.size.height) { newValue in
-                            headerStackHeight = newValue
+                            updateHeaderStackHeight(newValue)
                         }
                 }
             )
@@ -425,6 +425,24 @@ struct DashboardHomeTab<Header: View, SyncBanner: View, MetricContent: View, Qui
                 x: 0,
                 y: 10
             )
+        }
+    }
+
+    private func updateScrollOffset(_ value: CGFloat) {
+        guard abs(scrollOffset - value) > 0.5 else { return }
+
+        DispatchQueue.main.async {
+            guard abs(scrollOffset - value) > 0.5 else { return }
+            scrollOffset = value
+        }
+    }
+
+    private func updateHeaderStackHeight(_ value: CGFloat) {
+        guard value > 0, abs(headerStackHeight - value) > 0.5 else { return }
+
+        DispatchQueue.main.async {
+            guard abs(headerStackHeight - value) > 0.5 else { return }
+            headerStackHeight = value
         }
     }
 }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -58,6 +58,7 @@ struct DashboardHomeTimelineHero: View {
     let onTapWeight: () -> Void
     let onTapBodyFat: () -> Void
     let onTapFFMI: () -> Void
+    let onShareBodyScore: (() -> Void)?
 
     private var hasUsablePhoto: Bool {
         PhotoTimelineHUDPolicy.hasUsablePhoto(metric)
@@ -106,7 +107,6 @@ struct DashboardHomeTimelineHero: View {
                 timelineDateBar
                     .padding(.horizontal, 20)
                     .padding(.top, 16)
-                    .allowsHitTesting(false)
             }
 
             timelineMetricsHUD
@@ -137,8 +137,24 @@ struct DashboardHomeTimelineHero: View {
                 .padding(.horizontal, 11)
                 .padding(.vertical, 7)
                 .background(Capsule().fill(Color.black.opacity(0.42)))
+                .allowsHitTesting(false)
 
             Spacer(minLength: 0)
+
+            if let onShareBodyScore {
+                Button {
+                    onShareBodyScore()
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(width: 32, height: 32)
+                        .background(Circle().fill(Color.black.opacity(0.42)))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Share Body Score")
+                .accessibilityIdentifier("body_score_hero_share_button")
+            }
 
             Text(timelinePositionText)
                 .font(.system(size: 12, weight: .semibold))
@@ -147,6 +163,7 @@ struct DashboardHomeTimelineHero: View {
                 .padding(.horizontal, 10)
                 .padding(.vertical, 6)
                 .background(Capsule().fill(Color.black.opacity(0.34)))
+                .allowsHitTesting(false)
         }
     }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
@@ -504,34 +504,45 @@ extension DashboardViewLiquid {
     // MARK: - Quick Actions
 
     var quickActions: some View {
-        HStack(spacing: 12) {
+        let bodyScore = bodyScoreText()
+        let shareAction = makeBodyScoreShareAction(score: bodyScore.score)
+
+        return HStack(spacing: 12) {
             GlassPillButton(icon: "plus.circle.fill", title: "Log") {
                 showAddEntrySheet = true
             }
 
-            GlassPillButton(icon: "square.and.arrow.up.fill", title: "Share Score") {
-                if let payload = makeBodyScoreSharePayload() {
-                    bodyScoreSharePayload = payload
-                    isBodyScoreSharePresented = true
+            if let shareAction {
+                GlassPillButton(icon: "square.and.arrow.up.fill", title: "Share Score") {
+                    shareAction()
                 }
+                .accessibilityIdentifier("body_score_quick_share_button")
             }
-            .accessibilityIdentifier("body_score_share_button")
 
             Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    func makeBodyScoreSharePayload() -> BodyScoreSharePayload? {
-        let bodyScore = bodyScoreText()
+    func makeBodyScoreSharePayload(metric: BodyMetrics? = nil) -> BodyScoreSharePayload? {
+        let selectedMetric = metric ?? currentMetric
+        let calculatedResult = selectedMetric.flatMap { bodyScoreResult(for: $0) }
+        let cachedResult = latestBodyScoreResult()
+
+        let bodyScore: (score: Int, scoreText: String, tagline: String)
+        if let result = calculatedResult ?? cachedResult {
+            bodyScore = (result.score, "\(result.score)", result.statusTagline)
+        } else {
+            bodyScore = bodyScoreText()
+        }
 
         // Avoid prompting to share when the score is effectively missing
         guard bodyScore.score > 0 else {
             return nil
         }
 
-        let ffmiValue = heroFFMIValue()
-        let ffmiCaption = heroFFMICaption()
+        let ffmiValue = calculatedResult.map { String(format: "%.1f", $0.ffmi) } ?? heroFFMIValue()
+        let ffmiCaption = calculatedResult?.ffmiStatus ?? heroFFMICaption()
         let bodyFatValue = heroBodyFatValue()
         let bodyFatCaption = heroBodyFatCaption()
         let weightValue = heroWeightValue()
@@ -549,7 +560,7 @@ extension DashboardViewLiquid {
             weightValue: weightValue,
             weightCaption: weightCaption,
             deltaText: deltaText,
-            bodyFatPercentage: currentMetric?.bodyFatPercentage,
+            bodyFatPercentage: selectedMetric?.bodyFatPercentage ?? currentMetric?.bodyFatPercentage,
             gender: authManager.currentUser?.profile?.gender
         )
     }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HomeTimelineControls.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HomeTimelineControls.swift
@@ -100,7 +100,18 @@ extension DashboardViewLiquid {
             onTapFFMI: {
                 selectedMetricType = .ffmi
                 isMetricDetailActive = true
-            }
+            },
+            onShareBodyScore: makeBodyScoreShareAction(metric: metric, score: bodyScore.score)
         )
+    }
+
+    func makeBodyScoreShareAction(metric: BodyMetrics? = nil, score: Int? = nil) -> (() -> Void)? {
+        if let score, score <= 0 { return nil }
+
+        return {
+            if let payload = makeBodyScoreSharePayload(metric: metric) {
+                bodyScoreSharePayload = payload
+            }
+        }
     }
 }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
@@ -543,9 +543,7 @@ extension DashboardViewLiquid {
         if let cached = metricEntriesCache[type] {
             return cached
         }
-        let payload = metricEntriesPayload(for: type)
-        metricEntriesCache[type] = payload
-        return payload
+        return metricEntriesPayload(for: type)
     }
 
     func cachedChartData(
@@ -555,9 +553,7 @@ extension DashboardViewLiquid {
         if let cached = fullChartCache[type] {
             return cached
         }
-        let data = generator()
-        fullChartCache[type] = data
-        return data
+        return generator()
     }
 
     func weightRangeStats() -> MetricRangeStats? {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
@@ -445,11 +445,14 @@ extension DashboardViewLiquid {
             return dailyMetricsLookupCache
         }
 
-        rebuildDailyMetricsLookupCache()
-        return dailyMetricsLookupCache
+        return makeDailyMetricsLookup()
     }
 
     func rebuildDailyMetricsLookupCache() {
+        dailyMetricsLookupCache = makeDailyMetricsLookup()
+    }
+
+    private func makeDailyMetricsLookup() -> [Date: DailyMetrics] {
         var lookup = [Date: DailyMetrics](minimumCapacity: recentDailyMetrics.count)
         let calendar = Calendar.current
 
@@ -464,7 +467,7 @@ extension DashboardViewLiquid {
             }
         }
 
-        dailyMetricsLookupCache = lookup
+        return lookup
     }
 
     func generateWeightChartData() -> [MetricDataPoint] {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -72,10 +72,11 @@ extension DashboardViewLiquid {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(Rectangle())
+            .highPriorityGesture(photoTimelineRootSwipeGesture)
+            .simultaneousGesture(photoTimelineRootSwipeGesture)
         }
-        .contentShape(Rectangle())
-        .highPriorityGesture(photoTimelineRootSwipeGesture)
-        .simultaneousGesture(photoTimelineRootSwipeGesture)
+        .accessibilityIdentifier("photo_timeline_root_pager")
     }
 
     private var photoTimelineRootNavigation: some View {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -49,38 +49,104 @@ extension DashboardViewLiquid {
     }
 
     var photoTimelineRoot: some View {
-        ZStack {
-            switch selectedPhotoTimelineRootPage {
-            case .timeline:
-                Group {
-                    if bodyMetrics.isEmpty {
-                        photoTimelineHUDEmptyState
-                    } else {
-                        photoTimelineHUD
+        VStack(spacing: 0) {
+            photoTimelineRootNavigation
+                .padding(.horizontal, 20)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+
+            ZStack {
+                switch selectedPhotoTimelineRootPage {
+                case .timeline:
+                    Group {
+                        if bodyMetrics.isEmpty {
+                            photoTimelineHUDEmptyState
+                        } else {
+                            photoTimelineHUD
+                        }
                     }
+                    .accessibilityIdentifier("photo_timeline_root_page_timeline")
+                case .analytics:
+                    photoTimelineAnalyticsPage
+                        .accessibilityIdentifier("photo_timeline_root_page_analytics")
                 }
-                .accessibilityIdentifier("photo_timeline_root_page_timeline")
-            case .analytics:
-                photoTimelineAnalyticsPage
-                    .accessibilityIdentifier("photo_timeline_root_page_analytics")
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .contentShape(Rectangle())
         .highPriorityGesture(photoTimelineRootSwipeGesture)
+        .simultaneousGesture(photoTimelineRootSwipeGesture)
         .accessibilityIdentifier("photo_timeline_root_pager")
     }
 
-    private var photoTimelineRootSwipeGesture: some Gesture {
-        DragGesture(minimumDistance: 18, coordinateSpace: .local)
-            .onEnded { value in
-                let horizontal = value.translation.width
-                let vertical = value.translation.height
-                guard abs(horizontal) > abs(vertical), abs(horizontal) > 44 else { return }
+    private var photoTimelineRootNavigation: some View {
+        HStack(spacing: 22) {
+            photoTimelineRootNavigationButton(page: .timeline)
+                .accessibilityIdentifier("photo_timeline_root_nav_timeline")
 
-                withAnimation(.easeOut(duration: 0.2)) {
-                    selectedPhotoTimelineRootPage = horizontal < 0 ? .analytics : .timeline
-                }
+            photoTimelineRootNavigationButton(page: .analytics)
+                .accessibilityIdentifier("photo_timeline_root_nav_stats")
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier("photo_timeline_root_nav")
+    }
+
+    private func photoTimelineRootNavigationButton(page: PhotoTimelineRootPage) -> some View {
+        Button {
+            withAnimation(.easeOut(duration: 0.2)) {
+                selectedPhotoTimelineRootPage = page
             }
+        } label: {
+            VStack(spacing: 6) {
+                Text(page.navigationTitle)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(
+                        selectedPhotoTimelineRootPage == page
+                            ? Color.white
+                            : Color.white.opacity(0.58)
+                    )
+
+                Capsule()
+                    .fill(
+                        selectedPhotoTimelineRootPage == page
+                            ? Color.white
+                            : Color.clear
+                    )
+                    .frame(width: 24, height: 2)
+            }
+            .frame(minHeight: 32, alignment: .bottom)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var photoTimelineRootSwipeGesture: some Gesture {
+        DragGesture(minimumDistance: 12, coordinateSpace: .local)
+            .onChanged { value in
+                updatePhotoTimelineRootPage(from: value.translation, isFinal: false)
+            }
+            .onEnded { value in
+                updatePhotoTimelineRootPage(from: value.translation, isFinal: true)
+                hasHandledPhotoTimelineRootSwipe = false
+            }
+    }
+
+    private func updatePhotoTimelineRootPage(from translation: CGSize, isFinal: Bool) {
+        let horizontal = translation.width
+        let vertical = translation.height
+        let threshold: CGFloat = isFinal ? 44 : 72
+        guard abs(horizontal) > abs(vertical), abs(horizontal) > threshold else { return }
+        guard isFinal || !hasHandledPhotoTimelineRootSwipe else { return }
+
+        let nextPage: PhotoTimelineRootPage = horizontal < 0 ? .analytics : .timeline
+        guard selectedPhotoTimelineRootPage != nextPage else { return }
+
+        hasHandledPhotoTimelineRootSwipe = true
+        withAnimation(.easeOut(duration: 0.2)) {
+            selectedPhotoTimelineRootPage = nextPage
+        }
     }
 
     var hudTimelineSection: some View {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -43,10 +43,7 @@ extension DashboardViewLiquid {
                 authManager: authManager,
                 realtimeSyncManager: realtimeSyncManager
             )
-            refreshGlobalTimelineStore()
-            if !viewModel.bodyMetrics.isEmpty {
-                updateAnimatedValues(for: selectedIndex)
-            }
+            scheduleDashboardDerivedStateRefresh(animatedIndex: selectedIndex)
         }
         .accessibilityIdentifier("photo_timeline_hud")
     }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -76,7 +76,6 @@ extension DashboardViewLiquid {
         .contentShape(Rectangle())
         .highPriorityGesture(photoTimelineRootSwipeGesture)
         .simultaneousGesture(photoTimelineRootSwipeGesture)
-        .accessibilityIdentifier("photo_timeline_root_pager")
     }
 
     private var photoTimelineRootNavigation: some View {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -66,12 +66,12 @@ extension DashboardViewLiquid {
             }
         }
         .contentShape(Rectangle())
-        .gesture(photoTimelineRootSwipeGesture)
+        .highPriorityGesture(photoTimelineRootSwipeGesture)
         .accessibilityIdentifier("photo_timeline_root_pager")
     }
 
     private var photoTimelineRootSwipeGesture: some Gesture {
-        DragGesture(minimumDistance: 28)
+        DragGesture(minimumDistance: 18, coordinateSpace: .local)
             .onEnded { value in
                 let horizontal = value.translation.width
                 let vertical = value.translation.height

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -49,24 +49,38 @@ extension DashboardViewLiquid {
     }
 
     var photoTimelineRoot: some View {
-        TabView(selection: $selectedPhotoTimelineRootPage) {
-            Group {
-                if bodyMetrics.isEmpty {
-                    photoTimelineHUDEmptyState
-                } else {
-                    photoTimelineHUD
+        ZStack {
+            switch selectedPhotoTimelineRootPage {
+            case .timeline:
+                Group {
+                    if bodyMetrics.isEmpty {
+                        photoTimelineHUDEmptyState
+                    } else {
+                        photoTimelineHUD
+                    }
+                }
+                .accessibilityIdentifier("photo_timeline_root_page_timeline")
+            case .analytics:
+                photoTimelineAnalyticsPage
+                    .accessibilityIdentifier("photo_timeline_root_page_analytics")
+            }
+        }
+        .contentShape(Rectangle())
+        .gesture(photoTimelineRootSwipeGesture)
+        .accessibilityIdentifier("photo_timeline_root_pager")
+    }
+
+    private var photoTimelineRootSwipeGesture: some Gesture {
+        DragGesture(minimumDistance: 28)
+            .onEnded { value in
+                let horizontal = value.translation.width
+                let vertical = value.translation.height
+                guard abs(horizontal) > abs(vertical), abs(horizontal) > 44 else { return }
+
+                withAnimation(.easeOut(duration: 0.2)) {
+                    selectedPhotoTimelineRootPage = horizontal < 0 ? .analytics : .timeline
                 }
             }
-            .tag(PhotoTimelineRootPage.timeline)
-            .accessibilityIdentifier("photo_timeline_root_page_timeline")
-
-            photoTimelineAnalyticsPage
-                .tag(PhotoTimelineRootPage.analytics)
-                .accessibilityIdentifier("photo_timeline_root_page_analytics")
-        }
-        .tabViewStyle(.page(indexDisplayMode: .always))
-        .indexViewStyle(.page(backgroundDisplayMode: .interactive))
-        .accessibilityIdentifier("photo_timeline_root_pager")
     }
 
     var hudTimelineSection: some View {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -82,10 +82,8 @@ extension DashboardViewLiquid {
     private var photoTimelineRootNavigation: some View {
         HStack(spacing: 22) {
             photoTimelineRootNavigationButton(page: .timeline)
-                .accessibilityIdentifier("photo_timeline_root_nav_timeline")
 
             photoTimelineRootNavigationButton(page: .analytics)
-                .accessibilityIdentifier("photo_timeline_root_nav_stats")
 
             Spacer(minLength: 0)
         }
@@ -120,6 +118,10 @@ extension DashboardViewLiquid {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(page.navigationTitle)
+        .accessibilityAddTraits(selectedPhotoTimelineRootPage == page ? [.isSelected] : [])
+        .accessibilityIdentifier(page.accessibilityIdentifier)
     }
 
     private var photoTimelineRootSwipeGesture: some Gesture {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -147,7 +147,8 @@ struct DashboardViewLiquid: View {
 
         let withLifecycle = base
             .onAppear {
-                DispatchQueue.main.async {
+                Task { @MainActor in
+                    await Task.yield()
                     handleOnAppear()
                 }
             }
@@ -371,7 +372,9 @@ struct DashboardViewLiquid: View {
         rebuildDailyMetricsLookup: Bool = false,
         animatedIndex: Int? = nil
     ) {
-        DispatchQueue.main.async {
+        Task { @MainActor in
+            await Task.yield()
+
             if rebuildDailyMetricsLookup {
                 rebuildDailyMetricsLookupCache()
             }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -77,6 +77,7 @@ struct DashboardViewLiquid: View {
     @State private var selectedTab: DashboardTab = .home
     @State private var isPhotosTabEnabled = true
     @State var selectedPhotoTimelineRootPage: PhotoTimelineRootPage = .timeline
+    @State var hasHandledPhotoTimelineRootSwipe = false
     @State var isMetricDetailActive = false
     @State var selectedMetricType: MetricType = .weight
     @State private var isStatsDestinationActive = false
@@ -110,6 +111,15 @@ struct DashboardViewLiquid: View {
     enum PhotoTimelineRootPage: Hashable {
         case timeline
         case analytics
+
+        var navigationTitle: String {
+            switch self {
+            case .timeline:
+                "Timeline"
+            case .analytics:
+                "Stats"
+            }
+        }
     }
 
     enum MetricType {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -120,6 +120,15 @@ struct DashboardViewLiquid: View {
                 "Stats"
             }
         }
+
+        var accessibilityIdentifier: String {
+            switch self {
+            case .timeline:
+                "photo_timeline_root_nav_timeline"
+            case .analytics:
+                "photo_timeline_root_nav_stats"
+            }
+        }
     }
 
     enum MetricType {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -84,7 +84,6 @@ struct DashboardViewLiquid: View {
     @State var progressPhotoAttachTarget: BodyMetrics?
     @State private var chartMode: ChartMode = .trend
     @State var bodyScoreRefreshToken = UUID()
-    @State var isBodyScoreSharePresented = false
     @State var bodyScoreSharePayload: BodyScoreSharePayload?
     @State private var hasPerformedInitialRefresh = false
     @State var featureGateRefreshToken = UUID()
@@ -143,6 +142,7 @@ struct DashboardViewLiquid: View {
         let base = ZStack {
             dashboardBackground
             dashboardContent
+            bodyScoreShareOverlay
         }
 
         let withLifecycle = base
@@ -239,17 +239,13 @@ struct DashboardViewLiquid: View {
             )
             .toolbarBackground(Material.ultraThinMaterial, for: ToolbarPlacement.tabBar)
             .toolbarBackground(Visibility.visible, for: ToolbarPlacement.tabBar)
-            .sheet(isPresented: $isBodyScoreSharePresented) {
-                if let payload = bodyScoreSharePayload {
-                    BodyScoreShareSheet(payload: payload)
-                }
-            }
             .onScreenshot {
                 guard selectedTab == .home else { return }
                 guard !isMetricDetailActive else { return }
                 guard let payload = makeBodyScoreSharePayload() else { return }
-                bodyScoreSharePayload = payload
-                isBodyScoreSharePresented = true
+                DispatchQueue.main.async {
+                    bodyScoreSharePayload = payload
+                }
             }
             .onChange(of: showAddEntrySheet) { _, isPresented in
                 guard !isPresented else { return }
@@ -258,6 +254,18 @@ struct DashboardViewLiquid: View {
             }
 
         return withSheetsAndNavigation
+    }
+
+    @ViewBuilder
+    private var bodyScoreShareOverlay: some View {
+        if let payload = bodyScoreSharePayload {
+            BodyScoreShareSheet(payload: payload) {
+                bodyScoreSharePayload = nil
+            }
+            .ignoresSafeArea()
+            .zIndex(20)
+            .transition(.opacity)
+        }
     }
 
     private var homeTab: some View {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -147,8 +147,9 @@ struct DashboardViewLiquid: View {
 
         let withLifecycle = base
             .onAppear {
-                // Load saved metrics order from AppStorage
-                handleOnAppear()
+                DispatchQueue.main.async {
+                    handleOnAppear()
+                }
             }
             .onDisappear {
                 syncBannerDismissTask?.cancel()
@@ -163,17 +164,16 @@ struct DashboardViewLiquid: View {
                 handleCoreDataContextChange(notification)
             }
             .onReceive(viewModel.$recentDailyMetrics) { _ in
-                rebuildDailyMetricsLookupCache()
-                refreshGlobalTimelineStore()
+                scheduleDashboardDerivedStateRefresh(rebuildDailyMetricsLookup: true)
             }
             .onReceive(viewModel.$bodyMetrics) { _ in
-                refreshGlobalTimelineStore()
+                scheduleDashboardDerivedStateRefresh()
             }
             .onChange(of: selectedRange) { _, newValue in
                 storedTimeRangeRawValue = newValue.rawValue
             }
             .onChange(of: selectedIndex) { _, newIndex in
-                updateAnimatedValues(for: newIndex)
+                scheduleDashboardDerivedStateRefresh(animatedIndex: newIndex)
             }
             .onChange(of: selectedTab) { _, newTab in
                 if newTab == .photos {
@@ -293,9 +293,7 @@ struct DashboardViewLiquid: View {
                     authManager: authManager,
                     realtimeSyncManager: realtimeSyncManager
                 )
-                if !viewModel.bodyMetrics.isEmpty {
-                    updateAnimatedValues(for: selectedIndex)
-                }
+                scheduleDashboardDerivedStateRefresh(animatedIndex: selectedIndex)
             }
         )
     }
@@ -311,10 +309,7 @@ struct DashboardViewLiquid: View {
                     loadOnlyNewest: true,
                     selectedIndex: selectedIndex
                 )
-                refreshGlobalTimelineStore()
-                if !viewModel.bodyMetrics.isEmpty {
-                    updateAnimatedValues(for: selectedIndex)
-                }
+                scheduleDashboardDerivedStateRefresh(animatedIndex: selectedIndex)
             }
         }
 
@@ -326,10 +321,7 @@ struct DashboardViewLiquid: View {
                     authManager: authManager,
                     realtimeSyncManager: realtimeSyncManager
                 )
-                refreshGlobalTimelineStore()
-                if !viewModel.bodyMetrics.isEmpty {
-                    updateAnimatedValues(for: selectedIndex)
-                }
+                scheduleDashboardDerivedStateRefresh(animatedIndex: selectedIndex)
             }
         }
 
@@ -371,9 +363,23 @@ struct DashboardViewLiquid: View {
                 loadOnlyNewest: true,
                 selectedIndex: selectedIndex
             )
+            scheduleDashboardDerivedStateRefresh(animatedIndex: selectedIndex)
+        }
+    }
+
+    func scheduleDashboardDerivedStateRefresh(
+        rebuildDailyMetricsLookup: Bool = false,
+        animatedIndex: Int? = nil
+    ) {
+        DispatchQueue.main.async {
+            if rebuildDailyMetricsLookup {
+                rebuildDailyMetricsLookupCache()
+            }
+
             refreshGlobalTimelineStore()
-            if !viewModel.bodyMetrics.isEmpty {
-                updateAnimatedValues(for: selectedIndex)
+
+            if let animatedIndex, !viewModel.bodyMetrics.isEmpty {
+                updateAnimatedValues(for: animatedIndex)
             }
         }
     }
@@ -435,9 +441,7 @@ struct DashboardViewLiquid: View {
                     authManager: authManager,
                     realtimeSyncManager: realtimeSyncManager
                 )
-                if !viewModel.bodyMetrics.isEmpty {
-                    updateAnimatedValues(for: selectedIndex)
-                }
+                scheduleDashboardDerivedStateRefresh(animatedIndex: selectedIndex)
             }
         )
     }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -562,6 +562,26 @@ final class BodyScoreShareCardTests: XCTestCase {
         XCTAssertEqual(image.size.height, size.height, accuracy: 0.5)
     }
 
+    func testShareCardRendersEveryLaunchExportAspect() throws {
+        for aspect in BodyScoreShareAspect.allCases {
+            let size = aspect.pixelSize
+            let renderer = ImageRenderer(
+                content: BodyScoreShareCardView(
+                    payload: makePayload(bodyFatPercentage: 18.6, gender: "male"),
+                    aspect: aspect
+                )
+                .frame(width: size.width, height: size.height)
+                .environment(\.colorScheme, .dark)
+            )
+            renderer.scale = 1.0
+
+            let image = try XCTUnwrap(renderer.uiImage, "Missing rendered image for \(aspect.rawValue)")
+
+            XCTAssertEqual(image.size.width, size.width, accuracy: 0.5)
+            XCTAssertEqual(image.size.height, size.height, accuracy: 0.5)
+        }
+    }
+
     private func makePayload(
         bodyFatPercentage: Double?,
         gender: String?
@@ -2025,24 +2045,84 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         XCTAssertFalse(OnboardingStateManager.shared.hasCompletedCurrentVersion)
     }
 
-    func testProfileDetailsCompletesOnboardingWhenFirstPhotoDisabled() {
+    func testProfileDetailsCompletesOnboardingWhenFirstPhotoDisabled() async {
         let viewModel = OnboardingFlowViewModel(includesFirstPhotoStep: false)
         viewModel.currentStep = .profileDetails
 
-        viewModel.goToNextStep()
+        await viewModel.finishOnboardingAndShowPaywall()
 
         XCTAssertEqual(viewModel.currentStep, .paywall)
         XCTAssertTrue(OnboardingStateManager.shared.hasCompletedCurrentVersion)
     }
 
-    func testFirstPhotoStepCanCompleteToPaywall() {
+    func testFirstPhotoStepCanCompleteToPaywall() async {
         let viewModel = OnboardingFlowViewModel(includesFirstPhotoStep: true)
         viewModel.currentStep = .firstPhoto
 
-        viewModel.goToNextStep()
+        await viewModel.completeFirstPhotoStep()
 
         XCTAssertEqual(viewModel.currentStep, .paywall)
         XCTAssertTrue(OnboardingStateManager.shared.hasCompletedCurrentVersion)
+    }
+
+    func testFirstPhotoCompletionMarksLocalUserComplete() async {
+        let userId = "onboarding-first-photo-complete-\(UUID().uuidString)"
+        let previousUser = AuthManager.shared.currentUser
+        let previousAuthenticationState = AuthManager.shared.isAuthenticated
+
+        defer {
+            AuthManager.shared.currentUser = previousUser
+            AuthManager.shared.isAuthenticated = previousAuthenticationState
+            OnboardingProgressStore.shared.clearProgress(for: userId)
+        }
+
+        AuthManager.shared.currentUser = User(
+            id: userId,
+            email: "first-photo-complete@example.com",
+            name: "First Photo",
+            profile: UserProfile(
+                id: userId,
+                email: "first-photo-complete@example.com",
+                username: nil,
+                fullName: "First Photo",
+                dateOfBirth: nil,
+                height: nil,
+                heightUnit: nil,
+                gender: nil,
+                activityLevel: nil,
+                goalWeight: nil,
+                goalWeightUnit: nil,
+                onboardingCompleted: false
+            ),
+            onboardingCompleted: false
+        )
+        AuthManager.shared.isAuthenticated = true
+
+        let viewModel = OnboardingFlowViewModel(includesFirstPhotoStep: true)
+        viewModel.currentStep = .firstPhoto
+
+        await viewModel.completeFirstPhotoStep()
+
+        XCTAssertEqual(viewModel.currentStep, .paywall)
+        XCTAssertTrue(OnboardingStateManager.shared.hasCompletedCurrentVersion)
+        XCTAssertTrue(AuthManager.shared.currentUser?.onboardingCompleted == true)
+        XCTAssertEqual(AuthManager.shared.currentUser?.profile?.onboardingCompleted, true)
+        XCTAssertNil(OnboardingProgressStore.shared.snapshotForTesting(for: userId))
+    }
+
+    func testProfileCompletionSyncPersistsCurrentOnboardingVersion() {
+        let suiteName = "onboarding-profile-sync-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let manager = OnboardingStateManager(defaults: defaults, currentVersion: 2)
+
+        manager.syncCompletionFlagFromProfile(true)
+
+        XCTAssertTrue(manager.hasCompletedCurrentVersion)
+        XCTAssertEqual(defaults.integer(forKey: Constants.onboardingCompletedVersionKey), 2)
     }
 
     func testFirstPhotoBackNavigationAndPaywallBackNavigation() {

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -212,8 +212,13 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].exists)
 
         let statsNav = app.descendants(matching: .any)["photo_timeline_root_nav_stats"]
-        XCTAssertTrue(statsNav.waitForExistence(timeout: 5))
-        statsNav.tap()
+        if statsNav.waitForExistence(timeout: 5) {
+            statsNav.tap()
+        } else {
+            let statsButton = app.buttons["Stats"]
+            XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
+            statsButton.tap()
+        }
 
         XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].waitForExistence(timeout: 10))
         let presenceSummary = app.descendants(matching: .any)["photo_timeline_stats_presence_summary"]

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -181,8 +181,7 @@ final class LogYourBodyUITests: XCTestCase {
         app.launchArguments = ["-lybUITestPaidMVPFixture"]
         app.launch()
 
-        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_pager"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_timeline"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_timeline"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["Start with a photo"].waitForExistence(timeout: 5))
         XCTAssertFalse(app.staticTexts["Weight log"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["legacy_full_dashboard_beta"].exists)
@@ -206,19 +205,13 @@ final class LogYourBodyUITests: XCTestCase {
         app.launchArguments = ["-lybUITestPhotoTimelineHUDFixture"]
         app.launch()
 
-        let pager = app.descendants(matching: .any)["photo_timeline_root_pager"]
-        XCTAssertTrue(pager.waitForExistence(timeout: 10))
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_timeline"].waitForExistence(timeout: 10))
         XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_hud_stats_button"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].exists)
 
-        let statsNav = app.descendants(matching: .any)["photo_timeline_root_nav_stats"]
-        if statsNav.waitForExistence(timeout: 5) {
-            statsNav.tap()
-        } else {
-            let statsButton = app.buttons["Stats"]
-            XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
-            statsButton.tap()
-        }
+        let statsButton = app.buttons["Stats"]
+        XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
+        statsButton.tap()
 
         XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].waitForExistence(timeout: 10))
         let presenceSummary = app.descendants(matching: .any)["photo_timeline_stats_presence_summary"]

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -203,14 +203,17 @@ final class LogYourBodyUITests: XCTestCase {
 
     func testPhotoHUDFixtureRoutesToIntendedPostMVPDashboard() throws {
         let app = XCUIApplication()
-        app.launchArguments = [
-            "-lybUITestPhotoTimelineHUDFixture",
-            "-lybUITestPhotoTimelineAnalyticsFixture"
-        ]
+        app.launchArguments = ["-lybUITestPhotoTimelineHUDFixture"]
         app.launch()
 
-        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_pager"].waitForExistence(timeout: 10))
+        let pager = app.descendants(matching: .any)["photo_timeline_root_pager"]
+        XCTAssertTrue(pager.waitForExistence(timeout: 10))
         XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_hud_stats_button"].exists)
+        XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].exists)
+
+        let swipeStart = pager.coordinate(withNormalizedOffset: CGVector(dx: 0.85, dy: 0.5))
+        let swipeEnd = pager.coordinate(withNormalizedOffset: CGVector(dx: 0.15, dy: 0.5))
+        swipeStart.press(forDuration: 0.05, thenDragTo: swipeEnd)
 
         XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].waitForExistence(timeout: 10))
         let presenceSummary = app.descendants(matching: .any)["photo_timeline_stats_presence_summary"]

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -211,9 +211,9 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_hud_stats_button"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].exists)
 
-        let swipeStart = pager.coordinate(withNormalizedOffset: CGVector(dx: 0.85, dy: 0.5))
-        let swipeEnd = pager.coordinate(withNormalizedOffset: CGVector(dx: 0.15, dy: 0.5))
-        swipeStart.press(forDuration: 0.05, thenDragTo: swipeEnd)
+        let statsNav = app.descendants(matching: .any)["photo_timeline_root_nav_stats"]
+        XCTAssertTrue(statsNav.waitForExistence(timeout: 5))
+        statsNav.tap()
 
         XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].waitForExistence(timeout: 10))
         let presenceSummary = app.descendants(matching: .any)["photo_timeline_stats_presence_summary"]

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -255,6 +255,34 @@ final class LogYourBodyUITests: XCTestCase {
         attachScreenshot(named: "launch-quality-home-timeline", from: app)
     }
 
+    func testLaunchQualityGateCapturesBodyScoreShareSheet() throws {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-lybUITestPhotoTimelineHUDFixture",
+            "-lybUITestPhaseInsightFixture",
+            "-lybUITestGlp1WeeklyCheckInFixture"
+        ]
+        app.launch()
+
+        XCTAssertTrue(app.descendants(matching: .any)["dashboard_home_timeline_hero"].waitForExistence(timeout: 10))
+
+        let shareButton = app.descendants(matching: .any)["body_score_hero_share_button"]
+        XCTAssertTrue(shareButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(shareButton.isHittable)
+        shareButton.tap()
+
+        let shareCard = app.descendants(matching: .any)["body_score_share_card"]
+        XCTAssertTrue(shareCard.waitForExistence(timeout: 8))
+        XCTAssertTrue(app.descendants(matching: .any)["body_score_share_avatar_visual"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["body_score_share_save_button"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["body_score_share_system_button"].exists)
+
+        let cardFrame = shareCard.frame
+        let windowFrame = app.windows.firstMatch.frame
+        XCTAssertGreaterThan(cardFrame.width, windowFrame.width * 0.88)
+        attachScreenshot(named: "launch-quality-body-score-share", from: app)
+    }
+
     func testLaunchQualityGateCapturesOnboardingFixedCTA() throws {
         let app = XCUIApplication()
         app.launchArguments = ["-lybUITestBodyScoreOnboardingFixture"]
@@ -270,6 +298,24 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertGreaterThan(startButton.frame.minY, windowFrame.height * 0.72)
         XCTAssertLessThanOrEqual(startButton.frame.maxY, windowFrame.maxY + 1)
         attachScreenshot(named: "launch-quality-onboarding-fixed-cta", from: app)
+    }
+
+    func testLaunchQualityGateCapturesOnboardingFirstPhotoCTA() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-lybUITestBodyScoreFirstPhotoFixture"]
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["Start your visual timeline."].waitForExistence(timeout: 10))
+
+        let addPhotoButton = app.buttons["Add first photo"]
+        let skipButton = app.buttons["Skip for now"]
+        XCTAssertTrue(addPhotoButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(skipButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(addPhotoButton.isHittable)
+        XCTAssertTrue(skipButton.isHittable)
+        XCTAssertFalse(app.buttons["Continue"].exists)
+
+        attachScreenshot(named: "launch-quality-onboarding-first-photo", from: app)
     }
 
     func testPhaseInsightFixtureShowsDeterministicCuttingInsight() throws {

--- a/scripts/ios/launch-quality-audit.sh
+++ b/scripts/ios/launch-quality-audit.sh
@@ -9,6 +9,8 @@ DESTINATION="${DESTINATION:-platform=iOS Simulator,name=LYB Golden iPhone 16}"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 ARTIFACT_DIR="${ARTIFACT_DIR:-$IOS_DIR/test_results/launch-quality-audit/$STAMP}"
 RUN_SWIFTLINT="${RUN_SWIFTLINT:-true}"
+RUN_RUNTIME_WARNING_AUDIT="${RUN_RUNTIME_WARNING_AUDIT:-true}"
+FAIL_ON_RUNTIME_WARNINGS="${FAIL_ON_RUNTIME_WARNINGS:-false}"
 XCODEBUILD_SETTINGS="${XCODEBUILD_SETTINGS:-CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO}"
 
 read -r -a XCODEBUILD_SETTINGS_ARRAY <<< "$XCODEBUILD_SETTINGS"
@@ -27,39 +29,115 @@ COMMON_XCODEBUILD_ARGS=(
   -maximum-concurrent-test-simulator-destinations 1
 )
 
+cleanup_booted_simulator_apps() {
+  xcrun simctl terminate booted com.logyourbody.app >/dev/null 2>&1 || true
+  xcrun simctl terminate booted com.logyourbody.app.xctrunner >/dev/null 2>&1 || true
+}
+
+is_simulator_infra_failure() {
+  local log_file="$1"
+
+  grep -Eq \
+    'Failed to get background assertion|Timed out while acquiring background assertion|Failed to install or launch the test runner|Failed to launch app|Mach error -308|server died|Early unexpected exit|operation never finished bootstrapping|Test crashed with signal kill before establishing connection|Restarting after unexpected exit|unexpected exit, crash, or test timeout' \
+    "$log_file"
+}
+
+run_xcodebuild_test() {
+  local label="$1"
+  local result_bundle="$2"
+  local log_file="$3"
+  local attempt
+  local status
+  shift 3
+
+  : > "$log_file"
+
+  for attempt in 1 2; do
+    cleanup_booted_simulator_apps
+    rm -rf "$result_bundle"
+
+    echo "Running $label (attempt $attempt)" | tee -a "$log_file"
+    set +e
+    xcodebuild \
+      "${COMMON_XCODEBUILD_ARGS[@]}" \
+      -resultBundlePath "$result_bundle" \
+      "$@" \
+      "${XCODEBUILD_SETTINGS_ARRAY[@]}" \
+      test 2>&1 | tee -a "$log_file"
+    status="${PIPESTATUS[0]}"
+    set -e
+
+    if [[ "$status" -eq 0 ]]; then
+      return 0
+    fi
+
+    if [[ "$attempt" -eq 1 ]] && is_simulator_infra_failure "$log_file"; then
+      echo "Retrying $label after simulator launch failure" | tee -a "$log_file"
+      sleep 3
+      continue
+    fi
+
+    return "$status"
+  done
+}
+
+run_ui_test() {
+  local test_name="$1"
+  local result_bundle="$2"
+
+  run_xcodebuild_test \
+    "$test_name" \
+    "$result_bundle" \
+    "$ARTIFACT_DIR/launch-quality-ui-$test_name.log" \
+    "-only-testing:LogYourBodyUITests/LogYourBodyUITests/$test_name"
+}
+
 cd "$IOS_DIR"
 
 if [[ "$RUN_SWIFTLINT" == "true" ]]; then
   swiftlint lint --strict | tee "$ARTIFACT_DIR/swiftlint.log"
 fi
 
-xcodebuild \
-  "${COMMON_XCODEBUILD_ARGS[@]}" \
-  -resultBundlePath "$ARTIFACT_DIR/launch-quality-unit-tests.xcresult" \
+run_xcodebuild_test \
+  "launch-quality-unit-tests" \
+  "$ARTIFACT_DIR/launch-quality-unit-tests.xcresult" \
+  "$ARTIFACT_DIR/launch-quality-unit-tests.log" \
   -only-testing:LogYourBodyTests/PhotoTimelineHUDPolicyTests \
-  -only-testing:LogYourBodyTests/BodyScoreShareCardTests \
-  "${XCODEBUILD_SETTINGS_ARRAY[@]}" \
-  test | tee "$ARTIFACT_DIR/launch-quality-unit-tests.log"
+  -only-testing:LogYourBodyTests/BodyScoreShareCardTests
 
-xcodebuild \
-  "${COMMON_XCODEBUILD_ARGS[@]}" \
-  -resultBundlePath "$ARTIFACT_DIR/launch-quality-ui-tests.xcresult" \
-  -only-testing:LogYourBodyUITests/LogYourBodyUITests/testPhotoHUDFixtureRoutesToIntendedPostMVPDashboard \
-  -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesTimelineHomeSurface \
-  -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesOnboardingFixedCTA \
-  -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesOnboardingFirstPhotoCTA \
-  -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesBodyScoreShareSheet \
-  "${XCODEBUILD_SETTINGS_ARRAY[@]}" \
-  test | tee "$ARTIFACT_DIR/launch-quality-ui-tests.log"
+UI_TESTS=(
+  "testLaunchQualityGateCapturesOnboardingFixedCTA"
+  "testLaunchQualityGateCapturesTimelineHomeSurface"
+  "testPhotoHUDFixtureRoutesToIntendedPostMVPDashboard"
+  "testLaunchQualityGateCapturesOnboardingFirstPhotoCTA"
+  "testLaunchQualityGateCapturesBodyScoreShareSheet"
+)
 
-cat > "$ARTIFACT_DIR/summary.md" <<SUMMARY
-# iOS Launch Quality Audit
+UI_RESULT_BUNDLES=()
+for test_name in "${UI_TESTS[@]}"; do
+  result_bundle="$ARTIFACT_DIR/launch-quality-ui-$test_name.xcresult"
+  UI_RESULT_BUNDLES+=("$result_bundle")
+  run_ui_test "$test_name" "$result_bundle"
+done
 
-- Destination: \`$DESTINATION\`
-- Unit coverage: photo timeline HUD policy, Body Score share card layout
-- UI coverage: timeline routing, no bottom stats switch card, home/analytics/onboarding/share screenshot attachments
-- Build strategy: unit and UI selectors run separately with simulator parallelism disabled
-- Logs and result bundles: \`$ARTIFACT_DIR\`
-SUMMARY
+if [[ "$RUN_RUNTIME_WARNING_AUDIT" == "true" ]]; then
+  FAIL_ON_RUNTIME_WARNINGS="$FAIL_ON_RUNTIME_WARNINGS" \
+    bash "$ROOT_DIR/scripts/ios/xcresult-runtime-audit.sh" \
+      "$ARTIFACT_DIR/launch-quality-unit-tests.xcresult" \
+      "${UI_RESULT_BUNDLES[@]}" |
+    tee "$ARTIFACT_DIR/runtime-warnings.log"
+else
+  echo "Skipping XCTest runtime-warning audit" | tee "$ARTIFACT_DIR/runtime-warnings.log"
+fi
+
+{
+  printf '# iOS Launch Quality Audit\n\n'
+  printf -- '- Destination: `%s`\n' "$DESTINATION"
+  printf -- '- Unit coverage: photo timeline HUD policy, Body Score share card layout\n'
+  printf -- '- UI coverage: timeline routing, no bottom stats switch card, home/analytics/onboarding/share screenshot attachments\n'
+  printf -- '- Runtime warning audit: `runtime-warnings.log`, fail-on-warning=`%s`\n' "$FAIL_ON_RUNTIME_WARNINGS"
+  printf -- '- Build strategy: unit and UI selectors run separately with simulator parallelism disabled\n'
+  printf -- '- Logs and result bundles: `%s`\n' "$ARTIFACT_DIR"
+} > "$ARTIFACT_DIR/summary.md"
 
 echo "Launch quality audit logs written to $ARTIFACT_DIR"

--- a/scripts/ios/launch-quality-audit.sh
+++ b/scripts/ios/launch-quality-audit.sh
@@ -47,6 +47,8 @@ xcodebuild \
   -only-testing:LogYourBodyUITests/LogYourBodyUITests/testPhotoHUDFixtureRoutesToIntendedPostMVPDashboard \
   -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesTimelineHomeSurface \
   -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesOnboardingFixedCTA \
+  -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesOnboardingFirstPhotoCTA \
+  -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesBodyScoreShareSheet \
   "${XCODEBUILD_SETTINGS_ARRAY[@]}" \
   test | tee "$ARTIFACT_DIR/launch-quality-ui-tests.log"
 
@@ -55,7 +57,7 @@ cat > "$ARTIFACT_DIR/summary.md" <<SUMMARY
 
 - Destination: \`$DESTINATION\`
 - Unit coverage: photo timeline HUD policy, Body Score share card layout
-- UI coverage: timeline routing, no bottom stats switch card, home/analytics/onboarding screenshot attachments
+- UI coverage: timeline routing, no bottom stats switch card, home/analytics/onboarding/share screenshot attachments
 - Build strategy: unit and UI selectors run separately with simulator parallelism disabled
 - Logs and result bundles: \`$ARTIFACT_DIR\`
 SUMMARY

--- a/scripts/ios/resolve-simulator-destination.sh
+++ b/scripts/ios/resolve-simulator-destination.sh
@@ -48,7 +48,59 @@ SIMULATOR_ID="$(
 )"
 
 if [[ -z "$SIMULATOR_ID" ]]; then
+  RUNTIME_ID="$(
+    xcrun simctl list runtimes --json | ruby -rjson -e '
+      runtimes = JSON.parse(STDIN.read).fetch("runtimes", [])
+      candidates = runtimes.select do |runtime|
+        runtime["platform"] == "iOS" && runtime["isAvailable"] != false
+      end
+
+      preferred = candidates.max_by do |runtime|
+        runtime.fetch("version", "").scan(/\d+/).map(&:to_i)
+      end
+
+      puts preferred["identifier"] if preferred
+    '
+  )"
+
+  DEVICE_TYPE_ID="$(
+    xcrun simctl list devicetypes --json | ruby -rjson -e '
+      device_types = JSON.parse(STDIN.read).fetch("devicetypes", [])
+      candidates = device_types.select { |device| device.fetch("name", "").include?("iPhone") }
+
+      preferred = candidates.min_by do |device|
+        name = device.fetch("name", "")
+        rank =
+          if name == "iPhone 16"
+            0
+          elsif name.include?("iPhone 16")
+            1
+          elsif name.include?("iPhone 17")
+            2
+          elsif name.include?("iPhone 15")
+            3
+          else
+            4
+          end
+
+        [rank, name]
+      end
+
+      puts preferred["identifier"] if preferred
+    '
+  )"
+
+  if [[ -n "$RUNTIME_ID" && -n "$DEVICE_TYPE_ID" ]]; then
+    SIMULATOR_ID="$(xcrun simctl create "LYB CI iPhone" "$DEVICE_TYPE_ID" "$RUNTIME_ID")"
+    xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
+    xcrun simctl bootstatus "$SIMULATOR_ID" -b >/dev/null 2>&1 || true
+  fi
+fi
+
+if [[ -z "$SIMULATOR_ID" ]]; then
   echo "::error::No available xcodebuild iPhone simulator destination found for the iOS quality gate." >&2
+  xcrun simctl list runtimes >&2 || true
+  xcrun simctl list devicetypes >&2 || true
   xcodebuild -project "$PROJECT" -scheme "$SCHEME" -showdestinations >&2 || true
   exit 70
 fi

--- a/scripts/ios/xcresult-runtime-audit.sh
+++ b/scripts/ios/xcresult-runtime-audit.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -lt 1 ]]; then
+  echo "Usage: $0 <result-bundle.xcresult> [more.xcresult ...]" >&2
+  exit 64
+fi
+
+FAIL_ON_RUNTIME_WARNINGS="${FAIL_ON_RUNTIME_WARNINGS:-false}"
+TEMP_OUTPUT="$(mktemp)"
+trap 'rm -f "$TEMP_OUTPUT"' EXIT
+
+for result_bundle in "$@"; do
+  if [[ ! -d "$result_bundle" ]]; then
+    echo "Missing xcresult bundle: $result_bundle" >&2
+    exit 66
+  fi
+
+  xcrun xcresulttool get test-results tests \
+    --path "$result_bundle" \
+    --format json |
+    python3 -c '
+import json
+import sys
+
+bundle_path = sys.argv[1]
+payload = json.load(sys.stdin)
+
+def walk(node, current_test=None):
+    node_type = node.get("nodeType")
+    name = node.get("name", "")
+    test_id = node.get("nodeIdentifier") or name
+
+    if node_type == "Test Case":
+        current_test = test_id
+
+    if node_type == "Runtime Warning":
+        print("{}\t{}\t{}".format(bundle_path, current_test or "-", name))
+
+    for child in node.get("children", []):
+        walk(child, current_test)
+
+for root in payload.get("testNodes", []):
+    walk(root)
+' "$result_bundle" >> "$TEMP_OUTPUT"
+done
+
+warning_count="$(wc -l < "$TEMP_OUTPUT" | tr -d '[:space:]')"
+
+if [[ "$warning_count" == "0" ]]; then
+  echo "No XCTest runtime warnings found."
+  exit 0
+fi
+
+echo "XCTest runtime warnings found: $warning_count"
+cat "$TEMP_OUTPUT"
+
+if [[ "$FAIL_ON_RUNTIME_WARNINGS" == "true" ]]; then
+  exit 2
+fi


### PR DESCRIPTION
## Summary
- persist authenticated Body Score onboarding completion before routing to paywall, including local profile/onboarding-version state
- clean up the first-photo onboarding CTA by removing the duplicate Continue path and adding deterministic UI coverage
- stabilize Body Score social sharing with a full-screen in-app share overlay, metric-specific payloads, distinct share button identifiers, and exposed card/save/share accessibility IDs
- remove the bottom stats switch card from the timeline home and replace it with a top Timeline / Stats nav plus swipe support
- harden launch-quality coverage for onboarding, home timeline, Stats routing, first-photo CTA, and Body Score share screenshots
- eliminate launch-time SwiftUI state-mutation warnings by avoiding render-time dashboard cache writes and keeping nav accessibility identifiers off the root pager

## Validation
- `swiftlint lint --strict` passed from `apps/ios`
- `RUN_SWIFTLINT=false scripts/ios/launch-quality-audit.sh` passed: 10 unit tests, 5 UI tests, screenshots, and runtime-warning sweep in `apps/ios/test_results/launch-quality-audit/20260614-215747`
- focused route rerun passed: `apps/ios/test_results/launch-quality-audit/20260615-photo-hud-page-nav-rerun/photo-hud-route.xcresult`
- runtime audit passed: `FAIL_ON_RUNTIME_WARNINGS=true bash scripts/ios/xcresult-runtime-audit.sh apps/ios/test_results/launch-quality-audit/20260615-photo-hud-page-nav-rerun/photo-hud-route.xcresult`
- pre-push hook completed; filtered Turbo lint/typecheck/test found no JS tasks for this iOS-only diff. Local warning only: Node v22.22.1 vs repo engine Node 20.x.

## Notes
- Test simulator: `LYB Golden iPhone 16`
- Result bundles are local ignored artifacts, not committed.
- CI is running on the latest head commit and will remain the merge gate.