### PR TITLE
fix: stabilize entry photo flows

### DIFF
--- a/apps/ios/LogYourBody/Components/FullMetricChartView.swift
+++ b/apps/ios/LogYourBody/Components/FullMetricChartView.swift
@@ -281,7 +281,7 @@ struct FullMetricChartView: View {
     let unit: String
     let currentDate: String
     let chartData: [MetricChartDataPoint]
-    let onAdd: () -> Void
+    let onAdd: (() -> Void)?
     let metricEntries: MetricEntriesPayload?
     let relatedMetrics: [MetricDetailRelatedMetric]
 
@@ -314,7 +314,7 @@ struct FullMetricChartView: View {
         unit: String,
         currentDate: String,
         chartData: [MetricChartDataPoint],
-        onAdd: @escaping () -> Void,
+        onAdd: (() -> Void)?,
         metricEntries: MetricEntriesPayload?,
         relatedMetrics: [MetricDetailRelatedMetric] = [],
         goalValue: Double?,
@@ -362,16 +362,18 @@ struct FullMetricChartView: View {
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(false)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
-                    HapticManager.shared.selection()
-                    onAdd()
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(Color.metricAccent)
+            if let onAdd {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        HapticManager.shared.selection()
+                        onAdd()
+                    } label: {
+                        Image(systemName: "plus")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundColor(Color.metricAccent)
+                    }
+                    .accessibilityLabel("Add Entry")
                 }
-                .accessibilityLabel("Add Entry")
             }
         }
         .toolbar(.visible, for: .navigationBar)
@@ -960,20 +962,23 @@ struct FullMetricChartView: View {
 
                 Spacer()
 
-                Button {
-                    HapticManager.shared.selection()
-                    onAdd()
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(Color.metricAccent)
-                        .frame(width: 32, height: 32)
-                        .background(
-                            RoundedRectangle(cornerRadius: 10)
-                                .fill(Color.white.opacity(0.08))
-                        )
+                if let onAdd {
+                    Button {
+                        HapticManager.shared.selection()
+                        onAdd()
+                    } label: {
+                        Image(systemName: "plus")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundColor(Color.metricAccent)
+                            .frame(width: 32, height: 32)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(Color.white.opacity(0.08))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Add Entry")
                 }
-                .buttonStyle(.plain)
             }
 
             if let payload = metricEntries,

--- a/apps/ios/LogYourBody/Services/CoreDataManager.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager.swift
@@ -1023,6 +1023,44 @@ class CoreDataManager: ObservableObject {
         }
     }
 
+    @discardableResult
+    func updateBodyMetricPhoto(
+        id: String,
+        userId: String,
+        storagePath: String,
+        processedUrl: String
+    ) async throws -> Bool {
+        let context = viewContext
+
+        return try await context.perform {
+            let fetchRequest: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+            fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(format: "id == %@", id),
+                NSPredicate(format: "userId == %@", userId),
+                NSPredicate(format: "isMarkedDeleted == %@", NSNumber(value: false))
+            ])
+            fetchRequest.fetchLimit = 1
+
+            guard let cachedMetric = try context.fetch(fetchRequest).first else {
+                return false
+            }
+
+            let now = Date()
+            cachedMetric.photoUrl = processedUrl
+            cachedMetric.originalPhotoUrl = storagePath
+            cachedMetric.updatedAt = now
+            cachedMetric.lastModified = now
+            cachedMetric.isSynced = false
+            cachedMetric.syncStatus = "pending"
+
+            if context.hasChanges {
+                try context.save()
+            }
+
+            return true
+        }
+    }
+
     func markBodyMetricDeleted(id: String) async -> Bool {
         let context = viewContext
 

--- a/apps/ios/LogYourBody/Services/PhotoUploadManager.swift
+++ b/apps/ios/LogYourBody/Services/PhotoUploadManager.swift
@@ -446,14 +446,19 @@ class PhotoUploadManager: ObservableObject {
 
     private func updateMetricsWithPhoto(metricsId: String, storagePath: String, processedUrl: String) async throws {
         // Update local CoreData
-        guard let userId = authManager.currentUser?.id else { return }
-        if let cachedMetrics = await coreDataManager.fetchBodyMetrics(for: userId)
-            .first(where: { $0.id == metricsId }) {
-            cachedMetrics.photoUrl = processedUrl
-            cachedMetrics.originalPhotoUrl = storagePath
-            cachedMetrics.lastModified = Date()
-            cachedMetrics.isSynced = false
-            coreDataManager.save()
+        guard let userId = authManager.currentUser?.id else {
+            throw PhotoError.notAuthenticated
+        }
+
+        let didUpdate = try await coreDataManager.updateBodyMetricPhoto(
+            id: metricsId,
+            userId: userId,
+            storagePath: storagePath,
+            processedUrl: processedUrl
+        )
+
+        guard didUpdate else {
+            throw PhotoError.processingFailed("Could not save photo locally")
         }
 
         // Trigger sync to update remote

--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -20,6 +20,28 @@ struct PhotoUploadBatchPolicy {
     static func canChangeSelection(isProcessing: Bool) -> Bool {
         !isProcessing
     }
+
+    static func canStartUpload(selectedCount: Int, isSaving: Bool, isProcessing: Bool) -> Bool {
+        selectedCount > 0 && !isSaving && !isProcessing
+    }
+
+    static func canDismiss(isSaving: Bool, isProcessing: Bool) -> Bool {
+        !isSaving && !isProcessing
+    }
+
+    static func shouldDismissAfterUpload(successfulCount: Int, totalCount: Int) -> Bool {
+        totalCount > 0 && successfulCount == totalCount
+    }
+
+    static func uploadFailureMessage(successfulCount: Int, totalCount: Int) -> String {
+        guard successfulCount > 0 else {
+            return "Photo upload failed. Please try again."
+        }
+
+        let failedCount = max(totalCount - successfulCount, 0)
+        let noun = failedCount == 1 ? "photo" : "photos"
+        return "Uploaded \(successfulCount) of \(totalCount) photos. \(failedCount) \(noun) failed. Try again."
+    }
 }
 
 struct AddEntrySheet: View {
@@ -167,10 +189,22 @@ struct AddEntrySheet: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Cancel") {
+                        guard PhotoUploadBatchPolicy.canDismiss(
+                            isSaving: isSavingEntry,
+                            isProcessing: isProcessingPhotos
+                        ) else { return }
                         dismiss()
                     }
+                    .disabled(!PhotoUploadBatchPolicy.canDismiss(
+                        isSaving: isSavingEntry,
+                        isProcessing: isProcessingPhotos
+                    ))
                 }
             }
+            .interactiveDismissDisabled(!PhotoUploadBatchPolicy.canDismiss(
+                isSaving: isSavingEntry,
+                isProcessing: isProcessingPhotos
+            ))
             .standardErrorAlert(isPresented: $showError, message: errorMessage)
             .alert("Delete Photos After Import?", isPresented: $showDeletePhotosPrompt) {
                 Button("Keep Photos", role: .cancel) {
@@ -773,6 +807,18 @@ struct AddEntrySheet: View {
             saveBodyFat(userId: userId)
         case 2:
             let photosToSave = selectedPhotos
+            guard PhotoUploadBatchPolicy.canStartUpload(
+                selectedCount: photosToSave.count,
+                isSaving: isSavingEntry,
+                isProcessing: isProcessingPhotos
+            ) else { return }
+
+            isProcessingPhotos = true
+            photoProgress = 0
+            processedCount = 0
+            processingPhotoCount = photosToSave.count
+            photoIdentifiers.removeAll()
+
             Task {
                 await savePhotos(userId: userId, selectedPhotos: photosToSave)
             }
@@ -926,6 +972,7 @@ struct AddEntrySheet: View {
         photoIdentifiers.removeAll()
         var successfulUploadCount = 0
         var successfulPhotoIdentifiers: [String] = []
+        var failedPhotos: [PhotosPickerItem] = []
 
         defer {
             isProcessingPhotos = false
@@ -948,6 +995,7 @@ struct AddEntrySheet: View {
                 // Load the photo data
                 guard let data = try await item.loadTransferable(type: Data.self),
                       let image = UIImage(data: data) else {
+                    failedPhotos.append(item)
                     continue
                 }
 
@@ -978,23 +1026,32 @@ struct AddEntrySheet: View {
                     userId: userId
                 )
                 ErrorReporter.shared.captureNonFatal(error, context: context)
+                failedPhotos.append(item)
             }
-        }
-
-        if successfulUploadCount == 0 {
-            errorMessage = "Photo upload failed. Please try again."
-            showError = true
-            return
         }
 
         photoIdentifiers = successfulPhotoIdentifiers
 
-        // Delete photos from camera roll if enabled
+        // Delete successfully imported originals even if a later item failed.
         if deletePhotosAfterImport && !photoIdentifiers.isEmpty {
             await deletePhotosFromLibrary()
         }
 
         RealtimeSyncManager.shared.syncIfNeeded()
+
+        if !PhotoUploadBatchPolicy.shouldDismissAfterUpload(
+            successfulCount: successfulUploadCount,
+            totalCount: photosToUpload.count
+        ) {
+            selectedPhotos = failedPhotos
+            errorMessage = PhotoUploadBatchPolicy.uploadFailureMessage(
+                successfulCount: successfulUploadCount,
+                totalCount: photosToUpload.count
+            )
+            showError = true
+            return
+        }
+
         dismiss()
 
         trackEntrySaved(

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
@@ -91,9 +91,7 @@ extension DashboardViewLiquid {
                 unit: "steps",
                 currentDate: formatDate(dailyMetrics?.updatedAt ?? Date()),
                 chartData: cachedChartData(for: .steps, generator: generateFullScreenStepsChartData),
-                onAdd: {
-                    showAddEntrySheet = true
-                },
+                onAdd: nil,
                 metricEntries: cachedMetricEntries(for: .steps),
                 relatedMetrics: metricDetailRelatedMetrics(excluding: .steps),
                 goalValue: Double(stepGoal),
@@ -111,7 +109,7 @@ extension DashboardViewLiquid {
                 currentDate: formatDate(currentMetric?.date ?? Date()),
                 chartData: cachedChartData(for: .weight, generator: generateFullScreenWeightChartData),
                 onAdd: {
-                    showAddEntrySheet = true
+                    presentAddEntrySheet(initialTab: 0)
                 },
                 metricEntries: cachedMetricEntries(for: .weight),
                 relatedMetrics: metricDetailRelatedMetrics(excluding: .weight),
@@ -130,7 +128,7 @@ extension DashboardViewLiquid {
                 currentDate: formatDate(currentMetric?.date ?? Date()),
                 chartData: cachedChartData(for: .bodyFat, generator: generateFullScreenBodyFatChartData),
                 onAdd: {
-                    showAddEntrySheet = true
+                    presentAddEntrySheet(initialTab: 1)
                 },
                 metricEntries: cachedMetricEntries(for: .bodyFat),
                 relatedMetrics: metricDetailRelatedMetrics(excluding: .bodyFat),
@@ -148,9 +146,7 @@ extension DashboardViewLiquid {
                 unit: "",
                 currentDate: formatDate(currentMetric?.date ?? Date()),
                 chartData: cachedChartData(for: .ffmi, generator: generateFullScreenFFMIChartData),
-                onAdd: {
-                    showAddEntrySheet = true
-                },
+                onAdd: nil,
                 metricEntries: cachedMetricEntries(for: .ffmi),
                 relatedMetrics: metricDetailRelatedMetrics(excluding: .ffmi),
                 goalValue: ffmiGoal,
@@ -168,9 +164,7 @@ extension DashboardViewLiquid {
                 unit: "",
                 currentDate: formatDate(currentMetric?.date ?? Date()),
                 chartData: cachedChartData(for: .bodyScore, generator: generateFullScreenBodyScoreChartData),
-                onAdd: {
-                    showAddEntrySheet = true
-                },
+                onAdd: nil,
                 metricEntries: cachedMetricEntries(for: .bodyScore),
                 relatedMetrics: metricDetailRelatedMetrics(excluding: .bodyScore),
                 goalValue: nil,

--- a/apps/ios/LogYourBody/Views/EditEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/EditEntrySheet.swift
@@ -49,12 +49,18 @@ struct EditEntrySheet: View {
                             displayedComponents: .date
                         )
                         .datePickerStyle(.graphical)
+                        .onChange(of: selectedDate) { _, _ in
+                            errorMessage = nil
+                        }
                     }
 
                     Section(header: Text(primaryFieldLabel)) {
                         TextField("0.0", text: $primaryValue)
                             .keyboardType(.decimalPad)
                             .disabled(isSaving)
+                            .onChange(of: primaryValue) { _, _ in
+                                errorMessage = nil
+                            }
 
                         if metricType == .weight {
                             HStack {
@@ -109,7 +115,11 @@ struct EditEntrySheet: View {
                             Text("Save")
                         }
                     }
-                    .disabled(!canSave || isSaving)
+                    .disabled(!EditEntrySavePolicy.canAttemptSave(
+                        isSaving: isSaving,
+                        validationMessage: validationMessage,
+                        value: primaryValue
+                    ))
                 }
             }
         }
@@ -157,8 +167,11 @@ struct EditEntrySheet: View {
     }
 
     private var canSave: Bool {
-        guard !primaryValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
-        return validationMessage == nil
+        EditEntrySavePolicy.canAttemptSave(
+            isSaving: isSaving,
+            validationMessage: validationMessage,
+            value: primaryValue
+        )
     }
 
     private var showsHealthBanner: Bool {
@@ -191,8 +204,9 @@ struct EditEntrySheet: View {
     }
 
     private func saveChanges() async {
-        guard errorMessage == nil else { return }
+        guard canSave else { return }
 
+        errorMessage = nil
         isSaving = true
         defer { isSaving = false }
 
@@ -257,5 +271,13 @@ struct EditEntrySheet: View {
         } catch {
             return error.localizedDescription
         }
+    }
+}
+
+enum EditEntrySavePolicy {
+    static func canAttemptSave(isSaving: Bool, validationMessage: String?, value: String) -> Bool {
+        !isSaving
+            && validationMessage == nil
+            && !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -2284,6 +2284,175 @@ final class PhotoUploadBatchPolicyTests: XCTestCase {
         XCTAssertTrue(PhotoUploadBatchPolicy.canChangeSelection(isProcessing: false))
         XCTAssertFalse(PhotoUploadBatchPolicy.canChangeSelection(isProcessing: true))
     }
+
+    func testPhotoUploadBatchStartsOnlyWhenIdleWithSelection() {
+        XCTAssertTrue(PhotoUploadBatchPolicy.canStartUpload(selectedCount: 1, isSaving: false, isProcessing: false))
+        XCTAssertFalse(PhotoUploadBatchPolicy.canStartUpload(selectedCount: 0, isSaving: false, isProcessing: false))
+        XCTAssertFalse(PhotoUploadBatchPolicy.canStartUpload(selectedCount: 1, isSaving: true, isProcessing: false))
+        XCTAssertFalse(PhotoUploadBatchPolicy.canStartUpload(selectedCount: 1, isSaving: false, isProcessing: true))
+    }
+
+    func testPhotoUploadBatchDismissesOnlyWhenIdle() {
+        XCTAssertTrue(PhotoUploadBatchPolicy.canDismiss(isSaving: false, isProcessing: false))
+        XCTAssertFalse(PhotoUploadBatchPolicy.canDismiss(isSaving: true, isProcessing: false))
+        XCTAssertFalse(PhotoUploadBatchPolicy.canDismiss(isSaving: false, isProcessing: true))
+    }
+
+    func testPhotoUploadBatchDismissesOnlyAfterAllSelectedPhotosUpload() {
+        XCTAssertTrue(PhotoUploadBatchPolicy.shouldDismissAfterUpload(successfulCount: 3, totalCount: 3))
+        XCTAssertFalse(PhotoUploadBatchPolicy.shouldDismissAfterUpload(successfulCount: 2, totalCount: 3))
+        XCTAssertFalse(PhotoUploadBatchPolicy.shouldDismissAfterUpload(successfulCount: 0, totalCount: 0))
+    }
+
+    func testPhotoUploadBatchFailureMessageDistinguishesPartialAndFullFailure() {
+        XCTAssertEqual(
+            PhotoUploadBatchPolicy.uploadFailureMessage(successfulCount: 0, totalCount: 2),
+            "Photo upload failed. Please try again."
+        )
+        XCTAssertEqual(
+            PhotoUploadBatchPolicy.uploadFailureMessage(successfulCount: 2, totalCount: 3),
+            "Uploaded 2 of 3 photos. 1 photo failed. Try again."
+        )
+    }
+}
+
+final class EditEntrySavePolicyTests: XCTestCase {
+    func testEditEntryCanRetryAfterPreviousErrorWhenCurrentValueIsValid() {
+        XCTAssertTrue(EditEntrySavePolicy.canAttemptSave(
+            isSaving: false,
+            validationMessage: nil,
+            value: "20"
+        ))
+    }
+
+    func testEditEntrySaveIsBlockedForCurrentValidationErrorSavingOrBlankValue() {
+        XCTAssertFalse(EditEntrySavePolicy.canAttemptSave(
+            isSaving: false,
+            validationMessage: "Enter percentage between 3 and 60",
+            value: "99"
+        ))
+        XCTAssertFalse(EditEntrySavePolicy.canAttemptSave(
+            isSaving: true,
+            validationMessage: nil,
+            value: "20"
+        ))
+        XCTAssertFalse(EditEntrySavePolicy.canAttemptSave(
+            isSaving: false,
+            validationMessage: nil,
+            value: "   "
+        ))
+    }
+}
+
+@MainActor
+final class BodyMetricPhotoUpdateTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+    }
+
+    override func tearDown() async throws {
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+        try await super.tearDown()
+    }
+
+    func testUpdateBodyMetricPhotoMarksMetricPendingInsideContext() async throws {
+        let userId = "photo_update_user_\(UUID().uuidString)"
+        let metricId = UUID().uuidString
+        let date = Date(timeIntervalSince1970: 1_766_000_000)
+        let metric = makePhotoUpdateMetric(id: metricId, userId: userId, date: date)
+
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(metric, userId: userId, markAsSynced: true)
+
+        let didUpdate = try await CoreDataManager.shared.updateBodyMetricPhoto(
+            id: metricId,
+            userId: userId,
+            storagePath: "\(userId)/\(metricId).png",
+            processedUrl: "https://cdn.example.com/\(metricId).png"
+        )
+
+        XCTAssertTrue(didUpdate)
+
+        let updated = try await cachedPhotoState(metricId: metricId)
+        XCTAssertEqual(updated.photoUrl, "https://cdn.example.com/\(metricId).png")
+        XCTAssertEqual(updated.originalPhotoUrl, "\(userId)/\(metricId).png")
+        XCTAssertFalse(updated.isSynced)
+        XCTAssertEqual(updated.syncStatus, "pending")
+    }
+
+    func testUpdateBodyMetricPhotoDoesNotCrossUsers() async throws {
+        let ownerId = "photo_owner_\(UUID().uuidString)"
+        let otherUserId = "photo_other_\(UUID().uuidString)"
+        let metricId = UUID().uuidString
+        let date = Date(timeIntervalSince1970: 1_766_100_000)
+        let metric = makePhotoUpdateMetric(id: metricId, userId: ownerId, date: date)
+
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(metric, userId: ownerId, markAsSynced: true)
+
+        let didUpdate = try await CoreDataManager.shared.updateBodyMetricPhoto(
+            id: metricId,
+            userId: otherUserId,
+            storagePath: "\(otherUserId)/\(metricId).png",
+            processedUrl: "https://cdn.example.com/wrong-user.png"
+        )
+
+        XCTAssertFalse(didUpdate)
+
+        let updated = try await cachedPhotoState(metricId: metricId)
+        XCTAssertNil(updated.photoUrl)
+        XCTAssertNil(updated.originalPhotoUrl)
+        XCTAssertTrue(updated.isSynced)
+        XCTAssertEqual(updated.syncStatus, "synced")
+    }
+
+    private func makePhotoUpdateMetric(id: String, userId: String, date: Date) -> BodyMetrics {
+        BodyMetrics(
+            id: id,
+            userId: userId,
+            date: date,
+            weight: 81.2,
+            weightUnit: "kg",
+            bodyFatPercentage: 16.4,
+            bodyFatMethod: "manual",
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+
+    private func cachedPhotoState(metricId: String) async throws -> (
+        photoUrl: String?,
+        originalPhotoUrl: String?,
+        isSynced: Bool,
+        syncStatus: String?
+    ) {
+        let context = CoreDataManager.shared.viewContext
+
+        return try await context.perform {
+            let request: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", metricId)
+            request.fetchLimit = 1
+
+            guard let metric = try context.fetch(request).first else {
+                throw CoreDataPhotoUpdateTestError.missingMetric
+            }
+
+            return (
+                metric.photoUrl,
+                metric.originalPhotoUrl,
+                metric.isSynced,
+                metric.syncStatus
+            )
+        }
+    }
+
+    private enum CoreDataPhotoUpdateTestError: Error {
+        case missingMetric
+    }
 }
 
 final class PhotoMetadataServiceTests: XCTestCase {


### PR DESCRIPTION
## Summary
- make Add Entry photo uploads single-flight and block cancellation/dismissal while save or upload work is active
- keep failed bulk photo selections in the sheet with retry messaging instead of silently dismissing partial failures
- update uploaded photo URLs through a Core Data context-confined helper
- route metric-detail Add to the correct Weight/Body Fat tab and hide Add for derived/read-only metric details
- allow Edit Entry saves to recover after validation errors once the user corrects input

## Validation
- GBrain reachable; search/query returned no exact prior bug note for entry/photo flows
- Subagent Dalton audited entry/photo flows and identified the metric Add routing, edit validation dead-end, and partial photo failure risks addressed here
- Grok CLI review with `grok-composer-2.5-fast`: No blockers found
- `swiftlint lint --strict LogYourBody/Views/AddEntrySheet.swift LogYourBody/Views/EditEntrySheet.swift LogYourBody/Views/DashboardViewLiquid+MetricViews.swift LogYourBody/Components/FullMetricChartView.swift LogYourBody/Services/CoreDataManager.swift LogYourBody/Services/PhotoUploadManager.swift LogYourBodyTests/LogYourBodyTests.swift` passed
- XcodeBuildMCP focused tests passed: 11 passed, 0 failed (`PhotoUploadBatchPolicyTests`, `EditEntrySavePolicyTests`, `BodyMetricPhotoUpdateTests`)
- `git diff --check` passed
- `pnpm lint` passed
- `pnpm typecheck` passed
- `pnpm test` passed

## Graphite
- `gt branch track agent/codex/photo-entry-single-flight --parent main --no-interactive` succeeded
- `gt branch submit --dry-run --no-interactive --no-edit --no-ai --branch agent/codex/photo-entry-single-flight` succeeded
- Actual submit remains blocked by Graphite synced-repo settings: https://app.graphite.com/settings/synced-repos