### PR TITLE
fix: preserve missing profile height during sync

### DIFF
--- a/apps/ios/LogYourBody/Services/CoreDataManager.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager.swift
@@ -111,7 +111,7 @@ struct PendingProfileSyncItem {
     let id: String
     let fullName: String?
     let username: String?
-    let height: Double
+    let height: Double?
     let heightUnit: String?
     let gender: String?
     let dateOfBirth: Date?
@@ -2774,7 +2774,7 @@ extension CachedProfile {
             id: id ?? "",
             fullName: fullName,
             username: username,
-            height: height,
+            height: height > 0 ? height : nil,
             heightUnit: heightUnit,
             gender: gender,
             dateOfBirth: dateOfBirth,

--- a/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
+++ b/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
@@ -637,16 +637,18 @@ class RealtimeSyncManager: ObservableObject {
                 NSNull()
             }
 
-            let profileData: [String: Any] = [
+            var profileData: [String: Any] = [
                 "id": profile.id,
                 "full_name": profile.fullName as Any,
                 "username": profile.username as Any,
-                "height": profile.height,
                 "height_unit": profile.heightUnit as Any,
                 "gender": profile.gender as Any,
                 "date_of_birth": formattedBirthDate,
                 "activity_level": profile.activityLevel as Any
             ]
+            if let height = profile.height {
+                profileData["height"] = height
+            }
 
             try await supabaseManager.updateProfile(profileData, token: token)
             await coreDataManager.markAsSynced(entityName: "CachedProfile", ids: [profile.id])

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -4095,6 +4095,7 @@ final class AuthLegacyStorageMigrationTests: XCTestCase {
 final class StubSupabaseManager: SupabaseManager {
     private(set) var bodyMetricsBatches: [[[String: Any]]] = []
     private(set) var dailyMetricsBatches: [[[String: Any]]] = []
+    private(set) var profilePayloads: [[String: Any]] = []
     private(set) var dexaPayloads: [[String: Any]] = []
     private(set) var glp1DoseLogPayloads: [[String: Any]] = []
     private(set) var glp1MedicationPayloads: [[String: Any]] = []
@@ -4115,6 +4116,10 @@ final class StubSupabaseManager: SupabaseManager {
             guard let id = metric["id"] as? String else { return [:] }
             return ["id": id]
         }
+    }
+
+    override func updateProfile(_ profile: [String: Any], token: String) async throws {
+        profilePayloads.append(profile)
     }
 
     override func upsertData(table: String, data: Data, token: String) async throws -> [[String: Any]] {
@@ -4630,6 +4635,56 @@ final class SyncIntegrationTests: XCTestCase {
         XCTAssertEqual(profile.height, 181.0, accuracy: 0.001)
         XCTAssertEqual(profile.syncStatus, "synced")
         XCTAssertTrue(profile.isSynced)
+    }
+
+    func testSyncLocalChanges_OmitsMissingProfileHeight() async throws {
+        let coreData = CoreDataManager.shared
+
+        let userId = "sync_test_user_profile_no_height_\(UUID().uuidString)"
+        let profile = UserProfile(
+            id: userId,
+            email: "profile-no-height@example.com",
+            username: "profile_no_height",
+            fullName: "Profile No Height",
+            dateOfBirth: nil,
+            height: nil,
+            heightUnit: "cm",
+            gender: "male",
+            activityLevel: "active",
+            goalWeight: nil,
+            goalWeightUnit: nil,
+            onboardingCompleted: true
+        )
+
+        coreData.saveProfile(
+            profile,
+            userId: userId,
+            email: "profile-no-height@example.com",
+            markSynced: false
+        )
+
+        let snapshot = try await coreData.fetchPendingLocalSyncSnapshot(for: userId)
+        let pendingProfile = try XCTUnwrap(snapshot.profiles.first { $0.id == userId })
+        XCTAssertNil(pendingProfile.height)
+
+        let stubSupabase = StubSupabaseManager()
+        let manager = RealtimeSyncManager(
+            coreDataManager: coreData,
+            authManager: AuthManager.shared,
+            supabaseManager: stubSupabase
+        )
+
+        try await manager.syncLocalChanges(token: "test-token")
+
+        let payload = try XCTUnwrap(stubSupabase.profilePayloads.first)
+        XCTAssertEqual(payload["id"] as? String, userId)
+        XCTAssertNil(payload["height"])
+        XCTAssertEqual(payload["height_unit"] as? String, "cm")
+
+        let profiles = await cachedProfiles(id: userId)
+        let cachedProfile = try XCTUnwrap(profiles.first)
+        XCTAssertTrue(cachedProfile.isSynced)
+        XCTAssertEqual(cachedProfile.syncStatus, "synced")
     }
 
     func testUpdateOrCreateBodyMetric_IsIdempotentForSameId() async throws {


### PR DESCRIPTION
## Summary
- preserve missing cached profile height as `nil` in pending sync snapshots instead of coercing it to `0`
- omit absent height from offline profile replay payloads so reconnect/relaunch sync cannot overwrite a valid server height with zero
- add sync integration coverage for the nil-height profile replay path and capture profile payloads in the Supabase stub

## Validation
- GBrain queried for LogYourBody offline sync/profile pending-state prior context; results were not specific enough, so code exploration drove the fix
- Grok CLI with `grok-composer-2.5-fast`: `No blockers found` (CLI bootstrap was noisy but exited cleanly)
- `swiftlint lint --strict LogYourBody/Services/CoreDataManager.swift LogYourBody/Services/RealtimeSyncManager.swift LogYourBodyTests/LogYourBodyTests.swift` passed
- XcodeBuildMCP simulator tests: `SyncIntegrationTests` 25 passed, 0 failed
- `git diff --check` passed
- `pnpm lint` passed
- `pnpm typecheck` passed
- `pnpm test` passed

## Graphite
- `gt branch track agent/codex/offline-sync-durability --parent main --no-interactive` succeeded
- `gt branch submit --dry-run --no-interactive --no-edit --no-ai --branch agent/codex/offline-sync-durability` succeeded
- actual submit is blocked by Graphite synced-repo settings: https://app.graphite.com/settings/synced-repos