### PR TITLE
JOV-3183 Apply global size-based scroll bounce

### DIFF
--- a/apps/ios/LogYourBody/ContentView.swift
+++ b/apps/ios/LogYourBody/ContentView.swift
@@ -101,6 +101,7 @@ struct ContentView: View {
             loadingOverlay
         }
         .preferredColorScheme(.dark)
+        .scrollBounceBehavior(.basedOnSize, axes: .vertical)
         // Toast presenter removed - handle notifications at view level
         .fullScreenCover(isPresented: $showLegalConsent) {
             LegalConsentView(


### PR DESCRIPTION
## Summary
- Apply `.scrollBounceBehavior(.basedOnSize, axes: .vertical)` at the app root so short screens do not show empty vertical over-scroll while long screens still scroll normally.
- This follows up on current TestFlight feedback that over-scroll remains visible on multiple pages even though JOV-3183 is marked Done.

## Validation
- `swiftlint lint --strict --config apps/ios/.swiftlint.yml apps/ios/LogYourBody/ContentView.swift`
- `git diff --check`
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesTimelineHomeSurface` passed.

## Notes
- This is intentionally a one-line policy change at the root. Existing per-screen `.basedOnSize` modifiers remain in place.
- Untracked `docs/audits/ux-redesign-20260615/` exists locally and is intentionally not included.
