### PR TITLE
fix: preserve manual entry source

### DIFF
--- a/apps/ios/LogYourBody/Services/PhotoMetadataService.swift
+++ b/apps/ios/LogYourBody/Services/PhotoMetadataService.swift
@@ -157,7 +157,12 @@ class PhotoMetadataService {
                 boneMass: nil,
                 notes: nil,
                 photoUrl: photoUrl,
-                dataSource: dataSource ?? BodyMetricSource.photo.rawValue,
+                dataSource: resolvedDataSource(
+                    explicitDataSource: dataSource,
+                    photoUrl: photoUrl,
+                    weight: weight,
+                    bodyFatPercentage: bodyFatPercentage
+                ),
                 createdAt: Date(),
                 updatedAt: Date()
             )
@@ -191,6 +196,27 @@ class PhotoMetadataService {
         }
 
         return nil
+    }
+
+    private func resolvedDataSource(
+        explicitDataSource: String?,
+        photoUrl: String?,
+        weight: Double?,
+        bodyFatPercentage: Double?
+    ) -> String {
+        if let explicitDataSource {
+            return BodyMetricSource.normalizedRawValue(explicitDataSource)
+        }
+
+        if weight != nil || bodyFatPercentage != nil {
+            return BodyMetricSource.manual.rawValue
+        }
+
+        if photoUrl != nil {
+            return BodyMetricSource.photo.rawValue
+        }
+
+        return BodyMetricSource.photo.rawValue
     }
 
     /// Estimate body fat percentage based on nearby entries (with caching for performance)

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -2204,6 +2204,40 @@ final class PhotoMetadataServiceTests: XCTestCase {
         XCTAssertEqual(created.dataSource, BodyMetricSource.manual.rawValue)
         XCTAssertNil(created.photoUrl)
     }
+
+    func testCreateOrUpdateMetricsDefaultsNewManualMeasurementsToManualSource() async {
+        let userId = "manual_entry_default_source_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_100_000)
+
+        let weightEntry = await PhotoMetadataService.shared.createOrUpdateMetrics(
+            for: date,
+            weight: 82.4,
+            userId: userId
+        )
+
+        let bodyFatEntry = await PhotoMetadataService.shared.createOrUpdateMetrics(
+            for: date.addingTimeInterval(86_400),
+            bodyFatPercentage: 17.1,
+            userId: userId
+        )
+
+        XCTAssertEqual(weightEntry.dataSource, BodyMetricSource.manual.rawValue)
+        XCTAssertEqual(bodyFatEntry.dataSource, BodyMetricSource.manual.rawValue)
+    }
+
+    func testCreateOrUpdateMetricsKeepsPhotoDefaultForPhotoOnlyPlaceholder() async {
+        let userId = "photo_entry_default_source_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_200_000)
+
+        let photoEntry = await PhotoMetadataService.shared.createOrUpdateMetrics(
+            for: date,
+            userId: userId
+        )
+
+        XCTAssertEqual(photoEntry.dataSource, BodyMetricSource.photo.rawValue)
+        XCTAssertNil(photoEntry.weight)
+        XCTAssertNil(photoEntry.bodyFatPercentage)
+    }
 }
 
 final class BulkProgressPhotoImportPolicyTests: XCTestCase {


### PR DESCRIPTION
## Summary
- default newly-created manual weight/body-fat entries to the manual data source
- keep explicit source normalization unchanged
- preserve the existing photo placeholder default for photo-only metric rows

## Why
Manual entries created through the body metric logging path did not pass an explicit `dataSource`, so new rows could be saved and synced as `photo` rows. That corrupts entry provenance and can make local/cache/backend state disagree about where a metric came from.

## Validation
- `gbrain doctor --fast --json` (warnings only: missing manifest, DB checks skipped in fast mode)
- Grok CLI requested with `grok-composer-2.5-fast`; CLI emitted startup/auth noise and did not return usable findings
- `git diff --check`
- `cd apps/ios && swiftlint lint --strict LogYourBody/Services/PhotoMetadataService.swift LogYourBodyTests/LogYourBodyTests.swift`
- `cd apps/ios && swiftlint lint --strict`
- XcodeBuildMCP `test_sim` on `LYB Golden iPhone 16`: `-only-testing:LogYourBodyTests/PhotoMetadataServiceTests` (4/4 passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Graphite
- `gt branch track --parent main --no-interactive` succeeded
- `gt branch submit --dry-run --no-interactive --no-edit --no-ai` succeeded
- `gt branch submit --publish --merge-when-ready --no-interactive --no-edit --no-ai` is blocked by Graphite repo sync settings: `You can only submit to repos synced with Graphite`
