### PR TITLE
fix: stabilize launch overlay dismissal

### DIFF
--- a/apps/ios/LogYourBody/ContentView.swift
+++ b/apps/ios/LogYourBody/ContentView.swift
@@ -91,6 +91,17 @@ struct ContentView: View {
         )
     }
 
+    private func completeLaunchOverlayIfReady() {
+        guard !isLoadingComplete,
+              loadingManager.progress >= 1.0 else {
+            return
+        }
+
+        withAnimation(.easeInOut(duration: 0.25)) {
+            isLoadingComplete = true
+        }
+    }
+
     var body: some View {
         ZStack {
             Color.appBackground
@@ -126,13 +137,14 @@ struct ContentView: View {
             // Start loading process
             Task {
                 await loadingManager.startLoading()
-                // Check if loading is already complete
-                if !loadingManager.isLoading && loadingManager.progress >= 1.0 {
-                    withAnimation(.easeInOut(duration: 0.4)) {
-                        isLoadingComplete = true
-                    }
-                }
+                completeLaunchOverlayIfReady()
             }
+        }
+        .onChange(of: loadingManager.isLoading) { _, _ in
+            completeLaunchOverlayIfReady()
+        }
+        .onChange(of: loadingManager.progress) { _, _ in
+            completeLaunchOverlayIfReady()
         }
         .onReceive(NotificationCenter.default.publisher(for: OnboardingStateManager.onboardingStateDidChange)) { _ in
             hasCompletedOnboarding = onboardingStateManager.hasCompletedCurrentVersion(for: currentUserId)
@@ -239,14 +251,12 @@ struct ContentView: View {
 
     private var loadingOverlay: some View {
         Group {
-            if !isLoadingComplete {
+            if !isLoadingComplete && loadingManager.progress < 1.0 {
                 LoadingView(
                     progress: $loadingManager.progress,
                     loadingStatus: $loadingManager.loadingStatus,
                     onComplete: {
-                        withAnimation(.easeInOut(duration: 0.4)) {
-                            isLoadingComplete = true
-                        }
+                        completeLaunchOverlayIfReady()
                     }
                 )
                 .transition(.opacity)

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -5306,6 +5306,24 @@ final class DashboardViewModelHealthSyncWiringTests: XCTestCase {
 
 @MainActor
 final class LoadingManagerHealthSyncTests: XCTestCase {
+    func testStartLoadingCompletesBlockingPhase() async {
+        let authManager = AuthManager()
+        authManager.isAuthenticated = false
+
+        let mockCoordinator = MockHealthSyncCoordinator()
+        let manager = LoadingManager(
+            authManager: authManager,
+            healthSyncCoordinator: mockCoordinator
+        )
+
+        await manager.startLoading()
+
+        XCTAssertFalse(manager.isLoading)
+        XCTAssertEqual(manager.progress, 1.0, accuracy: 0.001)
+        XCTAssertEqual(manager.loadingStatus, "Ready!")
+        XCTAssertFalse(mockCoordinator.didCallWarmUpAfterLogin)
+    }
+
     func testRunWarmUpTasksInvokesHealthSyncWhenAuthenticated() async {
         let authManager = AuthManager()
         authManager.isAuthenticated = true

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -414,7 +414,7 @@ final class LogYourBodyUITests: XCTestCase {
         ]
         app.launch()
 
-        XCTAssertTrue(app.descendants(matching: .any)["dashboard_home_timeline_hero"].waitForExistence(timeout: 10))
+        XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 20))
 
         let prompt = app.buttons["photo_timeline_hud_glp1_weekly_checkin"]
         scrollUntilExists(prompt, in: app)


### PR DESCRIPTION
## Summary
- Dismiss the launch overlay as soon as loading reaches 100% so the Ready/100% splash cannot remain over the usable app
- Add a LoadingManager regression test for completing the blocking launch phase
- Make the GLP-1 weekly check-in UI smoke wait for the existing timeline root surface before interacting with the dose flow

## Validation
- `git diff --check`
- `cd apps/ios && swiftlint lint --strict --quiet`
- `xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -configuration Debug -destination 'platform=iOS Simulator,id=7EB60D3E-3637-43EA-969D-167ADC72BAEC' -only-testing:LogYourBodyTests/LoadingManagerHealthSyncTests -resultBundlePath /tmp/lyb-launch-overlay-unit.xcresult test`
- `xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -configuration Debug -destination 'platform=iOS Simulator,id=7EB60D3E-3637-43EA-969D-167ADC72BAEC' -only-testing:LogYourBodyUITests/LogYourBodyUITests/testGlp1WeeklyCheckInFixtureShowsPromptAndOpensDoseFlow -resultBundlePath /tmp/lyb-launch-overlay-glp1-ui.xcresult test`

## Notes
- Follow-up to #400. The previous failing UI result showed `dashboard_home_timeline_hero` in the hierarchy with the launch splash still rendered at Ready/100%; this removes that stuck overlay path.