### PR TITLE
JOV-3184 Cache timeline render data

### DIFF
--- a/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
+++ b/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
@@ -18,14 +18,30 @@ struct ProgressTimelineView: View {
     @State private var isDragging: Bool = false
     @State private var dragPosition: Double = 0.5
     @State private var currentDateLabel: String = ""
+    @State private var renderSignature: TimelineRenderSignature
+    @State private var renderData: TimelineRenderData
 
     private let timelineHeight: CGFloat = 50
     private let scrubberHandleSize: CGFloat = 44
 
+    init(
+        bodyMetrics: [BodyMetrics],
+        selectedIndex: Binding<Int>,
+        mode: Binding<TimelineMode>
+    ) {
+        self.bodyMetrics = bodyMetrics
+        _selectedIndex = selectedIndex
+        _mode = mode
+
+        let initialSignature = TimelineRenderSignature(metrics: bodyMetrics, mode: mode.wrappedValue)
+        _renderSignature = State(initialValue: initialSignature)
+        _renderData = State(initialValue: TimelineRenderData.make(metrics: bodyMetrics, mode: mode.wrappedValue))
+    }
+
     // MARK: - Body
 
     var body: some View {
-        let renderData = makeRenderData(metrics: bodyMetrics, mode: mode)
+        let currentRenderSignature = TimelineRenderSignature(metrics: bodyMetrics, mode: mode)
         let handlePosition = isDragging ? dragPosition : selectedPosition(
             in: renderData,
             selectedIndex: selectedIndex
@@ -67,6 +83,12 @@ struct ProgressTimelineView: View {
             .frame(height: timelineHeight)
         }
         .accessibilityIdentifier("dashboard_timeline_scrubber")
+        .onAppear {
+            refreshRenderDataIfNeeded(for: currentRenderSignature)
+        }
+        .onChange(of: currentRenderSignature) { _, newSignature in
+            refreshRenderDataIfNeeded(for: newSignature)
+        }
     }
 
     // MARK: - Subviews
@@ -194,39 +216,6 @@ struct ProgressTimelineView: View {
 
     // MARK: - Logic
 
-    private func makeRenderData(metrics: [BodyMetrics], mode: TimelineMode) -> TimelineRenderData {
-        let provider = TimelineDataProvider()
-        provider.loadMetrics(metrics)
-        guard !metrics.isEmpty else {
-            return TimelineRenderData(
-                metrics: [],
-                provider: provider,
-                anchors: [],
-                zoomLevel: .month
-            )
-        }
-
-        guard let firstDate = provider.bodyMetrics.first?.date,
-              let lastDate = provider.bodyMetrics.last?.date else {
-            return TimelineRenderData(
-                metrics: [],
-                provider: provider,
-                anchors: [],
-                zoomLevel: .month
-            )
-        }
-
-        let zoomLevel = TimelineZoomLevel.calculate(from: firstDate, to: lastDate)
-        let anchors = provider.generateAnchors(mode: mode, zoomLevel: zoomLevel)
-
-        return TimelineRenderData(
-            metrics: provider.bodyMetrics,
-            provider: provider,
-            anchors: anchors,
-            zoomLevel: zoomLevel
-        )
-    }
-
     private func selectedPosition(in renderData: TimelineRenderData, selectedIndex: Int) -> Double {
         guard selectedIndex >= 0, selectedIndex < bodyMetrics.count else {
             return dragPosition
@@ -284,10 +273,7 @@ struct ProgressTimelineView: View {
             return
         }
 
-        // Format date
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        currentDateLabel = formatter.string(from: nearestDate)
+        currentDateLabel = TimelineDateFormatterCache.string(from: nearestDate, style: .mediumDate)
 
         // Update selected index
         if let metric = provider.getMetric(for: nearestDate),
@@ -305,13 +291,75 @@ struct ProgressTimelineView: View {
         let impact = UIImpactFeedbackGenerator(style: .light)
         impact.impactOccurred()
     }
+
+    private func refreshRenderDataIfNeeded(for signature: TimelineRenderSignature) {
+        guard signature != renderSignature else { return }
+
+        renderSignature = signature
+        renderData = TimelineRenderData.make(metrics: bodyMetrics, mode: mode)
+    }
 }
 
-private struct TimelineRenderData {
+struct TimelineRenderSignature: Equatable {
+    let modeRawValue: String
+    let metricFingerprints: [MetricFingerprint]
+
+    init(metrics: [BodyMetrics], mode: TimelineMode) {
+        modeRawValue = mode.rawValue
+        metricFingerprints = metrics.map(MetricFingerprint.init)
+    }
+
+    struct MetricFingerprint: Equatable {
+        let id: String
+        let date: TimeInterval
+        let localDate: String
+        let photoUrl: String?
+        let weight: Double?
+        let bodyFatPercentage: Double?
+        let updatedAt: TimeInterval
+
+        init(metric: BodyMetrics) {
+            id = metric.id
+            date = metric.date.timeIntervalSinceReferenceDate
+            localDate = metric.localDate
+            photoUrl = metric.photoUrl
+            weight = metric.weight
+            bodyFatPercentage = metric.bodyFatPercentage
+            updatedAt = metric.updatedAt.timeIntervalSinceReferenceDate
+        }
+    }
+}
+
+struct TimelineRenderData {
     let metrics: [BodyMetrics]
     let provider: TimelineDataProvider
     let anchors: [TimelineAnchor]
     let zoomLevel: TimelineZoomLevel
+
+    static func make(metrics: [BodyMetrics], mode: TimelineMode) -> TimelineRenderData {
+        let provider = TimelineDataProvider()
+        provider.loadMetrics(metrics)
+        guard !metrics.isEmpty,
+              let firstDate = provider.bodyMetrics.first?.date,
+              let lastDate = provider.bodyMetrics.last?.date else {
+            return TimelineRenderData(
+                metrics: [],
+                provider: provider,
+                anchors: [],
+                zoomLevel: .month
+            )
+        }
+
+        let zoomLevel = TimelineZoomLevel.calculate(from: firstDate, to: lastDate)
+        let anchors = provider.generateAnchors(mode: mode, zoomLevel: zoomLevel)
+
+        return TimelineRenderData(
+            metrics: provider.bodyMetrics,
+            provider: provider,
+            anchors: anchors,
+            zoomLevel: zoomLevel
+        )
+    }
 }
 
 // MARK: - Preview

--- a/apps/ios/LogYourBody/Models/TimelineMode.swift
+++ b/apps/ios/LogYourBody/Models/TimelineMode.swift
@@ -92,19 +92,81 @@ struct TimelineDataResult {
         } else if daysDiff < 7 {
             return "\(daysDiff) days ago"
         } else if daysDiff < 30 {
-            let formatter = DateFormatter()
-            formatter.dateFormat = short ? "MMM d" : "MMMM d"
-            return formatter.string(from: date)
+            return TimelineDateFormatterCache.string(from: date, style: short ? .shortMonthDay : .longMonthDay)
         } else if daysDiff < 365 {
-            let formatter = DateFormatter()
-            formatter.dateFormat = short ? "MMM d" : "MMMM d, yyyy"
-            return formatter.string(from: date)
+            return TimelineDateFormatterCache.string(from: date, style: short ? .shortMonthDay : .longMonthDayYear)
         } else {
-            let formatter = DateFormatter()
-            formatter.dateFormat = short ? "MMM yyyy" : "MMMM yyyy"
-            return formatter.string(from: date)
+            return TimelineDateFormatterCache.string(from: date, style: short ? .shortMonthYear : .longMonthYear)
         }
     }
+}
+
+enum TimelineDateFormatterCache {
+    enum Style {
+        case shortMonthDay
+        case longMonthDay
+        case longMonthDayYear
+        case mediumDate
+        case shortMonthYear
+        case longMonthYear
+    }
+
+    static func string(from date: Date, style: Style) -> String {
+        formatter(for: style).string(from: date)
+    }
+
+    private static func formatter(for style: Style) -> DateFormatter {
+        switch style {
+        case .shortMonthDay:
+            return shortMonthDayFormatter
+        case .longMonthDay:
+            return longMonthDayFormatter
+        case .longMonthDayYear:
+            return longMonthDayYearFormatter
+        case .mediumDate:
+            return mediumDateFormatter
+        case .shortMonthYear:
+            return shortMonthYearFormatter
+        case .longMonthYear:
+            return longMonthYearFormatter
+        }
+    }
+
+    private static let shortMonthDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        return formatter
+    }()
+
+    private static let longMonthDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM d"
+        return formatter
+    }()
+
+    private static let longMonthDayYearFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM d, yyyy"
+        return formatter
+    }()
+
+    private static let mediumDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    private static let shortMonthYearFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM yyyy"
+        return formatter
+    }()
+
+    private static let longMonthYearFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter
+    }()
 }
 
 /// Timeline position with metadata for rendering

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -667,6 +667,78 @@ final class BodyScoreShareCardTests: XCTestCase {
 }
 
 final class DashboardTimelineProviderPerformanceTests: XCTestCase {
+    func testTimelineRenderSignatureTracksOnlyRenderInputs() {
+        let baseDate = Date(timeIntervalSince1970: 1_800_000_000)
+        let metric = makeMetric(
+            id: "metric",
+            date: baseDate,
+            weight: 181,
+            bodyFat: 18.4,
+            photoUrl: "https://example.com/original.jpg"
+        )
+        let sameMetric = makeMetric(
+            id: "metric",
+            date: baseDate,
+            weight: 181,
+            bodyFat: 18.4,
+            photoUrl: "https://example.com/original.jpg"
+        )
+        let changedPhoto = makeMetric(
+            id: "metric",
+            date: baseDate,
+            weight: 181,
+            bodyFat: 18.4,
+            photoUrl: "https://example.com/changed.jpg"
+        )
+        let changedUpdatedAt = makeMetric(
+            id: "metric",
+            date: baseDate,
+            weight: 181,
+            bodyFat: 18.4,
+            photoUrl: "https://example.com/original.jpg",
+            updatedAt: baseDate.addingTimeInterval(1)
+        )
+
+        let signature = TimelineRenderSignature(metrics: [metric], mode: .photo)
+
+        XCTAssertEqual(
+            signature,
+            TimelineRenderSignature(metrics: [sameMetric], mode: .photo)
+        )
+        XCTAssertNotEqual(
+            signature,
+            TimelineRenderSignature(metrics: [metric], mode: .avatar)
+        )
+        XCTAssertNotEqual(
+            signature,
+            TimelineRenderSignature(metrics: [changedPhoto], mode: .photo)
+        )
+        XCTAssertNotEqual(
+            signature,
+            TimelineRenderSignature(metrics: [changedUpdatedAt], mode: .photo)
+        )
+    }
+
+    func testTimelineRenderDataFactorySortsMetricsAndBuildsAnchors() {
+        let baseDate = Date(timeIntervalSince1970: 1_800_000_000)
+        let newest = makeMetric(id: "newest", date: baseDate, weight: 181, bodyFat: nil)
+        let oldest = makeMetric(id: "oldest", date: baseDate.addingTimeInterval(-86_400 * 3), weight: 184, bodyFat: nil)
+        let photo = makeMetric(
+            id: "photo",
+            date: baseDate.addingTimeInterval(-86_400),
+            weight: nil,
+            bodyFat: 18.4,
+            photoUrl: "https://example.com/photo.jpg"
+        )
+
+        let renderData = TimelineRenderData.make(metrics: [newest, photo, oldest], mode: .photo)
+
+        XCTAssertEqual(renderData.metrics.map(\.id), ["oldest", "photo", "newest"])
+        XCTAssertEqual(renderData.provider.bodyMetrics.map(\.id), ["oldest", "photo", "newest"])
+        XCTAssertFalse(renderData.anchors.isEmpty)
+        XCTAssertTrue(renderData.anchors.contains { $0.id == "photo" })
+    }
+
     func testLoadMetricsBuildsSortedTimelineIndexesOnce() {
         let provider = TimelineDataProvider()
         let baseDate = Date(timeIntervalSince1970: 1_800_000_000)
@@ -728,7 +800,8 @@ final class DashboardTimelineProviderPerformanceTests: XCTestCase {
         localDate: String? = nil,
         weight: Double?,
         bodyFat: Double?,
-        photoUrl: String? = nil
+        photoUrl: String? = nil,
+        updatedAt: Date? = nil
     ) -> BodyMetrics {
         BodyMetrics(
             id: id,
@@ -745,7 +818,7 @@ final class DashboardTimelineProviderPerformanceTests: XCTestCase {
             photoUrl: photoUrl,
             dataSource: BodyMetricSource.manual.rawValue,
             createdAt: date,
-            updatedAt: date
+            updatedAt: updatedAt ?? date
         )
     }
 }

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -447,10 +447,9 @@ final class LogYourBodyUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 12))
-        XCTAssertTrue(app.descendants(matching: .any)["dashboard_home_timeline_hero"].waitForExistence(timeout: 10))
 
         let avatarButton = app.buttons["home_mode_avatar_button"]
-        XCTAssertTrue(avatarButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(avatarButton.waitForExistence(timeout: 10))
         if avatarButton.isHittable {
             avatarButton.tap()
         }

--- a/docs/audits/jov-3184/ettrace-profile-tool-2026-06-15.md
+++ b/docs/audits/jov-3184/ettrace-profile-tool-2026-06-15.md
@@ -1,0 +1,46 @@
+# JOV-3184 ETTrace Profile Tool - 2026-06-15
+
+## Summary
+
+This pass adds a repo-owned ETTrace profiling entrypoint for the remaining
+JOV-3184 risk: getting a real symbolicated simulator trace after `xctrace`
+simulator recording produced unusable partial `.trace` bundles.
+
+The tool does not add ETTrace to the production app target. It builds or reuses
+a simulator ETTrace.xcframework inside a temporary run directory, links it with
+temporary xcodebuild flags, embeds ETTrace.framework into the debug simulator
+app bundle, installs that app on the simulator, and writes exact manual capture
+instructions.
+
+## Command
+
+```bash
+pnpm ios:ettrace-profile
+```
+
+For a launch-only connectivity smoke:
+
+```bash
+ETTRACE_CAPTURE=launch CAPTURE_SECONDS=45 pnpm ios:ettrace-profile
+```
+
+Manual mode is the recommended path for the actual timeline trace because the
+agent can start ETTrace, drive the installed app through XcodeBuildMCP, stop
+ETTrace, then preserve the fresh `output_*.json` files.
+
+## Intended Timeline Flow
+
+1. Launch the installed ETTrace-instrumented app with the timeline and performance-trace fixtures.
+2. Wait for the timeline hero to settle.
+3. Switch Avatar -> Photo.
+4. Open Stats.
+5. Return to Timeline.
+6. Preserve the processed flamegraph JSON written in the run directory.
+
+## Boundaries
+
+- Simulator/debug profiling only.
+- No committed ETTrace binary.
+- No permanent production target dependency.
+- The existing CI performance budget remains the merge gate; ETTrace captures
+  are diagnostic evidence used to tighten future frame and hitch budgets.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint:swift": "cd apps/ios && swiftlint lint --strict",
     "ios:launch-quality-audit": "bash scripts/ios/launch-quality-audit.sh",
     "ios:performance-audit": "bash scripts/ios/performance-audit.sh",
+    "ios:ettrace-profile": "bash scripts/ios/ettrace-profile.sh",
     "ios:quality-gate": "bash scripts/ios/quality-gate.sh"
   },
   "devDependencies": {

--- a/scripts/ios/ettrace-profile.sh
+++ b/scripts/ios/ettrace-profile.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IOS_DIR="$ROOT_DIR/apps/ios"
+PROJECT="${PROJECT:-LogYourBody.xcodeproj}"
+SCHEME="${SCHEME:-LogYourBody}"
+CONFIGURATION="${CONFIGURATION:-Debug}"
+DESTINATION="${DESTINATION:-platform=iOS Simulator,name=LYB Golden iPhone 16}"
+SIMULATOR_NAME="${SIMULATOR_NAME:-}"
+BUNDLE_ID="${BUNDLE_ID:-com.logyourbody.app}"
+RUN_DIR="${RUN_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/lyb-ettrace.XXXXXX")}"
+ETTRACE_TAG="${ETTRACE_TAG:-v1.1.0}"
+ETTRACE_SRC="${ETTRACE_SRC:-$RUN_DIR/ETTrace-src}"
+ETTRACE_XCFRAMEWORK="${ETTRACE_XCFRAMEWORK:-$RUN_DIR/ETTrace.xcframework}"
+ETTRACE_CAPTURE="${ETTRACE_CAPTURE:-manual}"
+CAPTURE_SECONDS="${CAPTURE_SECONDS:-45}"
+APP_LAUNCH_ARGS="${APP_LAUNCH_ARGS:--lybUITestPhotoTimelineHUDFixture -lybUITestTimelinePerformanceTraceFixture -lybUITestPhaseInsightFixture -lybUITestGlp1WeeklyCheckInFixture}"
+
+usage() {
+  cat <<'USAGE'
+Usage: pnpm ios:ettrace-profile
+
+Builds a simulator-only LogYourBody app with ETTrace linked through temporary
+xcodebuild flags, embeds ETTrace.framework into the built .app, installs it on
+the booted simulator, and writes capture instructions under RUN_DIR.
+
+Environment:
+  RUN_DIR                 Output folder. Defaults to a temp directory.
+  DESTINATION             xcodebuild simulator destination.
+  SIMULATOR_NAME          simctl boot target. Defaults to name= from DESTINATION.
+  ETTRACE_XCFRAMEWORK     Existing ETTrace.xcframework to reuse.
+  ETTRACE_TAG             ETTrace git tag when building a framework. Default v1.1.0.
+  ETTRACE_CAPTURE         manual or launch. Default manual.
+  CAPTURE_SECONDS         Seconds to record in launch mode. Default 45.
+  APP_LAUNCH_ARGS         Args passed to the app in launch mode.
+
+Examples:
+  pnpm ios:ettrace-profile
+
+  ETTRACE_CAPTURE=launch CAPTURE_SECONDS=45 pnpm ios:ettrace-profile
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+mkdir -p "$RUN_DIR"
+RUN_DIR="$(cd "$RUN_DIR" && pwd)"
+
+if [[ -z "$SIMULATOR_NAME" ]]; then
+  SIMULATOR_NAME="$(python3 - "$DESTINATION" <<'PY'
+import sys
+
+destination = sys.argv[1]
+for part in destination.split(","):
+    key, _, value = part.partition("=")
+    if key.strip() == "name":
+        print(value.strip())
+        break
+PY
+)"
+fi
+
+if [[ -z "$SIMULATOR_NAME" ]]; then
+  echo "error: SIMULATOR_NAME is required when DESTINATION has no name= segment" >&2
+  exit 2
+fi
+
+if ! command -v ettrace >/dev/null 2>&1; then
+  echo "error: ettrace CLI is not installed. Run: brew install emergetools/homebrew-tap/ettrace" >&2
+  exit 1
+fi
+
+build_ettrace_xcframework() {
+  if [[ -d "$ETTRACE_XCFRAMEWORK" ]]; then
+    return 0
+  fi
+
+  if [[ ! -d "$ETTRACE_SRC" ]]; then
+    git clone --depth 1 --branch "$ETTRACE_TAG" https://github.com/EmergeTools/ETTrace "$ETTRACE_SRC"
+  fi
+
+  rm -rf "$RUN_DIR/ETTrace-iphonesimulator.xcarchive" "$ETTRACE_XCFRAMEWORK"
+  (
+    cd "$ETTRACE_SRC"
+    xcodebuild archive \
+      -scheme ETTrace \
+      -archivePath "$RUN_DIR/ETTrace-iphonesimulator.xcarchive" \
+      -sdk iphonesimulator \
+      -destination "generic/platform=iOS Simulator" \
+      BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+      INSTALL_PATH="Library/Frameworks" \
+      SKIP_INSTALL=NO \
+      CLANG_CXX_LANGUAGE_STANDARD=c++17
+
+    xcodebuild -create-xcframework \
+      -framework "$RUN_DIR/ETTrace-iphonesimulator.xcarchive/Products/Library/Frameworks/ETTrace.framework" \
+      -output "$ETTRACE_XCFRAMEWORK"
+  )
+}
+
+find_ettrace_framework() {
+  find "$ETTRACE_XCFRAMEWORK" -type d -name ETTrace.framework -path "*simulator*" -print -quit
+}
+
+copy_dsyms() {
+  local derived_data="$1"
+  local dsyms="$2"
+  mkdir -p "$dsyms"
+
+  find "$derived_data/Build/Products" -maxdepth 4 -type d -name "*.dSYM" -print0 2>/dev/null |
+    while IFS= read -r -d "" dsym; do
+      rm -rf "$dsyms/$(basename "$dsym")"
+      cp -R "$dsym" "$dsyms/"
+    done
+
+  find "$RUN_DIR" -type d -name "ETTrace.framework.dSYM" -print0 2>/dev/null |
+    while IFS= read -r -d "" dsym; do
+      rm -rf "$dsyms/$(basename "$dsym")"
+      cp -R "$dsym" "$dsyms/"
+    done
+}
+
+write_instructions() {
+  local app="$1"
+  local dsyms="$2"
+  local instructions="$RUN_DIR/run-instructions.md"
+
+  cat > "$instructions" <<EOF
+# LogYourBody ETTrace Profile
+
+Run directory: \`$RUN_DIR\`
+App: \`$app\`
+dSYMs: \`$dsyms\`
+Destination: \`$DESTINATION\`
+Simulator: \`$SIMULATOR_NAME\`
+
+## Manual Runtime Capture
+
+1. Start ETTrace from this run directory:
+
+\`\`\`bash
+cd "$RUN_DIR"
+: > .ettrace-capture-start
+find "$RUN_DIR" -maxdepth 1 -name 'output_*.json' -delete
+ettrace --simulator --verbose --dsyms "$dsyms"
+\`\`\`
+
+2. In another terminal or with XcodeBuildMCP, launch and drive the installed app:
+
+\`\`\`bash
+xcrun simctl terminate booted "$BUNDLE_ID" || true
+xcrun simctl launch booted "$BUNDLE_ID" $APP_LAUNCH_ARGS
+\`\`\`
+
+3. Perform one focused flow, for example Avatar -> Photo -> Stats -> Timeline.
+4. Stop ETTrace with Ctrl-C.
+5. Preserve processed flamegraph output:
+
+\`\`\`bash
+PRESERVED_DIR="\$(mktemp -d "$RUN_DIR/run-\$(date +%Y%m%d-%H%M%S).XXXXXX")"
+find "$RUN_DIR" -maxdepth 1 -name 'output_*.json' -newer "$RUN_DIR/.ettrace-capture-start" -exec cp {} "\$PRESERVED_DIR/" \\;
+ls -la "\$PRESERVED_DIR"
+\`\`\`
+
+## Automated Launch Smoke
+
+This script can run a launch-only ETTrace smoke capture:
+
+\`\`\`bash
+ETTRACE_CAPTURE=launch CAPTURE_SECONDS=45 RUN_DIR="$RUN_DIR" pnpm ios:ettrace-profile
+\`\`\`
+
+Use manual mode for the timeline interaction trace; launch mode is only a
+connectivity proof for the ETTrace-instrumented simulator app.
+EOF
+
+  echo "Instructions written to $instructions"
+}
+
+preserve_outputs() {
+  local marker="$1"
+  local preserved_dir="$RUN_DIR/run-$(date +%Y%m%d-%H%M%S)"
+  mkdir -p "$preserved_dir"
+
+  find "$RUN_DIR" -maxdepth 1 -name "output_*.json" -newer "$marker" -print0 |
+    while IFS= read -r -d "" json; do
+      cp "$json" "$preserved_dir/"
+    done
+
+  if find "$preserved_dir" -maxdepth 1 -name "output_*.json" -print -quit | grep -q .; then
+    echo "Processed ETTrace output preserved in $preserved_dir"
+  else
+    echo "warning: no fresh output_*.json files found in $RUN_DIR" >&2
+  fi
+}
+
+build_ettrace_xcframework
+
+ETTRACE_FRAMEWORK="$(find_ettrace_framework)"
+if [[ -z "$ETTRACE_FRAMEWORK" ]]; then
+  echo "error: simulator ETTrace.framework not found under $ETTRACE_XCFRAMEWORK" >&2
+  exit 1
+fi
+
+DERIVED_DATA="$RUN_DIR/DerivedData"
+FRAMEWORK_PARENT="$(dirname "$ETTRACE_FRAMEWORK")"
+BUILD_LOG="$RUN_DIR/build-ettrace-app.log"
+
+(
+  cd "$IOS_DIR"
+  xcodebuild \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -configuration "$CONFIGURATION" \
+    -destination "$DESTINATION" \
+    -derivedDataPath "$DERIVED_DATA" \
+    -sdk iphonesimulator \
+    CODE_SIGNING_ALLOWED=NO \
+    CODE_SIGNING_REQUIRED=NO \
+    DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
+    "FRAMEWORK_SEARCH_PATHS=$FRAMEWORK_PARENT" \
+    'OTHER_LDFLAGS=$(inherited) -framework ETTrace' \
+    build | tee "$BUILD_LOG"
+)
+
+APP="$(find "$DERIVED_DATA/Build/Products/$CONFIGURATION-iphonesimulator" -maxdepth 1 -name "$SCHEME.app" -print -quit)"
+if [[ -z "$APP" || ! -d "$APP" ]]; then
+  echo "error: built app not found in $DERIVED_DATA" >&2
+  exit 1
+fi
+
+mkdir -p "$APP/Frameworks"
+rm -rf "$APP/Frameworks/ETTrace.framework"
+ditto "$ETTRACE_FRAMEWORK" "$APP/Frameworks/ETTrace.framework"
+
+DSYMS="$RUN_DIR/dsyms"
+copy_dsyms "$DERIVED_DATA" "$DSYMS"
+
+xcrun simctl boot "$SIMULATOR_NAME" >/dev/null 2>&1 || true
+xcrun simctl bootstatus "$SIMULATOR_NAME" -b >/dev/null
+open -a Simulator >/dev/null 2>&1 || true
+xcrun simctl install booted "$APP"
+
+write_instructions "$APP" "$DSYMS"
+
+if [[ "$ETTRACE_CAPTURE" == "manual" ]]; then
+  echo "Prepared ETTrace-instrumented app for manual capture."
+  echo "Run directory: $RUN_DIR"
+  exit 0
+fi
+
+if [[ "$ETTRACE_CAPTURE" != "launch" ]]; then
+  echo "error: ETTRACE_CAPTURE must be manual or launch" >&2
+  exit 2
+fi
+
+if [[ ! -t 1 ]]; then
+  echo "warning: ETTrace works best from a TTY; non-TTY launch capture may not produce output." >&2
+fi
+
+CAPTURE_MARKER="$RUN_DIR/.ettrace-capture-start"
+: > "$CAPTURE_MARKER"
+find "$RUN_DIR" -maxdepth 1 -name "output_*.json" -delete
+
+(
+  cd "$RUN_DIR"
+  ettrace --simulator --verbose --dsyms "$DSYMS"
+) | tee "$RUN_DIR/ettrace.log" &
+ETTRACE_PID="$!"
+
+sleep 3
+xcrun simctl terminate booted "$BUNDLE_ID" >/dev/null 2>&1 || true
+read -r -a LAUNCH_ARGS_ARRAY <<< "$APP_LAUNCH_ARGS"
+xcrun simctl launch booted "$BUNDLE_ID" "${LAUNCH_ARGS_ARRAY[@]}"
+sleep "$CAPTURE_SECONDS"
+kill -INT "$ETTRACE_PID" >/dev/null 2>&1 || true
+wait "$ETTRACE_PID" || true
+
+preserve_outputs "$CAPTURE_MARKER"


### PR DESCRIPTION
## Summary
- Cache `ProgressTimelineView` render data behind a lightweight render signature so timeline provider/anchor derivation is not rebuilt on every SwiftUI body pass.
- Reuse cached timeline date formatters in photo/avatar scrub labels.
- Keep the JOV-3184 trace lane useful by asserting the timeline hero, waiting for the Avatar/Photo controls, and exercising Avatar -> Photo -> Stats -> Timeline.
- Add `pnpm ios:ettrace-profile` for simulator-only ETTrace capture without adding ETTrace to the production target.

## Validation
- `swiftlint lint --strict --config apps/ios/.swiftlint.yml apps/ios/LogYourBody/Components/ProgressTimelineView.swift apps/ios/LogYourBody/Models/TimelineMode.swift apps/ios/LogYourBodyTests/LogYourBodyTests.swift apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift`
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/DashboardTimelineProviderPerformanceTests`: 4 passed.
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyUITests/LogYourBodyUITests/testTimelinePerformanceTraceWorkflow`: 1 passed, 17.119s.
- `ARTIFACT_DIR=apps/ios/test_results/performance-audit/jov-3184-render-cache-ci-20260615 RUN_LAUNCH_PERFORMANCE=false RUN_TIMELINE_TRACE_WORKFLOW=false pnpm ios:performance-audit`: passed; unit total 0.024s, slowest unit 0.018s.
- `ARTIFACT_DIR=apps/ios/test_results/performance-audit/jov-3184-render-cache-trace-20260615 RUN_SWIFTLINT=false RUN_LAUNCH_PERFORMANCE=false RUN_TIMELINE_TRACE_WORKFLOW=true pnpm ios:performance-audit`: passed; unit total 0.019s, slowest unit 0.013s, timeline workflow 16.246s / 35s budget.
- `bash -n scripts/ios/ettrace-profile.sh`
- `bash scripts/ios/ettrace-profile.sh --help`
- XcodeBuildMCP `build_run_sim` on `LYB Golden iPhone 16` with timeline fixtures: build/install/launch succeeded.
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:ci`
- Pre-push hook: filtered turbo lint/typecheck/test passed.

## Notes
- Local pnpm commands still warn that this shell is Node 22 while the repo asks for Node 20; all gates completed successfully.
- Local `testLaunchPerformance` remains flaky/unstable in simulator and is disabled in CI via `RUN_LAUNCH_PERFORMANCE=false`; this PR does not claim launch-metric closure.
- Simulator screenshot capture returned SpringBoard after the app process exited, so screenshot proof is intentionally not claimed here. The timeline trace workflow is the UI evidence for this slice.
