### PR TITLE
JOV-3183 Harden iOS launch quality timeout handling

### DIFF
--- a/scripts/ios/launch-quality-audit.sh
+++ b/scripts/ios/launch-quality-audit.sh
@@ -31,6 +31,40 @@ if [[ "$DESTINATION" == "auto" ]]; then
   DESTINATION="$(IOS_DIR="$IOS_DIR" PROJECT="$PROJECT" SCHEME="$SCHEME" bash "$ROOT_DIR/scripts/ios/resolve-simulator-destination.sh")"
 fi
 
+run_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+
+  if [[ -n "$TIMEOUT_BIN" ]]; then
+    "$TIMEOUT_BIN" --kill-after=30s "${timeout_seconds}s" "$@"
+    return $?
+  fi
+
+  python3 - "$timeout_seconds" "$@" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+timeout_seconds = float(sys.argv[1])
+command = sys.argv[2:]
+
+process = subprocess.Popen(command, start_new_session=True)
+try:
+    sys.exit(process.wait(timeout=timeout_seconds))
+except subprocess.TimeoutExpired:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=30)
+    except ProcessLookupError:
+        pass
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+    sys.exit(124)
+PY
+}
+
 COMMON_XCODEBUILD_ARGS=(
   -project "$PROJECT"
   -scheme "$SCHEME"
@@ -81,14 +115,9 @@ run_xcodebuild_test() {
     )
 
     set +e
-    if [[ -n "$TIMEOUT_BIN" ]]; then
-      "$TIMEOUT_BIN" \
-        --kill-after=30s \
-        "${XCODEBUILD_COMMAND_TIMEOUT_SECONDS}s" \
-        "${xcodebuild_command[@]}" 2>&1 | tee -a "$log_file"
-    else
+    run_with_timeout \
+      "$XCODEBUILD_COMMAND_TIMEOUT_SECONDS" \
       "${xcodebuild_command[@]}" 2>&1 | tee -a "$log_file"
-    fi
     status="${PIPESTATUS[0]}"
     set -e
 
@@ -127,14 +156,9 @@ build_for_testing_once() {
   )
 
   set +e
-  if [[ -n "$TIMEOUT_BIN" ]]; then
-    "$TIMEOUT_BIN" \
-      --kill-after=30s \
-      "${BUILD_FOR_TESTING_TIMEOUT_SECONDS}s" \
-      "${xcodebuild_command[@]}" 2>&1 | tee -a "$log_file"
-  else
+  run_with_timeout \
+    "$BUILD_FOR_TESTING_TIMEOUT_SECONDS" \
     "${xcodebuild_command[@]}" 2>&1 | tee -a "$log_file"
-  fi
   status="${PIPESTATUS[0]}"
   set -e
 


### PR DESCRIPTION
## Summary
- Add a Python-backed timeout fallback for launch-quality xcodebuild invocations when GNU timeout/gtimeout is unavailable on macOS runners
- Keep existing GNU timeout path and simulator-infra retry detection intact
- Prevent hung launch-quality xcodebuild processes from consuming the whole CI step without the script writing its timeout marker

## Evidence
- `bash -n scripts/ios/launch-quality-audit.sh`
- `git diff --check`
- Local full launch quality audit passed: `ARTIFACT_DIR=/tmp/lyb-launch-quality-repro-20260615-092105 DESTINATION='platform=iOS Simulator,name=LYB Golden iPhone 16' bash scripts/ios/launch-quality-audit.sh`
- Root checks already passed on preceding JOV-3183 validation: `pnpm lint`, `pnpm typecheck`, `pnpm test`

## Context
PR #380 merged and main CI exposed an iOS Launch Quality Gate failure/hang while the same launch-quality selector and full audit pass locally. This keeps the gate strict while making timeout handling portable on GitHub macOS runners.

Linear: JOV-3183