### PR TITLE
fix: persist onboarding launch gate durably

### DIFF
--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -192,6 +192,7 @@ final class OnboardingFlowViewModel: ObservableObject {
     let includesFirstPhotoStep: Bool
     private let healthKitManager: HealthKitManager
     private let calculator: BodyScoreCalculating
+    private let profileUpdateHandler: @MainActor ([String: Any]) async throws -> Void
     private var hasMarkedOnboardingComplete = false
     private let progressStore = OnboardingProgressStore.shared
     private var isRestoringProgress = false
@@ -214,13 +215,17 @@ final class OnboardingFlowViewModel: ObservableObject {
         entryContext: EntryContext = .authenticated,
         healthKitManager: HealthKitManager = .shared,
         calculator: BodyScoreCalculating = BodyScoreCalculator(),
-        includesFirstPhotoStep: Bool? = nil
+        includesFirstPhotoStep: Bool? = nil,
+        profileUpdateHandler: @escaping @MainActor ([String: Any]) async throws -> Void = {
+            try await AuthManager.shared.updateProfileDurably($0)
+        }
     ) {
         self.entryContext = entryContext
         self.healthKitManager = healthKitManager
         self.calculator = calculator
         self.includesFirstPhotoStep = includesFirstPhotoStep
             ?? (entryContext == .authenticated && PhotoTimelineHUDPolicy.shouldShowPhotoTimelineHUD())
+        self.profileUpdateHandler = profileUpdateHandler
 
         isRestoringProgress = true
         configureMeasurementPreference()
@@ -905,15 +910,25 @@ final class OnboardingFlowViewModel: ObservableObject {
         persistProgress()
     }
 
-    func completeOnboardingIfNeeded() async {
-        guard entryContext == .authenticated else { return }
-        guard !hasMarkedOnboardingComplete else { return }
+    @discardableResult
+    func completeOnboardingIfNeeded() async -> Bool {
+        guard entryContext == .authenticated else { return true }
+        guard !hasMarkedOnboardingComplete else { return true }
         hasMarkedOnboardingComplete = true
         isCompletingOnboarding = true
         defer { isCompletingOnboarding = false }
 
         let updates = buildOnboardingProfileUpdates()
-        await AuthManager.shared.updateProfile(updates)
+        do {
+            try await profileUpdateHandler(updates)
+        } catch {
+            hasMarkedOnboardingComplete = false
+            let message = "We couldn't save your setup. Check your connection and try again."
+            errorMessage = message
+            firstPhotoErrorMessage = message
+            return false
+        }
+
         applyCompletedOnboardingLocally(with: updates)
         OnboardingStateManager.shared.markCompleted(userId: AuthManager.shared.currentUser?.id)
         UserDefaults.standard.set(defaultHomeMode.rawValue, forKey: Constants.defaultHomeModeKey)
@@ -923,6 +938,8 @@ final class OnboardingFlowViewModel: ObservableObject {
         if didRequestHealthSync, UserDefaults.standard.bool(forKey: "healthKitSyncEnabled") {
             scheduleDeferredHealthSync()
         }
+
+        return true
     }
 
     func completeFirstPhotoStep() async {
@@ -934,7 +951,7 @@ final class OnboardingFlowViewModel: ObservableObject {
     }
 
     private func finishOnboardingAndShowPaywall(from previousStep: Step) async {
-        await completeOnboardingIfNeeded()
+        guard await completeOnboardingIfNeeded() else { return }
         currentStep = .paywall
         trackStepTransition(from: previousStep, to: currentStep)
     }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
@@ -389,7 +389,7 @@ struct BodyScoreProfileDetailsView: View {
                     updates["heightUnit"] = heightUnitStorageValue
                 }
 
-                await authManager.updateProfile(updates)
+                try await authManager.updateProfileDurably(updates)
 
                 await MainActor.run {
                     isSaving = false

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/ProfileCompletionGateView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/ProfileCompletionGateView.swift
@@ -1,8 +1,19 @@
 import SwiftUI
 
+@MainActor
+enum ProfileCompletionGatePolicy {
+    static func makeViewModel() -> OnboardingFlowViewModel {
+        OnboardingFlowViewModel(includesFirstPhotoStep: false)
+    }
+}
+
 struct ProfileCompletionGateView: View {
     @EnvironmentObject var authManager: AuthManager
-    @StateObject private var viewModel = OnboardingFlowViewModel()
+    @StateObject private var viewModel: OnboardingFlowViewModel
+
+    init(viewModel: OnboardingFlowViewModel? = nil) {
+        _viewModel = StateObject(wrappedValue: viewModel ?? ProfileCompletionGatePolicy.makeViewModel())
+    }
 
     var body: some View {
         BodyScoreProfileDetailsView(viewModel: viewModel)

--- a/apps/ios/LogYourBody/Services/AuthManager.swift
+++ b/apps/ios/LogYourBody/Services/AuthManager.swift
@@ -1299,22 +1299,31 @@ extension AuthManager {
         _ = try await signUp.prepareVerification(strategy: .emailCode)
     }
 
-    func updateProfile(_ updates: [String: Any]) async {
-        guard let userId = currentUser?.id else { return }
+    func updateProfileDurably(_ updates: [String: Any]) async throws {
+        guard let currentUser else { throw SupabaseError.notAuthenticated }
 
         var payload = updates
-        payload["id"] = userId
+        payload["id"] = currentUser.id
+        if payload["email"] == nil {
+            payload["email"] = currentUser.email
+        }
 
-        guard let token = await getSupabaseToken() else { return }
+        guard let token = await getSupabaseToken() else {
+            throw SupabaseError.tokenGenerationFailed
+        }
 
+        try await SupabaseManager.shared.updateProfile(payload, token: token)
+    }
+
+    func updateProfile(_ updates: [String: Any]) async {
         do {
-            try await SupabaseManager.shared.updateProfile(payload, token: token)
+            try await updateProfileDurably(updates)
         } catch {
             let context = ErrorContext(
                 feature: "profile",
                 operation: "updateProfile",
                 screen: nil,
-                userId: userId
+                userId: currentUser?.id
             )
             ErrorReporter.shared.captureNonFatal(error, context: context)
         }

--- a/apps/ios/LogYourBody/Services/SupabaseManager.swift
+++ b/apps/ios/LogYourBody/Services/SupabaseManager.swift
@@ -185,7 +185,7 @@ class SupabaseManager: ObservableObject {
     }
 
     func fetchProfile(userId: String, token: String) async throws -> [String: Any]? {
-        let url = URL(string: "\(supabaseURL)/rest/v1/user_profiles?id=eq.\(userId)")!
+        let url = URL(string: "\(supabaseURL)/rest/v1/profiles?id=eq.\(userId)&select=*")!
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue(supabaseAnonKey, forHTTPHeaderField: "apikey")
@@ -206,23 +206,18 @@ class SupabaseManager: ObservableObject {
     func updateProfile(_ profile: [String: Any], token: String) async throws {
         guard let userId = profile["id"] as? String else { throw SupabaseError.invalidData }
 
-        let url = URL(string: "\(supabaseURL)/rest/v1/user_profiles?id=eq.\(userId)")!
+        let sanitizedProfile = try Self.sanitizedProfilePayload(profile)
+        guard sanitizedProfile["id"] as? String == userId else {
+            throw SupabaseError.invalidData
+        }
+
+        let url = URL(string: "\(supabaseURL)/rest/v1/profiles?id=eq.\(userId)&select=id")!
         var request = URLRequest(url: url)
         request.httpMethod = "PATCH"
         request.setValue(supabaseAnonKey, forHTTPHeaderField: "apikey")
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        let isoFormatter = ISO8601DateFormatter()
-        let sanitizedProfile: [String: Any] = profile.reduce(into: [:]) { result, element in
-            let (key, value) = element
-
-            if let dateValue = value as? Date {
-                result[key] = isoFormatter.string(from: dateValue)
-            } else {
-                result[key] = value
-            }
-        }
+        request.setValue("return=representation", forHTTPHeaderField: "Prefer")
 
         guard JSONSerialization.isValidJSONObject(sanitizedProfile) else {
             ErrorTrackingService.shared.addBreadcrumb(
@@ -240,11 +235,106 @@ class SupabaseManager: ObservableObject {
         let jsonData = try JSONSerialization.data(withJSONObject: sanitizedProfile)
         request.httpBody = jsonData
 
-        let (_, response) = try await self.session.data(for: request)
+        let (responseData, response) = try await self.session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             throw SupabaseError.requestFailed
+        }
+
+        let rows = if responseData.isEmpty {
+            [[String: Any]]()
+        } else {
+            try JSONSerialization.jsonObject(with: responseData) as? [[String: Any]] ?? []
+        }
+        if rows.isEmpty {
+            try await upsertProfilePayload(sanitizedProfile, token: token)
+        }
+    }
+
+    private func upsertProfilePayload(_ profile: [String: Any], token: String) async throws {
+        guard profile["id"] is String else { throw SupabaseError.invalidData }
+
+        let url = URL(string: "\(supabaseURL)/rest/v1/profiles")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(supabaseAnonKey, forHTTPHeaderField: "apikey")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("return=representation,resolution=merge-duplicates", forHTTPHeaderField: "Prefer")
+
+        guard JSONSerialization.isValidJSONObject(profile) else {
+            throw SupabaseError.invalidData
+        }
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: profile)
+
+        let (responseData, response) = try await self.session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw SupabaseError.requestFailed
+        }
+
+        let rows = if responseData.isEmpty {
+            [[String: Any]]()
+        } else {
+            try JSONSerialization.jsonObject(with: responseData) as? [[String: Any]] ?? []
+        }
+        guard !rows.isEmpty else { throw SupabaseError.requestFailed }
+    }
+
+    nonisolated static func sanitizedProfilePayload(_ profile: [String: Any]) throws -> [String: Any] {
+        let isoFormatter = ISO8601DateFormatter()
+        let sanitizedProfile = profile.reduce(into: [String: Any]()) { result, element in
+            let (key, value) = element
+            guard let unwrappedValue = unwrapOptional(value) else { return }
+
+            let columnName = profileColumnName(for: key)
+            if let dateValue = unwrappedValue as? Date {
+                result[columnName] = isoFormatter.string(from: dateValue)
+            } else {
+                result[columnName] = unwrappedValue
+            }
+        }
+
+        guard JSONSerialization.isValidJSONObject(sanitizedProfile) else {
+            throw SupabaseError.invalidData
+        }
+
+        return sanitizedProfile
+    }
+
+    nonisolated private static func unwrapOptional(_ value: Any) -> Any? {
+        let mirror = Mirror(reflecting: value)
+        guard mirror.displayStyle == .optional else { return value }
+        return mirror.children.first?.value
+    }
+
+    nonisolated private static func profileColumnName(for key: String) -> String {
+        switch key {
+        case "fullName":
+            return "full_name"
+        case "dateOfBirth":
+            return "date_of_birth"
+        case "heightUnit":
+            return "height_unit"
+        case "activityLevel":
+            return "activity_level"
+        case "goalWeight":
+            return "goal_weight"
+        case "goalWeightUnit":
+            return "goal_weight_unit"
+        case "onboardingCompleted":
+            return "onboarding_completed"
+        case "avatarUrl":
+            return "avatar_url"
+        case "firstName":
+            return "first_name"
+        case "lastName":
+            return "last_name"
+        default:
+            return key
         }
     }
 

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -324,6 +324,35 @@ final class AuthProfileBootstrapPolicyTests: XCTestCase {
     }
 }
 
+final class SupabaseProfilePayloadTests: XCTestCase {
+    func testProfilePayloadNormalizesLaunchGateColumns() throws {
+        let birthDate = Date(timeIntervalSince1970: 631_152_000)
+        let payload: [String: Any] = [
+            "id": "profile-user",
+            "email": "profile@example.com",
+            "fullName": "Profile User",
+            "dateOfBirth": birthDate,
+            "heightUnit": "cm",
+            "onboardingCompleted": true,
+            "avatarUrl": Optional<String>.none as Any,
+            "activity_level": "active"
+        ]
+
+        let sanitized = try SupabaseManager.sanitizedProfilePayload(payload)
+
+        XCTAssertEqual(sanitized["id"] as? String, "profile-user")
+        XCTAssertEqual(sanitized["full_name"] as? String, "Profile User")
+        XCTAssertEqual(sanitized["date_of_birth"] as? String, ISO8601DateFormatter().string(from: birthDate))
+        XCTAssertEqual(sanitized["height_unit"] as? String, "cm")
+        XCTAssertEqual(sanitized["onboarding_completed"] as? Bool, true)
+        XCTAssertEqual(sanitized["activity_level"] as? String, "active")
+        XCTAssertNil(sanitized["avatar_url"])
+        XCTAssertNil(sanitized["fullName"])
+        XCTAssertNil(sanitized["dateOfBirth"])
+        XCTAssertNil(sanitized["onboardingCompleted"])
+    }
+}
+
 final class BodyCompositionMathGoldenTests: XCTestCase {
     private let calendar = Calendar.current
 
@@ -3062,8 +3091,17 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         XCTAssertFalse(OnboardingStateManager.shared.hasCompletedCurrentVersion)
     }
 
+    func testProfileCompletionGateSkipsFirstPhotoOnSubmit() {
+        let viewModel = ProfileCompletionGatePolicy.makeViewModel()
+
+        XCTAssertFalse(viewModel.includesFirstPhotoStep)
+    }
+
     func testProfileDetailsCompletesOnboardingWhenFirstPhotoDisabled() async {
-        let viewModel = OnboardingFlowViewModel(includesFirstPhotoStep: false)
+        let viewModel = OnboardingFlowViewModel(
+            includesFirstPhotoStep: false,
+            profileUpdateHandler: { _ in }
+        )
         viewModel.currentStep = .profileDetails
 
         await viewModel.finishOnboardingAndShowPaywall()
@@ -3072,8 +3110,28 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         XCTAssertTrue(OnboardingStateManager.shared.hasCompletedCurrentVersion)
     }
 
+    func testProfileDetailsDoesNotCompleteWhenDurableProfileWriteFails() async {
+        let viewModel = OnboardingFlowViewModel(
+            includesFirstPhotoStep: false,
+            profileUpdateHandler: { _ in throw SupabaseError.requestFailed }
+        )
+        viewModel.currentStep = .profileDetails
+
+        await viewModel.finishOnboardingAndShowPaywall()
+
+        XCTAssertEqual(viewModel.currentStep, .profileDetails)
+        XCTAssertFalse(OnboardingStateManager.shared.hasCompletedCurrentVersion)
+        XCTAssertEqual(
+            viewModel.errorMessage,
+            "We couldn't save your setup. Check your connection and try again."
+        )
+    }
+
     func testFirstPhotoStepCanCompleteToPaywall() async {
-        let viewModel = OnboardingFlowViewModel(includesFirstPhotoStep: true)
+        let viewModel = OnboardingFlowViewModel(
+            includesFirstPhotoStep: true,
+            profileUpdateHandler: { _ in }
+        )
         viewModel.currentStep = .firstPhoto
 
         await viewModel.completeFirstPhotoStep()
@@ -3115,7 +3173,10 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         )
         AuthManager.shared.isAuthenticated = true
 
-        let viewModel = OnboardingFlowViewModel(includesFirstPhotoStep: true)
+        let viewModel = OnboardingFlowViewModel(
+            includesFirstPhotoStep: true,
+            profileUpdateHandler: { _ in }
+        )
         viewModel.currentStep = .firstPhoto
 
         await viewModel.completeFirstPhotoStep()


### PR DESCRIPTION
## Summary
- route profile updates through the same `profiles` table used by session bootstrap and normalize profile payload keys to snake_case
- make onboarding/profile-completion writes durable before local completion flags are marked or progress is cleared
- keep forced profile-completion gate out of the first-photo onboarding branch
- add regression coverage for durable-write failures and launch-gate payload normalization

## Validation
- GBrain reachable; onboarding/session-loop search pointed to this risk cluster
- GBrain MCP code_callers failed with closed transport, `gbrain doctor --fast --json` returned health_score 90, and CLI code refs returned no indexed callers; callers mapped with `rg`
- Subagent Pauli audited onboarding/session restore and found the durable profile-write launch-gate blocker fixed here
- Grok CLI with `grok-composer-2.5-fast` attempted twice; first hit max-turn/bootstrap noise, second output exceeded context/truncated before usable findings
- `swiftlint lint --strict ...` passed
- XcodeBuildMCP focused simulator tests: 32 passed, 0 failed (`OnboardingFlowViewModelTests`, `SupabaseProfilePayloadTests`)
- `git diff --check` passed
- `pnpm lint` passed
- `pnpm typecheck` passed
- `pnpm test` passed

## Graphite
- `gt branch track agent/codex/onboarding-session-gates --parent main --no-interactive` succeeded
- `gt branch submit --dry-run --no-interactive --no-edit --no-ai --branch agent/codex/onboarding-session-gates` succeeded
- actual submit is blocked by Graphite synced-repo settings: https://app.graphite.com/settings/synced-repos