### PR TITLE
fix: correct LICENSE to proprietary (LYB is not open source)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,17 @@
-MIT License
+Copyright (c) 2024-2026 Jovie Technology Inc. All rights reserved.
 
-Copyright (c) 2024 Tim White
+This software and associated documentation files (the "Software") are the
+proprietary and confidential property of Jovie Technology Inc.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+No part of the Software may be reproduced, distributed, transmitted,
+displayed, published, or broadcast in any form or by any means, including
+photocopying, recording, or other electronic or mechanical methods, without
+the prior written permission of Jovie Technology Inc., except as expressly
+permitted by applicable law.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This repository is made public solely for continuous-integration and
+operational convenience. Public availability does not constitute an
+open-source release and grants no license to use, copy, modify, or
+distribute the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+For licensing inquiries, contact legal@jov.ie.

--- a/README.md
+++ b/README.md
@@ -164,11 +164,13 @@ The iOS app can be distributed via TestFlight or the App Store.
 
 ## Contributing
 
-We welcome contributions! Please see our contributing guidelines for more details.
+This is an internal Jovie Technology Inc. project. Contributions are limited to authorized team members and collaborators.
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is proprietary and confidential. All rights reserved by Jovie Technology Inc.
+
+See [LICENSE](LICENSE) for full terms. Unauthorized copying, distribution, or use of this software is strictly prohibited. This repository is public solely to support continuous integration; it is **not** open source.
 
 ## Support
 


### PR DESCRIPTION
## What
Replaces the MIT `LICENSE` with Jovie's proprietary "all rights reserved" notice (entity: **Jovie Technology Inc.**) and updates the README `## License` section to remove the open-source claim. Also softens the `## Contributing` section to internal-team language.

## Why
LogYourBody is public **only to save GitHub Actions CI minutes** — not as an open-source release. The MIT license + README claims were an explicit grant letting anyone copy, modify, sublicense, and sell LYB, which contradicts that intent.

## Notes
- LICENSE adds an explicit clause: *public availability does not constitute an open-source release and grants no license*.
- Copyright entity aligned to **Jovie Technology Inc.** (was individual "Tim White"). If LYB is intentionally held personally by Tim, change the entity before merge.
- ⚠️ **Legal caveat:** MIT is irrevocable for snapshots already published under it. This stops the grant going forward and removes the standing invitation, but cannot retroactively revoke rights for prior commits. Legal should be aware.

Do not merge until reviewed.