### PR TITLE
chore: add gbrain brain-first setup for the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ sentry-wizard
 .env
 .env.*
 !.env.example
+
+# gbrain (brain-first knowledge) local artifacts — see scripts/setup-gbrain.sh
+.gbrain-source
+.gbrain/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,22 @@ LogYourBody/
 
 ---
 
+## Brain-First Knowledge (gbrain)
+
+`gbrain` is the shared knowledge brain holding prior decisions, bug post-mortems, conventions, and architecture notes for this repo. **Query it before exploring the codebase or making an architectural decision.**
+
+```bash
+gbrain search "clerk proxy auth"          # keyword (tsvector)
+gbrain query "what is the timeline scrubber convention?"   # hybrid
+```
+
+- **Setup (one-time per machine):** `pnpm setup:gbrain` (or `bash scripts/setup-gbrain.sh`). It resolves the brain's Supabase URL from `GBRAIN_DATABASE_URL` or Doppler (`jovie-web/dev`) and writes `~/.gbrain/config.json`. The connection string is a secret and is never committed.
+- **Code-aware search (optional):** run `/sync-gbrain --full` in Claude Code to index this repo, enabling `gbrain code-def` / `code-refs` / `code-callers`. It pins the worktree with `.gbrain-source` (gitignored).
+- **Graceful degradation:** if gbrain is unreachable, fall back to normal repo exploration — never block on it.
+- **Writes are automatic** via the memory→gbrain sync hook; you do not push manually.
+
+---
+
 ## Branching Model
 
 ### Production / Trunk Branch

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "check": "pnpm --filter apps/web check",
     "format": "prettier --write .",
     "lint:swift": "cd apps/ios && swiftlint lint --strict",
+    "setup:gbrain": "bash scripts/setup-gbrain.sh",
     "ios:launch-quality-audit": "bash scripts/ios/launch-quality-audit.sh",
     "ios:performance-audit": "bash scripts/ios/performance-audit.sh",
     "ios:ettrace-profile": "bash scripts/ios/ettrace-profile.sh",

--- a/scripts/setup-gbrain.sh
+++ b/scripts/setup-gbrain.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# setup-gbrain.sh — point the local gbrain CLI at the shared LogYourBody brain.
+#
+# gbrain is the personal/org knowledge brain agents query before exploring the
+# repo (see "Brain-First Knowledge" in AGENTS.md). The brain lives in Supabase;
+# its connection string is a secret, so it is NOT committed. This script resolves
+# it from the environment or Doppler and writes it into ~/.gbrain/config.json.
+#
+# Idempotent and graceful: if gbrain, Doppler, or the secret are unavailable it
+# prints why and exits 0, so contributors who don't use gbrain are unaffected and
+# this can run in any bootstrap/postinstall flow without breaking it.
+#
+# Usage:
+#   bash scripts/setup-gbrain.sh         # or: pnpm setup:gbrain
+#
+# Overridable via env:
+#   GBRAIN_DATABASE_URL     full postgres URL (wins over Doppler)
+#   GBRAIN_DOPPLER_PROJECT  default: jovie-web
+#   GBRAIN_DOPPLER_CONFIG   default: dev
+#
+set -euo pipefail
+
+CONFIG="${GBRAIN_HOME:-$HOME/.gbrain}/config.json"
+DOPPLER_PROJECT="${GBRAIN_DOPPLER_PROJECT:-jovie-web}"
+DOPPLER_CONFIG="${GBRAIN_DOPPLER_CONFIG:-dev}"
+
+note() { printf '[setup-gbrain] %s\n' "$1"; }
+
+if ! command -v gbrain >/dev/null 2>&1; then
+  note "gbrain CLI not installed — skipping. Install it, then re-run to enable brain-first search."
+  exit 0
+fi
+
+# Resolve the brain database URL: explicit env wins, else Doppler.
+URL="${GBRAIN_DATABASE_URL:-}"
+SRC="env GBRAIN_DATABASE_URL"
+if [ -z "$URL" ] && command -v doppler >/dev/null 2>&1; then
+  URL="$(doppler secrets get GBRAIN_DATABASE_URL --plain \
+          --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" 2>/dev/null || true)"
+  SRC="Doppler $DOPPLER_PROJECT/$DOPPLER_CONFIG"
+fi
+
+if [ -z "$URL" ]; then
+  note "No GBRAIN_DATABASE_URL found (env or Doppler $DOPPLER_PROJECT/$DOPPLER_CONFIG) — skipping."
+  note "Set GBRAIN_DATABASE_URL, or run 'doppler login' with access to $DOPPLER_PROJECT, then re-run."
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  note "jq is required to edit the gbrain config safely — install jq, then re-run."
+  exit 0
+fi
+
+mkdir -p "$(dirname "$CONFIG")"
+if [ -f "$CONFIG" ]; then
+  # Only rewrite when something actually changes, so this stays a true no-op on re-run.
+  current="$(jq -r '.database_url // ""' "$CONFIG")"
+  engine="$(jq -r '.engine // ""' "$CONFIG")"
+  if [ "$current" = "$URL" ] && [ "$engine" = "supabase" ]; then
+    note "gbrain already configured (engine=supabase, url from $SRC) — no change."
+  else
+    cp "$CONFIG" "$CONFIG.bak"
+    tmp="$(mktemp)"
+    jq --arg url "$URL" '.database_url = $url | .engine = "supabase"' "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+    note "Updated gbrain config (engine=supabase, url from $SRC). Backup at $CONFIG.bak."
+  fi
+else
+  cat > "$CONFIG" <<JSON
+{
+  "engine": "supabase",
+  "database_url": "$URL",
+  "schema_pack": "gbrain-base-v2"
+}
+JSON
+  note "Wrote new gbrain config (engine=supabase, url from $SRC)."
+fi
+
+# Verify connectivity (non-fatal — report but never break the caller).
+if gbrain doctor --fast >/dev/null 2>&1; then
+  note "gbrain doctor OK — brain-first search is ready (try: gbrain search \"timeline scrubber\")."
+else
+  note "Config written but 'gbrain doctor' reported issues — run 'gbrain doctor' for detail."
+fi
+
+note "For code-aware search (gbrain code-def/code-refs), run '/sync-gbrain --full' in Claude Code to index this repo."


### PR DESCRIPTION
## What & why

Make the shared `gbrain` knowledge brain set up in one command, so agents can query prior decisions/conventions before exploring the codebase (the brain-first convention). Previously gbrain had to be configured by hand and its config pointed at a placeholder password.

## Changes
- **`scripts/setup-gbrain.sh`** — idempotent, graceful setup. Resolves the brain's Supabase connection string from `GBRAIN_DATABASE_URL` or Doppler (`jovie-web/dev`), writes `~/.gbrain/config.json` (`engine=supabase`), and verifies with `gbrain doctor`. The secret is **never committed**. If gbrain, Doppler, or the secret are unavailable it prints why and exits 0, so contributors who don't use gbrain (and CI) are unaffected. Project/config overridable via `GBRAIN_DOPPLER_PROJECT` / `GBRAIN_DOPPLER_CONFIG`.
- **`package.json`** — `pnpm setup:gbrain` convenience wrapper.
- **`.gitignore`** — ignore gbrain worktree artifacts (`.gbrain-source`, `.gbrain/`).
- **`AGENTS.md`** — new "Brain-First Knowledge (gbrain)" section: query-before-exploring convention, setup, code-aware search via `/sync-gbrain`, and graceful degradation.

## Verification
- `shellcheck scripts/setup-gbrain.sh`: clean
- Ran it 3×: first configures, runs 2–3 are clean no-ops (idempotent). `gbrain doctor` OK; `gbrain search`/`query`/`list` return real data from the brain.
- `package.json` validated as JSON; script committed executable (`100755`).

No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)