### PR TITLE
JOV-3219 Tighten weight logging validation

### DIFF
--- a/apps/ios/LogYourBody/Services/ValidationService.swift
+++ b/apps/ios/LogYourBody/Services/ValidationService.swift
@@ -35,7 +35,9 @@ final class ValidationService {
 
         let range = weightRange(for: unit)
         guard range.contains(weight) else {
-            throw ValidationError.invalidWeight("Weight must be between \(Int(range.lowerBound))-\(Int(range.upperBound)) \(unit)")
+            throw ValidationError.invalidWeight(
+                "Enter a weight between \(Int(range.lowerBound)) and \(Int(range.upperBound)) \(unit)"
+            )
         }
 
         return roundedToOneDecimal(weight)
@@ -86,9 +88,9 @@ final class ValidationService {
     private func weightRange(for unit: String) -> ClosedRange<Double> {
         switch unit.lowercased() {
         case "lbs":
-            return 44...1_100
+            return 70...660
         default:
-            return 20...500
+            return 32...300
         }
     }
 

--- a/apps/ios/LogYourBody/Utils/UnitConversion.swift
+++ b/apps/ios/LogYourBody/Utils/UnitConversion.swift
@@ -237,11 +237,11 @@ struct UnitConversion {
 
     // MARK: - Validation
 
-    /// Validate weight value is within reasonable range
+    /// Validate weight value is within reasonable adult tracking range
     /// - Parameter weightKg: Weight in kilograms
-    /// - Returns: True if valid (20-300 kg)
+    /// - Returns: True if valid (32-300 kg)
     static func isValidWeight(_ weightKg: Double) -> Bool {
-        return weightKg >= 20 && weightKg <= 300
+        return weightKg >= 32 && weightKg <= 300
     }
 
     /// Validate height value is within reasonable range

--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -385,6 +385,9 @@ struct AddEntrySheet: View {
                     .pickerStyle(MenuPickerStyle())
                     .frame(width: 80)
                     .accessibilityLabel("Weight unit")
+                    .onChange(of: weightUnit) { _, _ in
+                        validateWeight(weight)
+                    }
                 }
 
                 // Helper text
@@ -394,7 +397,7 @@ struct AddEntrySheet: View {
                         .foregroundColor(.error)
                         .accessibilityLabel("Weight validation error: \(error)")
                 } else {
-                    Text(resolvedWeightUnit == "kg" ? "Valid range: 20-500 kg" : "Valid range: 44-1100 lbs")
+                    Text("Use today's scale weight.")
                         .font(.appBodySmall)
                         .foregroundColor(.appTextTertiary)
                 }

--- a/apps/ios/LogYourBody/Views/EditEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/EditEntrySheet.swift
@@ -140,17 +140,15 @@ struct EditEntrySheet: View {
 
     private var validationMessage: String? {
         guard !primaryValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
-        guard let value = Double(primaryValue) else { return "Enter a valid number" }
 
         switch metricType {
         case .weight:
-            let bounds: (Double, Double) = measurementSystem == .metric ? (30, 300) : (70, 660)
-            if value < bounds.0 || value > bounds.1 {
-                return "Weight must be between \(Int(bounds.0)) and \(Int(bounds.1)) \(measurementSystem.weightUnit)"
+            return validationErrorDescription {
+                _ = try ValidationService.shared.validateWeight(primaryValue, unit: measurementSystem.weightUnit)
             }
         case .bodyFat:
-            if value < 3 || value > 60 {
-                return "Body fat must be between 3-60%"
+            return validationErrorDescription {
+                _ = try ValidationService.shared.validateBodyFat(primaryValue)
             }
         default:
             break
@@ -194,10 +192,6 @@ struct EditEntrySheet: View {
 
     private func saveChanges() async {
         guard errorMessage == nil else { return }
-        guard let parsedValue = Double(primaryValue) else {
-            errorMessage = "Enter a valid number"
-            return
-        }
 
         isSaving = true
         defer { isSaving = false }
@@ -210,11 +204,25 @@ struct EditEntrySheet: View {
 
         switch metricType {
         case .weight:
-            weightKg = convertToKilograms(parsedValue)
-            bodyFat = nil
+            do {
+                let validatedWeight = try ValidationService.shared.validateWeight(
+                    primaryValue,
+                    unit: measurementSystem.weightUnit
+                )
+                weightKg = convertToKilograms(validatedWeight)
+                bodyFat = nil
+            } catch {
+                errorMessage = error.localizedDescription
+                return
+            }
         case .bodyFat:
-            weightKg = nil
-            bodyFat = parsedValue
+            do {
+                weightKg = nil
+                bodyFat = try ValidationService.shared.validateBodyFat(primaryValue)
+            } catch {
+                errorMessage = error.localizedDescription
+                return
+            }
         default:
             break
         }
@@ -240,5 +248,14 @@ struct EditEntrySheet: View {
 
     private func convertToKilograms(_ value: Double) -> Double {
         measurementSystem == .metric ? value : value / 2.20462
+    }
+
+    private func validationErrorDescription(_ expression: () throws -> Void) -> String? {
+        do {
+            try expression()
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
     }
 }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -110,6 +110,13 @@ final class BodyCompositionMathGoldenTests: XCTestCase {
         }
     }
 
+    func testWeightSanityRangeMatchesLaunchValidationBounds() {
+        XCTAssertFalse(UnitConversion.isValidWeight(31.9))
+        XCTAssertTrue(UnitConversion.isValidWeight(32))
+        XCTAssertTrue(UnitConversion.isValidWeight(300))
+        XCTAssertFalse(UnitConversion.isValidWeight(300.1))
+    }
+
     func testTrendWeightUsesHandComputedEMAReference() throws {
         let context = try makeWeightContext([
             (dayOffset: 0, weight: 100),
@@ -1276,6 +1283,13 @@ final class PaidWeightLoggerMVPPolicyTests: XCTestCase {
                 isSaving: false
             )
         )
+        XCTAssertFalse(
+            PaidWeightLoggerMVPPolicy.canSaveWeight(
+                weightText: "999",
+                unit: "lbs",
+                isSaving: false
+            )
+        )
         XCTAssertTrue(
             PaidWeightLoggerMVPPolicy.canSaveWeight(
                 weightText: "182.4",
@@ -1288,7 +1302,7 @@ final class PaidWeightLoggerMVPPolicyTests: XCTestCase {
     func testWeightValidationMessageExplainsInvalidRange() {
         XCTAssertEqual(
             PaidWeightLoggerMVPPolicy.validationMessage(weightText: "12", unit: "lbs"),
-            "Weight must be between 44-1100 lbs"
+            "Enter a weight between 70 and 660 lbs"
         )
         XCTAssertNil(
             PaidWeightLoggerMVPPolicy.validationMessage(weightText: "182.4", unit: "lbs")
@@ -1315,26 +1329,26 @@ final class ValidationServiceTests: XCTestCase {
     func testWeightBoundariesAreInclusiveForPoundsAndKilograms() throws {
         let service = ValidationService.shared
 
-        XCTAssertEqual(try service.validateWeight("44", unit: "lbs"), 44)
-        XCTAssertEqual(try service.validateWeight("1100", unit: "lbs"), 1_100)
-        XCTAssertEqual(try service.validateWeight("20", unit: "kg"), 20)
-        XCTAssertEqual(try service.validateWeight("500", unit: "kg"), 500)
+        XCTAssertEqual(try service.validateWeight("70", unit: "lbs"), 70)
+        XCTAssertEqual(try service.validateWeight("660", unit: "lbs"), 660)
+        XCTAssertEqual(try service.validateWeight("32", unit: "kg"), 32)
+        XCTAssertEqual(try service.validateWeight("300", unit: "kg"), 300)
 
         assertValidationError(
-            try service.validateWeight("43.9", unit: "lbs"),
-            expectedMessage: "Weight must be between 44-1100 lbs"
+            try service.validateWeight("69.9", unit: "lbs"),
+            expectedMessage: "Enter a weight between 70 and 660 lbs"
         )
         assertValidationError(
-            try service.validateWeight("1100.1", unit: "lbs"),
-            expectedMessage: "Weight must be between 44-1100 lbs"
+            try service.validateWeight("660.1", unit: "lbs"),
+            expectedMessage: "Enter a weight between 70 and 660 lbs"
         )
         assertValidationError(
-            try service.validateWeight("19.9", unit: "kg"),
-            expectedMessage: "Weight must be between 20-500 kg"
+            try service.validateWeight("31.9", unit: "kg"),
+            expectedMessage: "Enter a weight between 32 and 300 kg"
         )
         assertValidationError(
-            try service.validateWeight("500.1", unit: "kg"),
-            expectedMessage: "Weight must be between 20-500 kg"
+            try service.validateWeight("300.1", unit: "kg"),
+            expectedMessage: "Enter a weight between 32 and 300 kg"
         )
     }
 
@@ -1391,12 +1405,12 @@ final class LogWeightFormValidatorTests: XCTestCase {
     func testRejectsOutOfRangeWeightValues() {
         let zeroPounds = LogWeightFormValidator.validate(weight: "0", bodyFat: "", unit: "lbs")
         XCTAssertFalse(zeroPounds.isValid)
-        XCTAssertEqual(zeroPounds.weightError, "Weight must be between 44-1100 lbs")
+        XCTAssertEqual(zeroPounds.weightError, "Enter a weight between 70 and 660 lbs")
         XCTAssertNil(zeroPounds.weightValue)
 
-        let extremePounds = LogWeightFormValidator.validate(weight: "9999", bodyFat: "", unit: "lbs")
+        let extremePounds = LogWeightFormValidator.validate(weight: "999", bodyFat: "", unit: "lbs")
         XCTAssertFalse(extremePounds.isValid)
-        XCTAssertEqual(extremePounds.weightError, "Weight must be between 44-1100 lbs")
+        XCTAssertEqual(extremePounds.weightError, "Enter a weight between 70 and 660 lbs")
         XCTAssertNil(extremePounds.weightValue)
     }
 
@@ -1443,14 +1457,14 @@ final class LogWeightFormValidatorTests: XCTestCase {
         XCTAssertNil(validation.bodyFatError)
 
         let expectedKgError = validationErrorDescription {
-            _ = try ValidationService.shared.validateWeight("500.1", unit: "kg")
+            _ = try ValidationService.shared.validateWeight("300.1", unit: "kg")
         }
         let expectedBodyFatError = validationErrorDescription {
             _ = try ValidationService.shared.validateBodyFat("60.1")
         }
 
         XCTAssertEqual(
-            LogWeightFormValidator.fieldError(for: "500.1", field: .weight, unit: "kg"),
+            LogWeightFormValidator.fieldError(for: "300.1", field: .weight, unit: "kg"),
             expectedKgError
         )
         XCTAssertEqual(

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -74,6 +74,27 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(savedWeight.waitForExistence(timeout: 5))
     }
 
+    func testPaidMVPWeightEntryRejectsImplausibleWeight() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-lybUITestWeightLoggerMVPFixture"]
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["Weight log"].waitForExistence(timeout: 10))
+
+        let weightField = app.textFields["mvp_weight_text_field"]
+        XCTAssertTrue(weightField.waitForExistence(timeout: 5))
+        weightField.tap()
+        weightField.typeText("999")
+
+        let validationMessage = app.descendants(matching: .any)["mvp_weight_validation_message"]
+        XCTAssertTrue(validationMessage.waitForExistence(timeout: 3))
+        XCTAssertEqual(validationMessage.label, "Enter a weight between 70 and 660 lbs")
+
+        let keyboardSaveButton = app.buttons["mvp_keyboard_save_weight_bar_button"]
+        XCTAssertTrue(keyboardSaveButton.waitForExistence(timeout: 3))
+        XCTAssertFalse(keyboardSaveButton.isEnabled)
+    }
+
     func testPaywallFixtureShowsRestoreAndLogoutEscapePaths() throws {
         let app = XCUIApplication()
         app.launchArguments = ["-lybUITestPaywallFixture"]


### PR DESCRIPTION
## Summary
- Tightens iOS weight validation to realistic launch bounds: 70-660 lbs and 32-300 kg.
- Replaces raw technical range copy with plain-language validation: "Enter a weight between ...".
- Keeps Add Entry/Edit Entry validation on the shared `ValidationService`, including unit-switch revalidation.
- Adds unit and UI coverage so implausible `999 lbs` is rejected and the keyboard save action stays disabled.

## Linear
- JOV-3219

## Validation
- `swiftlint lint --strict` from `apps/ios` passed.
- XcodeBuildMCP `test_sim` on `LYB Golden iPhone 16` passed: 13 selected tests, 0 failed.
  - `LogYourBodyTests/BodyCompositionMathGoldenTests/testWeightSanityRangeMatchesLaunchValidationBounds`
  - `LogYourBodyTests/PaidWeightLoggerMVPPolicyTests`
  - `LogYourBodyTests/ValidationServiceTests`
  - `LogYourBodyTests/LogWeightFormValidatorTests`
  - `LogYourBodyUITests/LogYourBodyUITests/testPaidMVPWeightEntryRejectsImplausibleWeight`
- `git diff --check` passed.
- `pnpm lint` passed.
- `pnpm typecheck` passed.
- `pnpm test` passed.

## Notes
- Local Node is v22 while package engines request Node 20.x; pnpm emits the existing warning but commands pass.
- Root web tests emit existing PDF/logging warnings and design-token contrast warnings, but the test command exits green.
