### PR TITLE
fix: keep saved profile state coherent

### DIFF
--- a/apps/ios/LogYourBody/Services/AuthManager.swift
+++ b/apps/ios/LogYourBody/Services/AuthManager.swift
@@ -1401,6 +1401,18 @@ extension AuthManager {
         currentUser = user
     }
 
+    @discardableResult
+    func applySavedProfileToCurrentUser(_ profile: UserProfile) -> Bool {
+        guard currentUser?.id == profile.id else { return false }
+
+        applyAuthenticatedProfile(
+            profile,
+            fallbackEmail: profile.email ?? currentUser?.email ?? ""
+        )
+        NotificationCenter.default.post(name: .profileUpdated, object: nil)
+        return true
+    }
+
     // MARK: - Account Deletion Helpers
 
     /// Best-effort call to backend delete-account pipeline.

--- a/apps/ios/LogYourBody/Views/ProfileSettingsViewV2.swift
+++ b/apps/ios/LogYourBody/Views/ProfileSettingsViewV2.swift
@@ -409,6 +409,8 @@ struct ProfileSettingsViewV2: View {
                     try await authManager.consolidateNameUpdate(editableName)
                 }
 
+                let onboardingCompleted = currentUser.profile?.onboardingCompleted ?? currentUser.onboardingCompleted
+
                 // Create updated profile
                 let updatedProfile = UserProfile(
                     id: currentUser.id,
@@ -422,7 +424,7 @@ struct ProfileSettingsViewV2: View {
                     activityLevel: currentUser.profile?.activityLevel,
                     goalWeight: currentUser.profile?.goalWeight,
                     goalWeightUnit: currentUser.profile?.goalWeightUnit,
-                    onboardingCompleted: currentUser.profile?.onboardingCompleted
+                    onboardingCompleted: onboardingCompleted
                 )
 
                 // Save to Core Data
@@ -435,19 +437,21 @@ struct ProfileSettingsViewV2: View {
                     "height": Double(editableHeightCm),
                     "heightUnit": useMetricHeight ? "cm" : "in",
                     "gender": editableGender.description,
-                    "onboardingCompleted": true
+                    "onboardingCompleted": onboardingCompleted
                 ]
 
                 await authManager.updateProfile(updates)
 
                 await MainActor.run {
-                    isSaving = false
-                    withAnimation {
-                        showingSaveSuccess = true
+                    let didApplyProfile = authManager.applySavedProfileToCurrentUser(updatedProfile)
+                    if !didApplyProfile {
+                        hasChanges = true
+                    } else {
+                        withAnimation {
+                            showingSaveSuccess = true
+                        }
                     }
-
-                    // Force UI refresh
-                    NotificationCenter.default.post(name: .profileUpdated, object: nil)
+                    isSaving = false
                 }
 
                 let elapsed = Date().timeIntervalSince(start)

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -3514,6 +3514,88 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         XCTAssertEqual(manager.currentUser?.email, "user_apple_123@apple.local.logyourbody")
     }
 
+    func testApplySavedProfileUpdatesPublishedCurrentUser() {
+        let manager = AuthManager()
+        manager.currentUser = LocalUser(
+            id: "profile-user",
+            email: "profile@example.com",
+            name: "Old Name",
+            avatarUrl: nil,
+            profile: UserProfile(
+                id: "profile-user",
+                email: "profile@example.com",
+                username: nil,
+                fullName: "Old Name",
+                dateOfBirth: nil,
+                height: nil,
+                heightUnit: "cm",
+                gender: nil,
+                activityLevel: nil,
+                goalWeight: nil,
+                goalWeightUnit: nil,
+                onboardingCompleted: false
+            ),
+            onboardingCompleted: false
+        )
+
+        let savedProfile = UserProfile(
+            id: "profile-user",
+            email: "profile@example.com",
+            username: nil,
+            fullName: "Updated Name",
+            dateOfBirth: Date(timeIntervalSince1970: 631_152_000),
+            height: 180,
+            heightUnit: "cm",
+            gender: "male",
+            activityLevel: nil,
+            goalWeight: nil,
+            goalWeightUnit: nil,
+            onboardingCompleted: true
+        )
+
+        let didApply = manager.applySavedProfileToCurrentUser(savedProfile)
+
+        XCTAssertTrue(didApply)
+        XCTAssertEqual(manager.currentUser?.name, "Updated Name")
+        XCTAssertEqual(manager.currentUser?.profile?.height, 180)
+        XCTAssertEqual(manager.currentUser?.profile?.gender, "male")
+        XCTAssertEqual(manager.currentUser?.onboardingCompleted, true)
+    }
+
+    func testApplySavedProfileRejectsDifferentUserProfile() {
+        let manager = AuthManager()
+        manager.currentUser = LocalUser(
+            id: "current-user",
+            email: "current@example.com",
+            name: "Current User",
+            avatarUrl: nil,
+            profile: nil,
+            onboardingCompleted: false
+        )
+
+        let didApply = manager.applySavedProfileToCurrentUser(
+            UserProfile(
+                id: "other-user",
+                email: "other@example.com",
+                username: nil,
+                fullName: "Other User",
+                dateOfBirth: nil,
+                height: 180,
+                heightUnit: "cm",
+                gender: "male",
+                activityLevel: nil,
+                goalWeight: nil,
+                goalWeightUnit: nil,
+                onboardingCompleted: true
+            )
+        )
+
+        XCTAssertFalse(didApply)
+        XCTAssertEqual(manager.currentUser?.id, "current-user")
+        XCTAssertNil(manager.currentUser?.profile)
+        XCTAssertFalse(manager.currentUser?.onboardingCompleted ?? true)
+    }
+
     func testSyntheticAuthEmailSanitizesClerkUserId() {
         XCTAssertEqual(
             AuthManager.syntheticAuthEmail(userId: " user:abc/123 "),


### PR DESCRIPTION
## Summary
- update AuthManager to apply a successfully saved profile back into the published current user
- keep profile settings from forcing onboarding completion while saving ordinary profile edits
- preserve the profile-updated notification as a single AuthManager-owned emit and keep mismatched account saves from showing success

## Stability impact
- prevents dashboard/profile-completion surfaces from using stale height, gender, or name after a profile save
- avoids accidentally flipping onboarding completion from profile settings

## Validation
- gbrain search/query used; hits were broad, no directly actionable prior note for this slice
- subagents audited auth/deep-link, onboarding/navigation, and photo/sync flows; next candidates captured for follow-up
- Grok CLI with `grok-composer-2.5-fast` reviewed the diff; it found the hardcoded onboarding-completion issue, which this PR fixes
- `swiftlint lint --strict apps/ios/LogYourBody/Services/AuthManager.swift apps/ios/LogYourBody/Views/ProfileSettingsViewV2.swift apps/ios/LogYourBodyTests/LogYourBodyTests.swift`
- XcodeBuildMCP simulator tests: `LogYourBodyTests/OnboardingFlowViewModelTests/testApplySavedProfileUpdatesPublishedCurrentUser`, `testApplySavedProfileRejectsDifferentUserProfile`
- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Graphite
- `gt branch track agent/codex/profile-state-coherence --parent main --no-interactive` passed
- `gt branch submit --dry-run --no-interactive --no-edit --no-ai --branch agent/codex/profile-state-coherence` passed
- real `gt branch submit` is blocked by Graphite synced-repo settings: https://app.graphite.com/settings/synced-repos