### PR TITLE
JOV-3181 Fix photo-backed body score share cards

### DIFF
--- a/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
+++ b/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
@@ -16,9 +16,14 @@ struct BodyScoreSharePayload: Identifiable {
     let deltaText: String?
     let bodyFatPercentage: Double?
     let gender: String?
+    let photoImage: UIImage?
 
     var avatarMatch: AvatarBodyFatCatalog.Match {
         AvatarBodyFatCatalog.match(bodyFatPercentage: bodyFatPercentage, gender: gender)
+    }
+
+    var visualBadgeText: String {
+        photoImage == nil ? avatarMatch.badgeText : "Progress photo"
     }
 }
 
@@ -63,7 +68,7 @@ struct BodyScoreShareCardView: View {
             ZStack {
                 Color.black
 
-                avatarStage(layout: layout)
+                visualStage(layout: layout)
                     .frame(width: geometry.size.width, height: geometry.size.height, alignment: .top)
 
                 LinearGradient(
@@ -100,22 +105,33 @@ struct BodyScoreShareCardView: View {
         return size.width / size.height
     }
 
-    private func avatarStage(layout: ShareCardLayout) -> some View {
+    private func visualStage(layout: ShareCardLayout) -> some View {
         VStack(spacing: 0) {
             Spacer(minLength: layout.visualTopOffset)
 
-            AvatarBodyRenderer(
-                bodyFatPercentage: payload.bodyFatPercentage,
-                gender: payload.gender,
-                height: layout.visualHeight,
-                padding: 0,
-                verticalPadding: 0,
-                horizontalFillScale: 1.04,
-                alignment: .bottom,
-                renderMode: .fillWidth
-            )
-            .frame(maxWidth: .infinity)
-            .accessibilityIdentifier("body_score_share_avatar_visual")
+            if let photoImage = payload.photoImage {
+                Image(uiImage: photoImage)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity)
+                    .frame(height: layout.visualHeight, alignment: .center)
+                    .clipped()
+                    .accessibilityLabel("Progress photo")
+                    .accessibilityIdentifier("body_score_share_photo_visual")
+            } else {
+                AvatarBodyRenderer(
+                    bodyFatPercentage: payload.bodyFatPercentage,
+                    gender: payload.gender,
+                    height: layout.visualHeight,
+                    padding: 0,
+                    verticalPadding: 0,
+                    horizontalFillScale: 1.04,
+                    alignment: .bottom,
+                    renderMode: .fillWidth
+                )
+                .frame(maxWidth: .infinity)
+                .accessibilityIdentifier("body_score_share_avatar_visual")
+            }
 
             Spacer(minLength: 0)
         }
@@ -132,7 +148,7 @@ struct BodyScoreShareCardView: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.78)
 
-                Text(payload.avatarMatch.badgeText)
+                Text(payload.visualBadgeText)
                     .font(.system(size: layout.badgeFontSize, weight: .medium))
                     .foregroundColor(Color.white.opacity(0.62))
                     .lineLimit(1)

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreRevealView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreRevealView.swift
@@ -179,7 +179,8 @@ struct BodyScoreRevealView: View {
             weightCaption: weightUnit,
             deltaText: nil,
             bodyFatPercentage: input.bodyFat.percentage,
-            gender: input.sex?.rawValue
+            gender: input.sex?.rawValue,
+            photoImage: nil
         )
     }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 extension DashboardViewLiquid {
     // MARK: - Hero Card
@@ -561,8 +562,19 @@ extension DashboardViewLiquid {
             weightCaption: weightCaption,
             deltaText: deltaText,
             bodyFatPercentage: selectedMetric?.bodyFatPercentage ?? currentMetric?.bodyFatPercentage,
-            gender: authManager.currentUser?.profile?.gender
+            gender: authManager.currentUser?.profile?.gender,
+            photoImage: sharePhotoImage(for: selectedMetric)
         )
+    }
+
+    private func sharePhotoImage(for metric: BodyMetrics?) -> UIImage? {
+        guard selectedDefaultHomeMode == .photo,
+              let photoUrl = metric?.photoUrl,
+              !photoUrl.isEmpty else {
+            return nil
+        }
+
+        return OptimizedProgressPhotoView.cachedImage(for: photoUrl)
     }
 
     // MARK: - Visual Divider

--- a/apps/ios/LogYourBody/Views/OptimizedProgressPhotoView.swift
+++ b/apps/ios/LogYourBody/Views/OptimizedProgressPhotoView.swift
@@ -196,6 +196,12 @@ enum ProgressPhotoImagePipeline {
 
 // Extension to preload images for smooth scrolling
 extension OptimizedProgressPhotoView {
+    @MainActor
+    static func cachedImage(for urlString: String?) -> UIImage? {
+        guard let urlString, !urlString.isEmpty else { return nil }
+        return imageCache.object(forKey: NSString(string: urlString))
+    }
+
     static func preloadImages(urls: [String]) {
         for urlString in urls {
             let cacheKey = NSString(string: urlString)

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -542,6 +542,19 @@ final class BodyScoreShareCardTests: XCTestCase {
 
         XCTAssertEqual(payload.avatarMatch.assetName, "avatar_male_15")
         XCTAssertEqual(payload.avatarMatch.badgeText, "Male 15% body fat")
+        XCTAssertEqual(payload.visualBadgeText, "Male 15% body fat")
+        XCTAssertNil(payload.photoImage)
+    }
+
+    func testPhotoBackedSharePayloadUsesProgressPhotoBadge() {
+        let payload = makePayload(
+            bodyFatPercentage: 16.4,
+            gender: "male",
+            photoImage: makeShareTestImage()
+        )
+
+        XCTAssertEqual(payload.visualBadgeText, "Progress photo")
+        XCTAssertNotNil(payload.photoImage)
     }
 
     func testShareCardRendersRequestedExportSize() throws {
@@ -582,9 +595,34 @@ final class BodyScoreShareCardTests: XCTestCase {
         }
     }
 
+    func testPhotoBackedShareCardRendersEveryLaunchExportAspect() throws {
+        for aspect in BodyScoreShareAspect.allCases {
+            let size = aspect.pixelSize
+            let renderer = ImageRenderer(
+                content: BodyScoreShareCardView(
+                    payload: makePayload(
+                        bodyFatPercentage: 18.6,
+                        gender: "male",
+                        photoImage: makeShareTestImage()
+                    ),
+                    aspect: aspect
+                )
+                .frame(width: size.width, height: size.height)
+                .environment(\.colorScheme, .dark)
+            )
+            renderer.scale = 1.0
+
+            let image = try XCTUnwrap(renderer.uiImage, "Missing rendered photo image for \(aspect.rawValue)")
+
+            XCTAssertEqual(image.size.width, size.width, accuracy: 0.5)
+            XCTAssertEqual(image.size.height, size.height, accuracy: 0.5)
+        }
+    }
+
     private func makePayload(
         bodyFatPercentage: Double?,
-        gender: String?
+        gender: String?,
+        photoImage: UIImage? = nil
     ) -> BodyScoreSharePayload {
         BodyScoreSharePayload(
             score: 82,
@@ -598,8 +636,26 @@ final class BodyScoreShareCardTests: XCTestCase {
             weightCaption: "lb",
             deltaText: "+4 over 30 days",
             bodyFatPercentage: bodyFatPercentage,
-            gender: gender
+            gender: gender,
+            photoImage: photoImage
         )
+    }
+
+    private func makeShareTestImage() -> UIImage {
+        let size = CGSize(width: 480, height: 640)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            // swiftlint:disable:next object_literal
+            UIColor(red: 0.05, green: 0.11, blue: 0.18, alpha: 1).setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+
+            // swiftlint:disable:next object_literal
+            UIColor(red: 0.12, green: 0.55, blue: 1.0, alpha: 1).setFill()
+            context.fill(CGRect(x: 110, y: 80, width: 260, height: 460))
+
+            UIColor.white.withAlphaComponent(0.82).setFill()
+            context.fill(CGRect(x: 170, y: 120, width: 140, height: 320))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- route dashboard Body Score shares through the cached real progress photo when the user is in Photo mode
- keep the existing avatar-backed share card for Avatar mode and onboarding shares
- add share-card coverage for both avatar and photo-backed export aspect sizes

## Validation
- `swiftlint lint --strict`
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,name=LYB Golden iPhone 16' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -test-timeouts-enabled YES -default-test-execution-time-allowance 90 -maximum-test-execution-time-allowance 180 -resultBundlePath /tmp/lyb-jov-3181-share-card-tests-2.xcresult -only-testing:LogYourBodyTests/BodyScoreShareCardTests CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO test`\n- pre-push hook: `turbo run lint/typecheck/test --filter=...[origin/main]` (no JS tasks for iOS-only diff)\n\n## Notes\n- This uses the already-loaded progress photo cache so the share card matches the visible timeline image without adding a new async export path. If the photo is not cached, the existing avatar fallback remains.\n\nLinear: JOV-3181