### PR TITLE
refactor: extract + test GLP-1 dose card data and catalog lookups

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		AD7243592E15FA5E002376C6 /* Config.xcconfig.example in Resources */ = {isa = PBXBuildFile; fileRef = AD723B0D2E15FA5C002376C6 /* Config.xcconfig.example */; };
 		AD72435C2E15FA5E002376C6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AD723B102E15FA5C002376C6 /* LaunchScreen.storyboard */; };
 		AD7D30A72E1490810072AA5B /* LogYourBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7D30A62E1490810072AA5B /* LogYourBodyTests.swift */; };
+		FE06A6A600000000000000B6 /* Glp1CardAndCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE06A6A600000000000000F6 /* Glp1CardAndCatalogTests.swift */; };
 		AD7D30B12E1490810072AA5B /* LogYourBodyUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7D30B02E1490810072AA5B /* LogYourBodyUITests.swift */; };
 		AD7D30B32E1490810072AA5B /* LogYourBodyUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7D30B22E1490810072AA5B /* LogYourBodyUITestsLaunchTests.swift */; };
 		AD8872332EB405C00041C426 /* BackgroundTaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8872322EB405C00041C426 /* BackgroundTaskType.swift */; };
@@ -266,6 +267,7 @@
 		ADDC488A2E2D8A6B003C97E7 /* WhatsNewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADDC487A2E2D8A6B003C97E7 /* WhatsNewRow.swift */; };
 		ADE146442EBF05E000B64DA0 /* TimelineMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE146432EBF05E000B64DA0 /* TimelineMode.swift */; };
 		ADE146462EBF090D00B64DA0 /* ProgressTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE146452EBF090D00B64DA0 /* ProgressTimelineView.swift */; };
+		FE05A5A500000000000000B5 /* Glp1DoseCardData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE05A5A500000000000000F5 /* Glp1DoseCardData.swift */; };
 		ADE146482EBF0B4800B64DA0 /* TimelineDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE146472EBF0B4800B64DA0 /* TimelineDataProvider.swift */; };
 		ADE1464E2EBF0BDF00B64DA0 /* TimelineZoomLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE1464B2EBF0BDF00B64DA0 /* TimelineZoomLevel.swift */; };
 		ADE1464F2EBF0BDF00B64DA0 /* TimelinePhotoSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE1464A2EBF0BDF00B64DA0 /* TimelinePhotoSampler.swift */; };
@@ -448,6 +450,7 @@
 		AD7D309C2E1490810072AA5B /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		AD7D30A22E1490810072AA5B /* LogYourBodyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LogYourBodyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD7D30A62E1490810072AA5B /* LogYourBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogYourBodyTests.swift; sourceTree = "<group>"; };
+		FE06A6A600000000000000F6 /* Glp1CardAndCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glp1CardAndCatalogTests.swift; sourceTree = "<group>"; };
 		AD7D30AC2E1490810072AA5B /* LogYourBodyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LogYourBodyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD7D30B02E1490810072AA5B /* LogYourBodyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogYourBodyUITests.swift; sourceTree = "<group>"; };
 		AD7D30B22E1490810072AA5B /* LogYourBodyUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogYourBodyUITestsLaunchTests.swift; sourceTree = "<group>"; };
@@ -630,6 +633,7 @@
 		ADDC487B2E2D8A6B003C97E7 /* WhatsNewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewView.swift; sourceTree = "<group>"; };
 		ADE146432EBF05E000B64DA0 /* TimelineMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineMode.swift; sourceTree = "<group>"; };
 		ADE146452EBF090D00B64DA0 /* ProgressTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ProgressTimelineView.swift; path = Components/ProgressTimelineView.swift; sourceTree = "<group>"; };
+		FE05A5A500000000000000F5 /* Glp1DoseCardData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Glp1DoseCardData.swift; path = Components/Glp1DoseCardData.swift; sourceTree = "<group>"; };
 		ADE146472EBF0B4800B64DA0 /* TimelineDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineDataProvider.swift; sourceTree = "<group>"; };
 		ADE1464A2EBF0BDF00B64DA0 /* TimelinePhotoSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelinePhotoSampler.swift; sourceTree = "<group>"; };
 		ADE1464B2EBF0BDF00B64DA0 /* TimelineZoomLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineZoomLevel.swift; sourceTree = "<group>"; };
@@ -784,6 +788,7 @@
 				C8D57BE85A4043A0A831CFE4 /* SkeletonLoaders.swift */,
 				ADA923012E22EF4600B82C49 /* Common */,
 				ADE146452EBF090D00B64DA0 /* ProgressTimelineView.swift */,
+				FE05A5A500000000000000F5 /* Glp1DoseCardData.swift */,
 			);
 			name = Components;
 			sourceTree = "<group>";
@@ -1156,6 +1161,7 @@
 			isa = PBXGroup;
 			children = (
 				AD7D30A62E1490810072AA5B /* LogYourBodyTests.swift */,
+				FE06A6A600000000000000F6 /* Glp1CardAndCatalogTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1593,6 +1599,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AD7D30A72E1490810072AA5B /* LogYourBodyTests.swift in Sources */,
+				FE06A6A600000000000000B6 /* Glp1CardAndCatalogTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1613,6 +1620,7 @@
 				ADDC479E2E2D89F3003C97E7 /* CommonComponents.swift in Sources */,
 				ADDC47A12E2D89F3003C97E7 /* ProcessingImagePlaceholder.swift in Sources */,
 				ADE146462EBF090D00B64DA0 /* ProgressTimelineView.swift in Sources */,
+				FE05A5A500000000000000B5 /* Glp1DoseCardData.swift in Sources */,
 				ADDC47A32E2D89F3003C97E7 /* SettingsComponents.swift in Sources */,
 				ADDC47A72E2D89F3003C97E7 /* Changelog.swift in Sources */,
 				ADDC47A82E2D89F3003C97E7 /* BodyMetrics.swift in Sources */,

--- a/apps/ios/LogYourBody/Components/Glp1DoseCardData.swift
+++ b/apps/ios/LogYourBody/Components/Glp1DoseCardData.swift
@@ -1,0 +1,44 @@
+//
+// Glp1DoseCardData.swift
+// LogYourBody
+//
+import Foundation
+
+/// Pure data preparation for the dashboard GLP-1 dose card.
+///
+/// Extracted from `DashboardViewLiquid.glp1MetricCard` so the sort / last-7 /
+/// mapping logic can be unit tested without rendering a SwiftUI view.
+struct Glp1DoseCardData {
+    let latestDose: Double
+    let unit: String
+    let latestTakenAt: Date
+    let dataPoints: [MetricSummaryCard.DataPoint]
+
+    /// Builds card data from raw dose logs, or `nil` when there is no logged dose
+    /// to headline. Mirrors the card's original behaviour exactly: logs are sorted
+    /// ascending by `takenAt`; the newest log must itself carry a dose or the card
+    /// is hidden; the last 7 logs form the sparkline, where rest-day entries (no
+    /// dose) are dropped but still consume their enumeration index.
+    static func make(from logs: [Glp1DoseLog]) -> Glp1DoseCardData? {
+        let sortedLogs = logs.sorted { $0.takenAt < $1.takenAt }
+
+        guard let latestLog = sortedLogs.last,
+              let latestDose = latestLog.doseAmount else {
+            return nil
+        }
+
+        let dataPoints: [MetricSummaryCard.DataPoint] = Array(sortedLogs.suffix(7))
+            .enumerated()
+            .compactMap { index, log in
+                guard let value = log.doseAmount else { return nil }
+                return MetricSummaryCard.DataPoint(index: index, value: value)
+            }
+
+        return Glp1DoseCardData(
+            latestDose: latestDose,
+            unit: latestLog.doseUnit ?? "mg",
+            latestTakenAt: latestLog.takenAt,
+            dataPoints: dataPoints
+        )
+    }
+}

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Glp1MetricCard.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Glp1MetricCard.swift
@@ -5,18 +5,7 @@ import SwiftUI
 extension DashboardViewLiquid {
     @ViewBuilder
     var glp1MetricCard: some View {
-        let sortedLogs = glp1DoseLogs.sorted { $0.takenAt < $1.takenAt }
-
-        if let latestLog = sortedLogs.last,
-           let latestDose = latestLog.doseAmount {
-            let unit = latestLog.doseUnit ?? "mg"
-            let dataPoints: [MetricSummaryCard.DataPoint] = Array(sortedLogs.suffix(7))
-                .enumerated()
-                .compactMap { index, log in
-                    guard let value = log.doseAmount else { return nil }
-                    return MetricSummaryCard.DataPoint(index: index, value: value)
-                }
-
+        if let cardData = Glp1DoseCardData.make(from: glp1DoseLogs) {
             Button {
                 selectedMetricType = .glp1
                 isMetricDetailActive = true
@@ -27,12 +16,12 @@ extension DashboardViewLiquid {
                     state: .data(
                         MetricSummaryCard.Content(
                             title: "GLP-1 Dose",
-                            value: String(format: "%.1f", latestDose),
-                            unit: unit,
-                            timestamp: formatCardDateOnly(latestLog.takenAt),
-                            dataPoints: dataPoints,
+                            value: String(format: "%.1f", cardData.latestDose),
+                            unit: cardData.unit,
+                            timestamp: formatCardDateOnly(cardData.latestTakenAt),
+                            dataPoints: cardData.dataPoints,
                             chartAccessibilityLabel: "GLP-1 dose history",
-                            chartAccessibilityValue: "Latest dose \(String(format: "%.1f", latestDose)) \(unit)",
+                            chartAccessibilityValue: "Latest dose \(String(format: "%.1f", cardData.latestDose)) \(cardData.unit)",
                             trend: nil,
                             footnote: nil
                         )

--- a/apps/ios/LogYourBodyTests/Glp1CardAndCatalogTests.swift
+++ b/apps/ios/LogYourBodyTests/Glp1CardAndCatalogTests.swift
@@ -1,0 +1,154 @@
+//
+// Glp1CardAndCatalogTests.swift
+// LogYourBodyTests
+//
+// Coverage for the GLP-1 dashboard card data prep (Glp1DoseCardData) and the
+// previously-untested medication catalog lookups (Glp1MedicationCatalog).
+//
+import XCTest
+@testable import LogYourBody
+
+final class Glp1CardAndCatalogTests: XCTestCase {
+    private let base = Date(timeIntervalSince1970: 1_800_000_000)
+
+    // MARK: - Glp1DoseCardData.make
+
+    func testCardDataNilForEmptyLogs() {
+        XCTAssertNil(Glp1DoseCardData.make(from: []))
+    }
+
+    func testCardDataNilWhenNewestLogIsRestDay() {
+        // Newest log has no dose -> card is hidden even though an earlier dose exists.
+        let logs = [
+            makeDoseLog(id: "a", takenAt: base, doseAmount: 2.5),
+            makeDoseLog(id: "rest", takenAt: base.addingTimeInterval(86_400), doseAmount: nil)
+        ]
+        XCTAssertNil(Glp1DoseCardData.make(from: logs))
+    }
+
+    func testCardDataUsesNewestLogAfterSorting() throws {
+        // Provide out of order; newest by takenAt should headline.
+        let logs = [
+            makeDoseLog(id: "new", takenAt: base.addingTimeInterval(86_400 * 2), doseAmount: 7.5, unit: "mg/week"),
+            makeDoseLog(id: "old", takenAt: base, doseAmount: 2.5, unit: "mg/week")
+        ]
+        let data = try XCTUnwrap(Glp1DoseCardData.make(from: logs))
+        XCTAssertEqual(data.latestDose, 7.5)
+        XCTAssertEqual(data.unit, "mg/week")
+        XCTAssertEqual(data.latestTakenAt, base.addingTimeInterval(86_400 * 2))
+    }
+
+    func testCardDataUnitFallsBackToMg() throws {
+        let data = try XCTUnwrap(Glp1DoseCardData.make(from: [
+            makeDoseLog(id: "a", takenAt: base, doseAmount: 1.0, unit: nil)
+        ]))
+        XCTAssertEqual(data.unit, "mg")
+    }
+
+    func testCardDataKeepsOnlyLastSevenLogs() throws {
+        let logs = (0..<10).map { i in
+            makeDoseLog(id: "d\(i)", takenAt: base.addingTimeInterval(Double(i) * 86_400), doseAmount: Double(i))
+        }
+        let data = try XCTUnwrap(Glp1DoseCardData.make(from: logs))
+        XCTAssertEqual(data.dataPoints.count, 7)
+        // Indices are re-based 0...6 over the last seven; values are doses 3...9.
+        XCTAssertEqual(data.dataPoints.map(\.index), Array(0...6))
+        XCTAssertEqual(data.dataPoints.map(\.value), (3...9).map(Double.init))
+    }
+
+    func testCardDataRestDayLeavesIndexGapInSparkline() throws {
+        // Middle log is a rest day: dropped from points but its index is consumed.
+        let logs = [
+            makeDoseLog(id: "a", takenAt: base, doseAmount: 1.0),
+            makeDoseLog(id: "rest", takenAt: base.addingTimeInterval(86_400), doseAmount: nil),
+            makeDoseLog(id: "c", takenAt: base.addingTimeInterval(86_400 * 2), doseAmount: 2.0)
+        ]
+        let data = try XCTUnwrap(Glp1DoseCardData.make(from: logs))
+        XCTAssertEqual(data.dataPoints.map(\.index), [0, 2])
+        XCTAssertEqual(data.dataPoints.map(\.value), [1.0, 2.0])
+    }
+
+    // MARK: - Glp1MedicationCatalog
+
+    func testPresetLookupIsCaseInsensitive() {
+        XCTAssertEqual(Glp1MedicationCatalog.preset(forBrand: "wegovy")?.brand, "Wegovy")
+        XCTAssertEqual(Glp1MedicationCatalog.preset(forBrand: "OZEMPIC")?.genericName, "semaglutide")
+    }
+
+    func testPresetLookupReturnsNilForUnknownBrand() {
+        XCTAssertNil(Glp1MedicationCatalog.preset(forBrand: "NotARealDrug"))
+    }
+
+    func testDoseConfigUsesBrandPreset() {
+        let med = makeMedication(brand: "Ozempic", genericName: "semaglutide", doseUnit: "mg/week")
+        let config = Glp1MedicationCatalog.doseConfig(for: med)
+        XCTAssertEqual(config.unit, "mg/week")
+        XCTAssertEqual(config.doses, [0.25, 0.5, 1.0, 2.0])
+    }
+
+    func testDoseConfigFallsBackToGenericMatch() {
+        // No brand match -> first preset whose generic matches (Saxenda for liraglutide).
+        let med = makeMedication(brand: nil, genericName: "liraglutide", doseUnit: "mg/day")
+        let config = Glp1MedicationCatalog.doseConfig(for: med)
+        XCTAssertEqual(config.unit, "mg/day")
+        XCTAssertEqual(config.doses, [0.6, 1.2, 1.8, 2.4, 3.0])
+    }
+
+    func testDoseConfigFinalFallbackUsesMedicationUnitAndDefaultLadder() {
+        let med = makeMedication(brand: nil, genericName: "made-up-peptide", doseUnit: "units/day")
+        let config = Glp1MedicationCatalog.doseConfig(for: med)
+        XCTAssertEqual(config.unit, "units/day")
+        XCTAssertEqual(config.doses, [0.25, 0.5, 1.0, 1.5, 2.0, 2.5])
+    }
+
+    func testAllPresetsAreWellFormed() {
+        let presets = Glp1MedicationCatalog.allPresets
+        XCTAssertFalse(presets.isEmpty)
+        for preset in presets {
+            XCTAssertFalse(preset.doseUnit.isEmpty, "\(preset.brand) has empty doseUnit")
+            XCTAssertFalse(preset.doses.isEmpty, "\(preset.brand) has no doses")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func makeDoseLog(id: String, takenAt: Date, doseAmount: Double?, unit: String? = "mg/week") -> Glp1DoseLog {
+        Glp1DoseLog(
+            id: id,
+            userId: "glp1-card-user",
+            takenAt: takenAt,
+            medicationId: "med",
+            doseAmount: doseAmount,
+            doseUnit: unit,
+            drugClass: "GLP-1 receptor agonist",
+            brand: "Ozempic",
+            isCompounded: false,
+            supplierType: nil,
+            supplierName: nil,
+            notes: nil,
+            createdAt: takenAt,
+            updatedAt: takenAt
+        )
+    }
+
+    private func makeMedication(brand: String?, genericName: String?, doseUnit: String?) -> Glp1Medication {
+        Glp1Medication(
+            id: "med",
+            userId: "glp1-card-user",
+            displayName: brand ?? "Custom",
+            genericName: genericName,
+            drugClass: "GLP-1 receptor agonist",
+            brand: brand,
+            route: "subcutaneous",
+            frequency: "once weekly",
+            doseUnit: doseUnit,
+            isCompounded: false,
+            hkIdentifier: nil,
+            startedAt: base,
+            endedAt: nil,
+            notes: nil,
+            createdAt: base,
+            updatedAt: base
+        )
+    }
+}


### PR DESCRIPTION
## What & why

Two GLP-1 pieces had no coverage: the dashboard dose card prepared its data inline in a SwiftUI `@ViewBuilder` (so it couldn't be tested), and `Glp1MedicationCatalog` (brand/generic dose-ladder lookups) had no tests at all.

## Change
- Extract `Glp1DoseCardData.make(from:)` from `glp1MetricCard` and rewire the view to use it. **Behavior is identical**: the card stays hidden unless the newest log itself carries a dose; the sparkline uses the last 7 logs; rest-day entries (no dose) are dropped from the sparkline but still consume their enumeration index (preserving the original index gaps).
- Add `Glp1CardAndCatalogTests` (12 tests):
  - **Card:** empty → nil, newest-is-rest-day → nil, newest-after-sort headline, `"mg"` unit fallback, last-7 windowing with re-based indices, and the rest-day index-gap case.
  - **Catalog:** `preset(forBrand:)` case-insensitivity + unknown → nil; `doseConfig` brand-match path, generic-fallback path (Saxenda for `liraglutide`), and the final default-ladder fallback using the medication's own unit; and that every preset is well-formed.

## Testing
- `Glp1CardAndCatalogTests`: **12 passed**; SwiftLint `--strict` clean
- Full `LogYourBodyTests`: my changes pass. One unrelated test, `OnboardingFlowViewModelTests.testProfileDetailsAdvancesToFirstPhotoWhenEnabled`, failed once then passed on isolated re-run — a **pre-existing flake** on `main`, not caused by this PR (nothing here touches onboarding). Flagging separately.
- `project.pbxproj`: two minimal 4-line file registrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)