### PR TITLE
fix: stabilize photo selection uploads

### DIFF
--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -5,6 +5,23 @@
 import SwiftUI
 import PhotosUI
 
+struct PhotoUploadBatchPolicy {
+    static func progress(completedCount: Int, totalCount: Int) -> Double {
+        guard totalCount > 0 else { return 0 }
+        return Double(completedCount) / Double(totalCount)
+    }
+
+    static func progressText(processedCount: Int, totalCount: Int) -> String {
+        guard totalCount > 0 else { return "Processing photos" }
+        let currentIndex = min(processedCount + 1, totalCount)
+        return "Processing \(currentIndex) of \(totalCount)"
+    }
+
+    static func canChangeSelection(isProcessing: Bool) -> Bool {
+        !isProcessing
+    }
+}
+
 struct AddEntrySheet: View {
     @Environment(\.dismiss)
     var dismiss
@@ -45,6 +62,7 @@ struct AddEntrySheet: View {
     @State private var isProcessingPhotos = false
     @State private var photoProgress: Double = 0
     @State private var processedCount = 0
+    @State private var processingPhotoCount = 0
     @State private var photoIdentifiers: [String] = []  // Store successfully uploaded PHAsset identifiers for deletion
 
     // GLP-1 entry
@@ -681,6 +699,7 @@ struct AddEntrySheet: View {
                             selectedPhotos = []
                         }
                         .foregroundColor(.appPrimary)
+                        .disabled(!PhotoUploadBatchPolicy.canChangeSelection(isProcessing: isProcessingPhotos))
                     }
 
                     if isProcessingPhotos {
@@ -688,7 +707,12 @@ struct AddEntrySheet: View {
                             ProgressView(value: photoProgress)
                                 .tint(.appPrimary)
 
-                            Text("Processing \(processedCount + 1) of \(selectedPhotos.count)")
+                            Text(
+                                PhotoUploadBatchPolicy.progressText(
+                                    processedCount: processedCount,
+                                    totalCount: processingPhotoCount
+                                )
+                            )
                                 .font(.appCaption)
                                 .foregroundColor(.appTextSecondary)
                         }
@@ -748,8 +772,9 @@ struct AddEntrySheet: View {
         case 1:
             saveBodyFat(userId: userId)
         case 2:
+            let photosToSave = selectedPhotos
             Task {
-                await savePhotos(userId: userId)
+                await savePhotos(userId: userId, selectedPhotos: photosToSave)
             }
         case 3:
             saveGlp1Dose(userId: userId)
@@ -891,19 +916,30 @@ struct AddEntrySheet: View {
         }
     }
 
-    private func savePhotos(userId: String) async {
+    private func savePhotos(userId: String, selectedPhotos photosToUpload: [PhotosPickerItem]) async {
+        guard !photosToUpload.isEmpty else { return }
+
         isProcessingPhotos = true
         photoProgress = 0
         processedCount = 0
+        processingPhotoCount = photosToUpload.count
         photoIdentifiers.removeAll()
         var successfulUploadCount = 0
         var successfulPhotoIdentifiers: [String] = []
 
-        for (index, item) in selectedPhotos.enumerated() {
+        defer {
+            isProcessingPhotos = false
+            processingPhotoCount = 0
+        }
+
+        for (index, item) in photosToUpload.enumerated() {
             do {
                 defer {
                     processedCount = index + 1
-                    photoProgress = Double(processedCount) / Double(selectedPhotos.count)
+                    photoProgress = PhotoUploadBatchPolicy.progress(
+                        completedCount: processedCount,
+                        totalCount: photosToUpload.count
+                    )
                 }
 
                 // Extract PHAsset identifier if available
@@ -946,7 +982,6 @@ struct AddEntrySheet: View {
         }
 
         if successfulUploadCount == 0 {
-            isProcessingPhotos = false
             errorMessage = "Photo upload failed. Please try again."
             showError = true
             return
@@ -959,7 +994,6 @@ struct AddEntrySheet: View {
             await deletePhotosFromLibrary()
         }
 
-        isProcessingPhotos = false
         RealtimeSyncManager.shared.syncIfNeeded()
         dismiss()
 

--- a/apps/ios/LogYourBody/Views/ProgressPhotoAttachSheet.swift
+++ b/apps/ios/LogYourBody/Views/ProgressPhotoAttachSheet.swift
@@ -68,6 +68,13 @@ struct ProgressPhotoAttachPolicy {
             return false
         }
     }
+
+    static func isBusy(status: ProgressPhotoAttachStatus) -> Bool {
+        if case .processing = status {
+            return true
+        }
+        return false
+    }
 }
 
 struct ProgressPhotoAttachSheet: View {
@@ -84,16 +91,14 @@ struct ProgressPhotoAttachSheet: View {
     @State private var selectedImageDate: Date?
     @State private var attachStatus: ProgressPhotoAttachStatus = .empty
     @State private var isCameraPresented = false
+    @State private var photoSelectionLoadID = UUID()
 
     private var targetDate: Date {
         targetMetric?.date ?? selectedImageDate ?? fallbackDate
     }
 
     private var isBusy: Bool {
-        if case .processing = attachStatus {
-            return true
-        }
-        return uploadManager.isUploading
+        ProgressPhotoAttachPolicy.isBusy(status: attachStatus)
     }
 
     private var isSuccess: Bool {
@@ -437,6 +442,9 @@ struct ProgressPhotoAttachSheet: View {
     }
 
     private func loadSelectedPhoto(_ item: PhotosPickerItem?) {
+        let loadID = UUID()
+        photoSelectionLoadID = loadID
+
         guard let item else {
             selectedImage = nil
             selectedImageDate = nil
@@ -458,12 +466,14 @@ struct ProgressPhotoAttachSheet: View {
 
                 let photoDate = PhotoMetadataService.shared.extractDate(from: data)
                 await MainActor.run {
+                    guard photoSelectionLoadID == loadID else { return }
                     selectedImage = image
                     selectedImageDate = photoDate
                     attachStatus = .ready
                 }
             } catch {
                 await MainActor.run {
+                    guard photoSelectionLoadID == loadID else { return }
                     attachStatus = .failed("Could not read that photo. Choose another image.")
                 }
             }
@@ -504,6 +514,7 @@ struct ProgressPhotoAttachSheet: View {
     }
 
     private func handleCameraImage(_ image: UIImage) {
+        photoSelectionLoadID = UUID()
         selectedImage = image
         selectedImageDate = nil
         attachStatus = .ready
@@ -567,6 +578,7 @@ struct ProgressPhotoAttachSheet: View {
 
     #if DEBUG
     private func selectFixturePhoto() {
+        photoSelectionLoadID = UUID()
         selectedImage = makeFixtureProgressPhoto()
         selectedImageDate = targetDate
         attachStatus = .ready

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -2141,6 +2141,33 @@ final class ProgressPhotoAttachPolicyTests: XCTestCase {
             )
         )
     }
+
+    func testProgressPhotoAttachBusyStateOnlyComesFromLocalProcessingStatus() {
+        XCTAssertTrue(ProgressPhotoAttachPolicy.isBusy(status: .processing))
+        XCTAssertFalse(ProgressPhotoAttachPolicy.isBusy(status: .empty))
+        XCTAssertFalse(ProgressPhotoAttachPolicy.isBusy(status: .ready))
+        XCTAssertFalse(ProgressPhotoAttachPolicy.isBusy(status: .success))
+        XCTAssertFalse(ProgressPhotoAttachPolicy.isBusy(status: .failed("Upload failed")))
+    }
+}
+
+final class PhotoUploadBatchPolicyTests: XCTestCase {
+    func testPhotoUploadBatchProgressHandlesEmptyAndCompletedCounts() {
+        XCTAssertEqual(PhotoUploadBatchPolicy.progress(completedCount: 0, totalCount: 0), 0)
+        XCTAssertEqual(PhotoUploadBatchPolicy.progress(completedCount: 1, totalCount: 4), 0.25)
+        XCTAssertEqual(PhotoUploadBatchPolicy.progress(completedCount: 4, totalCount: 4), 1.0)
+    }
+
+    func testPhotoUploadBatchProgressTextCapsCurrentIndexAtTotal() {
+        XCTAssertEqual(PhotoUploadBatchPolicy.progressText(processedCount: 0, totalCount: 0), "Processing photos")
+        XCTAssertEqual(PhotoUploadBatchPolicy.progressText(processedCount: 0, totalCount: 3), "Processing 1 of 3")
+        XCTAssertEqual(PhotoUploadBatchPolicy.progressText(processedCount: 3, totalCount: 3), "Processing 3 of 3")
+    }
+
+    func testPhotoUploadBatchSelectionCannotChangeWhileProcessing() {
+        XCTAssertTrue(PhotoUploadBatchPolicy.canChangeSelection(isProcessing: false))
+        XCTAssertFalse(PhotoUploadBatchPolicy.canChangeSelection(isProcessing: true))
+    }
 }
 
 final class PhotoMetadataServiceTests: XCTestCase {


### PR DESCRIPTION
## Summary
- make the progress-photo attach sheet busy only for its own local processing state, so unrelated background photo uploads no longer trap the sheet
- ignore stale async photo-library load results after the user changes selection, switches to camera, or uses the debug fixture
- snapshot selected add-entry photos before upload and disable changing the selected batch while processing
- add policy coverage for attach busy state and upload batch progress/selection rules

## Why
Photo attach/add-entry upload flows could race with SwiftUI state changes: an old `PhotosPickerItem` load could overwrite a newer selection, a global upload flag could disable the attach sheet during unrelated work, and the add-entry upload loop iterated the live `selectedPhotos` array while the UI still allowed clearing it.

## Validation
- `gbrain doctor --fast --json` (warnings only: missing manifest, DB checks skipped in fast mode)
- `gbrain search "ProgressPhotoAttachSheet photo upload selectedPhotos stale isUploading AddEntrySheet"`
- `git diff --check`
- `cd apps/ios && swiftlint lint --strict LogYourBody/Views/ProgressPhotoAttachSheet.swift LogYourBody/Views/AddEntrySheet.swift LogYourBodyTests/LogYourBodyTests.swift`
- `cd apps/ios && swiftlint lint --strict`
- XcodeBuildMCP `test_sim` on `LYB Golden iPhone 16`: `-only-testing:LogYourBodyTests/ProgressPhotoAttachPolicyTests -only-testing:LogYourBodyTests/PhotoUploadBatchPolicyTests` (7/7 passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Grok
- Requested read-only review with `grok-composer-2.5-fast`
- Grok CLI failed before producing findings due MCP/bootstrap/auth noise and `Max turns reached`

## Graphite
- `gt branch track --parent main --no-interactive` succeeded
- `gt branch submit --dry-run --no-interactive --no-edit --no-ai` succeeded
- `gt branch submit --publish --merge-when-ready --no-interactive --no-edit --no-ai` is blocked by Graphite repo sync settings: `You can only submit to repos synced with Graphite`
