### PR TITLE
fix: harden paid launch entry gates

### DIFF
--- a/apps/ios/LogYourBody/ContentView.swift
+++ b/apps/ios/LogYourBody/ContentView.swift
@@ -18,6 +18,27 @@ enum LaunchSurfacePolicy {
     }
 }
 
+enum EntryDeepLinkPolicy {
+    static func canOpenEntrySheet(
+        isAuthenticated: Bool,
+        user: User?,
+        hasCompletedOnboarding: Bool,
+        isSubscribed: Bool
+    ) -> Bool {
+        guard isAuthenticated else { return false }
+
+        let isProfileComplete = ProfileCompletionPolicy.isComplete(user: user)
+
+        return !LaunchSurfacePolicy.requiresBodyCompositionOnboarding(
+            hasCompletedOnboarding: hasCompletedOnboarding
+        ) &&
+            !LaunchSurfacePolicy.requiresCompleteProfile(
+                isProfileComplete: isProfileComplete
+            ) &&
+            isSubscribed
+    }
+}
+
 enum ProfileCompletionPolicy {
     static func isComplete(user: User?) -> Bool {
         guard let user else { return false }

--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -302,7 +302,8 @@ struct LogYourBodyApp: App {
             await seedFullDashboardUITestFixtureData(userId: userId)
         }
 
-        if arguments.contains("-lybUITestGlp1WeeklyCheckInFixture") {
+        if arguments.contains("-lybUITestGlp1WeeklyCheckInFixture") &&
+            !arguments.contains("-lybUITestGlp1EmptyMedicationFixture") {
             await seedGlp1WeeklyCheckInUITestFixtureData(userId: userId)
         }
 
@@ -445,20 +446,13 @@ struct LogYourBodyApp: App {
     }
 
     private var canOpenEntrySheetFromDeepLink: Bool {
-        guard authManager.isAuthenticated,
-              let user = authManager.currentUser else {
-            return false
-        }
+        let user = authManager.currentUser
 
-        let hasCompletedOnboarding = OnboardingStateManager.shared.hasCompletedCurrentVersion(for: user.id)
-        let isProfileComplete = ProfileCompletionPolicy.isComplete(user: user)
-
-        return !LaunchSurfacePolicy.requiresBodyCompositionOnboarding(
-            hasCompletedOnboarding: hasCompletedOnboarding
-        ) &&
-            !LaunchSurfacePolicy.requiresCompleteProfile(
-                isProfileComplete: isProfileComplete
-            ) &&
-            revenueCatManager.isSubscribed
+        return EntryDeepLinkPolicy.canOpenEntrySheet(
+            isAuthenticated: authManager.isAuthenticated,
+            user: user,
+            hasCompletedOnboarding: OnboardingStateManager.shared.hasCompletedCurrentVersion(for: user?.id),
+            isSubscribed: revenueCatManager.isSubscribed
+        )
     }
 }

--- a/apps/ios/LogYourBody/Services/RevenueCatManager.swift
+++ b/apps/ios/LogYourBody/Services/RevenueCatManager.swift
@@ -357,25 +357,12 @@ class RevenueCatManager: NSObject, ObservableObject {
         // print("💰 Logging out user")
 
         guard isConfigured else {
-            customerInfo = nil
-            isSubscribed = false
-            cachedIsSubscribed = false
-            currentOffering = nil
-            currentEntitlementSnapshot = nil
-            resetSubscriptionAnalyticsCache()
+            clearLocalSubscriptionState()
             return
         }
 
         do {
             try await purchasesClient.logOut()
-            await MainActor.run {
-                self.customerInfo = nil
-                self.isSubscribed = false
-                self.cachedIsSubscribed = false
-                self.currentOffering = nil
-                self.currentEntitlementSnapshot = nil
-                self.resetSubscriptionAnalyticsCache()
-            }
         } catch {
             let appError = AppError.billing(operation: "logoutUser", underlying: error)
             let context = ErrorContext(
@@ -386,6 +373,8 @@ class RevenueCatManager: NSObject, ObservableObject {
             )
             ErrorReporter.shared.capture(appError, context: context)
         }
+
+        clearLocalSubscriptionState()
     }
 
     // MARK: - Subscription Status
@@ -414,12 +403,8 @@ class RevenueCatManager: NSObject, ObservableObject {
                 userId: nil
             )
             ErrorReporter.shared.capture(appError, context: context)
-
-            await MainActor.run {
-                self.isSubscribed = false
-                self.cachedIsSubscribed = false
-                self.currentEntitlementSnapshot = nil
-            }
+            // Do not revoke cached access on transient RevenueCat/App Store/network failures.
+            // A later successful refresh with an inactive entitlement still invalidates access.
         }
     }
 
@@ -881,6 +866,15 @@ class RevenueCatManager: NSObject, ObservableObject {
         cachedSubscriptionAnalyticsPhase = RevenueCatSubscriptionAnalyticsPhase.none.rawValue
         cachedSubscriptionAnalyticsAppUserId = ""
         cachedTrialExpirationTimestamp = 0
+    }
+
+    private func clearLocalSubscriptionState() {
+        customerInfo = nil
+        isSubscribed = false
+        cachedIsSubscribed = false
+        currentOffering = nil
+        currentEntitlementSnapshot = nil
+        resetSubscriptionAnalyticsCache()
     }
 
     private func subscriptionAnalyticsPhase(

--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -1173,6 +1173,8 @@ struct AddEntrySheet: View {
         guard includesGlp1Entry, selectedTab == 3 else { return }
         guard let userId = authManager.currentUser?.id else { return }
 
+        glp1UserId = userId
+
         Task {
             await loadGlp1Medications(userId: userId)
         }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -39,6 +39,81 @@ final class LaunchSurfacePolicyTests: XCTestCase {
         )
     }
 
+    func testEntryDeepLinkPolicyRequiresFullLaunchGateChain() {
+        let user = makeLaunchPolicyUser(id: "eligible-user")
+
+        XCTAssertFalse(
+            EntryDeepLinkPolicy.canOpenEntrySheet(
+                isAuthenticated: false,
+                user: user,
+                hasCompletedOnboarding: true,
+                isSubscribed: true
+            )
+        )
+        XCTAssertFalse(
+            EntryDeepLinkPolicy.canOpenEntrySheet(
+                isAuthenticated: true,
+                user: nil,
+                hasCompletedOnboarding: true,
+                isSubscribed: true
+            )
+        )
+        XCTAssertFalse(
+            EntryDeepLinkPolicy.canOpenEntrySheet(
+                isAuthenticated: true,
+                user: user,
+                hasCompletedOnboarding: false,
+                isSubscribed: true
+            )
+        )
+        XCTAssertFalse(
+            EntryDeepLinkPolicy.canOpenEntrySheet(
+                isAuthenticated: true,
+                user: makeLaunchPolicyUser(id: "incomplete-user", height: 0),
+                hasCompletedOnboarding: true,
+                isSubscribed: true
+            )
+        )
+        XCTAssertFalse(
+            EntryDeepLinkPolicy.canOpenEntrySheet(
+                isAuthenticated: true,
+                user: user,
+                hasCompletedOnboarding: true,
+                isSubscribed: false
+            )
+        )
+        XCTAssertTrue(
+            EntryDeepLinkPolicy.canOpenEntrySheet(
+                isAuthenticated: true,
+                user: user,
+                hasCompletedOnboarding: true,
+                isSubscribed: true
+            )
+        )
+    }
+
+    @MainActor
+    func testEntryDeepLinkPolicyBlocksAccountSwitchWithPreviousOnboardingCompletion() {
+        let suiteName = "entry-deeplink-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let manager = OnboardingStateManager(defaults: defaults, currentVersion: 1)
+        manager.markCompleted(userId: "previous-user")
+
+        let newUser = makeLaunchPolicyUser(id: "new-user")
+
+        XCTAssertFalse(manager.hasCompletedCurrentVersion(for: newUser.id))
+        XCTAssertFalse(
+            EntryDeepLinkPolicy.canOpenEntrySheet(
+                isAuthenticated: true,
+                user: newUser,
+                hasCompletedOnboarding: manager.hasCompletedCurrentVersion(for: newUser.id),
+                isSubscribed: true
+            )
+        )
+    }
+
     func testProfileCompletionPolicyRequiresRealNameHeightGenderAndDateOfBirth() {
         let dateOfBirth = Date(timeIntervalSince1970: 631_152_000)
         let completeProfile = UserProfile(
@@ -88,6 +163,34 @@ final class LaunchSurfacePolicyTests: XCTestCase {
         XCTAssertFalse(ProfileCompletionPolicy.isComplete(profile: blankNameProfile, fallbackName: nil))
         XCTAssertFalse(ProfileCompletionPolicy.isComplete(profile: zeroHeightProfile, fallbackName: nil))
         XCTAssertTrue(ProfileCompletionPolicy.isComplete(profile: blankNameProfile, fallbackName: "Fallback User"))
+    }
+
+    private func makeLaunchPolicyUser(
+        id: String,
+        name: String = "Launch User",
+        height: Double = 180
+    ) -> User {
+        User(
+            id: id,
+            email: "\(id)@example.com",
+            name: name,
+            avatarUrl: nil,
+            profile: UserProfile(
+                id: "profile-\(id)",
+                email: "\(id)@example.com",
+                username: nil,
+                fullName: name,
+                dateOfBirth: Date(timeIntervalSince1970: 631_152_000),
+                height: height,
+                heightUnit: "cm",
+                gender: "male",
+                activityLevel: nil,
+                goalWeight: nil,
+                goalWeightUnit: nil,
+                onboardingCompleted: true
+            ),
+            onboardingCompleted: true
+        )
     }
 }
 
@@ -3298,7 +3401,7 @@ final class RevenueCatPurchaseRestoreFlowTests: XCTestCase {
         XCTAssertEqual(fixture.manager.errorMessage, "No active subscriptions found")
     }
 
-    func testRefreshFailureInvalidatesStaleSubscribedCache() async {
+    func testRefreshFailurePreservesCachedSubscribedAccess() async {
         let fixture = makeFixture(cachedSubscribed: true)
         defer { fixture.cleanup() }
 
@@ -3307,8 +3410,50 @@ final class RevenueCatPurchaseRestoreFlowTests: XCTestCase {
 
         await fixture.manager.refreshCustomerInfo()
 
+        XCTAssertTrue(fixture.manager.isSubscribed)
+        XCTAssertTrue(fixture.defaults.bool(forKey: Self.isSubscribedKey))
+    }
+
+    func testRefreshInactiveCustomerInvalidatesStaleSubscribedCache() async {
+        let fixture = makeFixture(cachedSubscribed: true)
+        defer { fixture.cleanup() }
+
+        XCTAssertTrue(fixture.manager.isSubscribed)
+        fixture.client.customerInfoResult = .success(Self.customer(isActive: false))
+
+        await fixture.manager.refreshCustomerInfo()
+
         XCTAssertFalse(fixture.manager.isSubscribed)
         XCTAssertFalse(fixture.defaults.bool(forKey: Self.isSubscribedKey))
+    }
+
+    func testLogoutUserFailureStillClearsLocalSubscriptionState() async {
+        let fixture = makeFixture(cachedSubscribed: true)
+        defer { fixture.cleanup() }
+
+        fixture.client.customerInfoResult = .success(Self.customer(isActive: true))
+        await fixture.manager.refreshCustomerInfo()
+        fixture.client.logOutResult = .failure(MockRevenueCatPurchasesClient.MockError.logOutFailed)
+
+        await fixture.manager.logoutUser()
+
+        XCTAssertFalse(fixture.manager.isSubscribed)
+        XCTAssertFalse(fixture.defaults.bool(forKey: Self.isSubscribedKey))
+        XCTAssertNil(fixture.manager.customerInfo)
+    }
+
+    func testLogoutUserSuccessClearsLocalSubscriptionState() async {
+        let fixture = makeFixture(cachedSubscribed: true)
+        defer { fixture.cleanup() }
+
+        fixture.client.customerInfoResult = .success(Self.customer(isActive: true))
+        await fixture.manager.refreshCustomerInfo()
+
+        await fixture.manager.logoutUser()
+
+        XCTAssertFalse(fixture.manager.isSubscribed)
+        XCTAssertFalse(fixture.defaults.bool(forKey: Self.isSubscribedKey))
+        XCTAssertNil(fixture.manager.customerInfo)
     }
 
     func testEntitlementIdentifierMatchesRevenueCatDashboardContract() {
@@ -3391,6 +3536,7 @@ private final class MockRevenueCatPurchasesClient: RevenueCatPurchasesProtocol {
     enum MockError: Error {
         case notImplemented
         case customerInfoFailed
+        case logOutFailed
     }
 
     var customerInfoResult: Result<RevenueCatCustomerSnapshot, Error> = .success(
@@ -3402,6 +3548,7 @@ private final class MockRevenueCatPurchasesClient: RevenueCatPurchasesProtocol {
     var restoreResult: Result<RevenueCatCustomerSnapshot, Error> = .success(
         RevenueCatCustomerSnapshot(originalAppUserId: "unit-test-user", entitlement: nil)
     )
+    var logOutResult: Result<Void, Error> = .success(())
     var onPurchase: (() -> Void)?
     var onRestore: (() -> Void)?
 
@@ -3420,7 +3567,9 @@ private final class MockRevenueCatPurchasesClient: RevenueCatPurchasesProtocol {
         RevenueCatCustomerSnapshot(originalAppUserId: userId, entitlement: nil)
     }
 
-    func logOut() async throws {}
+    func logOut() async throws {
+        try logOutResult.get()
+    }
 
     func customerInfo(entitlementID: String) async throws -> RevenueCatCustomerSnapshot {
         try customerInfoResult.get()

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -434,6 +434,38 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(app.buttons["Save GLP-1"].exists)
     }
 
+    func testGlp1WeeklyCheckInFixtureOpensMedicationSelectorWhenEmpty() throws {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-lybUITestPhotoTimelineHUDFixture",
+            "-lybUITestGlp1WeeklyCheckInFixture",
+            "-lybUITestGlp1EmptyMedicationFixture"
+        ]
+        app.launch()
+
+        XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 20))
+
+        let prompt = app.buttons["photo_timeline_hud_glp1_weekly_checkin"]
+        scrollUntilExists(prompt, in: app)
+        XCTAssertTrue(prompt.waitForExistence(timeout: 8))
+
+        scrollUntilHittable(prompt, in: app)
+        XCTAssertTrue(prompt.isHittable)
+        prompt.tap()
+
+        XCTAssertTrue(app.staticTexts["Log GLP-1 dose"].waitForExistence(timeout: 10))
+
+        let addMedication = app.buttons["Add medication"]
+        XCTAssertTrue(addMedication.waitForExistence(timeout: 5))
+        scrollUntilHittable(addMedication, in: app)
+        XCTAssertTrue(addMedication.isHittable)
+        addMedication.tap()
+
+        XCTAssertTrue(app.staticTexts["Select GLP-1"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Save medication"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Cancel"].exists)
+    }
+
     func testBulkPhotoImportLockedByDefaultInIntegrations() throws {
         let app = XCUIApplication()
         app.launchArguments = ["-lybUITestWeightLoggerMVPFixture"]


### PR DESCRIPTION
## Summary
- Preserve cached paid access on transient RevenueCat refresh failures, while still clearing stale access when RevenueCat returns an inactive entitlement.
- Always clear local subscription state on logout, even if the RevenueCat logout call fails, to avoid cross-account paywall bypass.
- Extract and test the /log entry deep-link gate so it requires auth, per-user onboarding completion, complete profile, and subscription.
- Fix the empty GLP-1 weekly check-in path so Add medication opens the selector instead of a blank sheet, with a UI regression fixture.

## Validation
- GBrain checked: doctor health score 90, warnings only; paid-MVP product namespace verified as pro1.
- Grok subagents reviewed billing/paywall gates, launch/deep-link coverage, and modal traps; final Grok code review found no blocking findings.
- git diff --check
- swiftlint lint --strict
- pnpm lint
- pnpm typecheck
- pnpm test
- XcodeBuildMCP simulator unit tests: LogYourBodyTests/LaunchSurfacePolicyTests + RevenueCatPurchaseRestoreFlowTests, 15 passed / 0 failed
- XcodeBuildMCP simulator UI test: LogYourBodyUITests/testGlp1WeeklyCheckInFixtureOpensMedicationSelectorWhenEmpty, 1 passed / 0 failed

## Notes
- Graphite branch tracking/dry run succeeded, but submit is blocked by account-side synced-repo configuration: "You can only submit to repos synced with Graphite."