### PR TITLE
fix: polish iOS metrics and share quality

### DIFF
--- a/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
+++ b/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
@@ -107,7 +107,7 @@ struct BodyScoreShareCardView: View {
             if let photoImage = payload.photoImage {
                 Image(uiImage: photoImage)
                     .resizable()
-                    .scaledToFit()
+                    .scaledToFill()
                     .frame(maxWidth: .infinity)
                     .frame(height: layout.visualHeight, alignment: .center)
                     .clipped()
@@ -196,10 +196,20 @@ struct BodyScoreShareCardView: View {
                 Spacer(minLength: 0)
             }
 
-            HStack(spacing: layout.metricSpacing) {
-                shareMetric("Weight", payload.weightValue, payload.weightCaption, layout: layout)
-                shareMetric("Body Fat", payload.bodyFatValue, payload.bodyFatCaption, layout: layout)
-                shareMetric("FFMI", payload.ffmiValue, payload.ffmiCaption, layout: layout)
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: layout.metricSpacing) {
+                    shareMetric("Weight", payload.weightValue, payload.weightCaption, layout: layout)
+                    shareMetric("Body Fat", payload.bodyFatValue, payload.bodyFatCaption, layout: layout)
+                    shareMetric("FFMI", payload.ffmiValue, payload.ffmiCaption, layout: layout)
+                }
+
+                VStack(spacing: layout.metricSpacing * 0.55) {
+                    HStack(spacing: layout.metricSpacing) {
+                        shareMetric("Weight", payload.weightValue, payload.weightCaption, layout: layout)
+                        shareMetric("Body Fat", payload.bodyFatValue, payload.bodyFatCaption, layout: layout)
+                    }
+                    shareMetric("FFMI", payload.ffmiValue, payload.ffmiCaption, layout: layout)
+                }
             }
 
             Text("Shared from LogYourBody")
@@ -307,36 +317,36 @@ struct ShareCardLayout {
     var summarySpacing: CGFloat { 17 * scale }
     var scoreSpacing: CGFloat { 13 * scale }
     var scoreLabelSpacing: CGFloat { 4 * scale }
-    var scoreFontSize: CGFloat { 58 * scale }
+    var scoreFontSize: CGFloat { 54 * scale }
     var scoreLabelFontSize: CGFloat { 11 * scale }
     var taglineFontSize: CGFloat { 15 * scale }
     var deltaFontSize: CGFloat { 12 * scale }
     var metricSpacing: CGFloat { 13 * scale }
     var metricTextSpacing: CGFloat { 4 * scale }
     var metricTitleFontSize: CGFloat { 10 * scale }
-    var metricValueFontSize: CGFloat { 20 * scale }
+    var metricValueFontSize: CGFloat { 18 * scale }
     var metricCaptionFontSize: CGFloat { 10 * scale }
     var footerFontSize: CGFloat { 11 * scale }
 
     var visualTopOffset: CGFloat {
         switch aspect {
         case .square:
-            return size.height * 0.18
-        case .portrait:
-            return size.height * 0.14
-        case .story:
             return size.height * 0.12
+        case .portrait:
+            return size.height * 0.08
+        case .story:
+            return size.height * 0.08
         }
     }
 
     var visualHeight: CGFloat {
         switch aspect {
         case .square:
-            return size.height * 0.55
+            return size.height * 0.60
         case .portrait:
-            return size.height * 0.58
+            return size.height * 0.66
         case .story:
-            return size.height * 0.54
+            return size.height * 0.62
         }
     }
 
@@ -354,11 +364,11 @@ struct ShareCardLayout {
     var summaryMatteHeight: CGFloat {
         switch aspect {
         case .square:
-            return size.height * 0.58
+            return size.height * 0.60
         case .portrait:
-            return size.height * 0.52
+            return size.height * 0.54
         case .story:
-            return size.height * 0.42
+            return size.height * 0.46
         }
     }
 
@@ -407,7 +417,7 @@ struct BodyScoreShareSheet: View {
 
                 BodyScoreShareCardView(payload: payload, aspect: selectedAspect)
                     .frame(width: size.width, height: size.height)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
             .frame(maxWidth: .infinity)
 

--- a/apps/ios/LogYourBody/Components/DashboardMetricsList.swift
+++ b/apps/ios/LogYourBody/Components/DashboardMetricsList.swift
@@ -26,7 +26,7 @@ struct DashboardMetricsList<CardContent: View>: View {
     }
 
     var body: some View {
-        VStack(spacing: 14) {
+        LazyVStack(spacing: 12) {
             ForEach(metricsOrder) { metricId in
                 cardContent(metricId)
                     .overlay(
@@ -69,7 +69,7 @@ struct DashboardMetricsList<CardContent: View>: View {
             }
         }
         .animation(
-            .interactiveSpring(response: 0.30, dampingFraction: 0.85),
+            .easeOut(duration: 0.16),
             value: metricsOrder
         )
         .animation(

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/MetricSummaryCard.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/MetricSummaryCard.swift
@@ -13,9 +13,9 @@ import Charts
 /// Apple Health-style metric card with inline chart, states, and accessibility support.
 public struct MetricSummaryCard: View {
     public struct DataPoint: Identifiable {
-        public let id = UUID()
         public let index: Int
         public let value: Double
+        public var id: Int { index }
 
         public init(index: Int, value: Double) {
             self.index = index

--- a/apps/ios/LogYourBody/Views/DashboardMetricsSection.swift
+++ b/apps/ios/LogYourBody/Views/DashboardMetricsSection.swift
@@ -57,6 +57,7 @@ struct DashboardMetricsSection: View {
                 metricCardView(for: metric)
             }
         )
+        .accessibilityIdentifier("photo_timeline_stats_metric_stack")
     }
 
     @ViewBuilder
@@ -106,6 +107,7 @@ struct DashboardMetricsSection: View {
             )
         }
         .buttonStyle(MetricCardButtonStyle())
+        .accessibilityIdentifier("photo_timeline_stats_metric_card_steps")
     }
 
     @ViewBuilder
@@ -137,6 +139,7 @@ struct DashboardMetricsSection: View {
                 )
             }
             .buttonStyle(MetricCardButtonStyle())
+            .accessibilityIdentifier("photo_timeline_stats_metric_card_weight")
         }
     }
 
@@ -169,6 +172,7 @@ struct DashboardMetricsSection: View {
                 )
             }
             .buttonStyle(MetricCardButtonStyle())
+            .accessibilityIdentifier("photo_timeline_stats_metric_card_body_fat")
         }
     }
 
@@ -201,6 +205,7 @@ struct DashboardMetricsSection: View {
                 )
             }
             .buttonStyle(MetricCardButtonStyle())
+            .accessibilityIdentifier("photo_timeline_stats_metric_card_ffmi")
         }
     }
 }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -75,7 +75,6 @@ extension DashboardViewLiquid {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .contentShape(Rectangle())
-            .highPriorityGesture(photoTimelineRootSwipeGesture)
             .simultaneousGesture(photoTimelineRootSwipeGesture)
         }
     }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -550,12 +550,26 @@ final class BodyScoreShareCardTests: XCTestCase {
         XCTAssertEqual(BodyScoreShareAspect.defaultExportAspect, .portrait)
     }
 
+    func testMetricSummaryDataPointIdentityIsStableAcrossRenders() {
+        let first = MetricSummaryCard.DataPoint(index: 4, value: 181.2)
+        let second = MetricSummaryCard.DataPoint(index: 4, value: 179.8)
+
+        XCTAssertEqual(first.id, second.id)
+    }
+
     func testShareCardLayoutScalesDownForNarrowStoryPreview() {
         let layout = ShareCardLayout(size: CGSize(width: 260, height: 462), aspect: .story)
 
         XCTAssertLessThan(layout.scale, 0.7)
         XCTAssertLessThan(layout.scoreFontSize, 42)
         XCTAssertLessThan(layout.metricValueFontSize, 14)
+    }
+
+    func testShareCardLayoutReservesBottomMatteForStoryPreviewText() {
+        let layout = ShareCardLayout(size: CGSize(width: 260, height: 462), aspect: .story)
+
+        XCTAssertGreaterThan(layout.summaryMatteHeight, layout.size.height * 0.44)
+        XCTAssertLessThan(layout.visualTopOffset + layout.visualHeight, layout.size.height * 0.72)
     }
 
     func testSharePayloadUsesSameNearestAvatarBucketAsHomeHero() {

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -284,6 +284,9 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertLessThanOrEqual(hero.frame.maxX, windowFrame.maxX + 1)
 
         XCTAssertFalse(app.descendants(matching: .any)["photo_timeline_hud_stats_button"].exists)
+        let statsButton = app.buttons["Stats"]
+        XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
+        XCTAssertLessThan(statsButton.frame.midY, windowFrame.height * 0.18)
         attachScreenshot(named: "launch-quality-home-timeline", from: app)
     }
 
@@ -612,6 +615,8 @@ final class LogYourBodyUITests: XCTestCase {
         let windowFrame = app.windows.firstMatch.frame
         XCTAssertGreaterThan(cardFrame.width, windowFrame.width * 0.88)
         XCTAssertGreaterThan(cardFrame.height, cardFrame.width * 1.18)
+        XCTAssertGreaterThan(cardFrame.minY, windowFrame.minY + 72)
+        XCTAssertLessThanOrEqual(cardFrame.maxY, windowFrame.maxY - 72)
         attachScreenshot(named: "launch-quality-body-score-share", from: app)
     }
 
@@ -622,6 +627,7 @@ final class LogYourBodyUITests: XCTestCase {
 
         let statsButton = app.buttons["Stats"]
         XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
+        XCTAssertLessThan(statsButton.frame.midY, app.windows.firstMatch.frame.height * 0.18)
         statsButton.tap()
 
         let analyticsPage = app.descendants(matching: .any)["photo_timeline_root_page_analytics"]
@@ -640,6 +646,10 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(presenceSummary.waitForExistence(timeout: 5))
         XCTAssertTrue(presenceSummary.label.contains("Measured"))
         XCTAssertTrue(presenceSummary.label.contains("Interpolated"))
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_stats_metric_stack"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_stats_metric_card_weight"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_stats_metric_card_body_fat"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_stats_metric_card_ffmi"].exists)
         XCTAssertFalse(app.staticTexts["Timeline states"].exists)
         attachScreenshot(named: "launch-quality-analytics", from: app)
         XCTAssertFalse(app.descendants(matching: .any)["legacy_full_dashboard_beta"].exists)


### PR DESCRIPTION
## Summary

- JOV-3168: polish the iOS stats surface toward an Apple Health-style stacked metric screen without rebuilding the flow.
- Remove timeline/stats switching jank from the duplicated horizontal swipe gesture and harden launch-quality assertions that Stats is top nav, not a bottom card.
- Improve Body Score share preview/export layout: full-bleed visual image, tighter reserved bottom matte, compact metric fallback, and top-aligned preview.
- Improve metric card render stability by giving chart points stable identities and lazily rendering the metric stack.

## Validation

- `swiftlint lint --strict` from `apps/ios` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/BodyScoreShareCardTests` ✅ 9 passed
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesCriticalSurfaces` ✅ 1 passed
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyUITests/LogYourBodyUITests/testTimelinePerformanceTraceWorkflow` ✅ 1 passed
- `RUN_SWIFTLINT=false RUN_LAUNCH_PERFORMANCE=false RUN_TIMELINE_TRACE_WORKFLOW=true ARTIFACT_DIR=/tmp/lyb-performance-audit-20260615 bash scripts/ios/performance-audit.sh` ✅

## Performance Audit

`/tmp/lyb-performance-audit-20260615/summary.md`:

- Performance unit total: 0.026s / 2.000s budget ✅
- Slowest performance unit: 0.020s / 0.750s budget ✅
- Timeline trace workflow: 15.151s / 35.000s budget ✅
- Launch performance XCTest skipped in this local artifact run.

## Screenshot Evidence

Exported from passing launch-quality UI xcresult:

- `/tmp/lyb-ui-polish-attachments-final/408354D1-62F4-4D4D-BCB7-EE994E522727.png` home timeline
- `/tmp/lyb-ui-polish-attachments-final/66AA4F5D-B11D-452B-9741-21B0695C919D.png` stats surface
- `/tmp/lyb-ui-polish-attachments-final/57474B25-E85A-4986-B7FE-86C3F0E71D94.png` Body Score share preview
- `/tmp/lyb-ui-polish-attachments-final/BD6D977A-710A-4557-9CF5-CF8E9DC42F1F.png` onboarding fixed CTA
- `/tmp/lyb-ui-polish-attachments-final/1C719869-A631-45E6-BF01-940B177F76D3.png` first photo CTA

## Notes

- Existing local warnings remain: Node 22 is outside the repo's Node 20 engine, Next lint is deprecated, and some test fixtures intentionally log PDF/auth negative-path warnings.
- Existing Swift 6/deprecation warnings are outside this diff.
