### PR TITLE
feat: complete GLP-1 dose history logging

### DIFF
--- a/apps/ios/LogYourBody/Models/Glp1DoseLog.swift
+++ b/apps/ios/LogYourBody/Models/Glp1DoseLog.swift
@@ -38,3 +38,55 @@ struct Glp1DoseLog: Identifiable, Codable {
         case updatedAt = "updated_at"
     }
 }
+
+enum Glp1DoseHistoryFormatter {
+    static func doseText(_ log: Glp1DoseLog) -> String {
+        if isRestDay(log) {
+            return "Rest day"
+        }
+
+        guard let amount = log.doseAmount else {
+            return log.doseUnit ?? "Dose"
+        }
+
+        let unit = log.doseUnit ?? "dose"
+        return "\(numberText(amount)) \(unit)"
+    }
+
+    static func numberText(_ value: Double) -> String {
+        if value.rounded() == value {
+            return String(Int(value))
+        }
+
+        return String(format: "%.2f", value)
+            .replacingOccurrences(of: #"0+$"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: #"\.$"#, with: "", options: .regularExpression)
+    }
+
+    static func isRestDay(_ log: Glp1DoseLog) -> Bool {
+        log.doseAmount == nil && (log.notes?.localizedCaseInsensitiveContains("rest day") ?? false)
+    }
+
+    static func dateText(_ date: Date, now: Date = Date(), calendar: Calendar = .current) -> String {
+        if calendar.isDate(date, inSameDayAs: now) {
+            return "Today"
+        }
+
+        guard let yesterday = calendar.date(byAdding: .day, value: -1, to: now) else {
+            return mediumDateText(date)
+        }
+
+        if calendar.isDate(date, inSameDayAs: yesterday) {
+            return "Yesterday"
+        }
+
+        return mediumDateText(date)
+    }
+
+    private static func mediumDateText(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
+    }
+}

--- a/apps/ios/LogYourBody/Models/LogYourBody.xcdatamodeld/LogYourBody.xcdatamodel/contents
+++ b/apps/ios/LogYourBody/Models/LogYourBody.xcdatamodeld/LogYourBody.xcdatamodel/contents
@@ -74,6 +74,7 @@
         <attribute name="notes" optional="YES" attributeType="String"/>
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isMarkedDeleted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isSynced" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="syncStatus" attributeType="String" defaultValueString="synced"/>
     </entity>

--- a/apps/ios/LogYourBody/Services/CoreDataManager.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager.swift
@@ -1826,9 +1826,13 @@ class CoreDataManager: ObservableObject {
     func saveGlp1DoseLogs(
         _ logs: [Glp1DoseLog],
         userId: String,
-        markAsSynced: Bool = true
+        markAsSynced: Bool = true,
+        completion: ((Result<Void, Error>) -> Void)? = nil
     ) {
-        guard !logs.isEmpty else { return }
+        guard !logs.isEmpty else {
+            completion?(.success(()))
+            return
+        }
 
         let context = viewContext
 
@@ -1848,6 +1852,10 @@ class CoreDataManager: ObservableObject {
                     cached.createdAt = log.createdAt
                 }
 
+                if markAsSynced, cached.isMarkedDeleted {
+                    continue
+                }
+
                 cached.userId = userId
                 cached.takenAt = log.takenAt
                 cached.medicationId = log.medicationId
@@ -1860,6 +1868,7 @@ class CoreDataManager: ObservableObject {
                 cached.supplierName = log.supplierName
                 cached.notes = log.notes
                 cached.updatedAt = log.updatedAt
+                cached.isMarkedDeleted = false
                 cached.isSynced = markAsSynced
                 cached.syncStatus = markAsSynced ? "synced" : "pending"
             }
@@ -1868,6 +1877,7 @@ class CoreDataManager: ObservableObject {
                 if context.hasChanges {
                     try context.save()
                 }
+                completion?(.success(()))
             } catch {
                 #if DEBUG
                 let appError = AppError.coreData(operation: "saveGlp1DoseLogs", underlying: error)
@@ -1879,6 +1889,19 @@ class CoreDataManager: ObservableObject {
                 )
                 ErrorReporter.shared.capture(appError, context: contextInfo)
                 #endif
+                completion?(.failure(error))
+            }
+        }
+    }
+
+    func saveGlp1DoseLogsAndWait(
+        _ logs: [Glp1DoseLog],
+        userId: String,
+        markAsSynced: Bool = true
+    ) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            saveGlp1DoseLogs(logs, userId: userId, markAsSynced: markAsSynced) { result in
+                continuation.resume(with: result)
             }
         }
     }
@@ -1888,7 +1911,10 @@ class CoreDataManager: ObservableObject {
 
         return await context.perform {
             let request: NSFetchRequest<CachedGlp1DoseLog> = CachedGlp1DoseLog.fetchRequest()
-            request.predicate = NSPredicate(format: "userId == %@", userId)
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(format: "userId == %@", userId),
+                NSPredicate(format: "isMarkedDeleted == %@", NSNumber(value: false))
+            ])
             request.sortDescriptors = [NSSortDescriptor(key: "takenAt", ascending: true)]
 
             do {
@@ -1906,6 +1932,48 @@ class CoreDataManager: ObservableObject {
                 ErrorReporter.shared.capture(appError, context: contextInfo)
                 #endif
                 return []
+            }
+        }
+    }
+
+    func markGlp1DoseLogDeleted(id: String, userId: String) async -> Bool {
+        let context = viewContext
+
+        return await context.perform {
+            let request: NSFetchRequest<CachedGlp1DoseLog> = CachedGlp1DoseLog.fetchRequest()
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(format: "id == %@", id),
+                NSPredicate(format: "userId == %@", userId)
+            ])
+            request.fetchLimit = 1
+
+            guard let cached = try? context.fetch(request).first else {
+                return false
+            }
+
+            let now = Date()
+            cached.isMarkedDeleted = true
+            cached.updatedAt = now
+            cached.isSynced = false
+            cached.syncStatus = "pending"
+
+            do {
+                if context.hasChanges {
+                    try context.save()
+                }
+                return true
+            } catch {
+                #if DEBUG
+                let appError = AppError.coreData(operation: "markGlp1DoseLogDeleted", underlying: error)
+                let contextInfo = ErrorContext(
+                    feature: "coreData",
+                    operation: "markGlp1DoseLogDeleted",
+                    screen: nil,
+                    userId: userId
+                )
+                ErrorReporter.shared.capture(appError, context: contextInfo)
+                #endif
+                return false
             }
         }
     }

--- a/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
+++ b/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
@@ -376,6 +376,8 @@ class RealtimeSyncManager: ObservableObject {
         let unsyncedDexa = await coreDataManager.fetchUnsyncedDexaResults(for: userId)
         let deletedBodyMetrics = unsynced.bodyMetrics.filter(\.isMarkedDeleted)
         let bodyMetricsToUpsert = unsynced.bodyMetrics.filter { !$0.isMarkedDeleted }
+        let deletedGlp1DoseLogs = unsyncedGlp1.filter(\.isMarkedDeleted)
+        let glp1DoseLogsToUpsert = unsyncedGlp1.filter { !$0.isMarkedDeleted }
 
         // Batch sync for efficiency
         if !deletedBodyMetrics.isEmpty {
@@ -394,8 +396,12 @@ class RealtimeSyncManager: ObservableObject {
             try await syncProfilesBatch(unsynced.profiles, token: token)
         }
 
-        if !unsyncedGlp1.isEmpty {
-            try await syncGlp1DoseLogsBatch(unsyncedGlp1, token: token)
+        if !deletedGlp1DoseLogs.isEmpty {
+            try await syncDeletedGlp1DoseLogsBatch(deletedGlp1DoseLogs, token: token)
+        }
+
+        if !glp1DoseLogsToUpsert.isEmpty {
+            try await syncGlp1DoseLogsBatch(glp1DoseLogsToUpsert, token: token)
         }
 
         if !unsyncedMedications.isEmpty {
@@ -419,6 +425,23 @@ class RealtimeSyncManager: ObservableObject {
 
             metric.syncStatus = "synced"
             metric.isSynced = true
+        }
+
+        coreDataManager.save()
+    }
+
+    nonisolated private func syncDeletedGlp1DoseLogsBatch(_ logs: [CachedGlp1DoseLog], token: String) async throws {
+        for log in logs {
+            guard let id = log.id else { continue }
+
+            try await supabaseManager.deleteData(
+                table: "glp1_dose_logs",
+                id: id,
+                token: token
+            )
+
+            log.syncStatus = "synced"
+            log.isSynced = true
         }
 
         coreDataManager.save()

--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -57,7 +57,13 @@ struct AddEntrySheet: View {
     @State private var glp1IsLoadingMedications = false
     @State private var isPresentingGlp1AddMedication = false
     @State private var glp1UseCustomDose = false
+    @State private var glp1IsRestDay = false
     @State private var glp1UserId: String?
+    @State private var glp1DoseLogs: [Glp1DoseLog] = []
+    @State private var glp1DoseNotes: String = ""
+    @State private var editingGlp1DoseLogId: String?
+    @State private var editingGlp1DoseCreatedAt: Date?
+    @State private var pendingDeleteGlp1DoseLog: Glp1DoseLog?
 
     @State private var showError = false
     @State private var errorMessage = ""
@@ -181,7 +187,7 @@ struct AddEntrySheet: View {
 
     private var glp1EntryView: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Log GLP-1 dose")
+            Text(editingGlp1DoseLogId == nil ? "Log GLP-1 dose" : "Edit GLP-1 dose")
                 .font(.appHeadline)
                 .padding(.top)
 
@@ -266,11 +272,38 @@ struct AddEntrySheet: View {
                         let unit = glp1UnitForSelectedMedication ?? glp1DoseUnit
 
                         VStack(alignment: .leading, spacing: 12) {
-                            Text("Dose")
+                            HStack {
+                                Text(editingGlp1DoseLogId == nil ? "Dose" : "Editing dose")
+                                    .font(.appBodySmall)
+                                    .foregroundColor(.appTextSecondary)
+
+                                Spacer()
+
+                                if editingGlp1DoseLogId != nil {
+                                    Button("Cancel") {
+                                        resetGlp1DoseEditing()
+                                    }
+                                    .font(.appBodySmall)
+                                    .foregroundColor(.appTextSecondary)
+                                }
+                            }
+
+                            Toggle("Rest day", isOn: $glp1IsRestDay)
                                 .font(.appBodySmall)
                                 .foregroundColor(.appTextSecondary)
+                                .onChange(of: glp1IsRestDay) { _, isRestDay in
+                                    if !isRestDay {
+                                        updateGlp1DoseFromSelection()
+                                    } else {
+                                        glp1Error = nil
+                                    }
+                                }
 
-                            if !options.isEmpty {
+                            if glp1IsRestDay {
+                                Text("Record this date as a planned no-dose day.")
+                                    .font(.appBodySmall)
+                                    .foregroundColor(.appTextTertiary)
+                            } else if !options.isEmpty {
                                 Picker("Dose", selection: $selectedGlp1DoseIndex) {
                                     ForEach(options.indices, id: \.self) { index in
                                         Text(String(format: "%.2f", options[index]))
@@ -293,16 +326,18 @@ struct AddEntrySheet: View {
                                 }
                             }
 
-                            Toggle("Custom dose", isOn: $glp1UseCustomDose)
-                                .font(.appBodySmall)
-                                .foregroundColor(.appTextSecondary)
-                                .onChange(of: glp1UseCustomDose) { _, isCustom in
-                                    if !isCustom {
-                                        updateGlp1DoseFromSelection()
+                            if !glp1IsRestDay {
+                                Toggle("Custom dose", isOn: $glp1UseCustomDose)
+                                    .font(.appBodySmall)
+                                    .foregroundColor(.appTextSecondary)
+                                    .onChange(of: glp1UseCustomDose) { _, isCustom in
+                                        if !isCustom {
+                                            updateGlp1DoseFromSelection()
+                                        }
                                     }
-                                }
+                            }
 
-                            if glp1UseCustomDose {
+                            if glp1UseCustomDose && !glp1IsRestDay {
                                 HStack(spacing: 12) {
                                     TextField("0.0", text: $glp1Dose)
                                         .keyboardType(.decimalPad)
@@ -331,6 +366,17 @@ struct AddEntrySheet: View {
                                     .font(.appBodySmall)
                                     .foregroundColor(.appTextTertiary)
                             }
+
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Notes")
+                                    .font(.appBodySmall)
+                                    .foregroundColor(.appTextSecondary)
+
+                                TextField("Optional context", text: $glp1DoseNotes)
+                                    .font(.appBody)
+                                    .modernTextFieldStyle()
+                                    .accessibilityLabel("GLP-1 dose notes")
+                            }
                         }
                         .onAppear {
                             if glp1Dose.isEmpty {
@@ -341,6 +387,8 @@ struct AddEntrySheet: View {
                     }
                 }
             }
+
+            glp1DoseHistorySection
 
             Spacer()
         }
@@ -354,6 +402,115 @@ struct AddEntrySheet: View {
                 }
             }
         }
+        .confirmationDialog(
+            "Delete dose?",
+            isPresented: glp1DeleteConfirmationBinding,
+            titleVisibility: .visible
+        ) {
+            if let log = pendingDeleteGlp1DoseLog {
+                Button("Delete dose", role: .destructive) {
+                    deleteGlp1Dose(log)
+                }
+            }
+
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            if let log = pendingDeleteGlp1DoseLog {
+                Text("This removes \(Glp1DoseHistoryFormatter.doseText(log)) from your dose history.")
+            }
+        }
+    }
+
+    private var glp1DoseHistorySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Recent doses")
+                    .font(.appBodySmall)
+                    .foregroundColor(.appTextSecondary)
+
+                Spacer()
+
+                if glp1DoseLogs.count > recentGlp1DoseLogs.count {
+                    Text("\(glp1DoseLogs.count) total")
+                        .font(.appBodySmall)
+                        .foregroundColor(.appTextTertiary)
+                }
+            }
+
+            if recentGlp1DoseLogs.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("No doses logged yet")
+                        .font(.appBody)
+                        .foregroundColor(.appText)
+
+                    Text("Save a dose here and it will appear in your history.")
+                        .font(.appBodySmall)
+                        .foregroundColor(.appTextSecondary)
+                }
+                .padding(14)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.appCard)
+                .cornerRadius(Constants.cornerRadius)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(recentGlp1DoseLogs) { log in
+                        glp1DoseHistoryRow(log)
+
+                        if log.id != recentGlp1DoseLogs.last?.id {
+                            Divider()
+                                .background(Color.appBorder)
+                        }
+                    }
+                }
+                .background(Color.appCard)
+                .cornerRadius(Constants.cornerRadius)
+            }
+        }
+        .accessibilityIdentifier("glp1DoseHistorySection")
+    }
+
+    private func glp1DoseHistoryRow(_ log: Glp1DoseLog) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(log.brand ?? "GLP-1")
+                    .font(.appBody)
+                    .foregroundColor(.appText)
+                    .lineLimit(1)
+
+                Text("\(Glp1DoseHistoryFormatter.doseText(log)) • \(Glp1DoseHistoryFormatter.dateText(log.takenAt))")
+                    .font(.appBodySmall)
+                    .foregroundColor(.appTextSecondary)
+                    .lineLimit(1)
+
+                if let notes = log.notes, !notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text(notes)
+                        .font(.appBodySmall)
+                        .foregroundColor(.appTextTertiary)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            Button("Edit") {
+                editGlp1Dose(log)
+            }
+            .font(.appBodySmall)
+            .foregroundColor(.appPrimary)
+            .buttonStyle(.borderless)
+            .accessibilityIdentifier("glp1DoseHistoryEditButton")
+
+            Button(role: .destructive) {
+                pendingDeleteGlp1DoseLog = log
+            } label: {
+                Image(systemName: "trash")
+                    .font(.appBodySmall)
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel("Delete dose")
+            .accessibilityIdentifier("glp1DoseHistoryDeleteButton")
+        }
+        .padding(14)
     }
 
     // MARK: - Weight Entry View
@@ -554,7 +711,11 @@ struct AddEntrySheet: View {
         case 2:
             return !selectedPhotos.isEmpty
         case 3:
-            return glp1SelectedMedication != nil && !glp1Dose.isEmpty && Double(glp1Dose) != nil && glp1Error == nil
+            guard glp1SelectedMedication != nil else { return false }
+            if glp1IsRestDay {
+                return true
+            }
+            return !glp1Dose.isEmpty && Double(glp1Dose) != nil && glp1Error == nil
         default:
             return false
         }
@@ -569,7 +730,7 @@ struct AddEntrySheet: View {
         case 2:
             return selectedPhotos.count > 1 ? "Upload \(selectedPhotos.count) Photos" : "Upload Photo"
         case 3:
-            return "Save GLP-1"
+            return editingGlp1DoseLogId == nil ? "Save GLP-1" : "Save Changes"
         default:
             return "Save"
         }
@@ -664,14 +825,21 @@ struct AddEntrySheet: View {
                 return
             }
 
-            guard let dose = Double(glp1Dose) else {
-                glp1Error = "Please enter a valid number"
-                return
-            }
+            let dose: Double?
+            if glp1IsRestDay {
+                dose = nil
+            } else {
+                guard let resolvedDose = Double(glp1Dose) else {
+                    glp1Error = "Please enter a valid number"
+                    return
+                }
 
-            if dose <= 0 {
-                glp1Error = "Dose must be greater than zero"
-                return
+                if resolvedDose <= 0 {
+                    glp1Error = "Dose must be greater than zero"
+                    return
+                }
+
+                dose = resolvedDose
             }
 
             glp1Error = nil
@@ -680,24 +848,25 @@ struct AddEntrySheet: View {
             let calendar = Calendar.current
             let takenDate = calendar.startOfDay(for: selectedDate)
             let log = Glp1DoseLog(
-                id: UUID().uuidString,
+                id: editingGlp1DoseLogId ?? UUID().uuidString,
                 userId: userId,
                 takenAt: takenDate,
                 medicationId: medication.id,
                 doseAmount: dose,
-                doseUnit: medication.doseUnit ?? glp1DoseUnit,
+                doseUnit: glp1IsRestDay ? nil : medication.doseUnit ?? glp1DoseUnit,
                 drugClass: medication.drugClass,
                 brand: medication.brand ?? medication.displayName,
                 isCompounded: medication.isCompounded,
                 supplierType: nil,
                 supplierName: nil,
-                notes: nil,
-                createdAt: now,
+                notes: glp1DoseLogNotesForSave(isRestDay: glp1IsRestDay),
+                createdAt: editingGlp1DoseCreatedAt ?? now,
                 updatedAt: now
             )
 
             Task {
                 CoreDataManager.shared.saveGlp1DoseLogs([log], userId: userId, markAsSynced: false)
+                await loadGlp1DoseLogs(userId: userId)
                 RealtimeSyncManager.shared.updatePendingSyncCount()
                 RealtimeSyncManager.shared.syncIfNeeded()
                 dismiss()
@@ -897,10 +1066,44 @@ struct AddEntrySheet: View {
         return config.unit
     }
 
+    private var recentGlp1DoseLogs: [Glp1DoseLog] {
+        Array(glp1DoseLogs.sorted(by: { $0.takenAt > $1.takenAt }).prefix(5))
+    }
+
+    private var normalizedGlp1DoseNotes: String? {
+        let trimmed = glp1DoseNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func glp1DoseLogNotesForSave(isRestDay: Bool) -> String? {
+        guard isRestDay else {
+            return normalizedGlp1DoseNotes
+        }
+
+        guard let notes = normalizedGlp1DoseNotes else {
+            return "Rest day"
+        }
+
+        return notes.localizedCaseInsensitiveContains("rest day") ? notes : "Rest day: \(notes)"
+    }
+
+    private var glp1DeleteConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { pendingDeleteGlp1DoseLog != nil },
+            set: { isPresented in
+                if !isPresented {
+                    pendingDeleteGlp1DoseLog = nil
+                }
+            }
+        )
+    }
+
     @MainActor
     private func loadGlp1Medications(userId: String) async {
         glp1IsLoadingMedications = true
         let cached = await CoreDataManager.shared.fetchGlp1Medications(for: userId)
+        await loadGlp1DoseLogs(userId: userId)
+
         if !cached.isEmpty {
             glp1Medications = cached.sorted { $0.startedAt < $1.startedAt }
 
@@ -923,6 +1126,10 @@ struct AddEntrySheet: View {
             glp1Medications = medications.sorted(by: { $0.startedAt < $1.startedAt })
             CoreDataManager.shared.saveGlp1Medications(medications, userId: userId)
 
+            let doseLogs = try await SupabaseManager.shared.fetchGlp1DoseLogs(userId: userId)
+            CoreDataManager.shared.saveGlp1DoseLogs(doseLogs, userId: userId)
+            glp1DoseLogs = doseLogs.sorted(by: { $0.takenAt < $1.takenAt })
+
             if selectedGlp1MedicationId == nil,
                let active = glp1Medications.last(where: { $0.endedAt == nil }) ?? glp1Medications.last {
                 selectedGlp1MedicationId = active.id
@@ -932,6 +1139,11 @@ struct AddEntrySheet: View {
         }
 
         glp1IsLoadingMedications = false
+    }
+
+    @MainActor
+    private func loadGlp1DoseLogs(userId: String) async {
+        glp1DoseLogs = await CoreDataManager.shared.fetchGlp1DoseLogs(for: userId)
     }
 
     private func loadGlp1MedicationsIfNeeded() {
@@ -948,6 +1160,7 @@ struct AddEntrySheet: View {
         glp1DoseUnit = config.unit
         selectedGlp1DoseIndex = 0
         glp1UseCustomDose = false
+        glp1IsRestDay = false
 
         if let first = config.doses.first {
             glp1Dose = String(first)
@@ -961,6 +1174,73 @@ struct AddEntrySheet: View {
     private func selectGlp1Medication(_ medication: Glp1Medication) {
         selectedGlp1MedicationId = medication.id
         applyDefaultDoseConfig(for: medication)
+    }
+
+    private func editGlp1Dose(_ log: Glp1DoseLog) {
+        editingGlp1DoseLogId = log.id
+        editingGlp1DoseCreatedAt = log.createdAt
+        selectedDate = log.takenAt
+        glp1DoseNotes = log.notes ?? ""
+        glp1IsRestDay = Glp1DoseHistoryFormatter.isRestDay(log)
+
+        if let medicationId = log.medicationId,
+           glp1Medications.contains(where: { $0.id == medicationId }) {
+            selectedGlp1MedicationId = medicationId
+        } else if let brand = log.brand,
+                  let medication = glp1Medications.first(where: { $0.displayName == brand || $0.brand == brand }) {
+            selectedGlp1MedicationId = medication.id
+        }
+
+        glp1DoseUnit = log.doseUnit ?? glp1UnitForSelectedMedication ?? glp1DoseUnit
+
+        guard let amount = log.doseAmount else {
+            glp1Dose = ""
+            glp1UseCustomDose = true
+            glp1Error = nil
+            return
+        }
+
+        if let matchingIndex = glp1DoseOptions.firstIndex(where: { abs($0 - amount) < 0.0001 }) {
+            selectedGlp1DoseIndex = matchingIndex
+            glp1UseCustomDose = false
+            glp1Dose = String(glp1DoseOptions[matchingIndex])
+        } else {
+            glp1UseCustomDose = true
+            glp1Dose = Glp1DoseHistoryFormatter.numberText(amount)
+        }
+
+        validateGlp1Dose(glp1Dose)
+    }
+
+    private func deleteGlp1Dose(_ log: Glp1DoseLog) {
+        Task {
+            let deleted = await CoreDataManager.shared.markGlp1DoseLogDeleted(id: log.id, userId: log.userId)
+            guard deleted else { return }
+
+            if editingGlp1DoseLogId == log.id {
+                resetGlp1DoseEditing()
+            }
+
+            pendingDeleteGlp1DoseLog = nil
+            await loadGlp1DoseLogs(userId: log.userId)
+            RealtimeSyncManager.shared.updatePendingSyncCount()
+            RealtimeSyncManager.shared.syncIfNeeded()
+            HapticManager.shared.successAction()
+        }
+    }
+
+    private func resetGlp1DoseEditing() {
+        editingGlp1DoseLogId = nil
+        editingGlp1DoseCreatedAt = nil
+        glp1DoseNotes = ""
+        glp1IsRestDay = false
+
+        if let medication = glp1SelectedMedication {
+            applyDefaultDoseConfig(for: medication)
+        } else {
+            glp1Dose = ""
+            glp1Error = nil
+        }
     }
 
     private func updateGlp1DoseFromSelection() {
@@ -985,6 +1265,10 @@ private struct Glp1AddMedicationView: View {
     @State private var searchText: String = ""
     @State private var selectedPreset: Glp1MedicationPreset?
     @State private var activeFilters: Set<Glp1Filter> = []
+    @State private var customCompoundName: String = ""
+    @State private var customDoseUnit: String = "mg/week"
+    @State private var customSchedule: Glp1CustomSchedule = .weekly
+    @State private var customScheduleDays: String = ""
 
     private var presets: [Glp1MedicationPreset] {
         Glp1MedicationCatalog.allPresets
@@ -1094,8 +1378,68 @@ private struct Glp1AddMedicationView: View {
                             }
                         }
                     }
+
+                    Section(header: Text("Custom compound")
+                        .font(.appCaption)
+                        .foregroundColor(.appTextSecondary)
+                        .textCase(nil)
+                    ) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text(
+                                "For informational reference only. Log what you are already taking; " +
+                                    "this does not provide dosing guidance."
+                            )
+                                .font(.appCaption)
+                                .foregroundColor(.appTextSecondary)
+                                .fixedSize(horizontal: false, vertical: true)
+
+                            TextField("Compound name", text: $customCompoundName)
+                                .font(.appBody)
+                                .modernTextFieldStyle()
+                                .accessibilityLabel("Custom compound name")
+
+                            Picker("Schedule", selection: $customSchedule) {
+                                ForEach(Glp1CustomSchedule.allCases) { schedule in
+                                    Text(schedule.label).tag(schedule)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+
+                            if customSchedule == .custom {
+                                TextField("Custom days, e.g. Mon/Wed/Fri", text: $customScheduleDays)
+                                    .font(.appBody)
+                                    .modernTextFieldStyle()
+                                    .accessibilityLabel("Custom compound schedule days")
+                            }
+
+                            TextField("Dose unit", text: $customDoseUnit)
+                                .font(.appBody)
+                                .modernTextFieldStyle()
+                                .accessibilityLabel("Custom compound dose unit")
+
+                            Button {
+                                createCustomMedication()
+                            } label: {
+                                Text("Use custom compound")
+                                    .font(.appBodySmall)
+                                    .fontWeight(.semibold)
+                                    .frame(height: 40)
+                                    .frame(maxWidth: .infinity)
+                                    .background(customCompoundCanSave ? Color.appPrimary : Color.appBorder)
+                                    .foregroundColor(customCompoundCanSave ? .black : .white)
+                                    .cornerRadius(Constants.cornerRadius)
+                            }
+                            .disabled(!customCompoundCanSave || isSaving)
+                        }
+                        .padding(.vertical, 6)
+                    }
                 }
                 .listStyle(.insetGrouped)
+                .onChange(of: searchText) { _, newValue in
+                    if customCompoundName.isEmpty {
+                        customCompoundName = newValue
+                    }
+                }
 
                 VStack(spacing: 8) {
                     if errorMessage != nil {
@@ -1184,6 +1528,24 @@ private struct Glp1AddMedicationView: View {
         presets.filter { preset in
             matchesSearch(preset) && matchesFilters(preset)
         }
+    }
+
+    private var customCompoundCanSave: Bool {
+        !trimmedCustomCompoundName.isEmpty
+            && !trimmedCustomDoseUnit.isEmpty
+            && (customSchedule != .custom || !trimmedCustomScheduleDays.isEmpty)
+    }
+
+    private var trimmedCustomCompoundName: String {
+        customCompoundName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedCustomDoseUnit: String {
+        customDoseUnit.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedCustomScheduleDays: String {
+        customScheduleDays.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private var groupedPresets: [Glp1Group] {
@@ -1374,6 +1736,41 @@ private struct Glp1AddMedicationView: View {
         }
     }
 
+    private enum Glp1CustomSchedule: String, CaseIterable, Identifiable {
+        case weekly
+        case daily
+        case everyOtherDay
+        case custom
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .weekly:
+                return "Weekly"
+            case .daily:
+                return "Daily"
+            case .everyOtherDay:
+                return "Every other"
+            case .custom:
+                return "Custom"
+            }
+        }
+
+        func frequencyText(customDays: String) -> String {
+            switch self {
+            case .weekly:
+                return "once weekly"
+            case .daily:
+                return "once daily"
+            case .everyOtherDay:
+                return "every other day"
+            case .custom:
+                return "custom: \(customDays)"
+            }
+        }
+    }
+
     private struct Glp1Group {
         let title: String
         let items: [Glp1MedicationPreset]
@@ -1400,6 +1797,47 @@ private struct Glp1AddMedicationView: View {
             startedAt: now,
             endedAt: nil,
             notes: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+
+        Task {
+            CoreDataManager.shared.endActiveGlp1Medications(for: userId, endedAt: now)
+            CoreDataManager.shared.saveGlp1Medications([medication], userId: userId, markAsSynced: false)
+
+            await MainActor.run {
+                onCreated(medication)
+                isSaving = false
+                dismiss()
+            }
+
+            RealtimeSyncManager.shared.updatePendingSyncCount()
+            RealtimeSyncManager.shared.syncIfNeeded()
+        }
+    }
+
+    private func createCustomMedication() {
+        guard customCompoundCanSave, !isSaving else { return }
+        errorMessage = nil
+        isSaving = true
+
+        let now = Date()
+        let name = trimmedCustomCompoundName
+        let medication = Glp1Medication(
+            id: UUID().uuidString,
+            userId: userId,
+            displayName: name,
+            genericName: name,
+            drugClass: "GLP-1 receptor agonist",
+            brand: name,
+            route: "subcutaneous",
+            frequency: customSchedule.frequencyText(customDays: trimmedCustomScheduleDays),
+            doseUnit: trimmedCustomDoseUnit,
+            isCompounded: true,
+            hkIdentifier: nil,
+            startedAt: now,
+            endedAt: nil,
+            notes: "For informational reference only",
             createdAt: now,
             updatedAt: now
         )

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
@@ -195,7 +195,7 @@ extension DashboardViewLiquid {
                 currentDate: currentDate,
                 chartData: cachedChartData(for: .glp1, generator: generateFullScreenGlp1ChartData),
                 onAdd: {
-                    showAddEntrySheet = true
+                    presentAddEntrySheet(initialTab: 3, includesGlp1Entry: true)
                 },
                 metricEntries: nil,
                 relatedMetrics: metricDetailRelatedMetrics(excluding: .glp1),

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -1475,6 +1475,168 @@ final class Glp1WeeklyCheckInPolicyTests: XCTestCase {
     }
 }
 
+final class Glp1DoseHistoryFormatterTests: XCTestCase {
+    func testDoseTextRemovesUnneededDecimalZeros() {
+        let log = makeDoseLog(amount: 2.50, unit: "mg/week")
+
+        XCTAssertEqual(Glp1DoseHistoryFormatter.doseText(log), "2.5 mg/week")
+    }
+
+    func testDateTextUsesPlainRelativeLabelsForRecentDoses() {
+        var calendar = Calendar(identifier: .iso8601)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let now = calendar.date(from: DateComponents(
+            timeZone: calendar.timeZone,
+            year: 2_026,
+            month: 6,
+            day: 16,
+            hour: 12
+        ))!
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: now)!
+
+        XCTAssertEqual(Glp1DoseHistoryFormatter.dateText(now, now: now, calendar: calendar), "Today")
+        XCTAssertEqual(Glp1DoseHistoryFormatter.dateText(yesterday, now: now, calendar: calendar), "Yesterday")
+    }
+
+    func testDoseTextShowsRestDayForNoDoseRestLog() {
+        let log = makeDoseLog(amount: nil, unit: nil, notes: "Rest day: traveling")
+
+        XCTAssertEqual(Glp1DoseHistoryFormatter.doseText(log), "Rest day")
+        XCTAssertTrue(Glp1DoseHistoryFormatter.isRestDay(log))
+    }
+
+    private func makeDoseLog(amount: Double?, unit: String?, notes: String? = nil) -> Glp1DoseLog {
+        let now = Date()
+
+        return Glp1DoseLog(
+            id: "dose",
+            userId: "glp1-user",
+            takenAt: now,
+            medicationId: "medication",
+            doseAmount: amount,
+            doseUnit: unit,
+            drugClass: "dual GIP/GLP-1 receptor agonist",
+            brand: "Zepbound",
+            isCompounded: false,
+            supplierType: nil,
+            supplierName: nil,
+            notes: notes,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+}
+
+@MainActor
+final class Glp1DoseCoreDataTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+    }
+
+    override func tearDown() async throws {
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+        try await super.tearDown()
+    }
+
+    func testDeletedDoseLogsAreHiddenButRemainPendingForSync() async throws {
+        let userId = "glp1-delete-\(UUID().uuidString)"
+        let log = makeDoseLog(userId: userId)
+
+        try await CoreDataManager.shared.saveGlp1DoseLogsAndWait([log], userId: userId, markAsSynced: true)
+        let savedLogIds = await CoreDataManager.shared.fetchGlp1DoseLogs(for: userId).map(\.id)
+
+        XCTAssertEqual(savedLogIds, [log.id])
+
+        let deleted = await CoreDataManager.shared.markGlp1DoseLogDeleted(id: log.id, userId: userId)
+        let visibleLogsAfterDelete = await CoreDataManager.shared.fetchGlp1DoseLogs(for: userId)
+
+        XCTAssertTrue(deleted)
+        XCTAssertTrue(visibleLogsAfterDelete.isEmpty)
+
+        let unsynced = await CoreDataManager.shared.fetchUnsyncedGlp1DoseLogs(for: userId)
+
+        XCTAssertEqual(unsynced.count, 1)
+        XCTAssertEqual(unsynced.first?.id, log.id)
+        XCTAssertEqual(unsynced.first?.isMarkedDeleted, true)
+        XCTAssertEqual(unsynced.first?.isSynced, false)
+        XCTAssertEqual(unsynced.first?.syncStatus, "pending")
+    }
+
+    func testRemoteDoseRefreshDoesNotResurrectPendingDeletedLog() async throws {
+        let userId = "glp1-tombstone-\(UUID().uuidString)"
+        let log = makeDoseLog(userId: userId)
+
+        try await CoreDataManager.shared.saveGlp1DoseLogsAndWait([log], userId: userId, markAsSynced: true)
+
+        let deleted = await CoreDataManager.shared.markGlp1DoseLogDeleted(id: log.id, userId: userId)
+        XCTAssertTrue(deleted)
+
+        let staleServerLog = Glp1DoseLog(
+            id: log.id,
+            userId: log.userId,
+            takenAt: log.takenAt,
+            medicationId: log.medicationId,
+            doseAmount: log.doseAmount,
+            doseUnit: log.doseUnit,
+            drugClass: log.drugClass,
+            brand: log.brand,
+            isCompounded: log.isCompounded,
+            supplierType: log.supplierType,
+            supplierName: log.supplierName,
+            notes: "stale server copy",
+            createdAt: log.createdAt,
+            updatedAt: log.updatedAt.addingTimeInterval(60)
+        )
+
+        try await CoreDataManager.shared.saveGlp1DoseLogsAndWait([staleServerLog], userId: userId, markAsSynced: true)
+
+        let visibleLogs = await CoreDataManager.shared.fetchGlp1DoseLogs(for: userId)
+        let unsynced = await CoreDataManager.shared.fetchUnsyncedGlp1DoseLogs(for: userId)
+
+        XCTAssertTrue(visibleLogs.isEmpty)
+        XCTAssertEqual(unsynced.count, 1)
+        XCTAssertEqual(unsynced.first?.id, log.id)
+        XCTAssertEqual(unsynced.first?.isMarkedDeleted, true)
+        XCTAssertEqual(unsynced.first?.isSynced, false)
+        XCTAssertEqual(unsynced.first?.syncStatus, "pending")
+    }
+
+    func testDoseLogNotesPersistThroughCoreData() async throws {
+        let userId = "glp1-notes-\(UUID().uuidString)"
+        let log = makeDoseLog(userId: userId, notes: "Left side injection")
+
+        try await CoreDataManager.shared.saveGlp1DoseLogsAndWait([log], userId: userId, markAsSynced: true)
+
+        let saved = await CoreDataManager.shared.fetchGlp1DoseLogs(for: userId)
+
+        XCTAssertEqual(saved.count, 1)
+        XCTAssertEqual(saved.first?.notes, "Left side injection")
+    }
+
+    private func makeDoseLog(userId: String, notes: String? = nil) -> Glp1DoseLog {
+        let now = Date(timeIntervalSince1970: 1_735_000_000)
+
+        return Glp1DoseLog(
+            id: UUID().uuidString,
+            userId: userId,
+            takenAt: now,
+            medicationId: "medication",
+            doseAmount: 5.0,
+            doseUnit: "mg/week",
+            drugClass: "dual GIP/GLP-1 receptor agonist",
+            brand: "Zepbound",
+            isCompounded: false,
+            supplierType: nil,
+            supplierName: nil,
+            notes: notes,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+}
+
 final class AuthSurfacePolicyTests: XCTestCase {
     func testAppleSignInShowsByDefaultForV1Launch() {
         XCTAssertTrue(AuthSurfacePolicy.defaultShowsAppleSignIn)

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -426,6 +426,11 @@ final class LogYourBodyUITests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["Log GLP-1 dose"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Zepbound"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.descendants(matching: .any)["glp1DoseHistorySection"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.switches["Rest day"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.textFields["GLP-1 dose notes"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Edit"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Delete dose"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.buttons["Save GLP-1"].exists)
     }
 


### PR DESCRIPTION
## Summary
- Adds GLP-1 dose history to the add-entry GLP-1 tab with edit and delete actions.
- Supports rest-day logs, persisted notes, and custom compounded medication setup with schedule/unit metadata.
- Preserves deleted local GLP-1 doses as tombstones until sync and prevents stale remote refreshes from resurrecting deleted entries.
- Routes the dashboard GLP-1 metric add action directly into the GLP-1 logging tab.

Linear: JOV-3130

## Validation
- `cd apps/ios && swiftlint lint --strict`
- iPhone 17 selected unit tests: `Glp1DoseHistoryFormatterTests` and `Glp1DoseCoreDataTests` passed, 6 tests total
- LYB Golden iPhone 16 selected unit tests passed from `/tmp/lyb-jov-3130-glp1-tests.xcresult`, 6 tests total
- iPhone 17 UI test passed: `LogYourBodyUITests/testGlp1WeeklyCheckInFixtureShowsPromptAndOpensDoseFlow`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Notes
- Root validation passes locally with the existing Node engine warning because this machine is on Node `v22.22.1` while the repo expects Node `20.x`.
- Local simulator screenshot proof was captured for the GLP-1 dose sheet; the untracked screenshot artifact is intentionally not included in this PR.