### PR TITLE
JOV-3148 Migrate iOS navigation stacks

### DIFF
--- a/apps/ios/LogYourBody/Components/BackgroundTaskDetailsSheet.swift
+++ b/apps/ios/LogYourBody/Components/BackgroundTaskDetailsSheet.swift
@@ -13,7 +13,7 @@ struct BackgroundTaskDetailsSheet: View {
     @State private var showCancelAllConfirmation = false
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ZStack {
                 Color.appBackground.ignoresSafeArea()
 

--- a/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
+++ b/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
@@ -307,7 +307,7 @@ struct BodyScoreShareSheet: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 24) {
                 Picker("Format", selection: $selectedAspect) {
                     ForEach(BodyScoreShareAspect.allCases) { aspect in

--- a/apps/ios/LogYourBody/Models/BackgroundTaskDetailsSheet.swift
+++ b/apps/ios/LogYourBody/Models/BackgroundTaskDetailsSheet.swift
@@ -13,7 +13,7 @@ struct BackgroundTaskDetailsSheet: View {
     @State private var showCancelAllConfirmation = false
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ZStack {
                 Color.appBackground.ignoresSafeArea()
 

--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -66,7 +66,7 @@ struct AddEntrySheet: View {
     @AppStorage(Constants.hasPromptedDeletePhotosKey) private var hasPromptedDeletePhotos = false
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 0) {
                 // Tab selector
                 Picker("Entry Type", selection: $selectedTab) {
@@ -988,7 +988,7 @@ private struct Glp1AddMedicationView: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 0) {
                 List {
                     Section {

--- a/apps/ios/LogYourBody/Views/BodySpecIntegrationView.swift
+++ b/apps/ios/LogYourBody/Views/BodySpecIntegrationView.swift
@@ -343,7 +343,7 @@ struct BodySpecIntegrationView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         BodySpecIntegrationView()
             .environmentObject(AuthManager.shared)
     }

--- a/apps/ios/LogYourBody/Views/BulkPhotoImportView.swift
+++ b/apps/ios/LogYourBody/Views/BulkPhotoImportView.swift
@@ -608,7 +608,7 @@ struct PhotoGridItem: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         BulkPhotoImportView()
             .environmentObject(AuthManager.shared)
     }

--- a/apps/ios/LogYourBody/Views/ChangePasswordView.swift
+++ b/apps/ios/LogYourBody/Views/ChangePasswordView.swift
@@ -265,7 +265,7 @@ enum PasswordError: LocalizedError {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ChangePasswordView()
             .preferredColorScheme(.dark)
     }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -233,30 +233,12 @@ struct DashboardViewLiquid: View {
                 )
                 .environmentObject(authManager)
             }
-            .background(
-                ZStack {
-                    NavigationLink(
-                        isActive: $isMetricDetailActive,
-                        destination: {
-                            fullMetricChartView
-                        },
-                        label: {
-                            EmptyView()
-                        }
-                    )
-
-                    NavigationLink(
-                        isActive: $isStatsDestinationActive,
-                        destination: {
-                            photoTimelineStatsDestination
-                        },
-                        label: {
-                            EmptyView()
-                        }
-                    )
-                }
-                    .hidden()
-            )
+            .navigationDestination(isPresented: $isMetricDetailActive) {
+                fullMetricChartView
+            }
+            .navigationDestination(isPresented: $isStatsDestinationActive) {
+                photoTimelineStatsDestination
+            }
             .toolbarBackground(Material.ultraThinMaterial, for: ToolbarPlacement.tabBar)
             .toolbarBackground(Visibility.visible, for: ToolbarPlacement.tabBar)
             .onScreenshot {

--- a/apps/ios/LogYourBody/Views/DeleteAccountView.swift
+++ b/apps/ios/LogYourBody/Views/DeleteAccountView.swift
@@ -306,7 +306,7 @@ struct AccountDeletionCleanupService {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         DeleteAccountView()
             .environmentObject(AuthManager())
     }

--- a/apps/ios/LogYourBody/Views/DietPhaseHistoryView.swift
+++ b/apps/ios/LogYourBody/Views/DietPhaseHistoryView.swift
@@ -12,7 +12,7 @@ enum PhaseType: String, CaseIterable {
 
 struct DietPhaseHistoryView: View {
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ZStack {
                 Color.appBackground
                     .ignoresSafeArea()

--- a/apps/ios/LogYourBody/Views/EditEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/EditEntrySheet.swift
@@ -33,7 +33,7 @@ struct EditEntrySheet: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 0) {
                 if showsHealthBanner {
                     healthIntegrationBanner

--- a/apps/ios/LogYourBody/Views/HealthDisclaimerView.swift
+++ b/apps/ios/LogYourBody/Views/HealthDisclaimerView.swift
@@ -174,7 +174,7 @@ struct DisclaimerSection: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         HealthDisclaimerView()
     }
     .preferredColorScheme(.dark)

--- a/apps/ios/LogYourBody/Views/IntegrationsView.swift
+++ b/apps/ios/LogYourBody/Views/IntegrationsView.swift
@@ -241,7 +241,7 @@ struct IntegrationsView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         IntegrationsView()
             .environmentObject(AuthManager.shared)
     }

--- a/apps/ios/LogYourBody/Views/LegalConsentView.swift
+++ b/apps/ios/LogYourBody/Views/LegalConsentView.swift
@@ -109,12 +109,12 @@ struct LegalConsentView: View {
         }
         .transition(.opacity.combined(with: .scale(scale: 0.95)))
         .sheet(isPresented: $showTermsSheet) {
-            NavigationView {
+            NavigationStack {
                 LegalDocumentView(documentType: .terms)
             }
         }
         .sheet(isPresented: $showPrivacySheet) {
-            NavigationView {
+            NavigationStack {
                 LegalDocumentView(documentType: .privacy)
             }
         }

--- a/apps/ios/LogYourBody/Views/LegalDocumentView.swift
+++ b/apps/ios/LogYourBody/Views/LegalDocumentView.swift
@@ -204,21 +204,21 @@ struct LegalDocumentView: View {
 // MARK: - Preview
 
 #Preview("Terms of Service") {
-    NavigationView {
+    NavigationStack {
         LegalDocumentView(documentType: .terms)
     }
     .preferredColorScheme(.dark)
 }
 
 #Preview("Privacy Policy") {
-    NavigationView {
+    NavigationStack {
         LegalDocumentView(documentType: .privacy)
     }
     .preferredColorScheme(.dark)
 }
 
 #Preview("Health Disclosure") {
-    NavigationView {
+    NavigationStack {
         LegalDocumentView(documentType: .healthDisclosure)
     }
     .preferredColorScheme(.dark)

--- a/apps/ios/LogYourBody/Views/LegalView.swift
+++ b/apps/ios/LogYourBody/Views/LegalView.swift
@@ -126,7 +126,7 @@ extension LegalView {
 // MARK: - Preview
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         LegalView()
     }
     .preferredColorScheme(.dark)

--- a/apps/ios/LogYourBody/Views/LogWeightView.swift
+++ b/apps/ios/LogYourBody/Views/LogWeightView.swift
@@ -28,7 +28,7 @@ struct LogWeightView: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ZStack {
                 // Background
                 Color.appBackground

--- a/apps/ios/LogYourBody/Views/LoginView.swift
+++ b/apps/ios/LogYourBody/Views/LoginView.swift
@@ -17,7 +17,6 @@ struct LoginView: View {
     @State private var showError = false
     @State private var errorMessage = ""
     @State private var isRetrying = false
-    @State private var navigateToSignUp = false
     @State private var showsAppleSignIn = AuthSurfacePolicy.defaultShowsAppleSignIn
 
     var body: some View {
@@ -92,14 +91,6 @@ struct LoginView: View {
                     )
                 }
                 .padding(.top, 20)
-
-                NavigationLink(
-                    destination: SignUpView(),
-                    isActive: $navigateToSignUp
-                ) {
-                    EmptyView()
-                }
-                .hidden()
 
                 Spacer(minLength: 40)
             }
@@ -270,7 +261,7 @@ struct LoginView: View {
 
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         LoginView()
             .environmentObject(AuthManager.shared)
     }

--- a/apps/ios/LogYourBody/Views/PaywallView.swift
+++ b/apps/ios/LogYourBody/Views/PaywallView.swift
@@ -114,12 +114,12 @@ struct PaywallView: View {
             AnalyticsService.shared.track(event: "paywall_view")
         }
         .sheet(isPresented: $showTermsSheet) {
-            NavigationView {
+            NavigationStack {
                 LegalDocumentView(documentType: .terms)
             }
         }
         .sheet(isPresented: $showPrivacySheet) {
-            NavigationView {
+            NavigationStack {
                 LegalDocumentView(documentType: .privacy)
             }
         }

--- a/apps/ios/LogYourBody/Views/ProfileSettingsViewV2.swift
+++ b/apps/ios/LogYourBody/Views/ProfileSettingsViewV2.swift
@@ -472,7 +472,7 @@ struct ProfileHeightPickerSheet: View {
     @Environment(\.dismiss)
     var dismiss
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 0) {
                 unitSelector
                 heightDisplay
@@ -605,7 +605,7 @@ struct DatePickerSheet: View {
     @Environment(\.dismiss)
     var dismiss
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack {
                 DatePicker(
                     "",
@@ -638,7 +638,7 @@ struct DatePickerSheet: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         ProfileSettingsViewV2()
             .environmentObject({
                 let authManager = AuthManager()

--- a/apps/ios/LogYourBody/Views/ProgressPhotoAttachSheet.swift
+++ b/apps/ios/LogYourBody/Views/ProgressPhotoAttachSheet.swift
@@ -114,7 +114,7 @@ struct ProgressPhotoAttachSheet: View {
     #endif
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ZStack {
                 Color.metricCanvas.ignoresSafeArea()
 

--- a/apps/ios/LogYourBody/Views/SecuritySessionsView.swift
+++ b/apps/ios/LogYourBody/Views/SecuritySessionsView.swift
@@ -347,7 +347,7 @@ struct SessionRowView: View {
 // MARK: - Preview
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         SecuritySessionsView()
             .environmentObject(AuthManager.shared)
     }

--- a/apps/ios/LogYourBody/Views/SignUpView.swift
+++ b/apps/ios/LogYourBody/Views/SignUpView.swift
@@ -34,17 +34,17 @@ struct SignUpView: View {
         .navigationBarHidden(true)
         .standardErrorAlert(isPresented: $showError, message: errorMessage)
         .sheet(isPresented: $showTermsSheet) {
-            NavigationView {
+            NavigationStack {
                 LegalDocumentView(documentType: .terms)
             }
         }
         .sheet(isPresented: $showPrivacySheet) {
-            NavigationView {
+            NavigationStack {
                 LegalDocumentView(documentType: .privacy)
             }
         }
         .sheet(isPresented: $showHealthDisclaimerSheet) {
-            NavigationView {
+            NavigationStack {
                 LegalDocumentView(documentType: .healthDisclosure)
             }
         }
@@ -291,7 +291,7 @@ struct SignUpView: View {
 // MARK: - Preview
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         SignUpView()
             .environmentObject(AuthManager.shared)
     }

--- a/apps/ios/LogYourBody/Views/SyncStatusView.swift
+++ b/apps/ios/LogYourBody/Views/SyncStatusView.swift
@@ -116,7 +116,7 @@ struct SyncDetailsView: View {
     @Environment(\.dismiss)
     private var dismiss
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 Section("Sync Status") {
                     HStack {

--- a/apps/ios/LogYourBody/Views/WhatsNewView.swift
+++ b/apps/ios/LogYourBody/Views/WhatsNewView.swift
@@ -41,7 +41,7 @@ struct WhatsNewView: View {
     private let changelogManager = ChangelogManager.shared
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 ForEach(changelogManager.entries, id: \.version) { entry in
                     Section {


### PR DESCRIPTION
## Summary
- replaces remaining SwiftUI `NavigationView` wrappers with `NavigationStack`
- removes the dead hidden sign-up `NavigationLink(isActive:)` from `LoginView`
- replaces dashboard hidden programmatic `NavigationLink(isActive:)` links with `navigationDestination(isPresented:)`

## Validation
- `rg -n "\\bNavigationView\\b|NavigationLink\\s*\\([^\\n]*isActive|isActive:\\s*\\$" apps/ios/LogYourBody -S` returned no matches
- `git diff --check` passed
- `swiftlint lint --strict` from `apps/ios` passed with 0 violations
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -configuration Debug -destination 'platform=iOS Simulator,name=LYB Golden iPhone 16' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO build-for-testing` passed
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -configuration Debug -destination 'platform=iOS Simulator,name=LYB Golden iPhone 16' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO -only-testing:LogYourBodyTests test-without-building` passed
- GitHub CI: iOS passed; launch-quality gate pending at last update

## Notes
- This is a mechanical navigation API cleanup for JOV-3148. It does not redesign individual settings/auth surfaces.
- XcodeBuildMCP `test_sim` timed out at the wrapper after 120s and left a stale runner; I terminated that stale runner and validated with direct `xcodebuild` on the same Golden simulator.
