### PR TITLE
Fix stale onboarding completion sync

### DIFF
--- a/apps/ios/LogYourBody/ContentView.swift
+++ b/apps/ios/LogYourBody/ContentView.swift
@@ -18,6 +18,11 @@ enum LaunchSurfacePolicy {
     }
 }
 
+private struct ProfileCompletionSyncKey: Equatable {
+    let userId: String?
+    let completionFlag: Bool
+}
+
 struct ContentView: View {
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var realtimeSyncManager: RealtimeSyncManager
@@ -28,7 +33,7 @@ struct ContentView: View {
     private let onboardingStateManager = OnboardingStateManager.shared
     @State private var currentUserId: String?
     @State private var hasCompletedOnboarding = OnboardingStateManager.shared.hasCompletedCurrentVersion
-    @State private var lastProfileCompletionSync: Bool?
+    @State private var lastProfileCompletionSync: ProfileCompletionSyncKey?
     @State private var isLoadingComplete = false
     @State private var isUnlocked = false
     @State private var showLegalConsent = false
@@ -42,11 +47,13 @@ struct ContentView: View {
 
     private func applyProfileCompletionIfNeeded(_ completionFlag: Bool?) {
         guard let completionFlag else { return }
-        guard lastProfileCompletionSync != completionFlag else { return }
+        let userId = currentUserId ?? authManager.currentUser?.id
+        let syncKey = ProfileCompletionSyncKey(userId: userId, completionFlag: completionFlag)
+        guard lastProfileCompletionSync != syncKey else { return }
 
-        lastProfileCompletionSync = completionFlag
-        onboardingStateManager.updateCompletionStatus(completionFlag)
-        hasCompletedOnboarding = onboardingStateManager.hasCompletedCurrentVersion
+        lastProfileCompletionSync = syncKey
+        onboardingStateManager.syncCompletionFlagFromProfile(completionFlag, userId: userId)
+        hasCompletedOnboarding = onboardingStateManager.hasCompletedCurrentVersion(for: userId)
     }
 
     // Check if user profile is complete
@@ -107,8 +114,8 @@ struct ContentView: View {
         }
         .onAppear {
             // Initialize onboarding status
-            hasCompletedOnboarding = onboardingStateManager.hasCompletedCurrentVersion
             currentUserId = authManager.currentUser?.id
+            hasCompletedOnboarding = onboardingStateManager.hasCompletedCurrentVersion(for: currentUserId)
 
             // Fallback: Check profile if UserDefaults doesn't have it
             if !hasCompletedOnboarding {
@@ -127,12 +134,12 @@ struct ContentView: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: OnboardingStateManager.onboardingStateDidChange)) { _ in
-            hasCompletedOnboarding = onboardingStateManager.hasCompletedCurrentVersion
+            hasCompletedOnboarding = onboardingStateManager.hasCompletedCurrentVersion(for: currentUserId)
         }
         .onChange(of: authManager.isAuthenticated) { _, newValue in
             currentUserId = authManager.currentUser?.id
             if newValue {
-                hasCompletedOnboarding = onboardingStateManager.hasCompletedCurrentVersion
+                hasCompletedOnboarding = onboardingStateManager.hasCompletedCurrentVersion(for: currentUserId)
             } else {
                 lastProfileCompletionSync = nil
                 if hasCompletedOnboarding {

--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -915,7 +915,7 @@ final class OnboardingFlowViewModel: ObservableObject {
         let updates = buildOnboardingProfileUpdates()
         await AuthManager.shared.updateProfile(updates)
         applyCompletedOnboardingLocally(with: updates)
-        OnboardingStateManager.shared.markCompleted()
+        OnboardingStateManager.shared.markCompleted(userId: AuthManager.shared.currentUser?.id)
         UserDefaults.standard.set(defaultHomeMode.rawValue, forKey: Constants.defaultHomeModeKey)
         clearPersistedProgress()
         PreAuthOnboardingStore.shared.clear()
@@ -1287,7 +1287,7 @@ final class OnboardingFlowViewModel: ObservableObject {
     private func persistProgress() {
         guard entryContext == .authenticated else { return }
         guard !isRestoringProgress else { return }
-        guard !OnboardingStateManager.shared.hasCompletedCurrentVersion else {
+        guard !OnboardingStateManager.shared.hasCompletedCurrentVersion(for: AuthManager.shared.currentUser?.id) else {
             clearPersistedProgress()
             return
         }
@@ -1328,7 +1328,7 @@ final class OnboardingFlowViewModel: ObservableObject {
     private func restorePersistedProgressIfNeeded() {
         guard entryContext == .authenticated else { return }
         guard let userId = AuthManager.shared.currentUser?.id else { return }
-        guard !OnboardingStateManager.shared.hasCompletedCurrentVersion else {
+        guard !OnboardingStateManager.shared.hasCompletedCurrentVersion(for: AuthManager.shared.currentUser?.id) else {
             progressStore.clearProgress(for: userId)
             return
         }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
@@ -367,7 +367,7 @@ struct BodyScoreProfileDetailsView: View {
         let trimmedLast = trimmedLastName
         let fullName = "\(trimmedFirst) \(trimmedLast)".trimmingCharacters(in: .whitespacesAndNewlines)
         let completesOnboardingNow = !viewModel.includesFirstPhotoStep ||
-            OnboardingStateManager.shared.hasCompletedCurrentVersion
+            OnboardingStateManager.shared.hasCompletedCurrentVersion(for: authManager.currentUser?.id)
 
         Task {
             do {

--- a/apps/ios/LogYourBody/Services/LoadingManager.swift
+++ b/apps/ios/LogYourBody/Services/LoadingManager.swift
@@ -158,7 +158,10 @@ class LoadingManager: ObservableObject {
 
                         // Sync onboarding state to UserDefaults via OnboardingStateManager
                         if let onboardingCompleted = profile.onboardingCompleted {
-                            OnboardingStateManager.shared.syncCompletionFlagFromProfile(onboardingCompleted)
+                            OnboardingStateManager.shared.syncCompletionFlagFromProfile(
+                                onboardingCompleted,
+                                userId: userId
+                            )
                             // print("✅ LoadingManager: Synced onboarding status from profile: \(onboardingCompleted)")
                         }
                     }

--- a/apps/ios/LogYourBody/Services/OnboardingStateManager.swift
+++ b/apps/ios/LogYourBody/Services/OnboardingStateManager.swift
@@ -15,16 +15,33 @@ final class OnboardingStateManager {
         return didComplete && storedVersion >= currentOnboardingVersion
     }
 
+    func hasCompletedCurrentVersion(for userId: String?) -> Bool {
+        guard hasCompletedCurrentVersion else { return false }
+        guard let storedUserId = defaults.string(forKey: Constants.onboardingCompletedUserIdKey),
+              !storedUserId.isEmpty,
+              let userId,
+              !userId.isEmpty else {
+            return true
+        }
+
+        return storedUserId == userId
+    }
+
     init(defaults: UserDefaults = .standard, currentVersion: Int = 1) {
         self.defaults = defaults
         self.currentOnboardingVersion = currentVersion
         ensureVersionConsistency()
     }
 
-    func markCompleted(version: Int? = nil) {
+    func markCompleted(version: Int? = nil, userId: String? = nil) {
         let versionToPersist = version ?? currentOnboardingVersion
         defaults.set(true, forKey: Constants.hasCompletedOnboardingKey)
         defaults.set(versionToPersist, forKey: Constants.onboardingCompletedVersionKey)
+        if let userId, !userId.isEmpty {
+            defaults.set(userId, forKey: Constants.onboardingCompletedUserIdKey)
+        } else {
+            defaults.removeObject(forKey: Constants.onboardingCompletedUserIdKey)
+        }
         AnalyticsService.shared.track(
             event: "onboarding_completed",
             properties: [
@@ -34,23 +51,36 @@ final class OnboardingStateManager {
         notifyChange()
     }
 
-    func updateCompletionStatus(_ isCompleted: Bool) {
+    func updateCompletionStatus(_ isCompleted: Bool, userId: String? = nil) {
         if isCompleted {
-            markCompleted()
+            markCompleted(userId: userId)
         } else {
+            if shouldPreserveLocalCompletionForStaleFalse(userId: userId) {
+                return
+            }
             defaults.set(false, forKey: Constants.hasCompletedOnboardingKey)
             defaults.removeObject(forKey: Constants.onboardingCompletedVersionKey)
+            defaults.removeObject(forKey: Constants.onboardingCompletedUserIdKey)
             notifyChange()
         }
     }
 
-    func syncCompletionFlagFromProfile(_ isCompleted: Bool) {
+    func syncCompletionFlagFromProfile(_ isCompleted: Bool, userId: String? = nil) {
         if isCompleted {
             defaults.set(true, forKey: Constants.hasCompletedOnboardingKey)
             defaults.set(currentOnboardingVersion, forKey: Constants.onboardingCompletedVersionKey)
+            if let userId, !userId.isEmpty {
+                defaults.set(userId, forKey: Constants.onboardingCompletedUserIdKey)
+            } else {
+                defaults.removeObject(forKey: Constants.onboardingCompletedUserIdKey)
+            }
         } else {
+            if shouldPreserveLocalCompletionForStaleFalse(userId: userId) {
+                return
+            }
             defaults.set(false, forKey: Constants.hasCompletedOnboardingKey)
             defaults.removeObject(forKey: Constants.onboardingCompletedVersionKey)
+            defaults.removeObject(forKey: Constants.onboardingCompletedUserIdKey)
         }
         notifyChange()
     }
@@ -59,6 +89,7 @@ final class OnboardingStateManager {
         guard newVersion > currentOnboardingVersion else { return }
         defaults.set(false, forKey: Constants.hasCompletedOnboardingKey)
         defaults.set(newVersion - 1, forKey: Constants.onboardingCompletedVersionKey)
+        defaults.removeObject(forKey: Constants.onboardingCompletedUserIdKey)
         notifyChange()
     }
 
@@ -67,6 +98,17 @@ final class OnboardingStateManager {
         if storedVersion < currentOnboardingVersion {
             defaults.set(false, forKey: Constants.hasCompletedOnboardingKey)
         }
+    }
+
+    private func shouldPreserveLocalCompletionForStaleFalse(userId: String?) -> Bool {
+        guard hasCompletedCurrentVersion else { return false }
+        guard let userId, !userId.isEmpty else { return false }
+        guard let completedUserId = defaults.string(forKey: Constants.onboardingCompletedUserIdKey),
+              !completedUserId.isEmpty else {
+            return false
+        }
+
+        return completedUserId == userId
     }
 
     private func notifyChange() {

--- a/apps/ios/LogYourBody/Utils/Constants.swift
+++ b/apps/ios/LogYourBody/Utils/Constants.swift
@@ -68,6 +68,7 @@ struct Constants {
     static let defaultHomeModeKey = "defaultHomeMode"
     static let hasCompletedOnboardingKey = "hasCompletedOnboarding"
     static let onboardingCompletedVersionKey = "onboardingCompletedVersion"
+    static let onboardingCompletedUserIdKey = "onboardingCompletedUserId"
     static let dailyWeighInReminderEnabledKey = "dailyWeighInReminderEnabled"
     static let dailyWeighInReminderHourKey = "dailyWeighInReminderHour"
     static let dailyWeighInReminderMinuteKey = "dailyWeighInReminderMinute"

--- a/apps/ios/LogYourBody/Utils/ShakeDetector.swift
+++ b/apps/ios/LogYourBody/Utils/ShakeDetector.swift
@@ -122,6 +122,8 @@ class DebugResetManager {
         // Also clear specific keys
         let keysToRemove = [
             Constants.hasCompletedOnboardingKey,
+            Constants.onboardingCompletedVersionKey,
+            Constants.onboardingCompletedUserIdKey,
             Constants.preferredMeasurementSystemKey,
             "healthKitSyncEnabled",
             "biometricLockEnabled",

--- a/apps/ios/LogYourBody/Views/DeleteAccountView.swift
+++ b/apps/ios/LogYourBody/Views/DeleteAccountView.swift
@@ -202,6 +202,7 @@ struct AccountDeletionCleanupService {
     static let accountUserDefaultsKeys: [String] = [
         Constants.hasCompletedOnboardingKey,
         Constants.onboardingCompletedVersionKey,
+        Constants.onboardingCompletedUserIdKey,
         Constants.preferredWeightUnitKey,
         Constants.preferredMeasurementSystemKey,
         Constants.goalWeightKey,

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -378,6 +378,7 @@ final class AccountDeletionCleanupServiceTests: XCTestCase {
             Constants.authTokenKey,
             Constants.hasCompletedOnboardingKey,
             Constants.onboardingCompletedVersionKey,
+            Constants.onboardingCompletedUserIdKey,
             Constants.defaultHomeModeKey,
             Constants.timelineModeKey,
             "healthKitSyncEnabled",
@@ -414,6 +415,7 @@ final class PhotoTimelineHUDPolicyTests: XCTestCase {
 
     func testDefaultHomeModeDefaultsToAvatar() {
         XCTAssertEqual(Constants.defaultHomeModeKey, "defaultHomeMode")
+        XCTAssertEqual(Constants.onboardingCompletedUserIdKey, "onboardingCompletedUserId")
         XCTAssertEqual(DefaultHomeMode.default, .avatar)
         XCTAssertEqual(DefaultHomeMode(storedValue: "photo"), .photo)
         XCTAssertEqual(DefaultHomeMode(storedValue: "unexpected"), .avatar)
@@ -2266,6 +2268,42 @@ final class OnboardingFlowViewModelTests: XCTestCase {
 
         XCTAssertTrue(manager.hasCompletedCurrentVersion)
         XCTAssertEqual(defaults.integer(forKey: Constants.onboardingCompletedVersionKey), 2)
+    }
+
+    func testProfileCompletionSyncIgnoresStaleFalseForSameCompletedUser() {
+        let suiteName = "onboarding-profile-stale-false-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let manager = OnboardingStateManager(defaults: defaults, currentVersion: 1)
+
+        manager.markCompleted(userId: "same-user")
+        manager.syncCompletionFlagFromProfile(false, userId: "same-user")
+
+        XCTAssertTrue(manager.hasCompletedCurrentVersion)
+        XCTAssertTrue(manager.hasCompletedCurrentVersion(for: "same-user"))
+        XCTAssertEqual(defaults.string(forKey: Constants.onboardingCompletedUserIdKey), "same-user")
+    }
+
+    func testProfileCompletionSyncClearsInheritedCompletionForDifferentUser() {
+        let suiteName = "onboarding-profile-user-switch-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let manager = OnboardingStateManager(defaults: defaults, currentVersion: 1)
+
+        manager.markCompleted(userId: "previous-user")
+        XCTAssertFalse(manager.hasCompletedCurrentVersion(for: "new-user"))
+
+        manager.syncCompletionFlagFromProfile(false, userId: "new-user")
+
+        XCTAssertFalse(manager.hasCompletedCurrentVersion)
+        XCTAssertFalse(manager.hasCompletedCurrentVersion(for: "previous-user"))
+        XCTAssertNil(defaults.string(forKey: Constants.onboardingCompletedUserIdKey))
     }
 
     func testFirstPhotoBackNavigationAndPaywallBackNavigation() {


### PR DESCRIPTION
## Summary
- Fixes JOV-3225 by scoping local onboarding completion to the user who completed it.
- Preserves completed onboarding when the same user receives a stale `onboardingCompleted=false` profile response.
- Clears inherited local completion for a different signed-in user so user switching cannot bypass onboarding.
- Extends account/debug cleanup for the new persisted completion user id.

## Validation
- `swiftlint lint --strict`
- `git diff --check`
- XcodeBuildMCP `test_sim` with 5 selected tests: onboarding stale false, user-switch clear, profile sync version, account cleanup, default home mode
- XcodeBuildMCP `build_run_sim` on `LYB Golden iPhone 16` with `-lybUITestBodyScoreOnboardingFixture`
- Simulator screenshot: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_b4fd623c-5a79-4774-9048-78a4761381a3.jpg`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Notes
- Local Node is v22.22.1 while the repo requests Node 20.x; pnpm reported the existing engine warning but all commands passed.
- Untracked UX audit artifacts under `docs/audits/ux-redesign-20260615/` are intentionally not part of this PR.

Linear: JOV-3225