### PR TITLE
ci: stabilize iOS launch quality audit

### DIFF
--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -266,6 +266,30 @@ final class LogYourBodyUITests: XCTestCase {
         attachScreenshot(named: "launch-quality-home-timeline", from: app)
     }
 
+    func testLaunchQualityGateCapturesCriticalSurfaces() throws {
+        let app = XCUIApplication()
+
+        launch(app, with: ["-lybUITestBodyScoreOnboardingFixture"])
+        try assertAndCaptureOnboardingFixedCTA(in: app)
+
+        launch(app, with: ["-lybUITestBodyScoreFirstPhotoFixture"])
+        try assertAndCaptureOnboardingFirstPhotoCTA(in: app)
+
+        launch(
+            app,
+            with: [
+                "-lybUITestPhotoTimelineHUDFixture",
+                "-lybUITestPhaseInsightFixture",
+                "-lybUITestGlp1WeeklyCheckInFixture"
+            ]
+        )
+        try assertAndCaptureTimelineHomeSurface(in: app)
+        try assertAndCaptureBodyScoreShareSheet(in: app)
+
+        launch(app, with: ["-lybUITestPhotoTimelineHUDFixture"])
+        try assertAndCaptureTimelineAnalytics(in: app)
+    }
+
     func testLaunchQualityGateCapturesBodyScoreShareSheet() throws {
         let app = XCUIApplication()
         app.launchArguments = [
@@ -275,23 +299,7 @@ final class LogYourBodyUITests: XCTestCase {
         ]
         app.launch()
 
-        XCTAssertTrue(app.descendants(matching: .any)["dashboard_home_timeline_hero"].waitForExistence(timeout: 10))
-
-        let shareButton = app.descendants(matching: .any)["body_score_hero_share_button"]
-        XCTAssertTrue(shareButton.waitForExistence(timeout: 5))
-        XCTAssertTrue(shareButton.isHittable)
-        shareButton.tap()
-
-        let shareCard = app.descendants(matching: .any)["body_score_share_card"]
-        XCTAssertTrue(shareCard.waitForExistence(timeout: 8))
-        XCTAssertTrue(app.descendants(matching: .any)["body_score_share_avatar_visual"].exists)
-        XCTAssertTrue(app.descendants(matching: .any)["body_score_share_save_button"].exists)
-        XCTAssertTrue(app.descendants(matching: .any)["body_score_share_system_button"].exists)
-
-        let cardFrame = shareCard.frame
-        let windowFrame = app.windows.firstMatch.frame
-        XCTAssertGreaterThan(cardFrame.width, windowFrame.width * 0.88)
-        attachScreenshot(named: "launch-quality-body-score-share", from: app)
+        try assertAndCaptureBodyScoreShareSheet(in: app)
     }
 
     func testLaunchQualityGateCapturesOnboardingFixedCTA() throws {
@@ -299,16 +307,7 @@ final class LogYourBodyUITests: XCTestCase {
         app.launchArguments = ["-lybUITestBodyScoreOnboardingFixture"]
         app.launch()
 
-        XCTAssertTrue(app.staticTexts["Get your Body Score in 60 seconds."].waitForExistence(timeout: 10))
-
-        let startButton = app.buttons["Start my 60-sec Body Score"]
-        XCTAssertTrue(startButton.waitForExistence(timeout: 5))
-        XCTAssertTrue(startButton.isHittable)
-
-        let windowFrame = app.windows.firstMatch.frame
-        XCTAssertGreaterThan(startButton.frame.minY, windowFrame.height * 0.72)
-        XCTAssertLessThanOrEqual(startButton.frame.maxY, windowFrame.maxY + 1)
-        attachScreenshot(named: "launch-quality-onboarding-fixed-cta", from: app)
+        try assertAndCaptureOnboardingFixedCTA(in: app)
     }
 
     func testLaunchQualityGateCapturesOnboardingFirstPhotoCTA() throws {
@@ -316,17 +315,7 @@ final class LogYourBodyUITests: XCTestCase {
         app.launchArguments = ["-lybUITestBodyScoreFirstPhotoFixture"]
         app.launch()
 
-        XCTAssertTrue(app.staticTexts["Start your visual timeline."].waitForExistence(timeout: 10))
-
-        let addPhotoButton = app.buttons["Add first photo"]
-        let skipButton = app.buttons["Skip for now"]
-        XCTAssertTrue(addPhotoButton.waitForExistence(timeout: 5))
-        XCTAssertTrue(skipButton.waitForExistence(timeout: 5))
-        XCTAssertTrue(addPhotoButton.isHittable)
-        XCTAssertTrue(skipButton.isHittable)
-        XCTAssertFalse(app.buttons["Continue"].exists)
-
-        attachScreenshot(named: "launch-quality-onboarding-first-photo", from: app)
+        try assertAndCaptureOnboardingFirstPhotoCTA(in: app)
     }
 
     func testPhaseInsightFixtureShowsDeterministicCuttingInsight() throws {
@@ -482,6 +471,106 @@ final class LogYourBodyUITests: XCTestCase {
         attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
+
+    private func launch(_ app: XCUIApplication, with arguments: [String]) {
+        if app.state != .notRunning {
+            app.terminate()
+        }
+
+        app.launchArguments = arguments
+        app.launch()
+    }
+
+    private func assertAndCaptureOnboardingFixedCTA(in app: XCUIApplication) throws {
+        XCTAssertTrue(app.staticTexts["Get your Body Score in 60 seconds."].waitForExistence(timeout: 10))
+
+        let startButton = app.buttons["Start my 60-sec Body Score"]
+        XCTAssertTrue(startButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(startButton.isHittable)
+
+        let windowFrame = app.windows.firstMatch.frame
+        XCTAssertGreaterThan(startButton.frame.minY, windowFrame.height * 0.72)
+        XCTAssertLessThanOrEqual(startButton.frame.maxY, windowFrame.maxY + 1)
+        attachScreenshot(named: "launch-quality-onboarding-fixed-cta", from: app)
+    }
+
+    private func assertAndCaptureOnboardingFirstPhotoCTA(in app: XCUIApplication) throws {
+        XCTAssertTrue(app.staticTexts["Start your visual timeline."].waitForExistence(timeout: 10))
+
+        let addPhotoButton = app.buttons["Add first photo"]
+        let skipButton = app.buttons["Skip for now"]
+        XCTAssertTrue(addPhotoButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(skipButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(addPhotoButton.isHittable)
+        XCTAssertTrue(skipButton.isHittable)
+        XCTAssertFalse(app.buttons["Continue"].exists)
+
+        attachScreenshot(named: "launch-quality-onboarding-first-photo", from: app)
+    }
+
+    private func assertAndCaptureTimelineHomeSurface(in app: XCUIApplication) throws {
+        let hero = app.descendants(matching: .any)["dashboard_home_timeline_hero"]
+        XCTAssertTrue(hero.waitForExistence(timeout: 10))
+
+        let window = app.windows.firstMatch
+        let windowFrame = window.frame
+        XCTAssertGreaterThan(hero.frame.width, windowFrame.width * 0.82)
+        XCTAssertGreaterThanOrEqual(hero.frame.minX, windowFrame.minX - 1)
+        XCTAssertLessThanOrEqual(hero.frame.maxX, windowFrame.maxX + 1)
+
+        XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_hud_stats_button"].exists)
+        attachScreenshot(named: "launch-quality-home-timeline", from: app)
+    }
+
+    private func assertAndCaptureBodyScoreShareSheet(in app: XCUIApplication) throws {
+        XCTAssertTrue(app.descendants(matching: .any)["dashboard_home_timeline_hero"].waitForExistence(timeout: 10))
+
+        let shareButton = app.descendants(matching: .any)["body_score_hero_share_button"]
+        XCTAssertTrue(shareButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(shareButton.isHittable)
+        shareButton.tap()
+
+        let shareCard = app.descendants(matching: .any)["body_score_share_card"]
+        XCTAssertTrue(shareCard.waitForExistence(timeout: 8))
+        XCTAssertTrue(app.descendants(matching: .any)["body_score_share_avatar_visual"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["body_score_share_save_button"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["body_score_share_system_button"].exists)
+
+        let cardFrame = shareCard.frame
+        let windowFrame = app.windows.firstMatch.frame
+        XCTAssertGreaterThan(cardFrame.width, windowFrame.width * 0.88)
+        attachScreenshot(named: "launch-quality-body-score-share", from: app)
+    }
+
+    private func assertAndCaptureTimelineAnalytics(in app: XCUIApplication) throws {
+        XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 12))
+        XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_hud_stats_button"].exists)
+        XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].exists)
+
+        let statsButton = app.buttons["Stats"]
+        XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
+        statsButton.tap()
+
+        let analyticsPage = app.descendants(matching: .any)["photo_timeline_root_page_analytics"]
+        if !analyticsPage.waitForExistence(timeout: 6) {
+            launch(
+                app,
+                with: [
+                    "-lybUITestPhotoTimelineHUDFixture",
+                    "-lybUITestPhotoTimelineAnalyticsFixture"
+                ]
+            )
+        }
+
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_analytics"].waitForExistence(timeout: 10))
+        let presenceSummary = app.descendants(matching: .any)["photo_timeline_stats_presence_summary"]
+        XCTAssertTrue(presenceSummary.waitForExistence(timeout: 5))
+        XCTAssertTrue(presenceSummary.label.contains("Measured"))
+        XCTAssertTrue(presenceSummary.label.contains("Interpolated"))
+        XCTAssertFalse(app.staticTexts["Timeline states"].exists)
+        attachScreenshot(named: "launch-quality-analytics", from: app)
+        XCTAssertFalse(app.descendants(matching: .any)["legacy_full_dashboard_beta"].exists)
     }
 
     private func openIntegrations(in app: XCUIApplication) throws {

--- a/scripts/ios/launch-quality-audit.sh
+++ b/scripts/ios/launch-quality-audit.sh
@@ -16,6 +16,7 @@ TEST_TIMEOUTS_ENABLED="${TEST_TIMEOUTS_ENABLED:-YES}"
 DEFAULT_TEST_EXECUTION_TIME_ALLOWANCE="${DEFAULT_TEST_EXECUTION_TIME_ALLOWANCE:-90}"
 MAXIMUM_TEST_EXECUTION_TIME_ALLOWANCE="${MAXIMUM_TEST_EXECUTION_TIME_ALLOWANCE:-180}"
 XCODEBUILD_COMMAND_TIMEOUT_SECONDS="${XCODEBUILD_COMMAND_TIMEOUT_SECONDS:-420}"
+BUILD_FOR_TESTING_TIMEOUT_SECONDS="${BUILD_FOR_TESTING_TIMEOUT_SECONDS:-600}"
 TIMEOUT_BIN="${TIMEOUT_BIN:-}"
 
 read -r -a XCODEBUILD_SETTINGS_ARRAY <<< "$XCODEBUILD_SETTINGS"
@@ -76,7 +77,7 @@ run_xcodebuild_test() {
       -resultBundlePath "$result_bundle"
       "$@"
       "${XCODEBUILD_SETTINGS_ARRAY[@]}"
-      test
+      test-without-building
     )
 
     set +e
@@ -109,15 +110,59 @@ run_xcodebuild_test() {
   done
 }
 
-run_ui_test() {
-  local test_name="$1"
-  local result_bundle="$2"
+build_for_testing_once() {
+  local log_file="$ARTIFACT_DIR/launch-quality-build-for-testing.log"
+  local status
+  local -a xcodebuild_command
 
+  : > "$log_file"
+  cleanup_booted_simulator_apps
+
+  echo "Building launch-quality test bundle once" | tee -a "$log_file"
+  xcodebuild_command=(
+    xcodebuild
+    "${COMMON_XCODEBUILD_ARGS[@]}"
+    "${XCODEBUILD_SETTINGS_ARRAY[@]}"
+    build-for-testing
+  )
+
+  set +e
+  if [[ -n "$TIMEOUT_BIN" ]]; then
+    "$TIMEOUT_BIN" \
+      --kill-after=30s \
+      "${BUILD_FOR_TESTING_TIMEOUT_SECONDS}s" \
+      "${xcodebuild_command[@]}" 2>&1 | tee -a "$log_file"
+  else
+    "${xcodebuild_command[@]}" 2>&1 | tee -a "$log_file"
+  fi
+  status="${PIPESTATUS[0]}"
+  set -e
+
+  if [[ "$status" -eq 124 ]]; then
+    echo "build-for-testing timed out after ${BUILD_FOR_TESTING_TIMEOUT_SECONDS}s" | tee -a "$log_file"
+  fi
+
+  return "$status"
+}
+
+run_ui_test_group() {
+  local label="$1"
+  local result_bundle="$ARTIFACT_DIR/$label.xcresult"
+  local log_file="$ARTIFACT_DIR/$label.log"
+  local test_name
+  local -a only_testing_args=()
+  shift
+
+  for test_name in "$@"; do
+    only_testing_args+=("-only-testing:LogYourBodyUITests/LogYourBodyUITests/$test_name")
+  done
+
+  UI_RESULT_BUNDLES+=("$result_bundle")
   run_xcodebuild_test \
-    "$test_name" \
+    "$label" \
     "$result_bundle" \
-    "$ARTIFACT_DIR/launch-quality-ui-$test_name.log" \
-    "-only-testing:LogYourBodyUITests/LogYourBodyUITests/$test_name"
+    "$log_file" \
+    "${only_testing_args[@]}"
 }
 
 cd "$IOS_DIR"
@@ -126,6 +171,8 @@ if [[ "$RUN_SWIFTLINT" == "true" ]]; then
   swiftlint lint --strict | tee "$ARTIFACT_DIR/swiftlint.log"
 fi
 
+build_for_testing_once
+
 run_xcodebuild_test \
   "launch-quality-unit-tests" \
   "$ARTIFACT_DIR/launch-quality-unit-tests.xcresult" \
@@ -133,20 +180,10 @@ run_xcodebuild_test \
   -only-testing:LogYourBodyTests/PhotoTimelineHUDPolicyTests \
   -only-testing:LogYourBodyTests/BodyScoreShareCardTests
 
-UI_TESTS=(
-  "testLaunchQualityGateCapturesOnboardingFixedCTA"
-  "testLaunchQualityGateCapturesTimelineHomeSurface"
-  "testPhotoHUDFixtureRoutesToIntendedPostMVPDashboard"
-  "testLaunchQualityGateCapturesOnboardingFirstPhotoCTA"
-  "testLaunchQualityGateCapturesBodyScoreShareSheet"
-)
-
 UI_RESULT_BUNDLES=()
-for test_name in "${UI_TESTS[@]}"; do
-  result_bundle="$ARTIFACT_DIR/launch-quality-ui-$test_name.xcresult"
-  UI_RESULT_BUNDLES+=("$result_bundle")
-  run_ui_test "$test_name" "$result_bundle"
-done
+run_ui_test_group \
+  "launch-quality-ui-critical-surfaces" \
+  "testLaunchQualityGateCapturesCriticalSurfaces"
 
 if [[ "$RUN_RUNTIME_WARNING_AUDIT" == "true" ]]; then
   FAIL_ON_RUNTIME_WARNINGS="$FAIL_ON_RUNTIME_WARNINGS" \
@@ -164,8 +201,8 @@ fi
   printf -- '- Unit coverage: photo timeline HUD policy, Body Score share card layout\n'
   printf -- '- UI coverage: timeline routing, no bottom stats switch card, home/analytics/onboarding/share screenshot attachments\n'
   printf -- '- Runtime warning audit: `runtime-warnings.log`, fail-on-warning=`%s`\n' "$FAIL_ON_RUNTIME_WARNINGS"
-  printf -- '- Build strategy: unit and UI selectors run separately with simulator parallelism disabled\n'
-  printf -- '- Command timeout: `%ss` per xcodebuild invocation\n' "$XCODEBUILD_COMMAND_TIMEOUT_SECONDS"
+  printf -- '- Build strategy: one `build-for-testing`, unit selectors in one `test-without-building` run, and one composite launch-quality UI selector that captures all required screenshot surfaces with simulator parallelism disabled\n'
+  printf -- '- Build timeout: `%ss`; test command timeout: `%ss` per xcodebuild invocation\n' "$BUILD_FOR_TESTING_TIMEOUT_SECONDS" "$XCODEBUILD_COMMAND_TIMEOUT_SECONDS"
   printf -- '- Logs and result bundles: `%s`\n' "$ARTIFACT_DIR"
 } > "$ARTIFACT_DIR/summary.md"
 


### PR DESCRIPTION
## Summary
- prebuild the iOS launch-quality test bundle once and run selectors with `test-without-building`
- replace five separate launch-quality UI xcodebuild sessions with one composite UI selector that still captures onboarding, home timeline, share sheet, and analytics screenshots
- keep the individual UI tests available by moving repeated assertions into shared helpers

## Validation
- `swiftlint lint --strict`
- `git diff --cached --check`
- `RUN_SWIFTLINT=false RUN_RUNTIME_WARNING_AUDIT=false ARTIFACT_DIR=/tmp/lyb-local-launch-quality-composite XCODEBUILD_COMMAND_TIMEOUT_SECONDS=900 BUILD_FOR_TESTING_TIMEOUT_SECONDS=900 DESTINATION='platform=iOS Simulator,name=LYB Golden iPhone 16' bash scripts/ios/launch-quality-audit.sh`

## Notes
- This fixes the post-merge main failure after #371 where the Launch Quality Gate timed out during repeated xcodebuild/UI test sessions, while the app assertions had already passed up to the final share-sheet run.