### PR TITLE
JOV-3217 Add timeline trace workflow budgets

### DIFF
--- a/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
+++ b/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
@@ -66,6 +66,7 @@ struct ProgressTimelineView: View {
             }
             .frame(height: timelineHeight)
         }
+        .accessibilityIdentifier("dashboard_timeline_scrubber")
     }
 
     // MARK: - Subviews
@@ -188,6 +189,7 @@ struct ProgressTimelineView: View {
                 .frame(width: scrubberHandleSize, height: scrubberHandleSize)
         }
         .frame(width: scrubberHandleSize, height: scrubberHandleSize)
+        .accessibilityIdentifier("dashboard_timeline_scrubber_handle")
     }
 
     // MARK: - Logic

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -16,6 +16,7 @@ struct DashboardTimelineScrubber: View {
                     mode: $timelineMode
                 )
                 .frame(height: 80)
+                .accessibilityIdentifier("dashboard_timeline_scrubber")
             }
         }
     }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -102,6 +102,10 @@ struct DashboardViewLiquid: View {
         #endif
     }
 
+    private var usesTimelinePerformanceTraceFixture: Bool {
+        ProcessInfo.processInfo.arguments.contains("-lybUITestTimelinePerformanceTraceFixture")
+    }
+
     enum DashboardTab: Hashable {
         case home
         case photos
@@ -308,7 +312,7 @@ struct DashboardViewLiquid: View {
             Task {
                 await viewModel.loadData(
                     authManager: authManager,
-                    loadOnlyNewest: true,
+                    loadOnlyNewest: !usesTimelinePerformanceTraceFixture,
                     selectedIndex: selectedIndex
                 )
                 scheduleDashboardDerivedStateRefresh(animatedIndex: selectedIndex)
@@ -316,7 +320,7 @@ struct DashboardViewLiquid: View {
         }
 
         // Then refresh async (loads all data in background) once per dashboard lifecycle
-        if !hasPerformedInitialRefresh {
+        if !hasPerformedInitialRefresh && !usesTimelinePerformanceTraceFixture {
             hasPerformedInitialRefresh = true
             Task {
                 await viewModel.refreshData(

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -415,6 +415,34 @@ final class LogYourBodyUITests: XCTestCase {
         }
     }
 
+    func testTimelinePerformanceTraceWorkflow() throws {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-lybUITestPhotoTimelineHUDFixture",
+            "-lybUITestTimelinePerformanceTraceFixture",
+            "-lybUITestPhaseInsightFixture",
+            "-lybUITestGlp1WeeklyCheckInFixture"
+        ]
+        app.launch()
+
+        XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 12))
+        XCTAssertTrue(app.descendants(matching: .any)["dashboard_home_timeline_hero"].waitForExistence(timeout: 10))
+
+        let avatarButton = app.buttons["home_mode_avatar_button"]
+        XCTAssertTrue(avatarButton.waitForExistence(timeout: 5))
+        if avatarButton.isHittable {
+            avatarButton.tap()
+        }
+
+        let photoButton = app.buttons["home_mode_photo_button"]
+        XCTAssertTrue(photoButton.waitForExistence(timeout: 5))
+        if photoButton.isHittable {
+            photoButton.tap()
+        }
+
+        try exerciseTimelineRootNavigation(in: app)
+    }
+
     private func scrollUntilHittable(
         _ element: XCUIElement,
         in app: XCUIApplication,
@@ -464,6 +492,29 @@ final class LogYourBodyUITests: XCTestCase {
         }
 
         return elements.contains(where: { $0.exists })
+    }
+
+    private func exerciseTimelineRootNavigation(in app: XCUIApplication) throws {
+        let timelinePage = app.descendants(matching: .any)["photo_timeline_root_page_timeline"]
+        XCTAssertTrue(timelinePage.waitForExistence(timeout: 5))
+
+        let start = timelinePage.coordinate(withNormalizedOffset: CGVector(dx: 0.82, dy: 0.48))
+        let end = timelinePage.coordinate(withNormalizedOffset: CGVector(dx: 0.18, dy: 0.48))
+        start.press(forDuration: 0.05, thenDragTo: end)
+
+        let analyticsPage = app.descendants(matching: .any)["photo_timeline_root_page_analytics"]
+        if !analyticsPage.waitForExistence(timeout: 5) {
+            let statsButton = app.buttons["Stats"]
+            XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
+            statsButton.tap()
+        }
+
+        XCTAssertTrue(analyticsPage.waitForExistence(timeout: 8))
+
+        let timelineButton = app.buttons["Timeline"]
+        XCTAssertTrue(timelineButton.waitForExistence(timeout: 5))
+        timelineButton.tap()
+        XCTAssertTrue(timelinePage.waitForExistence(timeout: 8))
     }
 
     private func attachScreenshot(named name: String, from app: XCUIApplication) {

--- a/docs/audits/jov-3184/performance-budget-summary-2026-06-15.md
+++ b/docs/audits/jov-3184/performance-budget-summary-2026-06-15.md
@@ -6,15 +6,18 @@ The iOS performance audit now emits a repeatable budget artifact instead of only
 
 ## Budgets
 
-| Check                      |             Default budget | Source                                                            |
-| -------------------------- | -------------------------: | ----------------------------------------------------------------- |
-| Performance unit total     |                       2.0s | `xcresulttool get test-results tests` or xcodebuild log fallback  |
-| Slowest performance unit   |                      0.75s | `xcresulttool get test-results tests` or xcodebuild log fallback  |
-| Launch performance UI test | 90.0s hard / 60.0s warning | `LogYourBodyUITests/testLaunchPerformance` result-bundle duration |
+| Check                      |             Default budget | Source                                                             |
+| -------------------------- | -------------------------: | ------------------------------------------------------------------ |
+| Performance unit total     |                       2.0s | `xcresulttool get test-results tests` or xcodebuild log fallback   |
+| Slowest performance unit   |                      0.75s | `xcresulttool get test-results tests` or xcodebuild log fallback   |
+| Launch performance UI test | 90.0s hard / 60.0s warning | `LogYourBodyUITests/testLaunchPerformance` result-bundle duration  |
+| Timeline trace workflow    | 35.0s hard / 28.0s warning | `LogYourBodyUITests/testTimelinePerformanceTraceWorkflow` duration |
 
 The helper also records whether XCTest published granular launch metric statistics. On the current Xcode lane, `xcresulttool get test-results metrics` returns an empty payload for `XCTApplicationLaunchMetric`, so the gate reports a warning and keeps the issue open for a focused Instruments or ETTrace capture before frame/hitch budgets are tightened.
 
 The full local audit runs the selected performance unit tests by default, with simulator parallelism disabled and the UI-test target explicitly skipped for the unit selectors. In hosted GitHub Actions, when `RUN_LAUNCH_PERFORMANCE=false`, the script defaults to summary mode for the post-launch-quality step so CI still publishes the same budget-summary artifact without starting a second Xcode test build inside the 8-minute post-audit step. Agents can force the full unit pass in CI with `RUN_PERFORMANCE_UNIT_TESTS=true`.
+
+`RUN_TIMELINE_TRACE_WORKFLOW=true` runs the focused Avatar/Photo plus Timeline/Stats workflow added for JOV-3217 and enforces its warning/hard duration budgets in the same summary JSON and Markdown outputs. See `docs/audits/jov-3217/performance-trace-budget-2026-06-15.md` for current trace evidence and the simulator `xctrace` limitation.
 
 ## Validation
 

--- a/docs/audits/jov-3185/standing-quality-gate.md
+++ b/docs/audits/jov-3185/standing-quality-gate.md
@@ -22,6 +22,7 @@ The gate writes artifacts under `apps/ios/test_results/quality-gate/` and runs:
 - Dashboard timeline provider performance tests.
 - Progress photo image pipeline performance tests.
 - Launch performance smoke test.
+- Optional focused Avatar/Photo plus Timeline/Stats workflow via `RUN_TIMELINE_TRACE_WORKFLOW=true`.
 
 For the lighter CI-equivalent local path, use:
 
@@ -41,4 +42,4 @@ The gate intentionally avoids App Store Connect, TestFlight, Doppler, and produc
 
 This is the first standing gate, not the final visual-regression system. It catches concrete layout/navigation regressions through UI assertions and preserves screenshots for review, but it does not yet perform pixel-diff snapshot comparison or Instruments-level hitch budgets.
 
-Next hardening step: add a real screenshot baseline/diff tool or ETTrace-derived hitch budget once the current simulator fixtures stabilize.
+Next hardening step: add a real screenshot baseline/diff tool and enforce the JOV-3217 frame/hitch budgets once simulator or device `xctrace` can capture a valid app trace in the active Xcode lane.

--- a/docs/audits/jov-3217/performance-trace-budget-2026-06-15.md
+++ b/docs/audits/jov-3217/performance-trace-budget-2026-06-15.md
@@ -1,0 +1,96 @@
+# JOV-3217 Performance Trace Budget - 2026-06-15
+
+## Summary
+
+This pass added a deterministic timeline performance workflow and wired it into the existing iOS performance-budget summary path. The workflow launches the seeded photo timeline, switches Avatar and Photo modes, opens Stats, then returns to Timeline.
+
+Simulator `xctrace` app recording is not reliable on the current local Xcode 17F42 lane: simulator device, attach-by-name, and app-launch recordings did not honor `--time-limit`; force-stopped traces exported with `Document Missing Template Error`. Host `xctrace` against `/bin/sleep` completed, so the blocker is specific to simulator app/device recording here rather than `xctrace` availability.
+
+## Enforced Budgets
+
+| Budget                            | Threshold | Source                                      |
+| --------------------------------- | --------: | ------------------------------------------- |
+| Timeline trace workflow warning   |     28.0s | `PERF_WARN_TIMELINE_TRACE_WORKFLOW_SECONDS` |
+| Timeline trace workflow hard fail |     35.0s | `PERF_MAX_TIMELINE_TRACE_WORKFLOW_SECONDS`  |
+
+The workflow can be run locally through:
+
+```bash
+RUN_TIMELINE_TRACE_WORKFLOW=true \
+RUN_SWIFTLINT=false \
+RUN_PERFORMANCE_UNIT_TESTS=false \
+RUN_LAUNCH_PERFORMANCE=false \
+DESTINATION='platform=iOS Simulator,name=LYB Golden iPhone 16' \
+bash scripts/ios/performance-audit.sh
+```
+
+## Observed Run
+
+| Check                                                                     | Result  |
+| ------------------------------------------------------------------------- | ------- |
+| Focused UI workflow                                                       | Passed  |
+| XcodeBuildMCP duration                                                    | 23.457s |
+| Direct `xcodebuild test-without-building` duration during attempted trace | 22.564s |
+| Summary status                                                            | Passed  |
+
+Summary smoke command:
+
+```bash
+python3 scripts/ios/performance-budget-summary.py \
+  --artifact-dir /tmp/lyb-jov-3217-summary-smoke \
+  --destination 'platform=iOS Simulator,name=LYB Golden iPhone 16' \
+  --unit-skipped \
+  --launch-skipped \
+  --timeline-workflow-xcresult /Users/timwhite/Library/Developer/XcodeBuildMCP/workspaces/LogYourBody-f25e48b4f67a/result-bundles/test_sim_2026-06-15T10-39-44-756Z_pid40762_2f6a4f41.xcresult \
+  --timeline-workflow-log /Users/timwhite/Library/Developer/XcodeBuildMCP/workspaces/LogYourBody-f25e48b4f67a/logs/test_sim_2026-06-15T10-39-44-756Z_pid40762_c006f2ea.log
+```
+
+## Instruments Attempts
+
+Available templates include `Time Profiler`, `SwiftUI`, `Animation Hitches`, and `App Launch`.
+
+Failed simulator capture command:
+
+```bash
+xcrun xctrace record \
+  --template 'Time Profiler' \
+  --device 7EB60D3E-3637-43EA-969D-167ADC72BAEC \
+  --all-processes \
+  --time-limit 35s \
+  --output /tmp/lyb-jov-3217-trace-20260615-034120/time-profiler.trace \
+  --no-prompt \
+  --quiet
+```
+
+The UI workflow passed while recording, but `xctrace` continued past the 35s limit. After SIGTERM, export failed:
+
+```text
+Export failed: Document Missing Template Error
+```
+
+Additional simulator `--attach LogYourBody` and `--launch -- LogYourBody.app` Time Profiler attempts also hung past their requested limits. Attaching by host PID returned `Cannot find process for provided pid`.
+
+Host smoke proof that `xctrace` itself works:
+
+```bash
+xcrun xctrace record \
+  --template 'Time Profiler' \
+  --time-limit 3s \
+  --output /tmp/lyb-jov-3217-host-xctrace-smoke-20260615-034817/host-sleep.trace \
+  --no-prompt \
+  --quiet \
+  --launch -- /bin/sleep 1
+```
+
+## Trace Budgets To Enforce Once Device Capture Works
+
+| Area                                        |    Budget |
+| ------------------------------------------- | --------: |
+| Cold launch to usable timeline hero         |   <= 2.5s |
+| Warm launch to usable timeline hero         |   <= 1.2s |
+| Timeline scrub p95 frame time               | <= 16.7ms |
+| Timeline scrub p99 frame time               | <= 33.3ms |
+| Hitches over 250ms during five-second scrub |         0 |
+| Avatar/Photo switch hitches over 250ms      |         0 |
+
+The current PR does not claim those frame or hitch budgets passed. It creates the deterministic workflow and summary hooks needed to enforce them when a valid device/simulator trace can be captured.

--- a/scripts/ios/performance-audit.sh
+++ b/scripts/ios/performance-audit.sh
@@ -10,6 +10,7 @@ STAMP="$(date +%Y%m%d-%H%M%S)"
 ARTIFACT_DIR="${ARTIFACT_DIR:-$IOS_DIR/test_results/performance-audit/$STAMP}"
 RUN_SWIFTLINT="${RUN_SWIFTLINT:-true}"
 RUN_LAUNCH_PERFORMANCE="${RUN_LAUNCH_PERFORMANCE:-true}"
+RUN_TIMELINE_TRACE_WORKFLOW="${RUN_TIMELINE_TRACE_WORKFLOW:-false}"
 XCODEBUILD_SETTINGS="${XCODEBUILD_SETTINGS:-CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO}"
 TEST_TIMEOUTS_ENABLED="${TEST_TIMEOUTS_ENABLED:-YES}"
 DEFAULT_TEST_EXECUTION_TIME_ALLOWANCE="${DEFAULT_TEST_EXECUTION_TIME_ALLOWANCE:-90}"
@@ -76,6 +77,17 @@ else
   echo "Skipping launch-performance XCTest because RUN_LAUNCH_PERFORMANCE=false" | tee "$ARTIFACT_DIR/launch-performance.log"
 fi
 
+if [[ "$RUN_TIMELINE_TRACE_WORKFLOW" == "true" ]]; then
+  xcodebuild \
+    "${COMMON_XCODEBUILD_ARGS[@]}" \
+    -resultBundlePath "$ARTIFACT_DIR/timeline-trace-workflow.xcresult" \
+    -only-testing:LogYourBodyUITests/LogYourBodyUITests/testTimelinePerformanceTraceWorkflow \
+    "${XCODEBUILD_SETTINGS_ARRAY[@]}" \
+    test | tee "$ARTIFACT_DIR/timeline-trace-workflow.log"
+else
+  echo "Skipping timeline trace workflow XCTest because RUN_TIMELINE_TRACE_WORKFLOW=false" | tee "$ARTIFACT_DIR/timeline-trace-workflow.log"
+fi
+
 SUMMARY_ARGS=(
   --artifact-dir "$ARTIFACT_DIR"
   --destination "$DESTINATION"
@@ -90,6 +102,15 @@ if [[ "$RUN_LAUNCH_PERFORMANCE" == "true" ]]; then
   )
 else
   SUMMARY_ARGS+=(--launch-skipped)
+fi
+
+if [[ "$RUN_TIMELINE_TRACE_WORKFLOW" == "true" ]]; then
+  SUMMARY_ARGS+=(
+    --timeline-workflow-xcresult "$ARTIFACT_DIR/timeline-trace-workflow.xcresult"
+    --timeline-workflow-log "$ARTIFACT_DIR/timeline-trace-workflow.log"
+  )
+else
+  SUMMARY_ARGS+=(--timeline-workflow-skipped)
 fi
 
 if [[ "$RUN_PERFORMANCE_UNIT_TESTS" != "true" ]]; then

--- a/scripts/ios/performance-budget-summary.py
+++ b/scripts/ios/performance-budget-summary.py
@@ -191,6 +191,7 @@ def write_summary(
     checks: list[BudgetCheck],
     unit_cases: list[TestCaseDuration],
     launch_cases: list[TestCaseDuration],
+    timeline_workflow_cases: list[TestCaseDuration],
     launch_metrics_available: bool,
 ) -> int:
     failed_checks = [check for check in checks if check.status == "failed"]
@@ -211,6 +212,7 @@ def write_summary(
         "checks": [asdict(check) for check in checks],
         "unitCases": [asdict(case) for case in unit_cases],
         "launchCases": [asdict(case) for case in launch_cases],
+        "timelineWorkflowCases": [asdict(case) for case in timeline_workflow_cases],
         "launchMetricStatisticsAvailable": launch_metrics_available,
     }
 
@@ -266,8 +268,11 @@ def main() -> int:
     parser.add_argument("--unit-log", type=Path)
     parser.add_argument("--launch-xcresult", type=Path)
     parser.add_argument("--launch-log", type=Path)
+    parser.add_argument("--timeline-workflow-xcresult", type=Path)
+    parser.add_argument("--timeline-workflow-log", type=Path)
     parser.add_argument("--unit-skipped", action="store_true")
     parser.add_argument("--launch-skipped", action="store_true")
+    parser.add_argument("--timeline-workflow-skipped", action="store_true")
     parser.add_argument("--summary-md", type=Path)
     parser.add_argument("--summary-json", type=Path)
     args = parser.parse_args()
@@ -280,14 +285,25 @@ def main() -> int:
         "unitTotalCaseSeconds": env_float("PERF_MAX_UNIT_TEST_TOTAL_SECONDS", 2.0),
         "launchMaxTestSeconds": env_float("PERF_MAX_LAUNCH_TEST_SECONDS", 90.0),
         "launchWarnTestSeconds": env_float("PERF_WARN_LAUNCH_TEST_SECONDS", 60.0),
+        "timelineWorkflowMaxSeconds": env_float("PERF_MAX_TIMELINE_TRACE_WORKFLOW_SECONDS", 35.0),
+        "timelineWorkflowWarnSeconds": env_float("PERF_WARN_TIMELINE_TRACE_WORKFLOW_SECONDS", 28.0),
         "failOnMissingLaunchMetrics": env_bool("PERF_FAIL_ON_MISSING_LAUNCH_METRICS", False),
     }
 
     unit_cases = [] if args.unit_skipped else collect_cases(args.unit_xcresult, args.unit_log)
     launch_cases = [] if args.launch_skipped else collect_cases(args.launch_xcresult, args.launch_log)
+    timeline_workflow_cases = (
+        []
+        if args.timeline_workflow_skipped
+        else collect_cases(args.timeline_workflow_xcresult, args.timeline_workflow_log)
+    )
     launch_case = next(
         (case for case in launch_cases if "testLaunchPerformance" in case.identifier),
         launch_cases[0] if launch_cases else None,
+    )
+    timeline_workflow_case = next(
+        (case for case in timeline_workflow_cases if "testTimelinePerformanceTraceWorkflow" in case.identifier),
+        timeline_workflow_cases[0] if timeline_workflow_cases else None,
     )
     launch_metrics_available = False if args.launch_skipped else has_xctest_metric_statistics(args.launch_xcresult)
 
@@ -411,7 +427,55 @@ def main() -> int:
             )
         )
 
-    return write_summary(args, budgets, checks, unit_cases, launch_cases, launch_metrics_available)
+    if args.timeline_workflow_skipped:
+        checks.append(
+            BudgetCheck(
+                id="timeline.trace_workflow_duration",
+                label="Timeline trace workflow",
+                observed_seconds=None,
+                budget_seconds=float(budgets["timelineWorkflowMaxSeconds"]),
+                status="skipped",
+                detail="Timeline trace workflow XCTest was disabled for this run.",
+            )
+        )
+    else:
+        timeline_workflow_duration = (
+            timeline_workflow_case.duration_seconds if timeline_workflow_case else None
+        )
+        timeline_workflow_status = "warning"
+        if timeline_workflow_duration is not None:
+            if timeline_workflow_duration > float(budgets["timelineWorkflowMaxSeconds"]):
+                timeline_workflow_status = "failed"
+            elif timeline_workflow_duration > float(budgets["timelineWorkflowWarnSeconds"]):
+                timeline_workflow_status = "warning"
+            else:
+                timeline_workflow_status = "passed"
+
+        checks.append(
+            BudgetCheck(
+                id="timeline.trace_workflow_duration",
+                label="Timeline trace workflow",
+                observed_seconds=timeline_workflow_duration,
+                budget_seconds=float(budgets["timelineWorkflowMaxSeconds"]),
+                status=timeline_workflow_status,
+                detail=(
+                    f"{timeline_workflow_case.identifier} reported "
+                    f"{timeline_workflow_duration:.3f}s end-to-end XCTest duration."
+                    if timeline_workflow_case and timeline_workflow_duration is not None
+                    else "No timeline trace workflow duration was found in the result bundle or log."
+                ),
+            )
+        )
+
+    return write_summary(
+        args,
+        budgets,
+        checks,
+        unit_cases,
+        launch_cases,
+        timeline_workflow_cases,
+        launch_metrics_available,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add a deterministic dashboard timeline performance workflow that launches seeded timeline data, toggles Avatar/Photo mode, opens Stats, then returns to Timeline.
- Wire the workflow into `scripts/ios/performance-audit.sh` behind `RUN_TIMELINE_TRACE_WORKFLOW=true`.
- Extend `performance-budget-summary.py` with a timeline workflow duration budget and JSON/Markdown output.
- Document JOV-3217 trace attempts, current enforced budget, and the frame/hitch budgets to enforce once valid app trace capture works.

## Validation
- `git diff --check HEAD`
- `swiftlint lint --strict apps/ios/LogYourBody/Views/DashboardViewLiquid.swift apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift apps/ios/LogYourBody/Components/ProgressTimelineView.swift apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift`
- `bash -n scripts/ios/performance-audit.sh`
- `python3 -m py_compile scripts/ios/performance-budget-summary.py`
- XcodeBuildMCP `test_sim` selector `LogYourBodyUITests/LogYourBodyUITests/testTimelinePerformanceTraceWorkflow` passed; result bundle `/Users/timwhite/Library/Developer/XcodeBuildMCP/workspaces/LogYourBody-f25e48b4f67a/result-bundles/test_sim_2026-06-15T10-39-44-756Z_pid40762_2f6a4f41.xcresult`
- `RUN_SWIFTLINT=false RUN_PERFORMANCE_UNIT_TESTS=false RUN_LAUNCH_PERFORMANCE=false RUN_TIMELINE_TRACE_WORKFLOW=true DESTINATION='platform=iOS Simulator,name=LYB Golden iPhone 16' ARTIFACT_DIR=/tmp/lyb-jov-3217-performance-audit-clean-20260615-035231 bash scripts/ios/performance-audit.sh` passed; timeline workflow 16.732s / 35.000s budget

## Trace limitation
- Local `xcrun xctrace` can list templates and can record a host `/bin/sleep` Time Profiler trace.
- Simulator app/device Time Profiler attempts on the current Xcode 17F42 lane did not honor `--time-limit`; interrupted traces exported with `Document Missing Template Error`.
- This PR does not claim frame-time or hitch budgets passed. It adds the stable workflow and budget hook needed to enforce those metrics when valid device/simulator trace capture is available.

Linear: JOV-3217