### PR TITLE
Fix iOS timeline share quality

### DIFF
--- a/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
+++ b/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
@@ -2,8 +2,7 @@ import SwiftUI
 import UIKit
 import Photos
 
-struct BodyScoreSharePayload: Identifiable {
-    let id = UUID()
+struct BodyScoreSharePayload {
     let score: Int
     let scoreText: String
     let tagline: String
@@ -57,6 +56,25 @@ enum BodyScoreShareAspect: String, CaseIterable, Identifiable {
             return CGSize(width: 1_080, height: 1_920)
         }
     }
+
+    static func preferredExportAspect(for image: UIImage?) -> BodyScoreShareAspect {
+        guard let image,
+              image.size.width > 0,
+              image.size.height > 0 else {
+            return defaultExportAspect
+        }
+
+        let ratio = image.size.width / image.size.height
+        if ratio > 0.86 {
+            return .square
+        }
+
+        if ratio < 0.66 {
+            return .story
+        }
+
+        return .portrait
+    }
 }
 
 struct BodyScoreShareCardView: View {
@@ -105,7 +123,7 @@ struct BodyScoreShareCardView: View {
             if let photoImage = payload.photoImage {
                 Image(uiImage: photoImage)
                     .resizable()
-                    .scaledToFill()
+                    .scaledToFit()
                     .frame(width: layout.size.width, height: layout.size.height, alignment: .center)
                     .clipped()
                     .accessibilityLabel("Progress photo")
@@ -376,10 +394,10 @@ struct ShareCardLayout {
     var textVisualGap: CGFloat { max(10 * scale, size.height * 0.018) }
 
     var estimatedSummaryContentHeight: CGFloat {
-        let scoreLabelStack = scoreLabelFontSize + taglineFontSize * 2.2 + deltaFontSize + scoreLabelSpacing * 3
+        let scoreLabelStack = scoreLabelFontSize + taglineFontSize * 2.6 + deltaFontSize + scoreLabelSpacing * 3
         let scoreRow = max(scoreFontSize * 1.02, scoreLabelStack)
         let metricRow = metricTitleFontSize + metricValueFontSize + metricCaptionFontSize + metricTextSpacing * 2
-        return scoreRow + summarySpacing + metricRow + summarySpacing + footerFontSize
+        return scoreRow + summarySpacing + metricRow * 1.12 + summarySpacing + footerFontSize * 1.2
     }
 
     var summaryTopY: CGFloat {
@@ -398,14 +416,17 @@ struct ShareCardLayout {
     }
 
     var summaryMatteHeight: CGFloat {
+        let minimumHeight = size.height - summaryTopY + bottomPadding
+        let baseHeight: CGFloat
         switch aspect {
         case .square:
-            return size.height * 0.60
+            baseHeight = size.height * 0.60
         case .portrait:
-            return size.height * 0.54
+            baseHeight = size.height * 0.54
         case .story:
-            return size.height * 0.46
+            baseHeight = size.height * 0.46
         }
+        return max(baseHeight, minimumHeight)
     }
 
     var bottomOverlayHeight: CGFloat {
@@ -426,7 +447,7 @@ struct BodyScoreShareSheet: View {
     let payload: BodyScoreSharePayload
     let onClose: (() -> Void)?
 
-    @State private var selectedAspect: BodyScoreShareAspect = .defaultExportAspect
+    @State private var selectedAspect: BodyScoreShareAspect
     @State private var renderedImage: UIImage?
     @State private var isRendering = false
     @State private var showSystemShareSheet = false
@@ -434,6 +455,7 @@ struct BodyScoreShareSheet: View {
     init(payload: BodyScoreSharePayload, onClose: (() -> Void)? = nil) {
         self.payload = payload
         self.onClose = onClose
+        _selectedAspect = State(initialValue: BodyScoreShareAspect.preferredExportAspect(for: payload.photoImage))
     }
 
     var body: some View {

--- a/apps/ios/LogYourBody/Components/DashboardMetricsList.swift
+++ b/apps/ios/LogYourBody/Components/DashboardMetricsList.swift
@@ -5,6 +5,8 @@ import UIKit
 struct DashboardMetricsList<CardContent: View>: View {
     typealias MetricIdentifier = DashboardViewLiquid.MetricIdentifier
 
+    @Environment(\.theme) private var theme
+
     @Binding var metricsOrder: [MetricIdentifier]
     @Binding var draggedMetric: MetricIdentifier?
     @Binding var dropTargetMetric: MetricIdentifier?
@@ -30,10 +32,10 @@ struct DashboardMetricsList<CardContent: View>: View {
             ForEach(metricsOrder) { metricId in
                 cardContent(metricId)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 22, style: .continuous)
+                        RoundedRectangle(cornerRadius: theme.radius.card, style: .continuous)
                             .stroke(
                                 (draggedMetric == metricId || dropTargetMetric == metricId) ?
-                                    Color.metricAccent.opacity(draggedMetric == metricId ? 0.9 : 0.6) :
+                                    theme.colors.primary.opacity(draggedMetric == metricId ? 0.9 : 0.6) :
                                     Color.clear,
                                 lineWidth: draggedMetric == metricId ? 2 : (dropTargetMetric == metricId ? 1.5 : 0)
                             )
@@ -41,7 +43,7 @@ struct DashboardMetricsList<CardContent: View>: View {
                     .scaleEffect(draggedMetric == metricId ? 1.03 : 1.0)
                     .opacity(1.0)
                     .shadow(
-                        color: draggedMetric == metricId ? Color.black.opacity(0.45) : Color.clear,
+                        color: draggedMetric == metricId ? theme.colors.background.opacity(0.45) : Color.clear,
                         radius: draggedMetric == metricId ? 18 : 0,
                         x: 0,
                         y: draggedMetric == metricId ? 10 : 0

--- a/apps/ios/LogYourBody/Components/LiquidGlassTimelineSlider.swift
+++ b/apps/ios/LogYourBody/Components/LiquidGlassTimelineSlider.swift
@@ -33,6 +33,10 @@ struct LiquidGlassTimelineSlider: View {
         !photoMetrics.isEmpty
     }
 
+    private var photoAnchorTicks: [TimelineTick] {
+        ticks.filter { $0.isPhotoAnchor }
+    }
+
     var body: some View {
         VStack(spacing: 16) {
             // Photo navigation with glass effect
@@ -100,7 +104,7 @@ struct LiquidGlassTimelineSlider: View {
                     )
 
                     // Photo thumbnails with glass effect
-                    ForEach(ticks.filter({ $0.isPhotoAnchor }), id: \.index) { tick in
+                    ForEach(photoAnchorTicks, id: \.index) { tick in
                         let tickProgress = Double(tick.index) / Double(metrics.count - 1)
                         let xPosition = geometry.size.width * CGFloat(tickProgress)
 

--- a/apps/ios/LogYourBody/Components/PhotoAnchoredTimelineSlider.swift
+++ b/apps/ios/LogYourBody/Components/PhotoAnchoredTimelineSlider.swift
@@ -446,6 +446,10 @@ struct PhotoAnchoredTimelineSlider: View {
 
             // Timeline slider with enhanced polish
             GeometryReader { geometry in
+                let photoTicks = calculateSmartTicks().filter { $0.hasPhoto }
+                let milestoneNotches = getMilestoneNotches()
+                let visibleMilestoneLabels = getVisibleMilestoneLabels(in: geometry.size.width)
+
                 ZStack(alignment: .leading) {
                     // Background track
                     RoundedRectangle(cornerRadius: 2)
@@ -462,13 +466,13 @@ struct PhotoAnchoredTimelineSlider: View {
                 .frame(height: 20, alignment: .center)
 
                 // Photo thumbnails only (no tick lines)
-                ForEach(calculateSmartTicks().filter { $0.hasPhoto }, id: \.index) { tick in
+                ForEach(photoTicks, id: \.index) { tick in
                     PhotoThumbnailTick(photoUrl: tick.photoUrl, isSelected: tick.index == selectedIndex)
                         .position(x: tick.position * geometry.size.width, y: 10)
                 }
 
                 // Milestone notches with varying heights
-                ForEach(getMilestoneNotches(), id: \.index) { milestone in
+                ForEach(milestoneNotches, id: \.index) { milestone in
                     Rectangle()
                         .fill(Color.white.opacity(milestone.importance == .yearly ? 0.6 : 0.4))
                         .frame(
@@ -479,7 +483,7 @@ struct PhotoAnchoredTimelineSlider: View {
                 }
 
                 // Milestone labels with collision detection
-                ForEach(getVisibleMilestoneLabels(in: geometry.size.width), id: \.index) { milestone in
+                ForEach(visibleMilestoneLabels, id: \.index) { milestone in
                     Text(milestone.displayLabel)
                         .font(.system(size: 10, weight: .medium))
                         .foregroundColor(.white.opacity(0.70))

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/MetricSummaryCard.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/MetricSummaryCard.swift
@@ -104,10 +104,10 @@ public struct MetricSummaryCard: View {
         self.isButtonContext = isButtonContext
     }
 
-    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.theme) private var theme
 
     @ScaledMetric(relativeTo: .largeTitle) private var valueFontSize: CGFloat = 44
     @ScaledMetric(relativeTo: .title3) private var unitFontSize: CGFloat = 18
@@ -116,42 +116,34 @@ public struct MetricSummaryCard: View {
 
     private let horizontalPadding: CGFloat = 16
     private let verticalPadding: CGFloat = 11
-    private let cardCornerRadius: CGFloat = 20
 
     private var isAccessibilityCategory: Bool {
         dynamicTypeSize >= .accessibility1
     }
 
     public var body: some View {
-        let shape = RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
+        let shape = RoundedRectangle(cornerRadius: theme.radius.card, style: .continuous)
 
-        return ZStack {
-            // Solid background layer
-            shape
-                .fill(cardBackgroundColor)
+        return VStack(alignment: .leading, spacing: 0) {
+            header
+                .padding(.horizontal, horizontalPadding)
+                .padding(.top, verticalPadding + 2)
 
-            // Optional material overlay for subtle softness (reduced for flatter look)
-            if !reduceTransparency {
-                shape
-                    .fill(.ultraThinMaterial.opacity(0.35))
-            }
-
-            // Border and soft shadow (Apple Health-style, low contrast)
-            shape
-                .strokeBorder(borderColor, lineWidth: 1)
-                .shadow(color: shadowColor, radius: 6, x: 0, y: 4)
-
-            VStack(alignment: .leading, spacing: 0) {
-                header
-                    .padding(.horizontal, horizontalPadding)
-                    .padding(.top, verticalPadding + 2)
-
-                stateView
-                    .padding(.horizontal, horizontalPadding)
-                    .padding(.top, verticalPadding)
-                    .padding(.bottom, verticalPadding)
-            }
+            stateView
+                .padding(.horizontal, horizontalPadding)
+                .padding(.top, verticalPadding)
+                .padding(.bottom, verticalPadding)
         }
+        .systemBGlassSurface(
+            cornerRadius: theme.radius.card,
+            tint: theme.colors.text,
+            tintOpacity: reduceTransparency ? 0 : 0.025,
+            borderColor: theme.colors.border,
+            borderOpacity: 0.85,
+            shadowOpacity: 0.18,
+            shadowRadius: 6,
+            shadowY: 4
+        )
         .contentShape(shape)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
@@ -256,9 +248,7 @@ public struct MetricSummaryCard: View {
             if let footnote = content.footnote, !footnote.isEmpty {
                 Text(footnote)
                     .font(.system(.footnote, design: .rounded))
-                    .foregroundStyle(
-                        colorScheme == .dark ? Color.metricTextSecondary : secondaryTextColor
-                    )
+                    .foregroundStyle(secondaryTextColor)
                     .lineLimit(2)
                     .minimumScaleFactor(0.85)
                     .fixedSize(horizontal: false, vertical: true)
@@ -306,14 +296,14 @@ public struct MetricSummaryCard: View {
                 if let caption = trend.caption, !caption.isEmpty {
                     Text("· \(caption)")
                         .font(.system(size: 12, weight: .medium, design: .rounded))
-                        .foregroundStyle(Color.metricTextSecondary)
+                        .foregroundStyle(secondaryTextColor)
                 }
             }
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .background(trendBackground(for: trend.direction))
-        .cornerRadius(cardCornerRadius)
+        .cornerRadius(theme.radius.full)
         .foregroundStyle(trendForeground(for: trend.direction))
     }
 
@@ -322,7 +312,7 @@ public struct MetricSummaryCard: View {
     }
 
     private func chart(for content: Content) -> some View {
-        let lineColor = Color.metricChartLine
+        let lineColor = accentColor
         let isSteps = isStepsContent(content)
         let minPoint = content.dataPoints.min(by: { $0.value < $1.value })
         let maxPoint = content.dataPoints.max(by: { $0.value < $1.value })
@@ -417,7 +407,7 @@ public struct MetricSummaryCard: View {
             HStack(spacing: 12) {
                 Image(systemName: iconName)
                     .font(.system(size: 18, weight: .semibold))
-                    .foregroundStyle(isError ? Color.red : accentColor)
+                    .foregroundStyle(isError ? theme.colors.error : accentColor)
 
                 Text(message)
                     .font(.system(.body, design: .rounded))
@@ -435,7 +425,7 @@ public struct MetricSummaryCard: View {
                         .cornerRadius(14)
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(isError ? Color.red : accentColor)
+                .foregroundStyle(isError ? theme.colors.error : accentColor)
                 .accessibilityHint(isError ? "Retry" : "Add data")
             }
         }
@@ -468,29 +458,16 @@ public struct MetricSummaryCard: View {
         }
     }
 
-    private var cardBackgroundColor: Color {
-        colorScheme == .dark ? Color.metricCard : Color.linearCard
-    }
-
-    private var borderColor: Color {
-        // Increased opacity for better card definition
-        colorScheme == .dark ? Color.metricCardBorder.opacity(0.6) : Color.black.opacity(0.10)
-    }
-
-    private var shadowColor: Color {
-        colorScheme == .dark ? Color.black.opacity(0.3) : Color.black.opacity(0.12)
-    }
-
     private var primaryTextColor: Color {
-        colorScheme == .dark ? Color.metricTextPrimary : Color.appText
+        theme.colors.text
     }
 
     private var secondaryTextColor: Color {
-        colorScheme == .dark ? Color.metricTextSecondary : Color.appTextSecondary
+        theme.colors.textSecondary
     }
 
     private var placeholderColor: Color {
-        colorScheme == .dark ? Color.white.opacity(0.12) : Color.black.opacity(0.08)
+        theme.colors.text.opacity(0.12)
     }
 
     private func trendIcon(for direction: Trend.Direction) -> String {
@@ -504,9 +481,9 @@ public struct MetricSummaryCard: View {
     private func trendBackground(for direction: Trend.Direction) -> Color {
         switch direction {
         case .up:
-            return Color.metricDeltaPositive.opacity(0.15)
+            return theme.colors.success.opacity(0.15)
         case .down:
-            return Color.metricDeltaNegative.opacity(0.15)
+            return theme.colors.error.opacity(0.15)
         case .flat:
             return secondaryTextColor.opacity(0.15)
         }
@@ -515,9 +492,9 @@ public struct MetricSummaryCard: View {
     private func trendForeground(for direction: Trend.Direction) -> Color {
         switch direction {
         case .up:
-            return Color.metricDeltaPositive
+            return theme.colors.success
         case .down:
-            return Color.metricDeltaNegative
+            return theme.colors.error
         case .flat:
             return secondaryTextColor
         }
@@ -525,9 +502,9 @@ public struct MetricSummaryCard: View {
 
     private func actionBackground(isError: Bool) -> some ShapeStyle {
         if reduceTransparency {
-            return AnyShapeStyle((isError ? Color.red : accentColor).opacity(0.12))
+            return AnyShapeStyle((isError ? theme.colors.error : accentColor).opacity(0.12))
         }
-        return AnyShapeStyle((isError ? Color.red : accentColor).opacity(0.08))
+        return AnyShapeStyle((isError ? theme.colors.error : accentColor).opacity(0.08))
     }
 
     private var accessibilityLabel: String {
@@ -640,5 +617,5 @@ struct MetricCardButtonStyle: ButtonStyle {
         }
         .padding(24)
     }
-    .background(Color.appBackground)
+    .background(DefaultTheme().colors.background)
 }

--- a/apps/ios/LogYourBody/DesignSystem/Theme.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Theme.swift
@@ -366,6 +366,8 @@ struct SurfaceStyleModifier: ViewModifier {
 private struct SystemBGlassSurfaceModifier: ViewModifier {
     @Environment(\.theme)
     private var theme
+    @Environment(\.accessibilityReduceTransparency)
+    private var reduceTransparency
 
     let cornerRadius: CGFloat?
     let tint: Color
@@ -383,12 +385,18 @@ private struct SystemBGlassSurfaceModifier: ViewModifier {
 
         content
             .background(
-                shape
-                    .fill(theme.materials.glassUltraThin)
-                    .overlay(
+                Group {
+                    if reduceTransparency {
+                        shape.fill(theme.colors.surface)
+                    } else {
                         shape
-                            .fill(tint.opacity(tintOpacity))
-                    )
+                            .fill(theme.materials.glassUltraThin)
+                            .overlay(
+                                shape
+                                    .fill(tint.opacity(tintOpacity))
+                            )
+                    }
+                }
             )
             .overlay(
                 shape
@@ -398,7 +406,7 @@ private struct SystemBGlassSurfaceModifier: ViewModifier {
                     )
             )
             .shadow(
-                color: Color.black.opacity(shadowOpacity),
+                color: theme.colors.background.opacity(shadowOpacity),
                 radius: shadowRadius,
                 x: 0,
                 y: shadowY

--- a/apps/ios/LogYourBody/Views/DashboardMetricsSection.swift
+++ b/apps/ios/LogYourBody/Views/DashboardMetricsSection.swift
@@ -5,6 +5,8 @@ import SwiftUI
 struct DashboardMetricsSection: View {
     typealias MetricIdentifier = DashboardViewLiquid.MetricIdentifier
 
+    @Environment(\.theme) private var theme
+
     @Binding var metricsOrder: [MetricIdentifier]
     @Binding var draggedMetric: MetricIdentifier?
     let onReorder: () -> Void
@@ -89,7 +91,7 @@ struct DashboardMetricsSection: View {
 
             MetricSummaryCard(
                 icon: "flame.fill",
-                accentColor: Color.metricAccentSteps,
+                accentColor: theme.colors.accentOrange,
                 state: .data(MetricSummaryCard.Content(
                     title: "Steps",
                     value: formatSteps(latestSteps.value),
@@ -121,7 +123,7 @@ struct DashboardMetricsSection: View {
             } label: {
                 MetricSummaryCard(
                     icon: "figure.stand",
-                    accentColor: Color.metricAccentWeight,
+                    accentColor: theme.colors.accentViolet,
                     state: .data(MetricSummaryCard.Content(
                         title: "Weight",
                         value: formatTrendWeightHeadline(currentMetric, weightUsesTrend),
@@ -154,7 +156,7 @@ struct DashboardMetricsSection: View {
             } label: {
                 MetricSummaryCard(
                     icon: "percent",
-                    accentColor: Color.metricAccentBodyFat,
+                    accentColor: theme.colors.accentPink,
                     state: .data(MetricSummaryCard.Content(
                         title: "Body Fat %",
                         value: formatBodyFatValue(currentMetric.bodyFatPercentage),
@@ -187,7 +189,7 @@ struct DashboardMetricsSection: View {
             } label: {
                 MetricSummaryCard(
                     icon: "figure.arms.open",
-                    accentColor: Color.metricAccentFFMI,
+                    accentColor: theme.colors.accentTeal,
                     state: .data(MetricSummaryCard.Content(
                         title: "FFMI",
                         value: formatFFMIValue(currentMetric),

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -38,6 +38,8 @@ struct DashboardEmptyStateLiquid: View {
 }
 
 struct DashboardHomeTimelineHero: View {
+    @Environment(\.theme) private var theme
+
     let metric: BodyMetrics
     let bodyMetrics: [BodyMetrics]
     @Binding var selectedIndex: Int
@@ -102,7 +104,7 @@ struct DashboardHomeTimelineHero: View {
             }
             .aspectRatio(4.0 / 5.0, contentMode: .fit)
             .frame(maxWidth: .infinity)
-            .background(shouldShowPhoto ? Color.black : Color.clear)
+            .background(theme.colors.background)
             .clipped()
             .overlay(alignment: .top) {
                 timelineDateBar
@@ -121,9 +123,9 @@ struct DashboardHomeTimelineHero: View {
     private var timelineGradient: some View {
         LinearGradient(
             colors: [
-                Color.black.opacity(0.62),
-                Color.black.opacity(0.05),
-                Color.black.opacity(0.86)
+                theme.colors.background.opacity(0.62),
+                theme.colors.background.opacity(0.05),
+                theme.colors.background.opacity(0.86)
             ],
             startPoint: .top,
             endPoint: .bottom
@@ -134,10 +136,10 @@ struct DashboardHomeTimelineHero: View {
         HStack(spacing: 10) {
             Text(dateText)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(.white)
+                .foregroundColor(theme.colors.text)
                 .padding(.horizontal, 11)
                 .padding(.vertical, 7)
-                .background(Capsule().fill(Color.black.opacity(0.42)))
+                .background(Capsule().fill(theme.colors.background.opacity(0.42)))
                 .allowsHitTesting(false)
 
             Spacer(minLength: 0)
@@ -148,9 +150,9 @@ struct DashboardHomeTimelineHero: View {
                 } label: {
                     Image(systemName: "square.and.arrow.up")
                         .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(.white)
+                        .foregroundColor(theme.colors.text)
                         .frame(width: 32, height: 32)
-                        .background(Circle().fill(Color.black.opacity(0.42)))
+                        .background(Circle().fill(theme.colors.background.opacity(0.42)))
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Share Body Score")
@@ -160,10 +162,10 @@ struct DashboardHomeTimelineHero: View {
             Text(timelinePositionText)
                 .font(.system(size: 12, weight: .semibold))
                 .monospacedDigit()
-                .foregroundColor(Color.white.opacity(0.72))
+                .foregroundColor(theme.colors.textSecondary)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 6)
-                .background(Capsule().fill(Color.black.opacity(0.34)))
+                .background(Capsule().fill(theme.colors.background.opacity(0.34)))
                 .allowsHitTesting(false)
         }
     }
@@ -177,7 +179,7 @@ struct DashboardHomeTimelineHero: View {
                     title: "Weight",
                     value: weightValue,
                     caption: weightCaption,
-                    color: Color.metricAccentWeight,
+                    color: theme.colors.accentViolet,
                     action: onTapWeight
                 )
 
@@ -187,7 +189,7 @@ struct DashboardHomeTimelineHero: View {
                     title: "Body Fat",
                     value: bodyFatValue,
                     caption: bodyFatCaption,
-                    color: Color.metricAccentBodyFat,
+                    color: theme.colors.accentPink,
                     action: onTapBodyFat
                 )
 
@@ -197,7 +199,7 @@ struct DashboardHomeTimelineHero: View {
                     title: "FFMI",
                     value: ffmiValue,
                     caption: ffmiCaption,
-                    color: Color.metricAccentFFMI,
+                    color: theme.colors.accentTeal,
                     action: onTapFFMI
                 )
             }
@@ -221,26 +223,26 @@ struct DashboardHomeTimelineHero: View {
             Text(bodyScoreText)
                 .font(.system(size: 50, weight: .bold, design: .rounded))
                 .monospacedDigit()
-                .foregroundColor(.white)
+                .foregroundColor(theme.colors.text)
                 .lineLimit(1)
                 .minimumScaleFactor(0.68)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("Body Score")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundColor(Color.white.opacity(0.66))
+                    .foregroundColor(theme.colors.textSecondary)
                     .textCase(.uppercase)
 
                 Text(bodyScoreTagline)
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(Color.white.opacity(0.86))
+                    .foregroundColor(theme.colors.text)
                     .lineLimit(1)
                     .minimumScaleFactor(0.72)
 
                 if let bodyScoreDeltaText {
                     Text(bodyScoreDeltaText)
                         .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(Color.white.opacity(0.62))
+                        .foregroundColor(theme.colors.textSecondary)
                         .lineLimit(1)
                         .minimumScaleFactor(0.78)
                 }
@@ -255,13 +257,15 @@ struct DashboardHomeTimelineHero: View {
 
     private var metricDivider: some View {
         Rectangle()
-            .fill(Color.white.opacity(0.16))
+            .fill(theme.colors.border)
             .frame(width: 1, height: 44)
             .padding(.horizontal, 10)
     }
 }
 
 private struct DashboardHomeTimelineMetricButton: View {
+    @Environment(\.theme) private var theme
+
     let title: String
     let value: String
     let caption: String
@@ -278,19 +282,19 @@ private struct DashboardHomeTimelineMetricButton: View {
 
                 Text(title)
                     .font(.system(size: 11, weight: .bold))
-                    .foregroundColor(Color.white.opacity(0.62))
+                    .foregroundColor(theme.colors.textSecondary)
                     .lineLimit(1)
 
                 Text(value)
                     .font(.system(size: 22, weight: .bold, design: .rounded))
                     .monospacedDigit()
-                    .foregroundColor(.white)
+                    .foregroundColor(theme.colors.text)
                     .lineLimit(1)
                     .minimumScaleFactor(0.68)
 
                 Text(caption)
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(Color.white.opacity(0.58))
+                    .foregroundColor(theme.colors.textTertiary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.72)
             }
@@ -322,9 +326,9 @@ private struct DashboardHomeTimelineAvatarPlaceholder: View {
                 bodyFatPercentage: bodyFatPercentage,
                 gender: gender,
                 height: geometry.size.height,
-                padding: 18,
-                verticalPadding: 10,
-                horizontalFillScale: 1,
+                padding: 0,
+                verticalPadding: 0,
+                horizontalFillScale: 1.08,
                 alignment: .bottom,
                 renderMode: .fillWidth
             )
@@ -339,6 +343,8 @@ private struct DashboardHomeTimelineAvatarPlaceholder: View {
 // MARK: - Home / Photos / Metrics Tabs
 
 struct DashboardHomeTab<Header: View, SyncBanner: View, MetricContent: View, QuickActions: View>: View {
+    @Environment(\.theme) private var theme
+
     let header: (CGFloat) -> Header
     let syncBanner: () -> SyncBanner
     let metricContent: () -> MetricContent
@@ -411,17 +417,17 @@ struct DashboardHomeTab<Header: View, SyncBanner: View, MetricContent: View, Qui
                 }
             )
             .background(
-                Color.black.opacity(0.9)
+                theme.colors.background.opacity(0.9)
                     .ignoresSafeArea(edges: .top)
                     .overlay(
                         Rectangle()
-                            .fill(.ultraThinMaterial)
+                            .fill(theme.materials.glassUltraThin)
                             .opacity(0.2 * scrollProgress)
                             .ignoresSafeArea(edges: .top)
                     )
             )
             .shadow(
-                color: Color.black.opacity(0.18 * scrollProgress),
+                color: theme.colors.background.opacity(0.18 * scrollProgress),
                 radius: 18,
                 x: 0,
                 y: 10
@@ -511,6 +517,8 @@ struct DashboardMetricsTab<Header: View, SyncBanner: View, TitleBlock: View, Met
 // MARK: - Steps Card
 
 struct DashboardStepsCard<ProgressView: View>: View {
+    @Environment(\.theme) private var theme
+
     let formattedSteps: String
     let formattedGoal: String
     let subtext: String
@@ -519,7 +527,7 @@ struct DashboardStepsCard<ProgressView: View>: View {
 
     var body: some View {
         LiquidGlassCard(
-            cornerRadius: 24,
+            cornerRadius: theme.radius.card,
             blurRadius: 20,
             padding: 14,
             showShadow: false,
@@ -545,16 +553,16 @@ struct DashboardStepsCard<ProgressView: View>: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Steps")
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(Color.white.opacity(0.7))
+                .foregroundColor(theme.colors.textSecondary)
 
             HStack(alignment: .firstTextBaseline, spacing: 6) {
                 Text(formattedSteps)
                     .font(.system(size: 26, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white)
+                    .foregroundColor(theme.colors.text)
 
                 Text("/" + formattedGoal)
                     .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(Color.white.opacity(0.65))
+                    .foregroundColor(theme.colors.textSecondary)
 
                 Spacer()
             }
@@ -564,7 +572,7 @@ struct DashboardStepsCard<ProgressView: View>: View {
 
             Text(subtext)
                 .font(.system(size: 12, weight: .medium))
-                .foregroundColor(Color.white.opacity(0.65))
+                .foregroundColor(theme.colors.textSecondary)
         }
     }
 }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Glp1MetricCard.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Glp1MetricCard.swift
@@ -23,7 +23,7 @@ extension DashboardViewLiquid {
             } label: {
                 MetricSummaryCard(
                     icon: "syringe",
-                    accentColor: Color.metricAccent,
+                    accentColor: theme.colors.primary,
                     state: .data(
                         MetricSummaryCard.Content(
                             title: "GLP-1 Dose",

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
@@ -426,7 +426,7 @@ extension DashboardViewLiquid {
             Text("Steps progress")
         }
         .gaugeStyle(.accessoryLinearCapacity)
-        .tint(Color.metricAccentSteps)
+        .tint(theme.colors.accentOrange)
         .labelsHidden()
         .accessibilityHidden(true)
     }
@@ -446,7 +446,7 @@ extension DashboardViewLiquid {
             Text(String(format: "Target %.1f%%", goal))
         }
         .gaugeStyle(.accessoryLinearCapacity)
-        .tint(Color.metricAccentBodyFat)
+        .tint(theme.colors.accentPink)
         .labelsHidden()
         .accessibilityLabel("Body fat \(String(format: "%.1f%%", current)), target \(String(format: "%.1f%%", goal))")
     }
@@ -469,7 +469,7 @@ extension DashboardViewLiquid {
                     Text(String(format: "Target %.1f %@", goal, unit))
                 }
                 .gaugeStyle(.accessoryLinearCapacity)
-                .tint(Color.metricAccentWeight)
+                .tint(theme.colors.accentViolet)
                 .labelsHidden()
                 .accessibilityLabel(
                     "Weight \(String(format: "%.1f %@", current, unit)), target \(String(format: "%.1f %@", goal, unit))"
@@ -481,11 +481,11 @@ extension DashboardViewLiquid {
                 HStack(spacing: 4) {
                     Image(systemName: "hand.tap.fill")
                         .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(Color.liquidTextPrimary.opacity(0.40))
+                        .foregroundColor(theme.colors.textQuaternary)
 
                     Text("Tap to set")
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(Color.liquidTextPrimary.opacity(0.40))
+                        .foregroundColor(theme.colors.textQuaternary)
                 }
                 .frame(maxWidth: .infinity, minHeight: 8, alignment: .leading)
             )
@@ -584,7 +584,7 @@ extension DashboardViewLiquid {
 
     var visualDivider: some View {
         Rectangle()
-            .fill(Color.liquidTextPrimary.opacity(0.15))
+            .fill(theme.colors.border)
             .frame(height: 1)
     }
 }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HomeTimelineControls.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HomeTimelineControls.swift
@@ -31,13 +31,12 @@ extension DashboardViewLiquid {
             }
         }
         .padding(4)
-        .background(
-            Capsule(style: .continuous)
-                .fill(Color.white.opacity(0.08))
-        )
-        .overlay(
-            Capsule(style: .continuous)
-                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+        .systemBGlassSurface(
+            cornerRadius: theme.radius.full,
+            tint: theme.colors.text,
+            tintOpacity: 0.025,
+            borderColor: theme.colors.border,
+            borderOpacity: 0.85
         )
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("home_mode_switch")
@@ -56,10 +55,10 @@ extension DashboardViewLiquid {
                 .minimumScaleFactor(0.8)
                 .frame(maxWidth: .infinity)
                 .frame(height: 34)
-                .foregroundColor(isSelected ? .black : Color.white.opacity(0.72))
+                .foregroundColor(isSelected ? theme.colors.background : theme.colors.textSecondary)
                 .background(
                     Capsule(style: .continuous)
-                        .fill(isSelected ? Color.white : Color.clear)
+                        .fill(isSelected ? theme.colors.text : Color.clear)
                 )
         }
         .buttonStyle(.plain)

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
@@ -86,7 +86,7 @@ extension DashboardViewLiquid {
             FullMetricChartView(
                 title: "Steps",
                 icon: "flame.fill",
-                iconColor: Color.metricAccentSteps,
+                iconColor: theme.colors.accentOrange,
                 currentValue: formatSteps(dailyMetrics?.steps),
                 unit: "steps",
                 currentDate: formatDate(dailyMetrics?.updatedAt ?? Date()),
@@ -105,7 +105,7 @@ extension DashboardViewLiquid {
             FullMetricChartView(
                 title: "Weight",
                 icon: "figure.stand",
-                iconColor: Color.metricAccentWeight,
+                iconColor: theme.colors.accentViolet,
                 currentValue: currentMetric.flatMap { formatWeightValue($0.weight) } ?? "–",
                 unit: weightUnit,
                 currentDate: formatDate(currentMetric?.date ?? Date()),
@@ -124,7 +124,7 @@ extension DashboardViewLiquid {
             FullMetricChartView(
                 title: "Body Fat %",
                 icon: "percent",
-                iconColor: Color.metricAccentBodyFat,
+                iconColor: theme.colors.accentPink,
                 currentValue: currentMetric.flatMap { formatBodyFatValue($0.bodyFatPercentage) } ?? "–",
                 unit: "%",
                 currentDate: formatDate(currentMetric?.date ?? Date()),
@@ -143,7 +143,7 @@ extension DashboardViewLiquid {
             FullMetricChartView(
                 title: "FFMI",
                 icon: "figure.arms.open",
-                iconColor: Color.metricAccentFFMI,
+                iconColor: theme.colors.accentTeal,
                 currentValue: currentMetric.map { formatFFMIValue($0) } ?? "–",
                 unit: "",
                 currentDate: formatDate(currentMetric?.date ?? Date()),
@@ -163,7 +163,7 @@ extension DashboardViewLiquid {
             FullMetricChartView(
                 title: "Body Score",
                 icon: "star.fill",
-                iconColor: Color.metricAccent,
+                iconColor: theme.colors.primary,
                 currentValue: bodyScore.scoreText,
                 unit: "",
                 currentDate: formatDate(currentMetric?.date ?? Date()),
@@ -189,7 +189,7 @@ extension DashboardViewLiquid {
             FullMetricChartView(
                 title: "GLP-1 Dose",
                 icon: "syringe",
-                iconColor: Color.metricAccent,
+                iconColor: theme.colors.primary,
                 currentValue: currentValue,
                 unit: unit,
                 currentDate: currentDate,

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift
@@ -12,7 +12,7 @@ extension DashboardViewLiquid {
 
     var photoTimelineAnalyticsPage: some View {
         ZStack {
-            Color.metricCanvas.ignoresSafeArea()
+            theme.colors.background.ignoresSafeArea()
 
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 18) {
@@ -35,11 +35,11 @@ extension DashboardViewLiquid {
         VStack(alignment: .leading, spacing: 6) {
             Text("Body trends")
                 .font(.system(size: 28, weight: .bold))
-                .foregroundColor(.white)
+                .foregroundColor(theme.colors.text)
 
             Text("Open a metric for chart and history.")
                 .font(.system(size: 14, weight: .medium))
-                .foregroundColor(Color.metricTextSecondary)
+                .foregroundColor(theme.colors.textSecondary)
         }
     }
 
@@ -48,31 +48,30 @@ extension DashboardViewLiquid {
             HStack {
                 Text("Timeline data")
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(theme.colors.text)
 
                 Spacer()
 
                 Text("\(timelinePresenceValueCount) values")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(Color.metricTextTertiary)
+                    .foregroundColor(theme.colors.textTertiary)
             }
 
             Text(photoTimelinePresenceLegendText)
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(Color.metricTextSecondary)
+                .foregroundColor(theme.colors.textSecondary)
                 .lineLimit(2)
                 .minimumScaleFactor(0.85)
                 .fixedSize(horizontal: false, vertical: true)
                 .accessibilityIdentifier("photo_timeline_stats_presence_legend")
         }
         .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 18)
-                .fill(Color.white.opacity(0.06))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 18)
-                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        .systemBGlassSurface(
+            cornerRadius: theme.radius.card,
+            tint: theme.colors.text,
+            tintOpacity: 0.025,
+            borderColor: theme.colors.border,
+            borderOpacity: 0.85
         )
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Timeline data. \(photoTimelinePresenceLegendText). \(timelinePresenceValueCount) values.")

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -100,14 +100,14 @@ extension DashboardViewLiquid {
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(
                         selectedPhotoTimelineRootPage == page
-                            ? Color.white
-                            : Color.white.opacity(0.58)
+                            ? theme.colors.text
+                            : theme.colors.textSecondary
                     )
 
                 Capsule()
                     .fill(
                         selectedPhotoTimelineRootPage == page
-                            ? Color.white
+                            ? theme.colors.text
                             : Color.clear
                     )
                     .frame(width: 24, height: 2)
@@ -173,9 +173,12 @@ extension DashboardViewLiquid {
             )
         }
         .padding(.vertical, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color.white.opacity(0.06))
+        .systemBGlassSurface(
+            cornerRadius: theme.radius.card,
+            tint: theme.colors.text,
+            tintOpacity: 0.025,
+            borderColor: theme.colors.border,
+            borderOpacity: 0.85
         )
         .accessibilityIdentifier("photo_timeline_hud_timeline")
     }
@@ -274,16 +277,16 @@ extension DashboardViewLiquid {
             VStack(alignment: .leading, spacing: 16) {
                 Image(systemName: "camera.metering.center.weighted")
                     .font(.system(size: 34, weight: .semibold))
-                    .foregroundColor(Color.white.opacity(0.78))
+                    .foregroundColor(theme.colors.textSecondary)
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Start with a photo")
                         .font(.system(size: 28, weight: .bold))
-                        .foregroundColor(.white)
+                        .foregroundColor(theme.colors.text)
 
                     Text("Add a progress photo or weight entry to build your body-composition timeline.")
                         .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(Color.white.opacity(0.68))
+                        .foregroundColor(theme.colors.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
@@ -294,21 +297,20 @@ extension DashboardViewLiquid {
                         .font(.system(size: 15, weight: .semibold))
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 14)
-                        .background(Capsule().fill(Color.white))
-                        .foregroundColor(.black)
+                        .background(Capsule().fill(theme.colors.text))
+                        .foregroundColor(theme.colors.background)
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("photo_timeline_hud_empty_add_photo_button")
             }
             .padding(24)
             .frame(maxWidth: .infinity, minHeight: 420, alignment: .bottomLeading)
-            .background(
-                RoundedRectangle(cornerRadius: 28)
-                    .fill(Color.white.opacity(0.07))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 28)
-                    .stroke(Color.white.opacity(0.10), lineWidth: 1)
+            .systemBGlassSurface(
+                cornerRadius: theme.radius.card,
+                tint: theme.colors.text,
+                tintOpacity: 0.03,
+                borderColor: theme.colors.border,
+                borderOpacity: 0.9
             )
             .padding(.horizontal, 20)
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineInsights.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineInsights.swift
@@ -20,7 +20,7 @@ extension DashboardViewLiquid {
                 HStack(spacing: 8) {
                     Text(insight.title)
                         .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(Color.liquidTextPrimary)
+                        .foregroundColor(theme.colors.text)
 
                     if let delta = insight.weightDeltaPercentPerWeek {
                         Text(formatPhaseInsightDelta(delta))
@@ -38,13 +38,13 @@ extension DashboardViewLiquid {
 
                 Text(insight.message)
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(Color.liquidTextPrimary.opacity(0.68))
+                    .foregroundColor(theme.colors.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
 
                 if let detail = insight.detail {
                     Text(detail)
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(Color.liquidTextPrimary.opacity(0.52))
+                        .foregroundColor(theme.colors.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
@@ -52,13 +52,12 @@ extension DashboardViewLiquid {
             Spacer(minLength: 0)
         }
         .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 18)
-                .fill(Color.white.opacity(0.06))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 18)
-                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        .systemBGlassSurface(
+            cornerRadius: theme.radius.card,
+            tint: theme.colors.text,
+            tintOpacity: 0.025,
+            borderColor: theme.colors.border,
+            borderOpacity: 0.85
         )
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("photo_timeline_hud_phase_insight")
@@ -88,7 +87,7 @@ extension DashboardViewLiquid {
                     HStack(spacing: 8) {
                         Text(summary.title)
                             .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(Color.liquidTextPrimary)
+                            .foregroundColor(theme.colors.text)
 
                         if let latestDoseText = summary.latestDoseText {
                             Text(latestDoseText)
@@ -106,7 +105,7 @@ extension DashboardViewLiquid {
 
                     Text(summary.message)
                         .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(Color.liquidTextPrimary.opacity(0.68))
+                        .foregroundColor(theme.colors.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
@@ -114,19 +113,18 @@ extension DashboardViewLiquid {
 
                 Text(summary.actionTitle)
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(.black)
+                    .foregroundColor(theme.colors.background)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 8)
-                    .background(Capsule().fill(Color.white))
+                    .background(Capsule().fill(theme.colors.text))
             }
             .padding(14)
-            .background(
-                RoundedRectangle(cornerRadius: 18)
-                    .fill(Color.white.opacity(0.06))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 18)
-                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            .systemBGlassSurface(
+                cornerRadius: theme.radius.card,
+                tint: theme.colors.text,
+                tintOpacity: 0.025,
+                borderColor: theme.colors.border,
+                borderOpacity: 0.85
             )
         }
         .buttonStyle(.plain)
@@ -188,13 +186,13 @@ extension DashboardViewLiquid {
     func phaseInsightColor(for kind: PhaseInsightKind) -> Color {
         switch kind {
         case .cutting:
-            return Color.metricAccentBodyFat
+            return theme.colors.accentPink
         case .maintaining:
-            return Color.metricAccent
+            return theme.colors.primary
         case .gaining:
-            return Color.metricAccentWeight
+            return theme.colors.accentViolet
         case .insufficientData:
-            return Color.metricTextTertiary
+            return theme.colors.textTertiary
         }
     }
 
@@ -211,11 +209,11 @@ extension DashboardViewLiquid {
     func glp1WeeklyCheckInColor(for status: Glp1WeeklyCheckInStatus) -> Color {
         switch status {
         case .setup:
-            return Color.metricAccent
+            return theme.colors.primary
         case .due:
-            return Color.metricAccentWeight
+            return theme.colors.accentViolet
         case .logged:
-            return Color.metricAccentSteps
+            return theme.colors.accentOrange
         }
     }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -21,6 +21,7 @@ struct DashboardViewLiquid: View {
 
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var realtimeSyncManager: RealtimeSyncManager
+    @Environment(\.theme) var theme
     @StateObject var viewModel = DashboardViewModel()
     @StateObject var globalTimelineStore = GlobalTimelineStore()
 
@@ -242,7 +243,7 @@ struct DashboardViewLiquid: View {
             .navigationDestination(isPresented: $isStatsDestinationActive) {
                 photoTimelineStatsDestination
             }
-            .toolbarBackground(Material.ultraThinMaterial, for: ToolbarPlacement.tabBar)
+            .toolbarBackground(theme.materials.glassUltraThin, for: ToolbarPlacement.tabBar)
             .toolbarBackground(Visibility.visible, for: ToolbarPlacement.tabBar)
             .onScreenshot {
                 guard selectedTab == .home else { return }
@@ -465,10 +466,10 @@ struct DashboardViewLiquid: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Your Metrics")
                         .font(.system(size: 18, weight: .bold))
-                        .foregroundColor(Color.liquidTextPrimary)
+                        .foregroundColor(theme.colors.text)
                     Text("Reorder and tap any card to drill in.")
                         .font(.system(size: 13, weight: .regular))
-                        .foregroundColor(Color.liquidTextPrimary.opacity(0.6))
+                        .foregroundColor(theme.colors.textSecondary)
                 }
                 .padding(.horizontal, 20)
             },
@@ -513,7 +514,7 @@ struct DashboardViewLiquid: View {
 
     private var dashboardBackground: some View {
         LinearGradient(
-            colors: [.black, .black.opacity(0.85)],
+            colors: [theme.colors.background, theme.colors.backgroundSecondary],
             startPoint: .top,
             endPoint: .bottom
         )
@@ -553,7 +554,7 @@ struct DashboardViewLiquid: View {
                         Text("Metrics")
                     }
             }
-            .tint(Color.appPrimary)
+            .tint(theme.colors.primary)
             .accessibilityIdentifier("legacy_full_dashboard_beta")
         }
     }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -548,6 +548,28 @@ final class PhotoTimelineHUDPolicyTests: XCTestCase {
 final class BodyScoreShareCardTests: XCTestCase {
     func testShareSheetDefaultsToPortraitExportAspect() {
         XCTAssertEqual(BodyScoreShareAspect.defaultExportAspect, .portrait)
+        XCTAssertEqual(BodyScoreShareAspect.preferredExportAspect(for: nil), .portrait)
+    }
+
+    func testPhotoShareAspectTracksNativeImageShape() {
+        XCTAssertEqual(
+            BodyScoreShareAspect.preferredExportAspect(
+                for: makeShareTestImage(size: CGSize(width: 480, height: 640))
+            ),
+            .portrait
+        )
+        XCTAssertEqual(
+            BodyScoreShareAspect.preferredExportAspect(
+                for: makeShareTestImage(size: CGSize(width: 360, height: 760))
+            ),
+            .story
+        )
+        XCTAssertEqual(
+            BodyScoreShareAspect.preferredExportAspect(
+                for: makeShareTestImage(size: CGSize(width: 640, height: 640))
+            ),
+            .square
+        )
     }
 
     func testMetricSummaryDataPointIdentityIsStableAcrossRenders() {
@@ -586,7 +608,8 @@ final class BodyScoreShareCardTests: XCTestCase {
         let previewSizes: [(BodyScoreShareAspect, CGSize)] = [
             (.square, CGSize(width: 320, height: 320)),
             (.portrait, CGSize(width: 320, height: 400)),
-            (.story, CGSize(width: 260, height: 462))
+            (.story, CGSize(width: 260, height: 462)),
+            (.story, CGSize(width: 1_080, height: 1_920))
         ]
 
         for (aspect, size) in previewSizes {
@@ -597,6 +620,11 @@ final class BodyScoreShareCardTests: XCTestCase {
                 avatarBottom + layout.textVisualGap,
                 layout.summaryTopY + 0.5,
                 "Avatar visual overlaps text budget for \(aspect.rawValue)"
+            )
+            XCTAssertGreaterThanOrEqual(
+                layout.summaryMatteHeight,
+                layout.size.height - layout.summaryTopY,
+                "Summary matte must cover the full text area for \(aspect.rawValue)"
             )
         }
     }
@@ -705,8 +733,7 @@ final class BodyScoreShareCardTests: XCTestCase {
         )
     }
 
-    private func makeShareTestImage() -> UIImage {
-        let size = CGSize(width: 480, height: 640)
+    private func makeShareTestImage(size: CGSize = CGSize(width: 480, height: 640)) -> UIImage {
         let renderer = UIGraphicsImageRenderer(size: size)
         return renderer.image { context in
             // swiftlint:disable:next object_literal
@@ -715,10 +742,24 @@ final class BodyScoreShareCardTests: XCTestCase {
 
             // swiftlint:disable:next object_literal
             UIColor(red: 0.12, green: 0.55, blue: 1.0, alpha: 1).setFill()
-            context.fill(CGRect(x: 110, y: 80, width: 260, height: 460))
+            context.fill(
+                CGRect(
+                    x: size.width * 0.23,
+                    y: size.height * 0.12,
+                    width: size.width * 0.54,
+                    height: size.height * 0.72
+                )
+            )
 
             UIColor.white.withAlphaComponent(0.82).setFill()
-            context.fill(CGRect(x: 170, y: 120, width: 140, height: 320))
+            context.fill(
+                CGRect(
+                    x: size.width * 0.35,
+                    y: size.height * 0.19,
+                    width: size.width * 0.30,
+                    height: size.height * 0.50
+                )
+            )
         }
     }
 }

--- a/scripts/ios/launch-ui-regression-audit.py
+++ b/scripts/ios/launch-ui-regression-audit.py
@@ -104,8 +104,12 @@ def write_outputs(artifact_dir: Path, violations: list[AuditViolation]) -> None:
                 "- Dashboard ScrollViews do not use large fake bottom spacers that create dead over-scroll.",
                 "- The removed bottom stats-card hook stays out of app source.",
                 "- Body Score share cards expose layout anchors for UI assertions.",
+                "- Body Score share cards preserve actual photo aspect defaults instead of forcing one crop.",
                 "- Body Score sharing resolves the actual progress photo before presenting the sheet.",
+                "- The dashboard avatar visual fills a full-width black stage with transparent assets.",
+                "- Dashboard/HUD launch surfaces stay on System B theme colors and real glass material.",
                 "- Timeline/Stats swipe navigation changes page on release, not during drag updates.",
+                "- Paid users default directly into the timeline HUD without a Statsig or legacy fallback gate.",
             ]
         )
 
@@ -148,6 +152,8 @@ def main() -> int:
         "body_score_share_summary",
         "body_score_share_metrics",
         "body_score_share_footer",
+        "preferredExportAspect(for: payload.photoImage)",
+        ".scaledToFit()",
     ]:
         require_token(
             root=root,
@@ -157,6 +163,85 @@ def main() -> int:
             detail=f"Missing share-card layout anchor `{token}`.",
             violations=violations,
         )
+
+    dashboard_components = app_dir / "Views/DashboardViewLiquid+Components.swift"
+    for token in [
+        ".background(theme.colors.background)",
+        "padding: 0,",
+        "horizontalFillScale: 1.08",
+        "renderMode: .fillWidth",
+    ]:
+        require_token(
+            root=root,
+            path=dashboard_components,
+            token=token,
+            check="avatar.full_width_transparent_stage",
+            detail=f"Missing avatar full-width hero-stage contract `{token}`.",
+            violations=violations,
+        )
+
+    system_b_surface_files = [
+        app_dir / "Views/DashboardViewLiquid+PhotoTimelineHUD.swift",
+        app_dir / "Views/DashboardViewLiquid+PhotoTimelineInsights.swift",
+        app_dir / "Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift",
+        app_dir / "Views/DashboardViewLiquid+HomeTimelineControls.swift",
+        app_dir / "DesignSystem/Organisms/MetricSummaryCard.swift",
+    ]
+    for path in system_b_surface_files:
+        require_token(
+            root=root,
+            path=path,
+            token=".systemBGlassSurface(",
+            check="dashboard.system_b_glass_surface",
+            detail="Dashboard/HUD cards must use the theme-backed System B glass surface.",
+            violations=violations,
+        )
+
+    system_b_dashboard_files = [
+        app_dir / "Components/DashboardMetricsList.swift",
+        app_dir / "DesignSystem/Organisms/MetricSummaryCard.swift",
+        app_dir / "Views/DashboardMetricsSection.swift",
+        app_dir / "Views/DashboardViewLiquid.swift",
+        app_dir / "Views/DashboardViewLiquid+Components.swift",
+        app_dir / "Views/DashboardViewLiquid+Glp1MetricCard.swift",
+        app_dir / "Views/DashboardViewLiquid+HeroAndActions.swift",
+        app_dir / "Views/DashboardViewLiquid+HomeTimelineControls.swift",
+        app_dir / "Views/DashboardViewLiquid+MetricViews.swift",
+        app_dir / "Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift",
+        app_dir / "Views/DashboardViewLiquid+PhotoTimelineHUD.swift",
+        app_dir / "Views/DashboardViewLiquid+PhotoTimelineInsights.swift",
+    ]
+    add_pattern_violations(
+        root=root,
+        paths=system_b_dashboard_files,
+        pattern=re.compile(
+            r"Color\.(?:metric|liquid|app|white|black)\b|"
+            r"Material\.ultraThinMaterial|"
+            r"Color\.metricCard|Color\.metricCardBorder|cardCornerRadius"
+        ),
+        check="dashboard.system_b_theme_tokens",
+        detail="Dashboard launch surfaces should use theme colors/materials instead of legacy color namespaces or fake glass.",
+        violations=violations,
+    )
+
+    main_tab_view = app_dir / "Views/MainTabView.swift"
+    require_token(
+        root=root,
+        path=main_tab_view,
+        token="static func surface() -> PaidAppSurface {\n        .photoTimelineHUD",
+        check="routing.timeline_hud_default",
+        detail="Paid app default surface must route straight to the timeline HUD for v1.",
+        violations=violations,
+    )
+
+    add_pattern_violations(
+        root=root,
+        paths=[main_tab_view],
+        pattern=re.compile(r"AnalyticsService\.shared\.isFeatureEnabled|Statsig\.checkGate"),
+        check="routing.no_feature_gate_default_surface",
+        detail="The v1 paid-app default surface must not depend on a feature gate or legacy fallback.",
+        violations=violations,
+    )
 
     require_token(
         root=root,

--- a/scripts/ios/performance-audit.sh
+++ b/scripts/ios/performance-audit.sh
@@ -9,6 +9,7 @@ DESTINATION="${DESTINATION:-platform=iOS Simulator,name=LYB Golden iPhone 16}"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 ARTIFACT_DIR="${ARTIFACT_DIR:-$IOS_DIR/test_results/performance-audit/$STAMP}"
 RUN_SWIFTLINT="${RUN_SWIFTLINT:-true}"
+RUN_SWIFTUI_PERFORMANCE_SMELL_AUDIT="${RUN_SWIFTUI_PERFORMANCE_SMELL_AUDIT:-true}"
 RUN_LAUNCH_PERFORMANCE="${RUN_LAUNCH_PERFORMANCE:-true}"
 RUN_TIMELINE_TRACE_WORKFLOW="${RUN_TIMELINE_TRACE_WORKFLOW:-false}"
 XCODEBUILD_SETTINGS="${XCODEBUILD_SETTINGS:-CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO}"
@@ -51,6 +52,15 @@ cd "$IOS_DIR"
 
 if [[ "$RUN_SWIFTLINT" == "true" ]]; then
   swiftlint lint --strict | tee "$ARTIFACT_DIR/swiftlint.log"
+fi
+
+if [[ "$RUN_SWIFTUI_PERFORMANCE_SMELL_AUDIT" == "true" ]]; then
+  python3 "$ROOT_DIR/scripts/ios/swiftui-performance-smell-audit.py" \
+    --root "$ROOT_DIR" \
+    --artifact-dir "$ARTIFACT_DIR" |
+    tee "$ARTIFACT_DIR/swiftui-performance-smell-audit.log"
+else
+  echo "Skipping static SwiftUI performance smell audit" | tee "$ARTIFACT_DIR/swiftui-performance-smell-audit.log"
 fi
 
 if [[ "$RUN_PERFORMANCE_UNIT_TESTS" == "true" ]]; then

--- a/scripts/ios/swiftui-performance-smell-audit.py
+++ b/scripts/ios/swiftui-performance-smell-audit.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Static SwiftUI performance smell checks for launch-critical iOS surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass
+class PerformanceSmell:
+    check: str
+    file: str
+    line: int
+    detail: str
+
+
+def line_number(text: str, index: int) -> int:
+    return text.count("\n", 0, index) + 1
+
+
+def add_pattern_smells(
+    *,
+    root: Path,
+    paths: list[Path],
+    pattern: re.Pattern[str],
+    check: str,
+    detail: str,
+    smells: list[PerformanceSmell],
+) -> None:
+    for path in paths:
+        if not path.is_file():
+            continue
+        text = path.read_text(errors="replace")
+        for match in pattern.finditer(text):
+            smells.append(
+                PerformanceSmell(
+                    check=check,
+                    file=str(path.relative_to(root)),
+                    line=line_number(text, match.start()),
+                    detail=detail,
+                )
+            )
+
+
+def write_outputs(artifact_dir: Path, smells: list[PerformanceSmell]) -> None:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    status = "failed" if smells else "passed"
+    payload = {
+        "schemaVersion": 1,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "smells": [asdict(smell) for smell in smells],
+    }
+    (artifact_dir / "swiftui-performance-smell-audit.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    )
+
+    lines = [
+        "# SwiftUI Performance Smell Audit",
+        "",
+        f"- Status: {status.capitalize()}",
+        f"- Smells: {len(smells)}",
+        "",
+    ]
+
+    if smells:
+        lines.extend(["## Smells", ""])
+        for smell in smells:
+            lines.append(f"- `{smell.check}` at `{smell.file}:{smell.line}`: {smell.detail}")
+    else:
+        lines.extend(
+            [
+                "## Covered Contracts",
+                "",
+                "- Launch-critical SwiftUI views do not decode images from raw data inside render paths.",
+                "- Launch-critical timeline controls do not filter, sort, or map collections inline inside `ForEach`.",
+                "- Launch-critical views do not create per-render UUID identities for stable visual rows.",
+            ]
+        )
+
+    (artifact_dir / "swiftui-performance-smell-audit.md").write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument("--artifact-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    app_dir = root / "apps/ios/LogYourBody"
+    launch_critical_files = [
+        app_dir / "Views/DashboardViewLiquid.swift",
+        app_dir / "Views/DashboardViewLiquid+PhotoTimelineHUD.swift",
+        app_dir / "Views/DashboardViewLiquid+Components.swift",
+        app_dir / "Views/DashboardViewLiquid+HomeTimelineControls.swift",
+        app_dir / "Views/DashboardViewLiquid+HeroAndActions.swift",
+        app_dir / "Components/AvatarBodyRenderer.swift",
+        app_dir / "Components/BodyScoreShareCard.swift",
+        app_dir / "Components/GlobalTimelineHeader.swift",
+        app_dir / "Components/LiquidGlassTimelineSlider.swift",
+        app_dir / "Components/PhotoAnchoredTimelineSlider.swift",
+        app_dir / "Components/ProgressTimelineView.swift",
+    ]
+    smells: list[PerformanceSmell] = []
+
+    add_pattern_smells(
+        root=root,
+        paths=launch_critical_files,
+        pattern=re.compile(r"Image\s*\(\s*uiImage:\s*UIImage\s*\(\s*data:"),
+        check="swiftui.no_render_path_image_decode",
+        detail="Decode/downsample image data before SwiftUI render work starts.",
+        smells=smells,
+    )
+
+    add_pattern_smells(
+        root=root,
+        paths=launch_critical_files,
+        pattern=re.compile(r"ForEach\s*\([^)]*\.(?:filter|sorted|map)\s*(?:\{|\\\()", re.MULTILINE),
+        check="swiftui.no_inline_collection_transform_in_foreach",
+        detail="Precompute collection transforms before `ForEach` so body updates stay cheap.",
+        smells=smells,
+    )
+
+    add_pattern_smells(
+        root=root,
+        paths=launch_critical_files,
+        pattern=re.compile(r"(?:var|let)\s+id\s*=\s*UUID\s*\(\s*\)"),
+        check="swiftui.no_per_render_uuid_identity",
+        detail="Use stable domain identity for launch-critical visual rows and cards.",
+        smells=smells,
+    )
+
+    write_outputs(args.artifact_dir, smells)
+    if smells:
+        print(f"SwiftUI performance smell audit failed with {len(smells)} smell(s).")
+        for smell in smells:
+            print(f"- {smell.check}: {smell.file}:{smell.line} {smell.detail}")
+    else:
+        print("SwiftUI performance smell audit passed.")
+    return 1 if smells else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Fixes Body Score sharing so the export aspect follows the source photo shape, photo-backed cards use fit semantics, and the summary matte reserves enough space to prevent text overlap.
- Makes the dashboard avatar timeline stage full-width on the black app surface instead of feeling like a floating padded card.
- Moves launch-critical dashboard cards, controls, and metric accents onto theme-backed System B glass tokens for a more cohesive surface.
- Adds a static SwiftUI performance smell audit and wires it into `scripts/ios/performance-audit.sh` so launch-critical render-path regressions are caught automatically.

## Validation
- `python3 scripts/ios/launch-ui-regression-audit.py --root /Users/timwhite/.codex/worktrees/bc03/LogYourBody --artifact-dir /tmp/lyb-launch-ui-audit-smoke` passed.
- `python3 scripts/ios/swiftui-performance-smell-audit.py --root /Users/timwhite/.codex/worktrees/bc03/LogYourBody --artifact-dir /tmp/lyb-swiftui-perf-audit-smoke` passed.
- `git diff --check` passed.
- `cd apps/ios && swiftlint lint --strict` passed with 0 violations.
- `RUN_SWIFTLINT=false RUN_PERFORMANCE_UNIT_TESTS=false RUN_LAUNCH_PERFORMANCE=false RUN_TIMELINE_TRACE_WORKFLOW=false bash scripts/ios/performance-audit.sh` passed.
- XcodeBuildMCP `test_sim` passed: `BodyScoreShareCardTests` 12/12, `DashboardTimelineProviderPerformanceTests` 6/6, and `LogYourBodyUITests/testLaunchQualityGateCapturesBodyScoreShareSheet` 1/1.
- XcodeBuildMCP `build_run_sim` reached `** BUILD SUCCEEDED **` and launched the app; the MCP call timed out after launch while waiting for completion.
- `pnpm lint`, `pnpm typecheck`, and `pnpm test` passed. Local Node warning remains: repo expects Node 20.x and this machine is on Node 22.22.1.

## Screenshot Artifacts
- Timeline/avatar HUD simulator screenshot: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_997341df-3f28-4123-8761-7a98f23aafc3.jpg`
- Share sheet UI-test screenshot: `/tmp/lyb-share-xcresult/0743DF7F-9676-44B9-8696-17A38566DF53.png`
- Performance audit artifacts: `apps/ios/test_results/performance-audit/20260615-143347`

## Notes
- This keeps the v1 paid surface ungated in the launch UI audit contract, matching the current product direction.
- The untracked local folder `docs/audits/ux-redesign-20260615/` was left out of this PR.
