### PR TITLE
refactor: extract + test battery sync-interval policy and chunking

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		AD7243592E15FA5E002376C6 /* Config.xcconfig.example in Resources */ = {isa = PBXBuildFile; fileRef = AD723B0D2E15FA5C002376C6 /* Config.xcconfig.example */; };
 		AD72435C2E15FA5E002376C6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AD723B102E15FA5C002376C6 /* LaunchScreen.storyboard */; };
 		AD7D30A72E1490810072AA5B /* LogYourBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7D30A62E1490810072AA5B /* LogYourBodyTests.swift */; };
+		FE04A4A400000000000000B4 /* SyncIntervalAndChunkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE04A4A400000000000000F4 /* SyncIntervalAndChunkingTests.swift */; };
 		AD7D30B12E1490810072AA5B /* LogYourBodyUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7D30B02E1490810072AA5B /* LogYourBodyUITests.swift */; };
 		AD7D30B32E1490810072AA5B /* LogYourBodyUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7D30B22E1490810072AA5B /* LogYourBodyUITestsLaunchTests.swift */; };
 		AD8872332EB405C00041C426 /* BackgroundTaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8872322EB405C00041C426 /* BackgroundTaskType.swift */; };
@@ -197,6 +198,7 @@
 		ADDC47B92E2D89F3003C97E7 /* BulkImportManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD933DFE2E249EA000801078 /* BulkImportManager.swift */; };
 		ADDC47BA2E2D89F3003C97E7 /* PhotoLibraryScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD933DFF2E249EA000801078 /* PhotoLibraryScanner.swift */; };
 		ADDC47BC2E2D89F3003C97E7 /* RealtimeSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8552552E19A5B5003552EE /* RealtimeSyncManager.swift */; };
+		FE03A3A300000000000000B3 /* BatterySyncIntervalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE03A3A300000000000000F3 /* BatterySyncIntervalPolicy.swift */; };
 		ADDC47BD2E2D89F3003C97E7 /* BackgroundRemovalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8552932E1CC15B003552EE /* BackgroundRemovalService.swift */; };
 		ADDC47BE2E2D89F3003C97E7 /* PhotoMetadataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF5C1B32E1CDB9C00E3FB4D /* PhotoMetadataService.swift */; };
 		ADDC47BF2E2D89F3003C97E7 /* SupabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFC6A232E187717004FCE40 /* SupabaseManager.swift */; };
@@ -448,12 +450,14 @@
 		AD7D309C2E1490810072AA5B /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		AD7D30A22E1490810072AA5B /* LogYourBodyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LogYourBodyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD7D30A62E1490810072AA5B /* LogYourBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogYourBodyTests.swift; sourceTree = "<group>"; };
+		FE04A4A400000000000000F4 /* SyncIntervalAndChunkingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncIntervalAndChunkingTests.swift; sourceTree = "<group>"; };
 		AD7D30AC2E1490810072AA5B /* LogYourBodyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LogYourBodyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD7D30B02E1490810072AA5B /* LogYourBodyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogYourBodyUITests.swift; sourceTree = "<group>"; };
 		AD7D30B22E1490810072AA5B /* LogYourBodyUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogYourBodyUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		AD8056FC2E25F5180028C0DD /* CameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
 		AD8552532E19A2A1003552EE /* ProfileSettingsViewV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingsViewV2.swift; sourceTree = "<group>"; };
 		AD8552552E19A5B5003552EE /* RealtimeSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeSyncManager.swift; sourceTree = "<group>"; };
+		FE03A3A300000000000000F3 /* BatterySyncIntervalPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatterySyncIntervalPolicy.swift; sourceTree = "<group>"; };
 		AD85525D2E19DC01003552EE /* AppVersionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionManager.swift; sourceTree = "<group>"; };
 		AD85525F2E19DC44003552EE /* Changelog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Changelog.swift; sourceTree = "<group>"; };
 		AD8552612E19DC9C003552EE /* VersionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionInfo.swift; sourceTree = "<group>"; };
@@ -960,6 +964,7 @@
 				AD933DFE2E249EA000801078 /* BulkImportManager.swift */,
 				AD933DFF2E249EA000801078 /* PhotoLibraryScanner.swift */,
 				AD8552552E19A5B5003552EE /* RealtimeSyncManager.swift */,
+				FE03A3A300000000000000F3 /* BatterySyncIntervalPolicy.swift */,
 				AD8552932E1CC15B003552EE /* BackgroundRemovalService.swift */,
 				ADF5C1B32E1CDB9C00E3FB4D /* PhotoMetadataService.swift */,
 				75034CADEA1D4697BDCB5555 /* ImageCacheService.swift */,
@@ -1156,6 +1161,7 @@
 			isa = PBXGroup;
 			children = (
 				AD7D30A62E1490810072AA5B /* LogYourBodyTests.swift */,
+				FE04A4A400000000000000F4 /* SyncIntervalAndChunkingTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1593,6 +1599,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AD7D30A72E1490810072AA5B /* LogYourBodyTests.swift in Sources */,
+				FE04A4A400000000000000B4 /* SyncIntervalAndChunkingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1681,6 +1688,7 @@
 				AD8872432EB87F290041C426 /* ProgressRing.swift in Sources */,
 				ADDC47BA2E2D89F3003C97E7 /* PhotoLibraryScanner.swift in Sources */,
 				ADDC47BC2E2D89F3003C97E7 /* RealtimeSyncManager.swift in Sources */,
+				FE03A3A300000000000000B3 /* BatterySyncIntervalPolicy.swift in Sources */,
 				ADDC47BD2E2D89F3003C97E7 /* BackgroundRemovalService.swift in Sources */,
 				ADDC47BE2E2D89F3003C97E7 /* PhotoMetadataService.swift in Sources */,
 				9B5611E2F8314E22A5BF7889 /* ImageCacheService.swift in Sources */,

--- a/apps/ios/LogYourBody/Services/BatterySyncIntervalPolicy.swift
+++ b/apps/ios/LogYourBody/Services/BatterySyncIntervalPolicy.swift
@@ -1,0 +1,29 @@
+//
+// BatterySyncIntervalPolicy.swift
+// LogYourBody
+//
+import UIKit
+
+/// Maps device battery state/level to an auto-sync interval.
+///
+/// Extracted from `RealtimeSyncManager.adjustSyncIntervalForBattery()` so the
+/// thresholds can be unit tested without a physical device (battery level/state
+/// are not controllable in the simulator).
+enum BatterySyncIntervalPolicy {
+    /// Sync aggressively while charging, then back off as the battery drains.
+    ///
+    /// - Note: `level` is `-1` when battery monitoring is unavailable; that falls
+    ///   through to the most conservative interval, which is the safe default.
+    static func interval(state: UIDevice.BatteryState, level: Float) -> TimeInterval {
+        switch (state, level) {
+        case (.charging, _), (.full, _):
+            return 60      // 1 minute — charging or full
+        case (_, let level) where level > 0.5:
+            return 300     // 5 minutes — above 50%
+        case (_, let level) where level > 0.2:
+            return 900     // 15 minutes — 20% to 50%
+        default:
+            return 1_800   // 30 minutes — below 20% (or level unknown)
+        }
+    }
+}

--- a/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
+++ b/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
@@ -196,23 +196,10 @@ class RealtimeSyncManager: ObservableObject {
     // MARK: - Battery Optimization
     private func adjustSyncIntervalForBattery() {
         UIDevice.current.isBatteryMonitoringEnabled = true
-        let batteryLevel = UIDevice.current.batteryLevel
-        let batteryState = UIDevice.current.batteryState
-
-        switch (batteryState, batteryLevel) {
-        case (.charging, _), (.full, _):
-            // Aggressive sync when charging
-            syncInterval = 60 // 1 minute
-        case (_, let level) where level > 0.5:
-            // Normal sync above 50% battery
-            syncInterval = 300 // 5 minutes
-        case (_, let level) where level > 0.2:
-            // Conservative sync below 50% battery
-            syncInterval = 900 // 15 minutes
-        default:
-            // Minimal sync below 20% battery
-            syncInterval = 1_800 // 30 minutes
-        }
+        syncInterval = BatterySyncIntervalPolicy.interval(
+            state: UIDevice.current.batteryState,
+            level: UIDevice.current.batteryLevel
+        )
 
         // Restart timer with new interval
         startAutoSync()

--- a/apps/ios/LogYourBodyTests/SyncIntervalAndChunkingTests.swift
+++ b/apps/ios/LogYourBodyTests/SyncIntervalAndChunkingTests.swift
@@ -1,0 +1,76 @@
+//
+// SyncIntervalAndChunkingTests.swift
+// LogYourBodyTests
+//
+// Coverage for the pure sync helpers in RealtimeSyncManager's subsystem:
+// the battery -> sync-interval policy and the Array.chunked batching primitive
+// that all five sync-batch upload paths rely on.
+//
+import XCTest
+import UIKit
+@testable import LogYourBody
+
+final class SyncIntervalAndChunkingTests: XCTestCase {
+    // MARK: - BatterySyncIntervalPolicy
+
+    func testChargingOrFullSyncsAggressivelyRegardlessOfLevel() {
+        XCTAssertEqual(BatterySyncIntervalPolicy.interval(state: .charging, level: 0.1), 60)
+        XCTAssertEqual(BatterySyncIntervalPolicy.interval(state: .full, level: 0.95), 60)
+        // Charging overrides an unknown (-1) level.
+        XCTAssertEqual(BatterySyncIntervalPolicy.interval(state: .charging, level: -1), 60)
+    }
+
+    func testAboveFiftyPercentUsesNormalInterval() {
+        XCTAssertEqual(BatterySyncIntervalPolicy.interval(state: .unplugged, level: 0.6), 300)
+        XCTAssertEqual(BatterySyncIntervalPolicy.interval(state: .unplugged, level: 0.51), 300)
+    }
+
+    func testBoundaryAtFiftyPercentIsConservative() {
+        // Exactly 0.5 is not > 0.5, so it falls into the 20-50% band.
+        XCTAssertEqual(BatterySyncIntervalPolicy.interval(state: .unplugged, level: 0.5), 900)
+        XCTAssertEqual(BatterySyncIntervalPolicy.interval(state: .unplugged, level: 0.3), 900)
+    }
+
+    func testBoundaryAtTwentyPercentIsMinimal() {
+        // Exactly 0.2 is not > 0.2, so it falls into the < 20% band.
+        XCTAssertEqual(BatterySyncIntervalPolicy.interval(state: .unplugged, level: 0.2), 1_800)
+        XCTAssertEqual(BatterySyncIntervalPolicy.interval(state: .unplugged, level: 0.1), 1_800)
+    }
+
+    func testUnknownLevelFallsBackToMinimal() {
+        // Battery monitoring unavailable reports level -1; default to the safest interval.
+        XCTAssertEqual(BatterySyncIntervalPolicy.interval(state: .unknown, level: -1), 1_800)
+    }
+
+    // MARK: - Array.chunked(into:)
+
+    func testChunkExactMultiple() {
+        let chunks = Array(1...10).chunked(into: 5)
+        XCTAssertEqual(chunks, [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    }
+
+    func testChunkWithRemainder() {
+        let chunks = Array(1...12).chunked(into: 5)
+        XCTAssertEqual(chunks.map(\.count), [5, 5, 2])
+        XCTAssertEqual(chunks.last, [11, 12])
+    }
+
+    func testChunkEmptyIsEmpty() {
+        XCTAssertTrue([Int]().chunked(into: 50).isEmpty)
+    }
+
+    func testChunkLargerThanCountIsSingleChunk() {
+        XCTAssertEqual([1, 2, 3].chunked(into: 10), [[1, 2, 3]])
+    }
+
+    func testChunkSizeOneSplitsEveryElement() {
+        XCTAssertEqual([1, 2, 3].chunked(into: 1), [[1], [2], [3]])
+    }
+
+    func testChunkPreservesAllElementsInOrder() {
+        let source = Array(0..<137)
+        let chunks = source.chunked(into: 50)
+        XCTAssertEqual(chunks.count, 3) // 50 + 50 + 37
+        XCTAssertEqual(chunks.flatMap { $0 }, source)
+    }
+}


### PR DESCRIPTION
## What & why

`RealtimeSyncManager` had two pieces of pure logic that drove sync behavior but had no coverage because they were locked behind device APIs / an internal extension:

1. **Battery → sync-interval thresholds** — buried in the private `adjustSyncIntervalForBattery()`, which reads `UIDevice.current` directly (uncontrollable in the simulator).
2. **`Array.chunked(into:)`** — the batching primitive every one of the five sync-batch upload paths uses to chunk records into groups of 50.

## Change
- Extract the battery mapping into a pure `BatterySyncIntervalPolicy.interval(state:level:)`. `adjustSyncIntervalForBattery()` now calls it; **behavior is unchanged** (identical thresholds).
- Add `SyncIntervalAndChunkingTests` (11 tests):
  - Battery: charging/full → 60s (overrides level), >50% → 300s, the **0.5 and 0.2 boundaries** (`not >`, so they fall to the more conservative band → 900s / 1800s), <20% → 1800s, and the `level == -1` (monitoring unavailable) fallback → 1800s.
  - `chunked`: exact multiple, remainder (`[5,5,2]`), empty → `[]`, size > count, size 1, and order/element preservation over 137 elements.

## Testing
- Full `LogYourBodyTests` target: **199 passed, 0 failures** (the rewire regressed nothing)
- SwiftLint `--strict` clean on changed files
- `project.pbxproj` change is two minimal 4-line file registrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)