### PR TITLE
JOV-3226: Preserve onboarding completion across auth refresh

### DIFF
--- a/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingMolecules.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingMolecules.swift
@@ -329,6 +329,7 @@ struct OnboardingScaffold<Content: View, CTA: View>: View {
                     .padding(.bottom, showsCTA ? 24 : 40)
             }
             .scrollIndicators(.hidden)
+            .scrollBounceBehavior(.basedOnSize, axes: .vertical)
             .accessibilityIdentifier("onboarding_scaffold_scroll")
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {

--- a/apps/ios/LogYourBody/Services/OnboardingStateManager.swift
+++ b/apps/ios/LogYourBody/Services/OnboardingStateManager.swift
@@ -102,11 +102,11 @@ final class OnboardingStateManager {
 
     private func shouldPreserveLocalCompletionForStaleFalse(userId: String?) -> Bool {
         guard hasCompletedCurrentVersion else { return false }
-        guard let userId, !userId.isEmpty else { return false }
         guard let completedUserId = defaults.string(forKey: Constants.onboardingCompletedUserIdKey),
               !completedUserId.isEmpty else {
             return false
         }
+        guard let userId, !userId.isEmpty else { return true }
 
         return completedUserId == userId
     }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -2431,6 +2431,24 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         XCTAssertEqual(defaults.string(forKey: Constants.onboardingCompletedUserIdKey), "same-user")
     }
 
+    func testCompletionUpdateIgnoresUnauthenticatedFalseForCompletedUser() {
+        let suiteName = "onboarding-auth-refresh-false-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let manager = OnboardingStateManager(defaults: defaults, currentVersion: 1)
+
+        manager.markCompleted(userId: "same-user")
+        manager.updateCompletionStatus(false)
+
+        XCTAssertTrue(manager.hasCompletedCurrentVersion)
+        XCTAssertTrue(manager.hasCompletedCurrentVersion(for: "same-user"))
+        XCTAssertEqual(defaults.string(forKey: Constants.onboardingCompletedUserIdKey), "same-user")
+        XCTAssertEqual(defaults.integer(forKey: Constants.onboardingCompletedVersionKey), 1)
+    }
+
     func testProfileCompletionSyncClearsInheritedCompletionForDifferentUser() {
         let suiteName = "onboarding-profile-user-switch-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/scripts/ios/launch-ui-regression-audit.py
+++ b/scripts/ios/launch-ui-regression-audit.py
@@ -102,6 +102,7 @@ def write_outputs(artifact_dir: Path, violations: list[AuditViolation]) -> None:
                 "## Covered Contracts",
                 "",
                 "- Dashboard ScrollViews do not use large fake bottom spacers that create dead over-scroll.",
+                "- Onboarding fixed-CTA screens use size-based vertical scroll bounce to avoid empty over-scroll.",
                 "- The removed bottom stats-card hook stays out of app source.",
                 "- Body Score share cards expose layout anchors for UI assertions.",
                 "- Body Score share cards preserve actual photo aspect defaults instead of forcing one crop.",
@@ -133,6 +134,15 @@ def main() -> int:
         pattern=re.compile(r"Spacer\s*\(\s*minLength:\s*(?:1[2-9]\d|[2-9]\d{2,})"),
         check="overscroll.no_large_fake_bottom_spacers",
         detail="Use real bottom padding or safe-area insets instead of fake ScrollView content.",
+        violations=violations,
+    )
+
+    require_token(
+        root=root,
+        path=app_dir / "Features/Onboarding/Components/OnboardingMolecules.swift",
+        token=".scrollBounceBehavior(.basedOnSize, axes: .vertical)",
+        check="onboarding.fixed_cta_size_based_bounce",
+        detail="Onboarding fixed-CTA ScrollViews must disable empty vertical over-scroll when content fits.",
         violations=violations,
     )
 


### PR DESCRIPTION
## Summary
- Preserve user-scoped onboarding completion when an auth refresh/sign-out transition sends a false completion update without a user id.
- Keep different-user false profile sync clearing inherited onboarding completion.
- Add size-based vertical bounce behavior to the shared fixed-CTA onboarding scaffold.
- Extend the launch UI regression audit to enforce onboarding fixed-CTA bounce control.

## Linear
- JOV-3226

## Validation
- `python3 scripts/ios/launch-ui-regression-audit.py --root /Users/timwhite/.codex/worktrees/bc03/LogYourBody --artifact-dir /tmp/lyb-jov-3226-launch-audit`
- `python3 scripts/ios/swiftui-performance-smell-audit.py --root /Users/timwhite/.codex/worktrees/bc03/LogYourBody --artifact-dir /tmp/lyb-jov-3226-perf-audit`
- `git diff --check`
- `cd apps/ios && swiftlint lint --strict --quiet`
- `xcodebuild ... -only-testing:LogYourBodyTests/OnboardingFlowViewModelTests/testCompletionUpdateIgnoresUnauthenticatedFalseForCompletedUser ... test` (3/3 selected onboarding completion tests passed)
- `xcodebuild ... -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesOnboardingFixedCTA ... test` (passed; screenshot exported to `/tmp/lyb-jov-3226-onboarding-ui-attachments/6E99AC85-CF34-4B69-823A-B36AFEA5126B.png`)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Notes
- `pnpm` still warns that local Node is v22.22.1 while the repo wants Node 20.x.
- Xcode still emits existing Swift 6 actor-isolation warnings in HealthSync/Loading/Dashboard code paths; this PR does not introduce them.
- Untracked local audit artifacts under `docs/audits/ux-redesign-20260615/` and `tmp/` were left untouched.
