### PR TITLE
JOV-3169: Polish metric detail timeline context

### DIFF
--- a/apps/ios/LogYourBody/Components/FullMetricChartView.swift
+++ b/apps/ios/LogYourBody/Components/FullMetricChartView.swift
@@ -46,10 +46,13 @@ enum TimeRange: String, CaseIterable {
 }
 
 struct MetricChartDataPoint: Identifiable, Sendable {
-    let id = UUID()
     let date: Date
     let value: Double
     let presence: MetricPresence
+
+    var id: String {
+        "\(date.timeIntervalSince1970)-\(value)-\(presence.rawValue)"
+    }
 
     var isEstimated: Bool {
         presence != .present
@@ -239,6 +242,14 @@ struct MetricEntriesPayload {
     let entries: [MetricHistoryEntry]
 }
 
+struct MetricDetailRelatedMetric: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let value: String
+    let caption: String
+    let systemImageName: String
+}
+
 func makeMetricFormatter(minFractionDigits: Int = 0, maxFractionDigits: Int = 1) -> NumberFormatter {
     MetricFormatterCache.formatter(minFractionDigits: minFractionDigits, maxFractionDigits: maxFractionDigits)
 }
@@ -272,10 +283,12 @@ struct FullMetricChartView: View {
     let chartData: [MetricChartDataPoint]
     let onAdd: () -> Void
     let metricEntries: MetricEntriesPayload?
+    let relatedMetrics: [MetricDetailRelatedMetric]
 
     let goalValue: Double?
 
     @Binding var selectedTimeRange: TimeRange
+    @Binding var selectedTimelineDate: Date?
     @State private var cachedSeries: [TimeRange: [MetricChartDataPoint]] = [:]
     @State private var isLoadingData = false
     @State private var lastFingerprint: String = ""
@@ -289,7 +302,39 @@ struct FullMetricChartView: View {
     @State private var historyEntryPendingDeletion: MetricHistoryEntry?
     @State private var showingHistoryDeleteConfirmation = false
 
-    private let chartHeight: CGFloat = 300
+    @ScaledMetric(relativeTo: .largeTitle) private var headlineValueFontSize: CGFloat = 56
+
+    private let chartHeight: CGFloat = 320
+
+    init(
+        title: String,
+        icon: String,
+        iconColor: Color,
+        currentValue: String,
+        unit: String,
+        currentDate: String,
+        chartData: [MetricChartDataPoint],
+        onAdd: @escaping () -> Void,
+        metricEntries: MetricEntriesPayload?,
+        relatedMetrics: [MetricDetailRelatedMetric] = [],
+        goalValue: Double?,
+        selectedTimeRange: Binding<TimeRange>,
+        selectedTimelineDate: Binding<Date?> = .constant(nil)
+    ) {
+        self.title = title
+        self.icon = icon
+        self.iconColor = iconColor
+        self.currentValue = currentValue
+        self.unit = unit
+        self.currentDate = currentDate
+        self.chartData = chartData
+        self.onAdd = onAdd
+        self.metricEntries = metricEntries
+        self.relatedMetrics = relatedMetrics
+        self.goalValue = goalValue
+        _selectedTimeRange = selectedTimeRange
+        _selectedTimelineDate = selectedTimelineDate
+    }
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -300,6 +345,7 @@ struct FullMetricChartView: View {
                     VStack(alignment: .leading, spacing: 20) {
                         headlineBlock
                         chartCard
+                        relatedMetricsRow
                         historyBlock
                     }
                     .padding(.horizontal, 16)
@@ -311,6 +357,7 @@ struct FullMetricChartView: View {
                 }
             }
         }
+        .accessibilityIdentifier("metric_detail_screen")
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(false)
@@ -361,71 +408,77 @@ struct FullMetricChartView: View {
     }
 
     private var headlineBlock: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(headlineValueText)
-                    .font(.system(size: 62, weight: .regular, design: .default))
-                    .foregroundColor(.white)
-                    .lineLimit(1)
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(iconColor)
+                    .frame(width: 30, height: 30)
+                    .background(
+                        Circle()
+                            .fill(iconColor.opacity(0.16))
+                    )
 
-                if !unit.isEmpty {
-                    Text(unit)
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(Color.metricTextSecondary)
-                }
+                Text("Latest")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(Color.metricTextSecondary)
             }
 
-            Text(headlineDateText)
-                .font(.system(size: 15, weight: .medium))
-                .foregroundColor(Color.white.opacity(0.65))
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(headlineValueText)
+                        .font(.system(size: headlineValueFontSize, weight: .semibold, design: .default))
+                        .foregroundColor(.white)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.58)
+                        .layoutPriority(2)
+                        .accessibilityIdentifier("metric_detail_headline")
+
+                    if !unit.isEmpty {
+                        Text(unit)
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundColor(Color.metricTextSecondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+                    }
+                }
+
+                Text(activePoint == nil ? "Updated \(headlineDateText)" : headlineDateText)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(Color.white.opacity(0.65))
+                    .lineLimit(1)
+            }
 
             if let stats = computeSeriesStats(for: displayedSeries) {
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(alignment: .top, spacing: 16) {
-                        statsCell(
-                            title: "Avg (\(selectedTimeRange.rawValue))",
-                            value: formatStatValue(stats.average),
-                            alignRight: false
-                        )
+                HStack(spacing: 10) {
+                    statsCell(
+                        title: "Average",
+                        value: formatStatValue(stats.average),
+                        caption: selectedTimeRange.rawValue
+                    )
 
-                        Spacer(minLength: 12)
-
-                        statsCell(
-                            title: changeCaptionText,
-                            value: formatDeltaValueCompact(stats.delta),
-                            valueColor: deltaColor(for: stats.delta),
-                            alignRight: true
-                        )
-                    }
-
-                    if let bounds = minMaxTexts(for: displayedSeries) {
-                        HStack(alignment: .top, spacing: 16) {
-                            statsCell(
-                                title: "Low",
-                                value: bounds.min,
-                                alignRight: false
-                            )
-
-                            Spacer(minLength: 12)
-
-                            statsCell(
-                                title: "High",
-                                value: bounds.max,
-                                alignRight: true
-                            )
-                        }
-                    }
+                    statsCell(
+                        title: "Change",
+                        value: formatDeltaValueCompact(stats.delta),
+                        caption: selectedTimeRange.rawValue,
+                        valueColor: deltaColor(for: stats.delta),
+                        alignRight: true
+                    )
                 }
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("metric_detail_headline_block")
     }
 
     @ViewBuilder
     private func statsCell(
         title: String,
         value: String,
+        caption: String,
         valueColor: Color = .white,
-        alignRight: Bool
+        alignRight: Bool = false
     ) -> some View {
         VStack(
             alignment: alignRight ? .trailing : .leading,
@@ -439,24 +492,18 @@ struct FullMetricChartView: View {
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundColor(valueColor)
                 .multilineTextAlignment(alignRight ? .trailing : .leading)
-        }
-    }
 
-    private var changeCaptionText: String {
-        switch selectedTimeRange {
-        case .week1:
-            return "Change vs 1 week ago"
-        case .month1:
-            return "Change vs 1 month ago"
-        case .month3:
-            return "Change vs 3 months ago"
-        case .month6:
-            return "Change vs 6 months ago"
-        case .year1:
-            return "Change vs 1 year ago"
-        case .all:
-            return "Change over time"
+            Text(caption)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(Color.metricTextTertiary)
         }
+        .frame(maxWidth: .infinity, alignment: alignRight ? .trailing : .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.white.opacity(0.06))
+        )
     }
 
     private func formatDeltaValueCompact(_ delta: Double) -> String {
@@ -540,16 +587,90 @@ struct FullMetricChartView: View {
                     .frame(height: chartHeight)
             }
         }
-        .padding(14)
+        .accessibilityIdentifier("metric_detail_chart")
+    }
+
+    @ViewBuilder
+    private var relatedMetricsRow: some View {
+        if !relatedMetrics.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Related")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(.white)
+
+                LazyVGrid(
+                    columns: [
+                        GridItem(.flexible(), spacing: 10),
+                        GridItem(.flexible(), spacing: 10)
+                    ],
+                    spacing: 10
+                ) {
+                    ForEach(relatedMetrics) { metric in
+                        relatedMetricTile(metric)
+                    }
+                }
+            }
+            .accessibilityIdentifier("metric_detail_related_metrics")
+        }
+    }
+
+    private func relatedMetricTile(_ metric: MetricDetailRelatedMetric) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: metric.systemImageName)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(relatedMetricAccent(for: metric.id))
+
+                Text(metric.title)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(Color.metricTextSecondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+            }
+
+            Text(metric.value)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(.white)
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+
+            Text(metric.caption)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(Color.metricTextTertiary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
         .background(
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color.metricCard)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white.opacity(0.065))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 20)
-                        .stroke(Color.metricCardBorder, lineWidth: 1)
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 1)
                 )
-                .shadow(color: Color.black.opacity(0.45), radius: 20, x: 0, y: 10)
         )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(metric.title), \(metric.value), \(metric.caption)")
+        .accessibilityIdentifier("metric_detail_related_metric_\(metric.id)")
+    }
+
+    private func relatedMetricAccent(for id: String) -> Color {
+        switch id {
+        case "steps":
+            return Color.metricAccentSteps
+        case "weight":
+            return Color.metricAccentWeight
+        case "body_fat":
+            return Color.metricAccentBodyFat
+        case "ffmi":
+            return Color.metricAccentFFMI
+        case "body_score":
+            return Color.metricAccent
+        default:
+            return Color.metricAccent
+        }
     }
 
     private var chartSkeleton: some View {
@@ -566,20 +687,18 @@ struct FullMetricChartView: View {
 
     private var chartHeader: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .center, spacing: 12) {
-                Text("Trend")
-                    .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(.white)
-
-                Spacer()
-
-                chartModeToggle
-            }
-
             timeRangeSelector
                 .fixedSize(horizontal: false, vertical: true)
 
-            chartPresenceLegend
+            HStack(alignment: .center, spacing: 12) {
+                chartModeToggle
+
+                Spacer()
+            }
+
+            if shouldShowPresenceLegend {
+                chartPresenceLegend
+            }
         }
     }
 
@@ -721,7 +840,7 @@ struct FullMetricChartView: View {
                     .foregroundStyle(Color.metricGridMajor.opacity(0.6))
             }
 
-            if let focus = activePoint {
+            if let focus = selectedFocusPoint {
                 RuleMark(x: .value("Selected", focus.date))
                     .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
                     .foregroundStyle(Color.white.opacity(0.4))
@@ -788,7 +907,10 @@ struct FullMetricChartView: View {
                                         isScrubbing = true
                                         HapticManager.shared.selection()
                                     }
-                                    activePoint = nearestPoint(to: date)
+                                    if let focus = nearestPoint(to: date) {
+                                        activePoint = focus
+                                        selectedTimelineDate = focus.date
+                                    }
                                 }
                             }
                             .onEnded { _ in
@@ -1109,22 +1231,37 @@ struct FullMetricChartView: View {
         }
     }
 
+    private var shouldShowPresenceLegend: Bool {
+        visiblePresenceLegendItems.contains { item in
+            item.presence != .present
+        }
+    }
+
     private var minSeriesValue: Double? {
         activeSeries.map(\.value).min()
     }
 
     private var headlineValueText: String {
-        if let point = activePoint {
+        if let point = selectedFocusPoint {
             return formatHeadlineValue(point.value)
         }
         return currentValue
     }
 
     private var headlineDateText: String {
-        if let point = activePoint {
+        if let point = selectedFocusPoint {
             return point.date.formatted(.dateTime.month().day().year())
         }
         return currentDate
+    }
+
+    private var selectedFocusPoint: MetricChartDataPoint? {
+        if let activePoint {
+            return activePoint
+        }
+
+        guard let selectedTimelineDate else { return nil }
+        return nearestPoint(to: selectedTimelineDate)
     }
 
     private var chartDataFingerprint: String {
@@ -1306,22 +1443,6 @@ struct FullMetricChartView: View {
             return Color.metricTextPrimary
         }
         return delta > 0 ? Color.metricDeltaPositive : Color.metricDeltaNegative
-    }
-
-    private func minMaxTexts(
-        for series: [MetricChartDataPoint]
-    ) -> (min: String, max: String)? {
-        guard
-            let minValue = series.map(\.value).min(),
-            let maxValue = series.map(\.value).max(),
-            minValue != maxValue
-        else {
-            return nil
-        }
-
-        let minText = formatStatValue(minValue)
-        let maxText = formatStatValue(maxValue)
-        return (min: minText, max: maxText)
     }
 
     @MainActor

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
@@ -6,6 +6,18 @@
 import SwiftUI
 
 extension DashboardViewLiquid {
+    var metricDetailSelectedDateBinding: Binding<Date?> {
+        Binding(
+            get: {
+                currentMetric?.date
+            },
+            set: { newDate in
+                guard let newDate else { return }
+                selectClosestMetric(to: newDate)
+            }
+        )
+    }
+
     var metricsView: some View {
         let stepsGoalText: String? = {
             let formatted = FormatterCache.stepsFormatter.string(from: NSNumber(value: stepGoal)) ?? "\(stepGoal)"
@@ -83,8 +95,10 @@ extension DashboardViewLiquid {
                     showAddEntrySheet = true
                 },
                 metricEntries: cachedMetricEntries(for: .steps),
+                relatedMetrics: metricDetailRelatedMetrics(excluding: .steps),
                 goalValue: Double(stepGoal),
-                selectedTimeRange: $selectedRange
+                selectedTimeRange: $selectedRange,
+                selectedTimelineDate: metricDetailSelectedDateBinding
             )
 
         case .weight:
@@ -100,8 +114,10 @@ extension DashboardViewLiquid {
                     showAddEntrySheet = true
                 },
                 metricEntries: cachedMetricEntries(for: .weight),
+                relatedMetrics: metricDetailRelatedMetrics(excluding: .weight),
                 goalValue: weightGoal,
-                selectedTimeRange: $selectedRange
+                selectedTimeRange: $selectedRange,
+                selectedTimelineDate: metricDetailSelectedDateBinding
             )
 
         case .bodyFat:
@@ -117,8 +133,10 @@ extension DashboardViewLiquid {
                     showAddEntrySheet = true
                 },
                 metricEntries: cachedMetricEntries(for: .bodyFat),
+                relatedMetrics: metricDetailRelatedMetrics(excluding: .bodyFat),
                 goalValue: bodyFatGoal,
-                selectedTimeRange: $selectedRange
+                selectedTimeRange: $selectedRange,
+                selectedTimelineDate: metricDetailSelectedDateBinding
             )
 
         case .ffmi:
@@ -134,8 +152,10 @@ extension DashboardViewLiquid {
                     showAddEntrySheet = true
                 },
                 metricEntries: cachedMetricEntries(for: .ffmi),
+                relatedMetrics: metricDetailRelatedMetrics(excluding: .ffmi),
                 goalValue: ffmiGoal,
-                selectedTimeRange: $selectedRange
+                selectedTimeRange: $selectedRange,
+                selectedTimelineDate: metricDetailSelectedDateBinding
             )
 
         case .bodyScore:
@@ -152,8 +172,10 @@ extension DashboardViewLiquid {
                     showAddEntrySheet = true
                 },
                 metricEntries: cachedMetricEntries(for: .bodyScore),
+                relatedMetrics: metricDetailRelatedMetrics(excluding: .bodyScore),
                 goalValue: nil,
-                selectedTimeRange: $selectedRange
+                selectedTimeRange: $selectedRange,
+                selectedTimelineDate: metricDetailSelectedDateBinding
             )
 
         case .glp1:
@@ -176,9 +198,87 @@ extension DashboardViewLiquid {
                     showAddEntrySheet = true
                 },
                 metricEntries: nil,
+                relatedMetrics: metricDetailRelatedMetrics(excluding: .glp1),
                 goalValue: nil,
-                selectedTimeRange: $selectedRange
+                selectedTimeRange: $selectedRange,
+                selectedTimelineDate: metricDetailSelectedDateBinding
             )
         }
+    }
+
+    func metricDetailRelatedMetrics(excluding selected: MetricType) -> [MetricDetailRelatedMetric] {
+        guard let currentMetric else { return [] }
+
+        var items: [MetricDetailRelatedMetric] = []
+
+        func append(
+            _ metricType: MetricType,
+            id: String,
+            title: String,
+            value: String,
+            caption: String,
+            systemImageName: String
+        ) {
+            guard metricType != selected else { return }
+            items.append(
+                MetricDetailRelatedMetric(
+                    id: id,
+                    title: title,
+                    value: value,
+                    caption: caption,
+                    systemImageName: systemImageName
+                )
+            )
+        }
+
+        let latestSteps = latestStepsSnapshot()
+        append(
+            .steps,
+            id: "steps",
+            title: "Steps",
+            value: formatSteps(latestSteps.value),
+            caption: formatCardDateOnly(latestSteps.date) ?? "No steps yet",
+            systemImageName: "flame.fill"
+        )
+
+        append(
+            .weight,
+            id: "weight",
+            title: "Weight",
+            value: "\(formatTrendWeightHeadline(currentMetric, usesTrend: weightUsesTrend)) \(weightUnit)",
+            caption: formatCardDate(currentMetric.date),
+            systemImageName: "figure.stand"
+        )
+
+        append(
+            .bodyFat,
+            id: "body_fat",
+            title: "Body Fat",
+            value: "\(formatBodyFatValue(currentMetric.bodyFatPercentage))%",
+            caption: formatCardDate(currentMetric.date),
+            systemImageName: "percent"
+        )
+
+        append(
+            .ffmi,
+            id: "ffmi",
+            title: "FFMI",
+            value: formatFFMIValue(currentMetric),
+            caption: formatCardDate(currentMetric.date),
+            systemImageName: "figure.arms.open"
+        )
+
+        if let bodyScore = bodyScoreResult(for: currentMetric) {
+            append(
+                .bodyScore,
+                id: "body_score",
+                title: "Body Score",
+                value: "\(bodyScore.score)",
+                caption: bodyScore.statusTagline,
+                systemImageName: "star.fill"
+            )
+        }
+
+        return items
     }
 }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -258,14 +258,12 @@ extension DashboardViewLiquid {
     }
 
     func selectClosestMetric(to date: Date) {
-        guard let match = bodyMetrics.enumerated().min(by: { lhs, rhs in
-            abs(lhs.element.date.timeIntervalSince(date)) < abs(rhs.element.date.timeIntervalSince(date))
-        }) else {
+        guard let index = nearestBodyMetricIndex(in: bodyMetrics, to: date) else {
             return
         }
 
-        selectedIndex = match.offset
-        updateAnimatedValues(for: match.offset)
+        selectedIndex = index
+        updateAnimatedValues(for: index)
     }
 
     func formatHUDDate(_ date: Date) -> String {
@@ -326,4 +324,10 @@ extension DashboardViewLiquid {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
+}
+
+func nearestBodyMetricIndex(in metrics: [BodyMetrics], to date: Date) -> Int? {
+    metrics.enumerated().min(by: { lhs, rhs in
+        abs(lhs.element.date.timeIntervalSince(date)) < abs(rhs.element.date.timeIntervalSince(date))
+    })?.offset
 }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -557,6 +557,16 @@ final class BodyScoreShareCardTests: XCTestCase {
         XCTAssertEqual(first.id, second.id)
     }
 
+    func testMetricChartDataPointIdentityIsStableAcrossRenders() {
+        let date = Date(timeIntervalSince1970: 1_771_000_000)
+        let first = MetricChartDataPoint(date: date, value: 181.2, presence: .present)
+        let second = MetricChartDataPoint(date: date, value: 181.2, presence: .present)
+        let interpolated = MetricChartDataPoint(date: date, value: 181.2, presence: .interpolated)
+
+        XCTAssertEqual(first.id, second.id)
+        XCTAssertNotEqual(first.id, interpolated.id)
+    }
+
     func testShareCardLayoutScalesDownForNarrowStoryPreview() {
         let layout = ShareCardLayout(size: CGSize(width: 260, height: 462), aspect: .story)
 
@@ -695,6 +705,34 @@ final class BodyScoreShareCardTests: XCTestCase {
 }
 
 final class DashboardTimelineProviderPerformanceTests: XCTestCase {
+    func testNearestBodyMetricIndexSelectsClosestTimelineDate() {
+        let calendar = Calendar(identifier: .gregorian)
+        let baseDate = calendar.date(from: DateComponents(year: 2_026, month: 6, day: 1))!
+        let metrics = [
+            makeMetric(id: "old", date: baseDate, weight: 181, bodyFat: 18.5),
+            makeMetric(
+                id: "middle",
+                date: calendar.date(byAdding: .day, value: 7, to: baseDate)!,
+                weight: 180,
+                bodyFat: 18.2
+            ),
+            makeMetric(
+                id: "new",
+                date: calendar.date(byAdding: .day, value: 14, to: baseDate)!,
+                weight: 179,
+                bodyFat: 18.0
+            )
+        ]
+
+        let scrubDate = calendar.date(byAdding: .day, value: 9, to: baseDate)!
+
+        XCTAssertEqual(nearestBodyMetricIndex(in: metrics, to: scrubDate), 1)
+    }
+
+    func testNearestBodyMetricIndexReturnsNilForEmptyTimeline() {
+        XCTAssertNil(nearestBodyMetricIndex(in: [], to: Date()))
+    }
+
     func testTimelineRenderSignatureTracksOnlyRenderInputs() {
         let baseDate = Date(timeIntervalSince1970: 1_800_000_000)
         let metric = makeMetric(

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -264,6 +264,48 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertFalse(app.descendants(matching: .any)["dashboard_home_timeline_photo_stage"].exists)
     }
 
+    func testMetricDetailOpensFromStatsAndShowsSharedTimelineContext() throws {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-lybUITestPhotoTimelineHUDFixture",
+            "-lybUITestPhaseInsightFixture"
+        ]
+        app.launch()
+
+        XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 12))
+
+        let statsButton = app.buttons["Stats"]
+        XCTAssertTrue(statsButton.waitForExistence(timeout: 5))
+        statsButton.tap()
+
+        let analyticsPage = app.descendants(matching: .any)["photo_timeline_root_page_analytics"]
+        XCTAssertTrue(analyticsPage.waitForExistence(timeout: 8))
+
+        let weightCard = app.descendants(matching: .any)["photo_timeline_stats_metric_card_weight"]
+        scrollUntilHittable(weightCard, in: app)
+        XCTAssertTrue(weightCard.waitForExistence(timeout: 8))
+        XCTAssertTrue(weightCard.isHittable)
+        weightCard.tap()
+
+        let detail = app.descendants(matching: .any)["metric_detail_screen"]
+        XCTAssertTrue(detail.waitForExistence(timeout: 8))
+        XCTAssertTrue(app.descendants(matching: .any)["metric_detail_headline"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.descendants(matching: .any)["metric_detail_chart"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.descendants(matching: .any)["metric_detail_related_metrics"].exists)
+        let relatedMetricIds = ["steps", "weight", "body_fat", "ffmi", "body_score"]
+        var visibleRelatedMetricCount = countVisibleRelatedMetrics(relatedMetricIds, in: app)
+        var remainingSwipes = 4
+        while visibleRelatedMetricCount < 2 && remainingSwipes > 0 {
+            swipeMetricDetailUp(in: app)
+            visibleRelatedMetricCount = countVisibleRelatedMetrics(relatedMetricIds, in: app)
+            remainingSwipes -= 1
+        }
+        XCTAssertGreaterThanOrEqual(visibleRelatedMetricCount, 2)
+        XCTAssertFalse(app.descendants(matching: .any)["metric_detail_chart_card"].exists)
+
+        attachScreenshot(named: "launch-quality-metric-detail", from: app)
+    }
+
     func testLaunchQualityGateCapturesTimelineHomeSurface() throws {
         let app = XCUIApplication()
         app.launchArguments = [
@@ -488,6 +530,20 @@ final class LogYourBodyUITests: XCTestCase {
             app.swipeUp()
             remainingSwipes -= 1
         }
+    }
+
+    private func countVisibleRelatedMetrics(_ ids: [String], in app: XCUIApplication) -> Int {
+        ids
+            .map { app.descendants(matching: .any)["metric_detail_related_metric_\($0)"] }
+            .filter(\.exists)
+            .count
+    }
+
+    private func swipeMetricDetailUp(in app: XCUIApplication) {
+        let window = app.windows.firstMatch
+        let start = window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.84))
+        let end = window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.36))
+        start.press(forDuration: 0.01, thenDragTo: end)
     }
 
     private func waitForTimelineRoot(in app: XCUIApplication, timeout: TimeInterval) -> Bool {


### PR DESCRIPTION
## Summary
- Simplifies the full-screen metric detail view so the current value, chart, and related metrics are the clear hierarchy.
- Links chart scrubbing back to the selected timeline date so the detail screen and dashboard context stay in sync.
- Adds related metric tiles plus stable chart point identity to reduce redraw churn.
- Adds unit and UI coverage for the metric detail route from Stats.

## Linear
- JOV-3169

## Validation
- git diff --check
- swiftlint lint --strict
- XcodeBuildMCP build_sim on LYB Golden iPhone 16
- XcodeBuildMCP test_sim: LogYourBodyTests/BodyScoreShareCardTests/testMetricChartDataPointIdentityIsStableAcrossRenders
- XcodeBuildMCP test_sim: LogYourBodyTests/DashboardTimelineProviderPerformanceTests/testNearestBodyMetricIndexSelectsClosestTimelineDate
- XcodeBuildMCP test_sim: LogYourBodyTests/DashboardTimelineProviderPerformanceTests/testNearestBodyMetricIndexReturnsNilForEmptyTimeline
- XcodeBuildMCP test_sim: LogYourBodyUITests/LogYourBodyUITests/testMetricDetailOpensFromStatsAndShowsSharedTimelineContext
- pnpm lint
- pnpm typecheck
- pnpm test

## UI Evidence
- UI test attached screenshot: launch-quality-metric-detail

## Notes
- Local root pnpm commands pass with the existing Node 20 engine warning under local Node 22.
- Left docs/audits/ux-redesign-20260615 untracked; it is not part of this PR.