### PR TITLE
fix: snapshot pending sync rows

### DIFF
--- a/apps/ios/LogYourBody/Services/CoreDataManager.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager.swift
@@ -23,6 +23,158 @@ struct CachedUserProfileSnapshot {
     }
 }
 
+struct PendingLocalSyncSnapshot {
+    let bodyMetrics: [PendingBodyMetricSyncItem]
+    let dailyMetrics: [PendingDailyMetricSyncItem]
+    let profiles: [PendingProfileSyncItem]
+    let glp1DoseLogs: [PendingGlp1DoseLogSyncItem]
+    let glp1Medications: [PendingGlp1MedicationSyncItem]
+    let dexaResults: [PendingDexaResultSyncItem]
+
+    static let empty = PendingLocalSyncSnapshot(
+        bodyMetrics: [],
+        dailyMetrics: [],
+        profiles: [],
+        glp1DoseLogs: [],
+        glp1Medications: [],
+        dexaResults: []
+    )
+
+    var counts: PendingLocalSyncCounts {
+        PendingLocalSyncCounts(
+            bodyMetrics: bodyMetrics.count,
+            dailyMetrics: dailyMetrics.count,
+            profiles: profiles.count,
+            glp1DoseLogs: glp1DoseLogs.count,
+            glp1Medications: glp1Medications.count,
+            dexaResults: dexaResults.count
+        )
+    }
+}
+
+struct PendingLocalSyncCounts {
+    let bodyMetrics: Int
+    let dailyMetrics: Int
+    let profiles: Int
+    let glp1DoseLogs: Int
+    let glp1Medications: Int
+    let dexaResults: Int
+
+    static let empty = PendingLocalSyncCounts(
+        bodyMetrics: 0,
+        dailyMetrics: 0,
+        profiles: 0,
+        glp1DoseLogs: 0,
+        glp1Medications: 0,
+        dexaResults: 0
+    )
+
+    var total: Int {
+        bodyMetrics + dailyMetrics + profiles + glp1DoseLogs + glp1Medications + dexaResults
+    }
+}
+
+struct PendingBodyMetricSyncItem {
+    let id: String
+    let userId: String
+    let date: Date
+    let localDate: String?
+    let weight: Double
+    let weightUnit: String?
+    let waistCircumference: Double
+    let hipCircumference: Double
+    let waistUnit: String?
+    let bodyFatPercentage: Double
+    let bodyFatMethod: String?
+    let muscleMass: Double
+    let boneMass: Double
+    let photoUrl: String?
+    let notes: String?
+    let dataSource: String?
+    let sourceMetadataJSON: String?
+    let createdAt: Date
+    let updatedAt: Date
+    let isMarkedDeleted: Bool
+}
+
+struct PendingDailyMetricSyncItem {
+    let id: String
+    let userId: String
+    let date: Date
+    let steps: Int32
+    let notes: String?
+    let createdAt: Date
+    let updatedAt: Date
+}
+
+struct PendingProfileSyncItem {
+    let id: String
+    let fullName: String?
+    let username: String?
+    let height: Double
+    let heightUnit: String?
+    let gender: String?
+    let dateOfBirth: Date?
+    let activityLevel: String?
+}
+
+struct PendingGlp1DoseLogSyncItem {
+    let id: String
+    let userId: String
+    let takenAt: Date
+    let medicationId: String?
+    let doseAmount: Double
+    let doseUnit: String?
+    let drugClass: String?
+    let brand: String?
+    let isCompounded: Bool
+    let supplierType: String?
+    let supplierName: String?
+    let notes: String?
+    let createdAt: Date
+    let updatedAt: Date
+    let isMarkedDeleted: Bool
+}
+
+struct PendingGlp1MedicationSyncItem {
+    let id: String
+    let userId: String
+    let displayName: String?
+    let genericName: String?
+    let drugClass: String?
+    let brand: String?
+    let route: String?
+    let frequency: String?
+    let doseUnit: String?
+    let isCompounded: Bool
+    let hkIdentifier: String?
+    let startedAt: Date
+    let endedAt: Date?
+    let notes: String?
+    let createdAt: Date
+    let updatedAt: Date
+}
+
+struct PendingDexaResultSyncItem {
+    let id: String
+    let userId: String
+    let bodyMetricsId: String?
+    let externalSource: String?
+    let externalResultId: String?
+    let externalUpdateTime: Date?
+    let scannerModel: String?
+    let locationId: String?
+    let locationName: String?
+    let acquireTime: Date?
+    let analyzeTime: Date?
+    let vatMassKg: Double
+    let vatVolumeCm3: Double
+    let resultPdfUrl: String?
+    let resultPdfName: String?
+    let createdAt: Date
+    let updatedAt: Date
+}
+
 class CoreDataManager: ObservableObject {
     static let shared = CoreDataManager()
 
@@ -1140,6 +1292,144 @@ class CoreDataManager: ObservableObject {
         }
     }
 
+    func fetchPendingLocalSyncSnapshot(for userId: String? = nil) async throws -> PendingLocalSyncSnapshot {
+        let context = viewContext
+
+        return try await context.perform {
+            do {
+                let bodyMetricsFetch: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+                var bodyPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    bodyPredicates.append(NSPredicate(format: "userId == %@", userId))
+                }
+                bodyMetricsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: bodyPredicates)
+
+                let dailyMetricsFetch: NSFetchRequest<CachedDailyMetrics> = CachedDailyMetrics.fetchRequest()
+                var dailyPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    dailyPredicates.append(NSPredicate(format: "userId == %@", userId))
+                }
+                dailyMetricsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: dailyPredicates)
+
+                let profilesFetch: NSFetchRequest<CachedProfile> = CachedProfile.fetchRequest()
+                var profilePredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    profilePredicates.append(NSPredicate(format: "id == %@", userId))
+                }
+                profilesFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: profilePredicates)
+
+                let glp1DoseLogsFetch: NSFetchRequest<CachedGlp1DoseLog> = CachedGlp1DoseLog.fetchRequest()
+                var glp1DoseLogPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    glp1DoseLogPredicates.append(NSPredicate(format: "userId == %@", userId))
+                }
+                glp1DoseLogsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: glp1DoseLogPredicates)
+
+                let glp1MedicationsFetch: NSFetchRequest<CachedGlp1Medication> = CachedGlp1Medication.fetchRequest()
+                var glp1MedicationPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    glp1MedicationPredicates.append(NSPredicate(format: "userId == %@", userId))
+                }
+                glp1MedicationsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: glp1MedicationPredicates)
+
+                let dexaResultsFetch: NSFetchRequest<CachedDexaResult> = CachedDexaResult.fetchRequest()
+                var dexaPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    dexaPredicates.append(NSPredicate(format: "userId == %@", userId))
+                }
+                dexaResultsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: dexaPredicates)
+
+                return PendingLocalSyncSnapshot(
+                    bodyMetrics: try context.fetch(bodyMetricsFetch).map { $0.pendingSyncItem() },
+                    dailyMetrics: try context.fetch(dailyMetricsFetch).map { $0.pendingSyncItem() },
+                    profiles: try context.fetch(profilesFetch).map { $0.pendingSyncItem() },
+                    glp1DoseLogs: try context.fetch(glp1DoseLogsFetch).map { $0.pendingSyncItem() },
+                    glp1Medications: try context.fetch(glp1MedicationsFetch).map { $0.pendingSyncItem() },
+                    dexaResults: try context.fetch(dexaResultsFetch).map { $0.pendingSyncItem() }
+                )
+            } catch {
+                let appError = AppError.coreData(operation: "fetchPendingLocalSyncSnapshot", underlying: error)
+                let contextInfo = ErrorContext(
+                    feature: "coreData",
+                    operation: "fetchPendingLocalSyncSnapshot",
+                    screen: nil,
+                    userId: userId
+                )
+                ErrorReporter.shared.capture(appError, context: contextInfo)
+                throw error
+            }
+        }
+    }
+
+    func fetchPendingLocalSyncCounts(for userId: String? = nil) async throws -> PendingLocalSyncCounts {
+        let context = viewContext
+
+        return try await context.perform {
+            do {
+                let bodyMetricsFetch: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+                var bodyPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    bodyPredicates.append(NSPredicate(format: "userId == %@", userId))
+                }
+                bodyMetricsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: bodyPredicates)
+
+                let dailyMetricsFetch: NSFetchRequest<CachedDailyMetrics> = CachedDailyMetrics.fetchRequest()
+                var dailyPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    dailyPredicates.append(NSPredicate(format: "userId == %@", userId))
+                }
+                dailyMetricsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: dailyPredicates)
+
+                let profilesFetch: NSFetchRequest<CachedProfile> = CachedProfile.fetchRequest()
+                var profilePredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    profilePredicates.append(NSPredicate(format: "id == %@", userId))
+                }
+                profilesFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: profilePredicates)
+
+                let glp1DoseLogsFetch: NSFetchRequest<CachedGlp1DoseLog> = CachedGlp1DoseLog.fetchRequest()
+                var glp1DoseLogPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    glp1DoseLogPredicates.append(NSPredicate(format: "userId == %@", userId))
+                }
+                glp1DoseLogsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: glp1DoseLogPredicates)
+
+                let glp1MedicationsFetch: NSFetchRequest<CachedGlp1Medication> = CachedGlp1Medication.fetchRequest()
+                var glp1MedicationPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    glp1MedicationPredicates.append(NSPredicate(format: "userId == %@", userId))
+                }
+                glp1MedicationsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: glp1MedicationPredicates)
+
+                let dexaResultsFetch: NSFetchRequest<CachedDexaResult> = CachedDexaResult.fetchRequest()
+                var dexaPredicates = [NSPredicate(format: "isSynced == %@", NSNumber(value: false))]
+                if let userId {
+                    dexaPredicates.append(NSPredicate(format: "userId == %@", userId))
+                }
+                dexaResultsFetch.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: dexaPredicates)
+
+                return PendingLocalSyncCounts(
+                    bodyMetrics: try context.count(for: bodyMetricsFetch),
+                    dailyMetrics: try context.count(for: dailyMetricsFetch),
+                    profiles: try context.count(for: profilesFetch),
+                    glp1DoseLogs: try context.count(for: glp1DoseLogsFetch),
+                    glp1Medications: try context.count(for: glp1MedicationsFetch),
+                    dexaResults: try context.count(for: dexaResultsFetch)
+                )
+            } catch {
+                let appError = AppError.coreData(operation: "fetchPendingLocalSyncCounts", underlying: error)
+                let contextInfo = ErrorContext(
+                    feature: "coreData",
+                    operation: "fetchPendingLocalSyncCounts",
+                    screen: nil,
+                    userId: userId
+                )
+                ErrorReporter.shared.capture(appError, context: contextInfo)
+                throw error
+            }
+        }
+    }
+
     @available(*, unavailable, message: "Use async fetchUnsyncedEntries() instead")
     func fetchUnsyncedEntriesSync() -> (
         bodyMetrics: [CachedBodyMetrics],
@@ -1183,6 +1473,81 @@ class CoreDataManager: ObservableObject {
             }
 
             self.save()
+        }
+    }
+
+    func markAsSynced(entityName: String, ids: Set<String>) async {
+        guard !ids.isEmpty else { return }
+
+        let context = viewContext
+        await context.perform {
+            do {
+                switch entityName {
+                case "CachedBodyMetrics":
+                    let request: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+                    request.predicate = NSPredicate(format: "id IN %@", Array(ids) as NSArray)
+                    try context.fetch(request).forEach {
+                        $0.isSynced = true
+                        $0.syncStatus = "synced"
+                    }
+
+                case "CachedDailyMetrics":
+                    let request: NSFetchRequest<CachedDailyMetrics> = CachedDailyMetrics.fetchRequest()
+                    request.predicate = NSPredicate(format: "id IN %@", Array(ids) as NSArray)
+                    try context.fetch(request).forEach {
+                        $0.isSynced = true
+                        $0.syncStatus = "synced"
+                    }
+
+                case "CachedProfile":
+                    let request: NSFetchRequest<CachedProfile> = CachedProfile.fetchRequest()
+                    request.predicate = NSPredicate(format: "id IN %@", Array(ids) as NSArray)
+                    try context.fetch(request).forEach {
+                        $0.isSynced = true
+                        $0.syncStatus = "synced"
+                    }
+
+                case "CachedGlp1DoseLog":
+                    let request: NSFetchRequest<CachedGlp1DoseLog> = CachedGlp1DoseLog.fetchRequest()
+                    request.predicate = NSPredicate(format: "id IN %@", Array(ids) as NSArray)
+                    try context.fetch(request).forEach {
+                        $0.isSynced = true
+                        $0.syncStatus = "synced"
+                    }
+
+                case "CachedGlp1Medication":
+                    let request: NSFetchRequest<CachedGlp1Medication> = CachedGlp1Medication.fetchRequest()
+                    request.predicate = NSPredicate(format: "id IN %@", Array(ids) as NSArray)
+                    try context.fetch(request).forEach {
+                        $0.isSynced = true
+                        $0.syncStatus = "synced"
+                    }
+
+                case "CachedDexaResult":
+                    let request: NSFetchRequest<CachedDexaResult> = CachedDexaResult.fetchRequest()
+                    request.predicate = NSPredicate(format: "id IN %@", Array(ids) as NSArray)
+                    try context.fetch(request).forEach {
+                        $0.isSynced = true
+                        $0.syncStatus = "synced"
+                    }
+
+                default:
+                    return
+                }
+
+                if context.hasChanges {
+                    try context.save()
+                }
+            } catch {
+                let appError = AppError.coreData(operation: "markAsSynced", underlying: error)
+                let contextInfo = ErrorContext(
+                    feature: "coreData",
+                    operation: "markAsSynced",
+                    screen: nil,
+                    userId: nil
+                )
+                ErrorReporter.shared.capture(appError, context: contextInfo)
+            }
         }
     }
 
@@ -2153,6 +2518,27 @@ class CoreDataManager: ObservableObject {
 }
 
 extension CachedGlp1Medication {
+    func pendingSyncItem() -> PendingGlp1MedicationSyncItem {
+        PendingGlp1MedicationSyncItem(
+            id: id ?? UUID().uuidString,
+            userId: userId ?? "",
+            displayName: displayName,
+            genericName: genericName,
+            drugClass: drugClass,
+            brand: brand,
+            route: route,
+            frequency: frequency,
+            doseUnit: doseUnit,
+            isCompounded: isCompounded,
+            hkIdentifier: hkIdentifier,
+            startedAt: startedAt ?? Date(),
+            endedAt: endedAt,
+            notes: notes,
+            createdAt: createdAt ?? Date(),
+            updatedAt: updatedAt ?? Date()
+        )
+    }
+
     func toGlp1Medication() -> Glp1Medication? {
         guard let id = id,
               let userId = userId,
@@ -2185,6 +2571,28 @@ extension CachedGlp1Medication {
 }
 
 extension CachedDexaResult {
+    func pendingSyncItem() -> PendingDexaResultSyncItem {
+        PendingDexaResultSyncItem(
+            id: id ?? UUID().uuidString,
+            userId: userId ?? "",
+            bodyMetricsId: bodyMetricsId,
+            externalSource: externalSource,
+            externalResultId: externalResultId,
+            externalUpdateTime: externalUpdateTime,
+            scannerModel: scannerModel,
+            locationId: locationId,
+            locationName: locationName,
+            acquireTime: acquireTime,
+            analyzeTime: analyzeTime,
+            vatMassKg: vatMassKg,
+            vatVolumeCm3: vatVolumeCm3,
+            resultPdfUrl: resultPdfUrl,
+            resultPdfName: resultPdfName,
+            createdAt: createdAt ?? Date(),
+            updatedAt: updatedAt ?? Date()
+        )
+    }
+
     func toDexaResult() -> DexaResult? {
         guard let id = id,
               let userId = userId,
@@ -2234,6 +2642,32 @@ extension CachedDexaResult {
 // MARK: - Model Extensions for Conversion
 
 extension CachedBodyMetrics {
+    func pendingSyncItem() -> PendingBodyMetricSyncItem {
+        let date = date ?? Date()
+        return PendingBodyMetricSyncItem(
+            id: id ?? UUID().uuidString,
+            userId: userId ?? "",
+            date: date,
+            localDate: localDate,
+            weight: weight,
+            weightUnit: weightUnit,
+            waistCircumference: waistCircumference,
+            hipCircumference: hipCircumference,
+            waistUnit: waistUnit,
+            bodyFatPercentage: bodyFatPercentage,
+            bodyFatMethod: bodyFatMethod,
+            muscleMass: muscleMass,
+            boneMass: boneMass,
+            photoUrl: photoUrl,
+            notes: notes,
+            dataSource: dataSource,
+            sourceMetadataJSON: sourceMetadataJSON,
+            createdAt: createdAt ?? date,
+            updatedAt: updatedAt ?? createdAt ?? date,
+            isMarkedDeleted: isMarkedDeleted
+        )
+    }
+
     func toBodyMetrics() -> BodyMetrics? {
         // Skip entries with missing required fields
         guard let id = id,
@@ -2270,6 +2704,19 @@ extension CachedBodyMetrics {
 }
 
 extension CachedDailyMetrics {
+    func pendingSyncItem() -> PendingDailyMetricSyncItem {
+        let date = date ?? Date()
+        return PendingDailyMetricSyncItem(
+            id: id ?? UUID().uuidString,
+            userId: userId ?? "",
+            date: date,
+            steps: steps,
+            notes: notes,
+            createdAt: createdAt ?? date,
+            updatedAt: updatedAt ?? createdAt ?? date
+        )
+    }
+
     func toDailyMetrics() -> DailyMetrics {
         DailyMetrics(
             id: id ?? UUID().uuidString,
@@ -2284,6 +2731,19 @@ extension CachedDailyMetrics {
 }
 
 extension CachedProfile {
+    func pendingSyncItem() -> PendingProfileSyncItem {
+        PendingProfileSyncItem(
+            id: id ?? "",
+            fullName: fullName,
+            username: username,
+            height: height,
+            heightUnit: heightUnit,
+            gender: gender,
+            dateOfBirth: dateOfBirth,
+            activityLevel: activityLevel
+        )
+    }
+
     func toUserProfile() -> UserProfile {
         let storedHeight = height
         let unit = heightUnit?.lowercased()
@@ -2323,6 +2783,26 @@ extension CachedProfile {
 }
 
 extension CachedGlp1DoseLog {
+    func pendingSyncItem() -> PendingGlp1DoseLogSyncItem {
+        PendingGlp1DoseLogSyncItem(
+            id: id ?? UUID().uuidString,
+            userId: userId ?? "",
+            takenAt: takenAt ?? Date(),
+            medicationId: medicationId,
+            doseAmount: doseAmount,
+            doseUnit: doseUnit,
+            drugClass: drugClass,
+            brand: brand,
+            isCompounded: isCompounded,
+            supplierType: supplierType,
+            supplierName: supplierName,
+            notes: notes,
+            createdAt: createdAt ?? takenAt ?? Date(),
+            updatedAt: updatedAt ?? createdAt ?? takenAt ?? Date(),
+            isMarkedDeleted: isMarkedDeleted
+        )
+    }
+
     func toGlp1DoseLog() -> Glp1DoseLog? {
         guard let id = id,
               let userId = userId,

--- a/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
+++ b/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
@@ -357,16 +357,12 @@ class RealtimeSyncManager: ObservableObject {
     }
 
     nonisolated func syncLocalChanges(for userId: String?, token: String) async throws {
-        let unsynced = await coreDataManager.fetchUnsyncedEntries(for: userId)
-        let unsyncedGlp1 = await coreDataManager.fetchUnsyncedGlp1DoseLogs(for: userId)
-        let unsyncedMedications = await coreDataManager.fetchUnsyncedGlp1Medications(for: userId)
-        let unsyncedDexa = await coreDataManager.fetchUnsyncedDexaResults(for: userId)
+        let unsynced = try await coreDataManager.fetchPendingLocalSyncSnapshot(for: userId)
         let deletedBodyMetrics = unsynced.bodyMetrics.filter(\.isMarkedDeleted)
         let bodyMetricsToUpsert = unsynced.bodyMetrics.filter { !$0.isMarkedDeleted }
-        let deletedGlp1DoseLogs = unsyncedGlp1.filter(\.isMarkedDeleted)
-        let glp1DoseLogsToUpsert = unsyncedGlp1.filter { !$0.isMarkedDeleted }
+        let deletedGlp1DoseLogs = unsynced.glp1DoseLogs.filter(\.isMarkedDeleted)
+        let glp1DoseLogsToUpsert = unsynced.glp1DoseLogs.filter { !$0.isMarkedDeleted }
 
-        // Batch sync for efficiency
         if !deletedBodyMetrics.isEmpty {
             try await syncDeletedBodyMetricsBatch(deletedBodyMetrics, token: token)
         }
@@ -391,65 +387,64 @@ class RealtimeSyncManager: ObservableObject {
             try await syncGlp1DoseLogsBatch(glp1DoseLogsToUpsert, token: token)
         }
 
-        if !unsyncedMedications.isEmpty {
-            try await syncGlp1MedicationsBatch(unsyncedMedications, token: token)
+        if !unsynced.glp1Medications.isEmpty {
+            try await syncGlp1MedicationsBatch(unsynced.glp1Medications, token: token)
         }
 
-        if !unsyncedDexa.isEmpty {
-            try await syncDexaResultsBatch(unsyncedDexa, token: token)
+        if !unsynced.dexaResults.isEmpty {
+            try await syncDexaResultsBatch(unsynced.dexaResults, token: token)
         }
     }
 
-    nonisolated private func syncDeletedBodyMetricsBatch(_ metrics: [CachedBodyMetrics], token: String) async throws {
-        for metric in metrics {
-            guard let id = metric.id else { continue }
+    nonisolated private func syncDeletedBodyMetricsBatch(
+        _ metrics: [PendingBodyMetricSyncItem],
+        token: String
+    ) async throws {
+        var syncedIds = Set<String>()
 
-            try await supabaseManager.deleteData(
-                table: "body_metrics",
-                id: id,
-                token: token
-            )
-
-            metric.syncStatus = "synced"
-            metric.isSynced = true
+        do {
+            for metric in metrics {
+                try await supabaseManager.deleteData(table: "body_metrics", id: metric.id, token: token)
+                syncedIds.insert(metric.id)
+            }
+        } catch {
+            await coreDataManager.markAsSynced(entityName: "CachedBodyMetrics", ids: syncedIds)
+            throw error
         }
 
-        coreDataManager.save()
+        await coreDataManager.markAsSynced(entityName: "CachedBodyMetrics", ids: syncedIds)
     }
 
-    nonisolated private func syncDeletedGlp1DoseLogsBatch(_ logs: [CachedGlp1DoseLog], token: String) async throws {
-        for log in logs {
-            guard let id = log.id else { continue }
+    nonisolated private func syncDeletedGlp1DoseLogsBatch(
+        _ logs: [PendingGlp1DoseLogSyncItem],
+        token: String
+    ) async throws {
+        var syncedIds = Set<String>()
 
-            try await supabaseManager.deleteData(
-                table: "glp1_dose_logs",
-                id: id,
-                token: token
-            )
-
-            log.syncStatus = "synced"
-            log.isSynced = true
+        do {
+            for log in logs {
+                try await supabaseManager.deleteData(table: "glp1_dose_logs", id: log.id, token: token)
+                syncedIds.insert(log.id)
+            }
+        } catch {
+            await coreDataManager.markAsSynced(entityName: "CachedGlp1DoseLog", ids: syncedIds)
+            throw error
         }
 
-        coreDataManager.save()
+        await coreDataManager.markAsSynced(entityName: "CachedGlp1DoseLog", ids: syncedIds)
     }
 
-    nonisolated private func syncBodyMetricsBatch(_ metrics: [CachedBodyMetrics], token: String) async throws {
-        let batchSize = 50 // Sync in batches to avoid timeouts
+    nonisolated private func syncBodyMetricsBatch(_ metrics: [PendingBodyMetricSyncItem], token: String) async throws {
+        let batchSize = 50
         let formatter = ISO8601DateFormatter()
 
         for batch in metrics.chunked(into: batchSize) {
-            let metricsData = batch.compactMap { metric -> [String: Any]? in
-                let id = metric.id ?? UUID().uuidString
-                let date = metric.date ?? Date()
-                let createdAt = metric.createdAt ?? date
-                let updatedAt = metric.updatedAt ?? createdAt
-
-                return [
-                    "id": id,
-                    "user_id": metric.userId ?? "",
-                    "date": formatter.string(from: date),
-                    "local_date": BodyMetricLocalDate.normalized(metric.localDate, fallback: date),
+            let metricsData = batch.map { metric -> [String: Any] in
+                [
+                    "id": metric.id,
+                    "user_id": metric.userId,
+                    "date": formatter.string(from: metric.date),
+                    "local_date": BodyMetricLocalDate.normalized(metric.localDate, fallback: metric.date),
                     "weight": metric.weight,
                     "weight_unit": metric.weightUnit ?? "kg",
                     "waist_circumference": metric.waistCircumference as Any,
@@ -463,76 +458,46 @@ class RealtimeSyncManager: ObservableObject {
                     "notes": metric.notes as Any,
                     "data_source": BodyMetricSource.normalizedRawValue(metric.dataSource),
                     "source_metadata": BodyMetricSourceMetadata(jsonString: metric.sourceMetadataJSON)?.jsonObject ?? [:],
-                    "created_at": formatter.string(from: createdAt),
-                    "updated_at": formatter.string(from: updatedAt)
+                    "created_at": formatter.string(from: metric.createdAt),
+                    "updated_at": formatter.string(from: metric.updatedAt)
                 ]
             }
 
             let response = try await supabaseManager.upsertBodyMetricsBatch(metricsData, token: token)
             let syncedIds = Set(response.compactMap { $0["id"] as? String })
-
-            for metric in batch {
-                if let id = metric.id, syncedIds.contains(id) {
-                    metric.syncStatus = "synced"
-                    metric.isSynced = true
-                }
-            }
-
-            coreDataManager.save()
+            await coreDataManager.markAsSynced(entityName: "CachedBodyMetrics", ids: syncedIds)
         }
     }
 
-    nonisolated private func syncDexaResultsBatch(_ results: [CachedDexaResult], token: String) async throws {
+    nonisolated private func syncDexaResultsBatch(_ results: [PendingDexaResultSyncItem], token: String) async throws {
         guard !results.isEmpty else { return }
 
         let batchSize = 50
         let formatter = ISO8601DateFormatter()
 
         for batch in results.chunked(into: batchSize) {
-            let payload: [[String: Any]] = batch.compactMap { result in
-                let id = result.id ?? UUID().uuidString
-                let userId = result.userId ?? ""
-                let createdAt = result.createdAt ?? Date()
-                let updatedAt = result.updatedAt ?? createdAt
-
-                let externalUpdateTimeValue: Any
-                if let externalUpdateTime = result.externalUpdateTime {
-                    externalUpdateTimeValue = formatter.string(from: externalUpdateTime)
+            let payload: [[String: Any]] = batch.map { result in
+                let externalUpdateTimeValue: Any = if let externalUpdateTime = result.externalUpdateTime {
+                    formatter.string(from: externalUpdateTime)
                 } else {
-                    externalUpdateTimeValue = NSNull()
+                    NSNull()
                 }
-
-                let acquireTimeValue: Any
-                if let acquireTime = result.acquireTime {
-                    acquireTimeValue = formatter.string(from: acquireTime)
+                let acquireTimeValue: Any = if let acquireTime = result.acquireTime {
+                    formatter.string(from: acquireTime)
                 } else {
-                    acquireTimeValue = NSNull()
+                    NSNull()
                 }
-
-                let analyzeTimeValue: Any
-                if let analyzeTime = result.analyzeTime {
-                    analyzeTimeValue = formatter.string(from: analyzeTime)
+                let analyzeTimeValue: Any = if let analyzeTime = result.analyzeTime {
+                    formatter.string(from: analyzeTime)
                 } else {
-                    analyzeTimeValue = NSNull()
+                    NSNull()
                 }
-
-                let vatMassValue: Any
-                if result.vatMassKg > 0 {
-                    vatMassValue = result.vatMassKg
-                } else {
-                    vatMassValue = NSNull()
-                }
-
-                let vatVolumeValue: Any
-                if result.vatVolumeCm3 > 0 {
-                    vatVolumeValue = result.vatVolumeCm3
-                } else {
-                    vatVolumeValue = NSNull()
-                }
+                let vatMassValue: Any = result.vatMassKg > 0 ? result.vatMassKg : NSNull()
+                let vatVolumeValue: Any = result.vatVolumeCm3 > 0 ? result.vatVolumeCm3 : NSNull()
 
                 return [
-                    "id": id,
-                    "user_id": userId,
+                    "id": result.id,
+                    "user_id": result.userId,
                     "body_metrics_id": result.bodyMetricsId as Any,
                     "external_source": result.externalSource as Any,
                     "external_result_id": result.externalResultId as Any,
@@ -546,55 +511,44 @@ class RealtimeSyncManager: ObservableObject {
                     "vat_volume_cm3": vatVolumeValue,
                     "result_pdf_url": result.resultPdfUrl as Any,
                     "result_pdf_name": result.resultPdfName as Any,
-                    "created_at": formatter.string(from: createdAt),
-                    "updated_at": formatter.string(from: updatedAt)
+                    "created_at": formatter.string(from: result.createdAt),
+                    "updated_at": formatter.string(from: result.updatedAt)
                 ]
             }
 
             let data = try JSONSerialization.data(withJSONObject: payload)
-            try await supabaseManager.upsertData(table: "dexa_results", data: data, token: token)
-
-            for result in batch {
-                result.isSynced = true
-                result.syncStatus = "synced"
-            }
-
-            coreDataManager.save()
+            let response = try await supabaseManager.upsertData(table: "dexa_results", data: data, token: token)
+            let syncedIds = Set(response.compactMap { $0["id"] as? String })
+            await coreDataManager.markAsSynced(entityName: "CachedDexaResult", ids: syncedIds)
         }
     }
 
-    nonisolated private func syncGlp1MedicationsBatch(_ medications: [CachedGlp1Medication], token: String) async throws {
+    nonisolated private func syncGlp1MedicationsBatch(
+        _ medications: [PendingGlp1MedicationSyncItem],
+        token: String
+    ) async throws {
         guard !medications.isEmpty else { return }
 
         let formatter = ISO8601DateFormatter()
         let batchSize = 50
 
-        let userIds = Set(medications.compactMap { $0.userId })
-
-        for userId in userIds {
+        for userId in Set(medications.map(\.userId)) {
             let userMeds = medications.filter { $0.userId == userId }
             let endDate = userMeds.compactMap { $0.endedAt }.max() ?? Date()
             try await supabaseManager.endActiveGlp1Medications(userId: userId, endedAt: endDate)
         }
 
         for batch in medications.chunked(into: batchSize) {
-            let payload: [[String: Any]] = batch.compactMap { medication in
-                let id = medication.id ?? UUID().uuidString
-                let userId = medication.userId ?? ""
-                let startedAt = medication.startedAt ?? Date()
-                let createdAt = medication.createdAt ?? startedAt
-                let updatedAt = medication.updatedAt ?? createdAt
-
-                let endedAtValue: Any
-                if let endedAt = medication.endedAt {
-                    endedAtValue = formatter.string(from: endedAt)
+            let payload: [[String: Any]] = batch.map { medication in
+                let endedAtValue: Any = if let endedAt = medication.endedAt {
+                    formatter.string(from: endedAt)
                 } else {
-                    endedAtValue = NSNull()
+                    NSNull()
                 }
 
                 return [
-                    "id": id,
-                    "user_id": userId,
+                    "id": medication.id,
+                    "user_id": medication.userId,
                     "display_name": medication.displayName as Any,
                     "generic_name": medication.genericName as Any,
                     "drug_class": medication.drugClass as Any,
@@ -604,42 +558,31 @@ class RealtimeSyncManager: ObservableObject {
                     "dose_unit": medication.doseUnit as Any,
                     "is_compounded": medication.isCompounded,
                     "hk_identifier": medication.hkIdentifier as Any,
-                    "started_at": formatter.string(from: startedAt),
+                    "started_at": formatter.string(from: medication.startedAt),
                     "ended_at": endedAtValue,
                     "notes": medication.notes as Any,
-                    "created_at": formatter.string(from: createdAt),
-                    "updated_at": formatter.string(from: updatedAt)
+                    "created_at": formatter.string(from: medication.createdAt),
+                    "updated_at": formatter.string(from: medication.updatedAt)
                 ]
             }
 
             let data = try JSONSerialization.data(withJSONObject: payload)
-            try await supabaseManager.upsertData(table: "glp1_medications", data: data, token: token)
-
-            for medication in batch {
-                medication.isSynced = true
-                medication.syncStatus = "synced"
-            }
-
-            coreDataManager.save()
+            let response = try await supabaseManager.upsertData(table: "glp1_medications", data: data, token: token)
+            let syncedIds = Set(response.compactMap { $0["id"] as? String })
+            await coreDataManager.markAsSynced(entityName: "CachedGlp1Medication", ids: syncedIds)
         }
     }
 
-    nonisolated private func syncGlp1DoseLogsBatch(_ logs: [CachedGlp1DoseLog], token: String) async throws {
+    nonisolated private func syncGlp1DoseLogsBatch(_ logs: [PendingGlp1DoseLogSyncItem], token: String) async throws {
         let batchSize = 50
         let formatter = ISO8601DateFormatter()
 
         for batch in logs.chunked(into: batchSize) {
-            let payload: [[String: Any]] = batch.compactMap { log in
-                let id = log.id ?? UUID().uuidString
-                let userId = log.userId ?? ""
-                let takenAt = log.takenAt ?? Date()
-                let createdAt = log.createdAt ?? takenAt
-                let updatedAt = log.updatedAt ?? createdAt
-
-                return [
-                    "id": id,
-                    "user_id": userId,
-                    "taken_at": formatter.string(from: takenAt),
+            let payload: [[String: Any]] = batch.map { log in
+                [
+                    "id": log.id,
+                    "user_id": log.userId,
+                    "taken_at": formatter.string(from: log.takenAt),
                     "medication_id": log.medicationId as Any,
                     "dose_amount": log.doseAmount,
                     "dose_unit": log.doseUnit as Any,
@@ -649,75 +592,55 @@ class RealtimeSyncManager: ObservableObject {
                     "supplier_type": log.supplierType as Any,
                     "supplier_name": log.supplierName as Any,
                     "notes": log.notes as Any,
-                    "created_at": formatter.string(from: createdAt),
-                    "updated_at": formatter.string(from: updatedAt)
+                    "created_at": formatter.string(from: log.createdAt),
+                    "updated_at": formatter.string(from: log.updatedAt)
                 ]
             }
 
             let data = try JSONSerialization.data(withJSONObject: payload)
-            try await supabaseManager.upsertData(table: "glp1_dose_logs", data: data, token: token)
-
-            for log in batch {
-                log.isSynced = true
-                log.syncStatus = "synced"
-            }
-
-            coreDataManager.save()
+            let response = try await supabaseManager.upsertData(table: "glp1_dose_logs", data: data, token: token)
+            let syncedIds = Set(response.compactMap { $0["id"] as? String })
+            await coreDataManager.markAsSynced(entityName: "CachedGlp1DoseLog", ids: syncedIds)
         }
     }
 
-    nonisolated private func syncDailyMetricsBatch(_ metrics: [CachedDailyMetrics], token: String) async throws {
-        // Similar batch implementation for daily metrics
+    nonisolated private func syncDailyMetricsBatch(_ metrics: [PendingDailyMetricSyncItem], token: String) async throws {
         let batchSize = 50
         let formatter = ISO8601DateFormatter()
 
         for batch in metrics.chunked(into: batchSize) {
-            let metricsData = batch.compactMap { metric -> [String: Any]? in
-                let id = metric.id ?? UUID().uuidString
-                let date = metric.date ?? Date()
-                let createdAt = metric.createdAt ?? date
-                let updatedAt = metric.updatedAt ?? createdAt
-
-                return [
-                    "id": id,
-                    "user_id": metric.userId ?? "",
-                    "date": formatter.string(from: date),
-                    "steps": metric.steps,
+            let metricsData = batch.map { metric -> [String: Any] in
+                [
+                    "id": metric.id,
+                    "user_id": metric.userId,
+                    "date": formatter.string(from: metric.date),
+                    "steps": Int(metric.steps),
                     "notes": metric.notes as Any,
-                    "created_at": formatter.string(from: createdAt),
-                    "updated_at": formatter.string(from: updatedAt)
+                    "created_at": formatter.string(from: metric.createdAt),
+                    "updated_at": formatter.string(from: metric.updatedAt)
                 ]
             }
 
             let response = try await supabaseManager.upsertDailyMetricsBatch(metricsData, token: token)
             let syncedIds = Set(response.compactMap { $0["id"] as? String })
-
-            for metric in batch {
-                if let id = metric.id, syncedIds.contains(id) {
-                    metric.syncStatus = "synced"
-                    metric.isSynced = true
-                }
-            }
-
-            coreDataManager.save()
+            await coreDataManager.markAsSynced(entityName: "CachedDailyMetrics", ids: syncedIds)
         }
     }
 
-    nonisolated private func syncProfilesBatch(_ profiles: [CachedProfile], token: String) async throws {
-        // Profile sync (usually just one per user)
+    nonisolated private func syncProfilesBatch(_ profiles: [PendingProfileSyncItem], token: String) async throws {
+        let formatter = ISO8601DateFormatter()
+
         for profile in profiles {
-            let formattedBirthDate: Any
-            if let dateOfBirth = profile.dateOfBirth {
-                formattedBirthDate = ISO8601DateFormatter().string(from: dateOfBirth)
+            let formattedBirthDate: Any = if let dateOfBirth = profile.dateOfBirth {
+                formatter.string(from: dateOfBirth)
             } else {
-                formattedBirthDate = NSNull()
+                NSNull()
             }
 
             let profileData: [String: Any] = [
-                "id": profile.id ?? "",
+                "id": profile.id,
                 "full_name": profile.fullName as Any,
                 "username": profile.username as Any,
-                // "avatar_url": profile.avatarUrl as Any, // Field doesn't exist
                 "height": profile.height,
                 "height_unit": profile.heightUnit as Any,
                 "gender": profile.gender as Any,
@@ -726,10 +649,7 @@ class RealtimeSyncManager: ObservableObject {
             ]
 
             try await supabaseManager.updateProfile(profileData, token: token)
-
-            profile.syncStatus = "synced"
-            // profile.lastSyncedAt = Date() // Field doesn't exist
-            coreDataManager.save()
+            await coreDataManager.markAsSynced(entityName: "CachedProfile", ids: [profile.id])
         }
     }
 
@@ -868,25 +788,27 @@ class RealtimeSyncManager: ObservableObject {
                 return
             }
 
-            let unsynced = await self.coreDataManager.fetchUnsyncedEntries(for: userId)
-            let unsyncedGlp1 = await self.coreDataManager.fetchUnsyncedGlp1DoseLogs(for: userId)
-            let unsyncedMedications = await self.coreDataManager.fetchUnsyncedGlp1Medications(for: userId)
-            let unsyncedDexa = await self.coreDataManager.fetchUnsyncedDexaResults(for: userId)
             let operationsCount = await MainActor.run {
                 self.pendingOperations.filter { $0.userId == userId }.count
             }
+
+            let unsynced: PendingLocalSyncCounts
+            do {
+                unsynced = try await self.coreDataManager.fetchPendingLocalSyncCounts(for: userId)
+            } catch {
+                await MainActor.run {
+                    self.pendingSyncCount = max(self.pendingSyncCount, operationsCount + 1)
+                }
+                return
+            }
+
             await MainActor.run {
-                self.unsyncedBodyCount = unsynced.bodyMetrics.count
-                self.unsyncedDailyCount = unsynced.dailyMetrics.count
-                self.unsyncedProfileCount = unsynced.profiles.count
-                self.unsyncedGlp1Count = unsyncedGlp1.count
-                self.unsyncedDexaCount = unsyncedDexa.count
-                self.pendingSyncCount = unsynced.bodyMetrics.count +
-                    unsynced.dailyMetrics.count +
-                    unsynced.profiles.count +
-                    unsyncedGlp1.count +
-                    unsyncedMedications.count +
-                    unsyncedDexa.count +
+                self.unsyncedBodyCount = unsynced.bodyMetrics
+                self.unsyncedDailyCount = unsynced.dailyMetrics
+                self.unsyncedProfileCount = unsynced.profiles
+                self.unsyncedGlp1Count = unsynced.glp1DoseLogs
+                self.unsyncedDexaCount = unsynced.dexaResults
+                self.pendingSyncCount = unsynced.total +
                     operationsCount
             }
         }
@@ -897,17 +819,13 @@ class RealtimeSyncManager: ObservableObject {
             return false
         }
 
-        let unsynced = await coreDataManager.fetchUnsyncedEntries(for: userId)
-        let unsyncedGlp1 = await coreDataManager.fetchUnsyncedGlp1DoseLogs(for: userId)
-        let unsyncedMedications = await coreDataManager.fetchUnsyncedGlp1Medications(for: userId)
-        let unsyncedDexa = await coreDataManager.fetchUnsyncedDexaResults(for: userId)
-        return !unsynced.bodyMetrics.isEmpty ||
-            !unsynced.dailyMetrics.isEmpty ||
-            !unsynced.profiles.isEmpty ||
-            !unsyncedGlp1.isEmpty ||
-            !unsyncedMedications.isEmpty ||
-            !unsyncedDexa.isEmpty ||
-            pendingOperations.contains { $0.userId == userId }
+        do {
+            let unsynced = try await coreDataManager.fetchPendingLocalSyncCounts(for: userId)
+            return unsynced.total > 0 ||
+                pendingOperations.contains { $0.userId == userId }
+        } catch {
+            return true
+        }
     }
     private func shouldPullLatestData() -> Bool {
         guard let lastSync = lastSyncDate else { return true }

--- a/apps/ios/LogYourBody/Services/SupabaseManager.swift
+++ b/apps/ios/LogYourBody/Services/SupabaseManager.swift
@@ -248,22 +248,25 @@ class SupabaseManager: ObservableObject {
         }
     }
 
-    func upsertData(table: String, data: Data, token: String) async throws {
+    @discardableResult
+    func upsertData(table: String, data: Data, token: String) async throws -> [[String: Any]] {
         let url = URL(string: "\(supabaseURL)/rest/v1/\(table)")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue(supabaseAnonKey, forHTTPHeaderField: "apikey")
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("resolution=merge-duplicates", forHTTPHeaderField: "Prefer")
+        request.setValue("return=representation,resolution=merge-duplicates", forHTTPHeaderField: "Prefer")
         request.httpBody = data
 
-        let (_, response) = try await self.session.data(for: request)
+        let (responseData, response) = try await self.session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             throw SupabaseError.requestFailed
         }
+
+        return try JSONSerialization.jsonObject(with: responseData) as? [[String: Any]] ?? []
     }
 
     func deleteData(table: String, id: String, token: String) async throws {

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -3866,6 +3866,9 @@ final class StubSupabaseManager: SupabaseManager {
     private(set) var bodyMetricsBatches: [[[String: Any]]] = []
     private(set) var dailyMetricsBatches: [[[String: Any]]] = []
     private(set) var dexaPayloads: [[String: Any]] = []
+    private(set) var glp1DoseLogPayloads: [[String: Any]] = []
+    private(set) var glp1MedicationPayloads: [[String: Any]] = []
+    private(set) var endedActiveMedicationRequests: [(userId: String, endedAt: Date)] = []
     private(set) var deletedRecords: [(table: String, id: String)] = []
 
     override func upsertBodyMetricsBatch(_ metrics: [[String: Any]], token: String) async throws -> [[String: Any]] {
@@ -3884,18 +3887,33 @@ final class StubSupabaseManager: SupabaseManager {
         }
     }
 
-    override func upsertData(table: String, data: Data, token: String) async throws {
-        guard table == "dexa_results" else {
-            return
-        }
-
+    override func upsertData(table: String, data: Data, token: String) async throws -> [[String: Any]] {
         let jsonObject = try JSONSerialization.jsonObject(with: data)
         let array = jsonObject as? [[String: Any]] ?? []
-        dexaPayloads.append(contentsOf: array)
+
+        switch table {
+        case "dexa_results":
+            dexaPayloads.append(contentsOf: array)
+        case "glp1_dose_logs":
+            glp1DoseLogPayloads.append(contentsOf: array)
+        case "glp1_medications":
+            glp1MedicationPayloads.append(contentsOf: array)
+        default:
+            return []
+        }
+
+        return array.compactMap { payload in
+            guard let id = payload["id"] as? String else { return nil }
+            return ["id": id]
+        }
     }
 
     override func deleteData(table: String, id: String, token: String) async throws {
         deletedRecords.append((table: table, id: id))
+    }
+
+    override func endActiveGlp1Medications(userId: String, endedAt: Date) async throws {
+        endedActiveMedicationRequests.append((userId: userId, endedAt: endedAt))
     }
 }
 
@@ -4892,7 +4910,9 @@ final class SyncIntegrationTests: XCTestCase {
             supabaseManager: stubSupabase
         )
 
-        try await manager.syncLocalChanges(token: "test-token")
+        try await Task.detached {
+            try await manager.syncLocalChanges(token: "test-token")
+        }.value
 
         // Verify Supabase payload
         XCTAssertEqual(stubSupabase.bodyMetricsBatches.count, 1)
@@ -5159,6 +5179,112 @@ final class SyncIntegrationTests: XCTestCase {
         let unsynced = await coreData.fetchUnsyncedEntries()
         let unsyncedForUser = unsynced.dailyMetrics.filter { $0.userId == userId }
         XCTAssertTrue(unsyncedForUser.isEmpty)
+    }
+
+    func testSyncLocalChanges_UsesSupabaseAndMarksGlp1DoseLogSynced() async throws {
+        let coreData = CoreDataManager.shared
+
+        let id = UUID().uuidString
+        let userId = "sync_test_user_glp1_log_\(UUID().uuidString)"
+        let medicationId = UUID().uuidString
+        let now = Date(timeIntervalSince1970: 1_780_100_000)
+        let log = Glp1DoseLog(
+            id: id,
+            userId: userId,
+            takenAt: now,
+            medicationId: medicationId,
+            doseAmount: 2.5,
+            doseUnit: "mg",
+            drugClass: "semaglutide",
+            brand: "Ozempic",
+            isCompounded: false,
+            supplierType: "pharmacy",
+            supplierName: "Test Pharmacy",
+            notes: "weekly dose",
+            createdAt: now.addingTimeInterval(-60),
+            updatedAt: now
+        )
+
+        try await coreData.saveGlp1DoseLogsAndWait([log], userId: userId, markAsSynced: false)
+
+        let stubSupabase = StubSupabaseManager()
+        let manager = RealtimeSyncManager(
+            coreDataManager: coreData,
+            authManager: AuthManager.shared,
+            supabaseManager: stubSupabase
+        )
+
+        try await manager.syncLocalChanges(token: "test-token")
+
+        XCTAssertEqual(stubSupabase.glp1DoseLogPayloads.count, 1)
+        let payload = try XCTUnwrap(stubSupabase.glp1DoseLogPayloads.first)
+        XCTAssertEqual(payload["id"] as? String, id)
+        XCTAssertEqual(payload["user_id"] as? String, userId)
+        XCTAssertEqual(payload["medication_id"] as? String, medicationId)
+        XCTAssertEqual(payload["dose_amount"] as? Double, 2.5)
+        XCTAssertEqual(payload["dose_unit"] as? String, "mg")
+        XCTAssertEqual(payload["brand"] as? String, "Ozempic")
+
+        let remaining = await coreData.fetchUnsyncedGlp1DoseLogs(for: userId)
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func testSyncLocalChanges_UsesSupabaseAndMarksGlp1MedicationSynced() async throws {
+        let coreData = CoreDataManager.shared
+
+        let id = UUID().uuidString
+        let userId = "sync_test_user_glp1_med_\(UUID().uuidString)"
+        let now = Date(timeIntervalSince1970: 1_780_200_000)
+        let endedAt = now.addingTimeInterval(3_600)
+
+        let context = coreData.viewContext
+        await context.perform {
+            let medication = CachedGlp1Medication(context: context)
+            medication.id = id
+            medication.userId = userId
+            medication.displayName = "Semaglutide"
+            medication.genericName = "semaglutide"
+            medication.drugClass = "glp1"
+            medication.brand = "Ozempic"
+            medication.route = "injection"
+            medication.frequency = "weekly"
+            medication.doseUnit = "mg"
+            medication.isCompounded = false
+            medication.hkIdentifier = "hk-med-\(UUID().uuidString)"
+            medication.startedAt = now
+            medication.endedAt = endedAt
+            medication.notes = "medication note"
+            medication.createdAt = now.addingTimeInterval(-120)
+            medication.updatedAt = endedAt
+            medication.isSynced = false
+            medication.syncStatus = "pending"
+
+            if context.hasChanges {
+                try? context.save()
+            }
+        }
+
+        let stubSupabase = StubSupabaseManager()
+        let manager = RealtimeSyncManager(
+            coreDataManager: coreData,
+            authManager: AuthManager.shared,
+            supabaseManager: stubSupabase
+        )
+
+        try await manager.syncLocalChanges(token: "test-token")
+
+        XCTAssertEqual(stubSupabase.endedActiveMedicationRequests.count, 1)
+        XCTAssertEqual(stubSupabase.endedActiveMedicationRequests.first?.userId, userId)
+        XCTAssertEqual(stubSupabase.glp1MedicationPayloads.count, 1)
+        let payload = try XCTUnwrap(stubSupabase.glp1MedicationPayloads.first)
+        XCTAssertEqual(payload["id"] as? String, id)
+        XCTAssertEqual(payload["user_id"] as? String, userId)
+        XCTAssertEqual(payload["display_name"] as? String, "Semaglutide")
+        XCTAssertEqual(payload["brand"] as? String, "Ozempic")
+        XCTAssertEqual(payload["ended_at"] as? String, ISO8601DateFormatter().string(from: endedAt))
+
+        let remaining = await coreData.fetchUnsyncedGlp1Medications(for: userId)
+        XCTAssertTrue(remaining.isEmpty)
     }
 
     func testSyncLocalChanges_UsesSupabaseAndMarksDexaResultsSynced() async throws {


### PR DESCRIPTION
## Summary
- fetch pending Core Data sync rows as value snapshots inside the Core Data context
- mark synced rows by backend-returned IDs inside the context instead of mutating managed objects across awaits
- add count-only pending sync checks that fail closed on Core Data errors
- cover detached sync plus GLP-1 dose and medication batch sync paths

## Validation
- GBrain reachable: `gbrain doctor --fast --json` (warnings only); repo-specific Core Data sync query had no prior note
- Subagent audit confirmed off-context mutation risk in `RealtimeSyncManager.syncLocalChanges`
- Grok CLI `grok-composer-2.5-fast` review blockers fixed: no empty snapshot on fetch failure, count-only pending checks, DEXA/GLP-1 mark-synced only by backend-returned IDs
- `swiftlint lint --strict LogYourBody/Services/CoreDataManager.swift LogYourBody/Services/RealtimeSyncManager.swift LogYourBody/Services/SupabaseManager.swift LogYourBodyTests/LogYourBodyTests.swift`
- XcodeBuildMCP focused sync tests passed: body metric upsert, body metric delete, daily metric, GLP-1 dose log, GLP-1 medication, DEXA result
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Graphite
- `gt branch track agent/codex/coredata-sync-snapshot-stability --parent main --no-interactive` succeeded
- `gt branch submit --dry-run --no-interactive --no-edit --no-ai --branch agent/codex/coredata-sync-snapshot-stability` succeeded
- actual Graphite submit remains blocked by account synced-repo settings: https://app.graphite.com/settings/synced-repos