### PR TITLE
fix: harden iOS launch and entry flows

### DIFF
--- a/apps/ios/LogYourBody/ContentView.swift
+++ b/apps/ios/LogYourBody/ContentView.swift
@@ -18,6 +18,27 @@ enum LaunchSurfacePolicy {
     }
 }
 
+enum ProfileCompletionPolicy {
+    static func isComplete(user: User?) -> Bool {
+        guard let user else { return false }
+        return isComplete(profile: user.profile, fallbackName: user.name)
+    }
+
+    static func isComplete(profile: UserProfile?, fallbackName: String?) -> Bool {
+        guard let profile else { return false }
+
+        let profileName = profile.fullName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallbackDisplayName = fallbackName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayName = profileName?.isEmpty == false ? profileName : fallbackDisplayName
+        let hasName = !(displayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        let hasDOB = profile.dateOfBirth != nil
+        let hasHeight = (profile.height ?? 0) > 0
+        let hasGender = !(profile.gender?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+
+        return hasName && hasDOB && hasHeight && hasGender
+    }
+}
+
 private struct ProfileCompletionSyncKey: Equatable {
     let userId: String?
     let completionFlag: Bool
@@ -58,19 +79,7 @@ struct ContentView: View {
 
     // Check if user profile is complete
     private var isProfileComplete: Bool {
-        // Safely check if profile exists and is complete
-        guard let user = authManager.currentUser,
-              let profile = user.profile else {
-            return false
-        }
-
-        let displayName = profile.fullName ?? user.name
-        let hasName = !(displayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
-        let hasDOB = profile.dateOfBirth != nil
-        let hasHeight = (profile.height ?? 0) > 0
-        let hasGender = !(profile.gender?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
-
-        return hasName && hasDOB && hasHeight && hasGender
+        ProfileCompletionPolicy.isComplete(user: authManager.currentUser)
     }
 
     private var shouldShowOnboarding: Bool {

--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -416,25 +416,7 @@ struct LogYourBodyApp: App {
             break
 
         case "log":
-            // Check if user is authenticated and has completed onboarding
-            guard authManager.isAuthenticated else {
-                // User needs to sign in first
-                return
-            }
-
-            // Check if body-composition onboarding/profile requirements apply before logging.
-            let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: Constants.hasCompletedOnboardingKey)
-            let isProfileComplete = checkProfileComplete()
-            let requiresOnboarding = LaunchSurfacePolicy.requiresBodyCompositionOnboarding(
-                hasCompletedOnboarding: hasCompletedOnboarding
-            )
-            let requiresProfile = LaunchSurfacePolicy.requiresCompleteProfile(
-                isProfileComplete: isProfileComplete
-            )
-
-            if requiresOnboarding || requiresProfile {
-                // User needs to complete onboarding first
-                // Don't open the add entry sheet
+            guard canOpenEntrySheetFromDeepLink else {
                 return
             }
 
@@ -462,11 +444,21 @@ struct LogYourBodyApp: App {
         }
     }
 
-    private func checkProfileComplete() -> Bool {
-        guard let profile = authManager.currentUser?.profile else { return false }
-        return profile.fullName != nil &&
-            profile.dateOfBirth != nil &&
-            profile.height != nil &&
-            profile.gender != nil
+    private var canOpenEntrySheetFromDeepLink: Bool {
+        guard authManager.isAuthenticated,
+              let user = authManager.currentUser else {
+            return false
+        }
+
+        let hasCompletedOnboarding = OnboardingStateManager.shared.hasCompletedCurrentVersion(for: user.id)
+        let isProfileComplete = ProfileCompletionPolicy.isComplete(user: user)
+
+        return !LaunchSurfacePolicy.requiresBodyCompositionOnboarding(
+            hasCompletedOnboarding: hasCompletedOnboarding
+        ) &&
+            !LaunchSurfacePolicy.requiresCompleteProfile(
+                isProfileComplete: isProfileComplete
+            ) &&
+            revenueCatManager.isSubscribed
     }
 }

--- a/apps/ios/LogYourBody/Services/BackgroundPhotoUploadService+Processing.swift
+++ b/apps/ios/LogYourBody/Services/BackgroundPhotoUploadService+Processing.swift
@@ -82,6 +82,11 @@ extension BackgroundPhotoUploadService {
                             createdAt: date,
                             updatedAt: date
                         )
+                        try await CoreDataManager.shared.saveBodyMetricsAndWait(
+                            metrics,
+                            userId: userId,
+                            markAsSynced: false
+                        )
                     }
 
                     // Upload photo with metrics

--- a/apps/ios/LogYourBody/Services/CoreDataManager.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager.swift
@@ -1497,7 +1497,7 @@ class CoreDataManager: ObservableObject {
             let userId = data["id"] as? String ?? ""
 
             let request: NSFetchRequest<CachedProfile> = CachedProfile.fetchRequest()
-            request.predicate = NSPredicate(format: "userId == %@", userId)
+            request.predicate = NSPredicate(format: "id == %@", userId)
             request.fetchLimit = 1
 
             do {

--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -45,7 +45,7 @@ struct AddEntrySheet: View {
     @State private var isProcessingPhotos = false
     @State private var photoProgress: Double = 0
     @State private var processedCount = 0
-    @State private var photoIdentifiers: [String] = []  // Store PHAsset identifiers for deletion
+    @State private var photoIdentifiers: [String] = []  // Store successfully uploaded PHAsset identifiers for deletion
 
     // GLP-1 entry
     @State private var glp1Dose: String = ""
@@ -67,6 +67,7 @@ struct AddEntrySheet: View {
 
     @State private var showError = false
     @State private var errorMessage = ""
+    @State private var isSavingEntry = false
     @State private var showDeletePhotosPrompt = false
     @AppStorage(Constants.deletePhotosAfterImportKey) private var deletePhotosAfterImport = false
     @AppStorage(Constants.hasPromptedDeletePhotosKey) private var hasPromptedDeletePhotos = false
@@ -124,7 +125,7 @@ struct AddEntrySheet: View {
                 // Save button
                 Button(action: saveEntry) {
                     HStack {
-                        if isProcessingPhotos {
+                        if isProcessingPhotos || isSavingEntry {
                             ProgressView()
                                 .progressViewStyle(CircularProgressViewStyle(tint: .black))
                                 .scaleEffect(0.8)
@@ -140,7 +141,7 @@ struct AddEntrySheet: View {
                     .foregroundColor(canSave ? .black : .white)
                     .cornerRadius(Constants.cornerRadius)
                 }
-                .disabled(!canSave || isProcessingPhotos)
+                .disabled(!canSave || isProcessingPhotos || isSavingEntry)
                 .padding()
             }
             .navigationTitle("Add Entry")
@@ -739,6 +740,7 @@ struct AddEntrySheet: View {
     // MARK: - Actions
     private func saveEntry() {
         guard let userId = authManager.currentUser?.id else { return }
+        guard !isSavingEntry, !isProcessingPhotos else { return }
 
         switch selectedTab {
         case 0:
@@ -762,8 +764,11 @@ struct AddEntrySheet: View {
             let weightInKg = resolvedWeightUnit == "lbs" ? validatedWeight.lbsToKg : validatedWeight
 
             weightError = nil
+            isSavingEntry = true
 
             Task {
+                defer { isSavingEntry = false }
+
                 _ = await PhotoMetadataService.shared.createOrUpdateMetrics(
                     for: selectedDate,
                     weight: weightInKg,
@@ -772,19 +777,17 @@ struct AddEntrySheet: View {
                 RealtimeSyncManager.shared.syncIfNeeded()
 
                 BodyScoreRecalculationService.shared.scheduleRecalculation()
+
+                trackEntrySaved(
+                    type: "weight",
+                    properties: [
+                        "unit": resolvedWeightUnit
+                    ]
+                )
+                HapticManager.shared.successAction()
+
+                dismiss()
             }
-
-            AnalyticsService.shared.track(
-                event: "entry_saved",
-                properties: [
-                    "type": "weight",
-                    "unit": resolvedWeightUnit
-                ]
-            )
-            trackLogEntrySaved(type: "weight")
-            HapticManager.shared.successAction()
-
-            dismiss()
         } catch let error as ValidationError {
             handleValidationError(error, for: .weight)
         } catch {
@@ -796,8 +799,11 @@ struct AddEntrySheet: View {
         do {
             let validatedBodyFat = try ValidationService.shared.validateBodyFat(bodyFat)
             bodyFatError = nil
+            isSavingEntry = true
 
             Task {
+                defer { isSavingEntry = false }
+
                 _ = await PhotoMetadataService.shared.createOrUpdateMetrics(
                     for: selectedDate,
                     bodyFatPercentage: validatedBodyFat,
@@ -806,11 +812,11 @@ struct AddEntrySheet: View {
                 RealtimeSyncManager.shared.syncIfNeeded()
 
                 BodyScoreRecalculationService.shared.scheduleRecalculation()
-            }
 
-            trackLogEntrySaved(type: "body_fat")
-            HapticManager.shared.successAction()
-            dismiss()
+                trackEntrySaved(type: "body_fat")
+                HapticManager.shared.successAction()
+                dismiss()
+            }
         } catch let error as ValidationError {
             handleValidationError(error, for: .bodyFat)
         } catch {
@@ -843,6 +849,7 @@ struct AddEntrySheet: View {
             }
 
             glp1Error = nil
+            isSavingEntry = true
 
             let now = Date()
             let calendar = Calendar.current
@@ -865,21 +872,22 @@ struct AddEntrySheet: View {
             )
 
             Task {
+                defer { isSavingEntry = false }
+
                 CoreDataManager.shared.saveGlp1DoseLogs([log], userId: userId, markAsSynced: false)
                 await loadGlp1DoseLogs(userId: userId)
                 RealtimeSyncManager.shared.updatePendingSyncCount()
                 RealtimeSyncManager.shared.syncIfNeeded()
+
+                trackEntrySaved(
+                    type: "glp1",
+                    properties: [
+                        "medication_id": medication.id,
+                        "dose_unit": medication.doseUnit ?? glp1DoseUnit
+                    ]
+                )
                 dismiss()
             }
-
-            AnalyticsService.shared.track(
-                event: "entry_saved",
-                properties: [
-                    "type": "glp1",
-                    "medication_id": medication.id,
-                    "dose_unit": medication.doseUnit ?? glp1DoseUnit
-                ]
-            )
         }
     }
 
@@ -888,13 +896,18 @@ struct AddEntrySheet: View {
         photoProgress = 0
         processedCount = 0
         photoIdentifiers.removeAll()
+        var successfulUploadCount = 0
+        var successfulPhotoIdentifiers: [String] = []
 
         for (index, item) in selectedPhotos.enumerated() {
             do {
-                // Extract PHAsset identifier if available
-                if let identifier = item.itemIdentifier {
-                    photoIdentifiers.append(identifier)
+                defer {
+                    processedCount = index + 1
+                    photoProgress = Double(processedCount) / Double(selectedPhotos.count)
                 }
+
+                // Extract PHAsset identifier if available
+                let itemIdentifier = item.itemIdentifier
 
                 // Load the photo data
                 guard let data = try await item.loadTransferable(type: Data.self),
@@ -917,8 +930,10 @@ struct AddEntrySheet: View {
                     image: image
                 )
 
-                processedCount = index + 1
-                photoProgress = Double(processedCount) / Double(selectedPhotos.count)
+                successfulUploadCount += 1
+                if let itemIdentifier {
+                    successfulPhotoIdentifiers.append(itemIdentifier)
+                }
             } catch {
                 let context = ErrorContext(
                     feature: "photos",
@@ -930,6 +945,15 @@ struct AddEntrySheet: View {
             }
         }
 
+        if successfulUploadCount == 0 {
+            isProcessingPhotos = false
+            errorMessage = "Photo upload failed. Please try again."
+            showError = true
+            return
+        }
+
+        photoIdentifiers = successfulPhotoIdentifiers
+
         // Delete photos from camera roll if enabled
         if deletePhotosAfterImport && !photoIdentifiers.isEmpty {
             await deletePhotosFromLibrary()
@@ -939,23 +963,22 @@ struct AddEntrySheet: View {
         RealtimeSyncManager.shared.syncIfNeeded()
         dismiss()
 
-        AnalyticsService.shared.track(
-            event: "entry_saved",
+        trackEntrySaved(
+            type: "photos",
             properties: [
-                "type": "photos",
-                "count": String(selectedPhotos.count)
+                "count": String(successfulUploadCount)
             ]
         )
-        trackLogEntrySaved(type: "photos")
         HapticManager.shared.successAction()
     }
 
-    private func trackLogEntrySaved(type: String) {
+    private func trackEntrySaved(type: String, properties: [String: String] = [:]) {
+        var eventProperties = properties
+        eventProperties["type"] = type
+
         AnalyticsService.shared.track(
-            event: "log_entry_saved",
-            properties: [
-                "type": type
-            ]
+            event: "entry_saved",
+            properties: eventProperties
         )
     }
 

--- a/apps/ios/LogYourBody/Views/MainTabView.swift
+++ b/apps/ios/LogYourBody/Views/MainTabView.swift
@@ -21,7 +21,7 @@ struct MainTabView: View {
     @AppStorage("healthKitSyncEnabled") private var healthKitSyncEnabled = true
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var realtimeSyncManager: RealtimeSyncManager
-    @State private var selectedSurface: PaidAppSurface = .weightLoggerMVP
+    @State private var selectedSurface: PaidAppSurface = PaidAppSurfacePolicy.surface()
 
     var body: some View {
         NavigationStack {

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -38,6 +38,57 @@ final class LaunchSurfacePolicyTests: XCTestCase {
             )
         )
     }
+
+    func testProfileCompletionPolicyRequiresRealNameHeightGenderAndDateOfBirth() {
+        let dateOfBirth = Date(timeIntervalSince1970: 631_152_000)
+        let completeProfile = UserProfile(
+            id: "profile-complete",
+            email: "complete@example.com",
+            username: nil,
+            fullName: "Complete User",
+            dateOfBirth: dateOfBirth,
+            height: 180,
+            heightUnit: "cm",
+            gender: "male",
+            activityLevel: nil,
+            goalWeight: nil,
+            goalWeightUnit: nil,
+            onboardingCompleted: true
+        )
+        let blankNameProfile = UserProfile(
+            id: "profile-blank-name",
+            email: "blank@example.com",
+            username: nil,
+            fullName: "   ",
+            dateOfBirth: dateOfBirth,
+            height: 180,
+            heightUnit: "cm",
+            gender: "male",
+            activityLevel: nil,
+            goalWeight: nil,
+            goalWeightUnit: nil,
+            onboardingCompleted: true
+        )
+        let zeroHeightProfile = UserProfile(
+            id: "profile-zero-height",
+            email: "height@example.com",
+            username: nil,
+            fullName: "Height User",
+            dateOfBirth: dateOfBirth,
+            height: 0,
+            heightUnit: "cm",
+            gender: "male",
+            activityLevel: nil,
+            goalWeight: nil,
+            goalWeightUnit: nil,
+            onboardingCompleted: true
+        )
+
+        XCTAssertTrue(ProfileCompletionPolicy.isComplete(profile: completeProfile, fallbackName: nil))
+        XCTAssertFalse(ProfileCompletionPolicy.isComplete(profile: blankNameProfile, fallbackName: nil))
+        XCTAssertFalse(ProfileCompletionPolicy.isComplete(profile: zeroHeightProfile, fallbackName: nil))
+        XCTAssertTrue(ProfileCompletionPolicy.isComplete(profile: blankNameProfile, fallbackName: "Fallback User"))
+    }
 }
 
 final class BodyCompositionMathGoldenTests: XCTestCase {
@@ -3514,6 +3565,17 @@ final class SyncIntegrationTests: XCTestCase {
         }
     }
 
+    private func cachedProfiles(id: String) async -> [CachedProfile] {
+        let context = CoreDataManager.shared.viewContext
+
+        return await context.perform {
+            let request: NSFetchRequest<CachedProfile> = CachedProfile.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id)
+
+            return (try? context.fetch(request)) ?? []
+        }
+    }
+
     private func makeBodySpecSummary(
         resultId: String,
         startTime: Date,
@@ -3888,6 +3950,46 @@ final class SyncIntegrationTests: XCTestCase {
         XCTAssertEqual(log.notes, "daily-metrics-mapped")
         XCTAssertEqual(log.createdAt.timeIntervalSince(createdAt), 0, accuracy: 0.001)
         XCTAssertEqual(log.updatedAt.timeIntervalSince(updatedAt), 0, accuracy: 0.001)
+    }
+
+    func testUpdateOrCreateProfile_IsIdempotentForSameId() async throws {
+        let coreData = CoreDataManager.shared
+
+        let userId = "sync_test_user_profile_\(UUID().uuidString)"
+        let firstPayload: [String: Any] = [
+            "id": userId,
+            "full_name": "First Name",
+            "username": "first_name",
+            "height": 178.0,
+            "height_unit": "cm",
+            "gender": "male",
+            "activity_level": "active",
+            "date_of_birth": "1990-01-01T00:00:00Z"
+        ]
+        let secondPayload: [String: Any] = [
+            "id": userId,
+            "full_name": "Updated Name",
+            "username": "updated_name",
+            "height": 181.0,
+            "height_unit": "cm",
+            "gender": "male",
+            "activity_level": "active",
+            "date_of_birth": "1990-01-01T00:00:00Z"
+        ]
+
+        coreData.updateOrCreateProfile(from: firstPayload)
+        coreData.updateOrCreateProfile(from: secondPayload)
+
+        let profiles = await cachedProfiles(id: userId)
+        XCTAssertEqual(profiles.count, 1)
+
+        let profile = try XCTUnwrap(profiles.first)
+        XCTAssertEqual(profile.id, userId)
+        XCTAssertEqual(profile.fullName, "Updated Name")
+        XCTAssertEqual(profile.username, "updated_name")
+        XCTAssertEqual(profile.height, 181.0, accuracy: 0.001)
+        XCTAssertEqual(profile.syncStatus, "synced")
+        XCTAssertTrue(profile.isSynced)
     }
 
     func testUpdateOrCreateBodyMetric_IsIdempotentForSameId() async throws {


### PR DESCRIPTION
## Summary
- Hardened iOS launch/session routing so the production surface, onboarding/profile completion, paywall, and `/log` deep-link gates agree.
- Fixed profile sync idempotency and background photo upload persistence bugs that could create stale or inconsistent local/backend state.
- Serialized Add Entry saves/uploads to prevent duplicate submissions, premature dismissals, false success states, and duplicate analytics.

## Bugs fixed
- `MainTabView` no longer flashes the wrong default surface on first render before the paid-app surface policy resolves.
- Profile completion now uses one shared policy for launch/deep-link routing and treats blank names, missing DOB, missing height, and missing gender as incomplete.
- `/log` deep links now require authenticated, current-version-onboarded, profile-complete, subscribed users before opening Add Entry.
- `CoreDataManager.updateOrCreateProfile(from:)` now matches `CachedProfile.id`, preventing duplicate cached profile rows across repeated sync pulls.
- Background photo processing now saves new metrics before uploading photos, so upload URL updates have a persisted target row.
- Add Entry weight/body-fat/GLP-1 saves now await persistence and sync before dismissal and analytics.
- Add Entry blocks duplicate submissions while save/upload work is in flight.
- Photo import now reports failure when every upload fails, counts only successful uploads, and deletes from Photos only after successful upload.
- Entry analytics now emit a single `entry_saved` event after persistence succeeds.

## Screens audited
- App launch/root routing
- Onboarding/profile completion routing
- Subscription/paywall routing
- Main tab shell and dashboard surface selection
- Add Entry sheet: weight, body fat, photos, GLP-1 medication
- Background photo upload and metrics sync
- Local cached profile sync

## Flows tested
- Profile completion policy rejects partial profile data and accepts complete fallback-auth identity data.
- Profile sync is idempotent for repeated remote profile pulls with the same id.
- iOS app builds for the `LogYourBody` scheme on iPhone 16 simulator.
- Full iOS unit-test target passes locally.
- Root monorepo lint, typecheck, and test suites pass locally.

## Validation
- `swiftlint lint --strict` from `apps/ios`: pass, 0 violations.
- `xcodebuild`/XcodeBuildMCP iPhone 16 simulator build: pass.
- `xcodebuild -quiet ... -only-testing:LogYourBodyTests ... test`: 238 passed, 0 failed, 0 skipped.
- `pnpm lint`: pass.
- `pnpm typecheck`: pass.
- `pnpm test`: pass.
- `git diff --check`: pass.
- GBrain checked before implementation and again before commit: healthy enough to proceed, warnings only.
- Grok Composer 2.5 Fast read-only subagent audits completed for auth/onboarding, data/sync/photos, and navigation/UI/analytics; a read-only diff review found no ship blockers.

## Remaining risks
- Full combined iOS scheme including UI tests hit an Xcode test-harness/debugger assertion locally; unit tests and simulator build passed cleanly.
- `/log` deep links that are blocked by auth/onboarding/profile/subscription gates are safely ignored today; a follow-up can add user-facing handoff messaging.
- Existing Swift 6 actor/deprecation warnings remain outside this focused patch.
- Local shell uses Node 22 while the repo declares Node 20.x; pnpm validation passed with engine warnings.
- Graphite CLI stack tracking is set locally, but `gt submit` is blocked by Graphite repo sync settings, so this PR was opened through GitHub.

## Recommended follow-up work
- Add UI tests for launch routing, gated `/log` deep links, and Add Entry duplicate-submit prevention.
- Add focused tests around background photo upload metric persistence and all-upload-failed behavior.
- Stabilize the full UI-test scheme harness separately from product reliability fixes.
- Convert the remaining Swift 6 concurrency warnings in managers/services into explicit actor-safe patterns.
