### PR TITLE
JOV-3181 Polish Body Score share preview

### DIFF
--- a/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
+++ b/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
@@ -32,6 +32,8 @@ enum BodyScoreShareAspect: String, CaseIterable, Identifiable {
     case portrait
     case story
 
+    static let defaultExportAspect: BodyScoreShareAspect = .portrait
+
     var id: String { rawValue }
 
     var displayName: String {
@@ -87,6 +89,7 @@ struct BodyScoreShareCardView: View {
         }
         .aspectRatio(aspectRatioValue, contentMode: .fit)
         .clipped()
+        .dynamicTypeSize(.medium)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("body_score_share_card")
     }
@@ -138,12 +141,14 @@ struct BodyScoreShareCardView: View {
                     .font(.system(size: layout.brandFontSize, weight: .semibold, design: .rounded))
                     .foregroundColor(.white)
                     .lineLimit(1)
+                    .allowsTightening(true)
                     .minimumScaleFactor(0.78)
 
                 Text(payload.visualBadgeText)
                     .font(.system(size: layout.badgeFontSize, weight: .medium))
                     .foregroundColor(Color.white.opacity(0.62))
                     .lineLimit(1)
+                    .allowsTightening(true)
                     .minimumScaleFactor(0.72)
             }
 
@@ -159,6 +164,7 @@ struct BodyScoreShareCardView: View {
                     .monospacedDigit()
                     .foregroundColor(.white)
                     .lineLimit(1)
+                    .allowsTightening(true)
                     .minimumScaleFactor(0.58)
 
                 VStack(alignment: .leading, spacing: layout.scoreLabelSpacing) {
@@ -167,6 +173,7 @@ struct BodyScoreShareCardView: View {
                         .foregroundColor(Color.white.opacity(0.66))
                         .textCase(.uppercase)
                         .lineLimit(1)
+                        .allowsTightening(true)
                         .minimumScaleFactor(0.7)
 
                     Text(payload.tagline)
@@ -181,6 +188,7 @@ struct BodyScoreShareCardView: View {
                             .font(.system(size: layout.deltaFontSize, weight: .medium))
                             .foregroundColor(Color.white.opacity(0.66))
                             .lineLimit(1)
+                            .allowsTightening(true)
                             .minimumScaleFactor(0.72)
                     }
                 }
@@ -198,6 +206,7 @@ struct BodyScoreShareCardView: View {
                 .font(.system(size: layout.footerFontSize, weight: .medium))
                 .foregroundColor(Color.white.opacity(0.58))
                 .lineLimit(1)
+                .allowsTightening(true)
                 .minimumScaleFactor(0.74)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -242,6 +251,7 @@ struct BodyScoreShareCardView: View {
                 .font(.system(size: layout.metricTitleFontSize, weight: .bold))
                 .foregroundColor(Color.white.opacity(0.58))
                 .lineLimit(1)
+                .allowsTightening(true)
                 .minimumScaleFactor(0.68)
 
             Text(value)
@@ -249,24 +259,40 @@ struct BodyScoreShareCardView: View {
                 .monospacedDigit()
                 .foregroundColor(.white)
                 .lineLimit(1)
+                .allowsTightening(true)
                 .minimumScaleFactor(0.58)
 
             Text(caption)
                 .font(.system(size: layout.metricCaptionFontSize, weight: .medium))
                 .foregroundColor(Color.white.opacity(0.54))
                 .lineLimit(1)
+                .allowsTightening(true)
                 .minimumScaleFactor(0.68)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
-private struct ShareCardLayout {
+struct ShareCardLayout {
     let size: CGSize
     let aspect: BodyScoreShareAspect
 
-    private var scale: CGFloat {
-        min(max(size.width / 390, 0.86), 2.8)
+    var scale: CGFloat {
+        let reference = referenceSize
+        let widthScale = reference.width > 0 ? size.width / reference.width : 1
+        let heightScale = reference.height > 0 ? size.height / reference.height : 1
+        return min(max(min(widthScale, heightScale), 0.58), 2.8)
+    }
+
+    private var referenceSize: CGSize {
+        switch aspect {
+        case .square:
+            return CGSize(width: 390, height: 520)
+        case .portrait:
+            return CGSize(width: 390, height: 620)
+        case .story:
+            return CGSize(width: 390, height: 760)
+        }
     }
 
     var horizontalPadding: CGFloat { 28 * scale }
@@ -354,7 +380,7 @@ struct BodyScoreShareSheet: View {
     let payload: BodyScoreSharePayload
     let onClose: (() -> Void)?
 
-    @State private var selectedAspect: BodyScoreShareAspect = .square
+    @State private var selectedAspect: BodyScoreShareAspect = .defaultExportAspect
     @State private var renderedImage: UIImage?
     @State private var isRendering = false
     @State private var showSystemShareSheet = false

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -544,6 +544,18 @@ final class PhotoTimelineHUDPolicyTests: XCTestCase {
 
 @MainActor
 final class BodyScoreShareCardTests: XCTestCase {
+    func testShareSheetDefaultsToPortraitExportAspect() {
+        XCTAssertEqual(BodyScoreShareAspect.defaultExportAspect, .portrait)
+    }
+
+    func testShareCardLayoutScalesDownForNarrowStoryPreview() {
+        let layout = ShareCardLayout(size: CGSize(width: 260, height: 462), aspect: .story)
+
+        XCTAssertLessThan(layout.scale, 0.7)
+        XCTAssertLessThan(layout.scoreFontSize, 42)
+        XCTAssertLessThan(layout.metricValueFontSize, 14)
+    }
+
     func testSharePayloadUsesSameNearestAvatarBucketAsHomeHero() {
         let payload = makePayload(bodyFatPercentage: 16.4, gender: "male")
 

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -611,6 +611,7 @@ final class LogYourBodyUITests: XCTestCase {
         let cardFrame = shareCard.frame
         let windowFrame = app.windows.firstMatch.frame
         XCTAssertGreaterThan(cardFrame.width, windowFrame.width * 0.88)
+        XCTAssertGreaterThan(cardFrame.height, cardFrame.width * 1.18)
         attachScreenshot(named: "launch-quality-body-score-share", from: app)
     }
 


### PR DESCRIPTION
## Summary
- Default Body Score sharing to the 4:5 format so the in-app preview matches the timeline hero/product image shape instead of starting square.
- Let share-card typography scale from both width and height and lock the card to medium dynamic type so narrow previews do not force export-sized text into the sheet.
- Add guards for the share-card default and the launch-quality share-sheet UI path.

## Validation
- `swiftlint lint --strict --config apps/ios/.swiftlint.yml apps/ios/LogYourBody/Components/BodyScoreShareCard.swift apps/ios/LogYourBodyTests/LogYourBodyTests.swift apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift`
- `git diff --check`
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/BodyScoreShareCardTests` passed 7 tests.
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesBodyScoreShareSheet` passed.
- Screenshot evidence extracted from the passing XCTest result: `/tmp/lyb-share-xcresult-attachments/1BC25078-5C6C-4F32-BA7B-A6BCCC6A0E53.png`.

## Notes
- This is a follow-up to closed JOV-3181 based on current TestFlight feedback; the previous issue is marked Done but the share preview still needed polish.
- Unrelated local onboarding changes are present in the worktree and intentionally not included in this PR.
