### PR TITLE
fix: preserve restored profile state

### DIFF
--- a/apps/ios/LogYourBody/Models/User.swift
+++ b/apps/ios/LogYourBody/Models/User.swift
@@ -56,4 +56,14 @@ struct UserProfile: Codable {
         case firstName = "first_name"
         case lastName = "last_name"
     }
+
+    var hasAppOwnedProfileData: Bool {
+        if dateOfBirth != nil { return true }
+        if let height, height > 0 { return true }
+        if let gender, !gender.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return true }
+        if let activityLevel, !activityLevel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return true }
+        if let goalWeight, goalWeight > 0 { return true }
+        if onboardingCompleted != nil { return true }
+        return false
+    }
 }

--- a/apps/ios/LogYourBody/Services/AuthManager.swift
+++ b/apps/ios/LogYourBody/Services/AuthManager.swift
@@ -69,6 +69,12 @@ enum EmailVerificationFlow: Equatable {
     case signIn
 }
 
+enum AuthProfileBootstrapPolicy {
+    static func shouldPersistProjectedProfile(_ profile: UserProfile) -> Bool {
+        profile.hasAppOwnedProfileData
+    }
+}
+
 // MARK: - AsyncGate Helper
 
 actor AsyncGate {
@@ -697,25 +703,6 @@ class AuthManager: NSObject, ObservableObject {
         self.lastExitReason = .none
 
         ErrorTrackingService.shared.updateUserId(localUser.id)
-        CoreDataManager.shared.saveProfile(
-            localUser.profile ?? UserProfile(
-                id: localUser.id,
-                email: localUser.email,
-                username: nil,
-                fullName: localUser.name,
-                dateOfBirth: nil,
-                height: nil,
-                heightUnit: "cm",
-                gender: nil,
-                activityLevel: nil,
-                goalWeight: nil,
-                goalWeightUnit: "kg",
-                onboardingCompleted: nil
-            ),
-            userId: localUser.id,
-            email: localUser.email
-        )
-
         var traits: [String: String] = [
             "email": email,
             "name": localUser.displayName,
@@ -1342,11 +1329,38 @@ extension AuthManager {
         }
 
         bootstrappedProfileSessionIds.insert(sessionId)
-        CoreDataManager.shared.saveProfile(profile, userId: user.id, email: user.email)
+
+        if let cachedProfile = await CoreDataManager.shared.fetchUserProfileSnapshot(for: user.id),
+           cachedProfile.hasPendingLocalChanges {
+            applyAuthenticatedProfile(cachedProfile.profile, fallbackEmail: user.email)
+            return
+        }
 
         do {
+            if let remoteProfile = try await SupabaseManager.shared.fetchProfile(userId: user.id) {
+                applyAuthenticatedProfile(remoteProfile, fallbackEmail: user.email)
+                CoreDataManager.shared.saveProfile(
+                    remoteProfile,
+                    userId: user.id,
+                    email: remoteProfile.email ?? user.email,
+                    markSynced: true
+                )
+                return
+            }
+
+            guard AuthProfileBootstrapPolicy.shouldPersistProjectedProfile(profile) else {
+                bootstrappedProfileSessionIds.remove(sessionId)
+                return
+            }
+
             try await SupabaseManager.shared.upsertProfile(profile)
+            CoreDataManager.shared.saveProfile(profile, userId: user.id, email: user.email, markSynced: true)
         } catch {
+            if let cachedProfile = await CoreDataManager.shared.fetchUserProfile(for: user.id) {
+                applyAuthenticatedProfile(cachedProfile, fallbackEmail: user.email)
+                return
+            }
+
             bootstrappedProfileSessionIds.remove(sessionId)
             let context = ErrorContext(
                 feature: "auth",
@@ -1356,6 +1370,26 @@ extension AuthManager {
             )
             ErrorReporter.shared.captureNonFatal(error, context: context)
         }
+    }
+
+    private func applyAuthenticatedProfile(_ profile: UserProfile, fallbackEmail: String) {
+        guard var user = currentUser else { return }
+
+        user.profile = profile
+
+        if let fullName = profile.fullName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !fullName.isEmpty {
+            user.name = fullName
+        } else if user.name == nil {
+            user.name = fallbackEmail.components(separatedBy: "@").first ?? "User"
+        }
+
+        if let onboardingCompleted = profile.onboardingCompleted {
+            user.onboardingCompleted = onboardingCompleted
+            OnboardingStateManager.shared.syncCompletionFlagFromProfile(onboardingCompleted, userId: user.id)
+        }
+
+        currentUser = user
     }
 
     // MARK: - Account Deletion Helpers

--- a/apps/ios/LogYourBody/Services/CoreDataManager.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager.swift
@@ -12,6 +12,17 @@ import Foundation
 import CoreData
 import HealthKit
 
+struct CachedUserProfileSnapshot {
+    let profile: UserProfile
+    let isSynced: Bool
+    let syncStatus: String?
+    let lastModified: Date?
+
+    var hasPendingLocalChanges: Bool {
+        !isSynced || syncStatus == "pending" || syncStatus == "failed"
+    }
+}
+
 class CoreDataManager: ObservableObject {
     static let shared = CoreDataManager()
 
@@ -902,7 +913,7 @@ class CoreDataManager: ObservableObject {
     }
 
     // MARK: - Daily Metrics Operations
-    func saveProfile(_ profile: UserProfile, userId: String, email: String) {
+    func saveProfile(_ profile: UserProfile, userId: String, email: String, markSynced: Bool = false) {
         let context = viewContext
 
         context.perform {
@@ -933,8 +944,8 @@ class CoreDataManager: ObservableObject {
                 cached.goalWeightUnit = profile.goalWeightUnit
                 cached.updatedAt = Date()
                 cached.lastModified = Date()
-                cached.isSynced = false
-                cached.syncStatus = "pending"
+                cached.isSynced = markSynced
+                cached.syncStatus = markSynced ? "synced" : "pending"
                 cached.isMarkedDeleted = false
 
                 self.save()
@@ -948,6 +959,45 @@ class CoreDataManager: ObservableObject {
                 )
                 ErrorReporter.shared.capture(appError, context: contextInfo)
                 // print("Failed to save profile: \(error)")
+            }
+        }
+    }
+
+    func fetchUserProfile(for userId: String) async -> UserProfile? {
+        await fetchUserProfileSnapshot(for: userId)?.profile
+    }
+
+    func fetchUserProfileSnapshot(for userId: String) async -> CachedUserProfileSnapshot? {
+        let context = viewContext
+
+        return await context.perform {
+            let fetchRequest: NSFetchRequest<CachedProfile> = CachedProfile.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "id == %@ AND isMarkedDeleted == %@", userId, NSNumber(value: false))
+            fetchRequest.fetchLimit = 1
+
+            do {
+                guard let cached = try context.fetch(fetchRequest).first else {
+                    return nil
+                }
+
+                return CachedUserProfileSnapshot(
+                    profile: cached.toUserProfile(),
+                    isSynced: cached.isSynced,
+                    syncStatus: cached.syncStatus,
+                    lastModified: cached.lastModified
+                )
+            } catch {
+                #if DEBUG
+                let appError = AppError.coreData(operation: "fetchUserProfileSnapshot", underlying: error)
+                let contextInfo = ErrorContext(
+                    feature: "coreData",
+                    operation: "fetchUserProfileSnapshot",
+                    screen: nil,
+                    userId: userId
+                )
+                ErrorReporter.shared.capture(appError, context: contextInfo)
+                #endif
+                return nil
             }
         }
     }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -261,6 +261,69 @@ final class LaunchSurfacePolicyTests: XCTestCase {
     }
 }
 
+final class AuthProfileBootstrapPolicyTests: XCTestCase {
+    func testIdentityOnlyProfileIsNotPersistedDuringSessionProjection() {
+        let profile = UserProfile(
+            id: "identity-only",
+            email: "identity@example.com",
+            username: nil,
+            fullName: "Identity User",
+            dateOfBirth: nil,
+            height: nil,
+            heightUnit: "cm",
+            gender: nil,
+            activityLevel: nil,
+            goalWeight: nil,
+            goalWeightUnit: "kg",
+            onboardingCompleted: nil
+        )
+
+        XCTAssertFalse(profile.hasAppOwnedProfileData)
+        XCTAssertFalse(AuthProfileBootstrapPolicy.shouldPersistProjectedProfile(profile))
+    }
+
+    func testCompletedOnboardingProfileCanBePersistedAfterExplicitUserInput() {
+        let profile = UserProfile(
+            id: "completed-profile",
+            email: "complete@example.com",
+            username: nil,
+            fullName: "Complete User",
+            dateOfBirth: nil,
+            height: nil,
+            heightUnit: "cm",
+            gender: nil,
+            activityLevel: nil,
+            goalWeight: nil,
+            goalWeightUnit: "kg",
+            onboardingCompleted: true
+        )
+
+        XCTAssertTrue(profile.hasAppOwnedProfileData)
+        XCTAssertTrue(AuthProfileBootstrapPolicy.shouldPersistProjectedProfile(profile))
+    }
+
+    func testProfileDetailsCountAsAppOwnedProfileData() {
+        let dateOfBirth = Date(timeIntervalSince1970: 631_152_000)
+        let profile = UserProfile(
+            id: "details-profile",
+            email: "details@example.com",
+            username: nil,
+            fullName: "Details User",
+            dateOfBirth: dateOfBirth,
+            height: 180,
+            heightUnit: "cm",
+            gender: "male",
+            activityLevel: nil,
+            goalWeight: nil,
+            goalWeightUnit: nil,
+            onboardingCompleted: nil
+        )
+
+        XCTAssertTrue(profile.hasAppOwnedProfileData)
+        XCTAssertTrue(AuthProfileBootstrapPolicy.shouldPersistProjectedProfile(profile))
+    }
+}
+
 final class BodyCompositionMathGoldenTests: XCTestCase {
     private let calendar = Calendar.current
 


### PR DESCRIPTION
## Summary
- stop Clerk session projection from saving identity-only placeholder profiles into Core Data
- hydrate restored sessions from pending local profile snapshots before remote data so offline edits are not overwritten
- cache fetched server profiles as synced and skip remote bootstrap writes for identity-only projections
- add policy coverage for identity-only versus app-owned profile data

## Validation
- gbrain query/search: no repo-specific session-restore profile guidance found; GBrain was reachable
- Grok CLI (grok-composer-2.5-fast): reported pending-local overwrite and identity-only bootstrap marker blockers; both addressed. Actor warning was a false positive because AuthManager is @MainActor.
- git diff --check
- swiftlint lint --strict LogYourBody/Models/User.swift LogYourBody/Services/AuthManager.swift LogYourBody/Services/CoreDataManager.swift LogYourBodyTests/LogYourBodyTests.swift
- swiftlint lint --strict
- XcodeBuildMCP test_sim -only-testing:LogYourBodyTests/AuthProfileBootstrapPolicyTests (3 passed)
- pnpm lint
- pnpm typecheck
- pnpm test

## Notes
- Existing warnings remain: local Node is v22 while the repo requests Node 20, and existing Swift 6/deprecation warnings still appear during iOS tests.