### PR TITLE
fix: prevent concurrent onboarding completion

### DIFF
--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -194,6 +194,7 @@ final class OnboardingFlowViewModel: ObservableObject {
     private let calculator: BodyScoreCalculating
     private let profileUpdateHandler: @MainActor ([String: Any]) async throws -> Void
     private var hasMarkedOnboardingComplete = false
+    private var isOnboardingCompletionInFlight = false
     private let progressStore = OnboardingProgressStore.shared
     private var isRestoringProgress = false
 
@@ -914,21 +915,25 @@ final class OnboardingFlowViewModel: ObservableObject {
     func completeOnboardingIfNeeded() async -> Bool {
         guard entryContext == .authenticated else { return true }
         guard !hasMarkedOnboardingComplete else { return true }
-        hasMarkedOnboardingComplete = true
+        guard !isOnboardingCompletionInFlight else { return false }
+        isOnboardingCompletionInFlight = true
         isCompletingOnboarding = true
-        defer { isCompletingOnboarding = false }
+        defer {
+            isOnboardingCompletionInFlight = false
+            isCompletingOnboarding = false
+        }
 
         let updates = buildOnboardingProfileUpdates()
         do {
             try await profileUpdateHandler(updates)
         } catch {
-            hasMarkedOnboardingComplete = false
             let message = "We couldn't save your setup. Check your connection and try again."
             errorMessage = message
             firstPhotoErrorMessage = message
             return false
         }
 
+        hasMarkedOnboardingComplete = true
         applyCompletedOnboardingLocally(with: updates)
         OnboardingStateManager.shared.markCompleted(userId: AuthManager.shared.currentUser?.id)
         UserDefaults.standard.set(defaultHomeMode.rawValue, forKey: Constants.defaultHomeModeKey)

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -3140,6 +3140,48 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         XCTAssertTrue(OnboardingStateManager.shared.hasCompletedCurrentVersion)
     }
 
+    func testFirstPhotoStepDoesNotAdvanceDuringConcurrentCompletionSave() async {
+        var releaseSave: CheckedContinuation<Void, Never>?
+        var updateAttempts = 0
+        let viewModel = OnboardingFlowViewModel(
+            includesFirstPhotoStep: true,
+            profileUpdateHandler: { _ in
+                updateAttempts += 1
+                await withCheckedContinuation { continuation in
+                    releaseSave = continuation
+                }
+                throw SupabaseError.requestFailed
+            }
+        )
+        viewModel.currentStep = .firstPhoto
+
+        let firstCompletion = Task {
+            await viewModel.completeFirstPhotoStep()
+        }
+        while releaseSave == nil {
+            await Task.yield()
+        }
+
+        await viewModel.completeFirstPhotoStep()
+
+        XCTAssertEqual(updateAttempts, 1)
+        XCTAssertEqual(viewModel.currentStep, .firstPhoto)
+        XCTAssertTrue(viewModel.isCompletingOnboarding)
+        XCTAssertFalse(OnboardingStateManager.shared.hasCompletedCurrentVersion)
+
+        releaseSave?.resume()
+        await firstCompletion.value
+
+        XCTAssertEqual(updateAttempts, 1)
+        XCTAssertEqual(viewModel.currentStep, .firstPhoto)
+        XCTAssertFalse(viewModel.isCompletingOnboarding)
+        XCTAssertFalse(OnboardingStateManager.shared.hasCompletedCurrentVersion)
+        XCTAssertEqual(
+            viewModel.firstPhotoErrorMessage,
+            "We couldn't save your setup. Check your connection and try again."
+        )
+    }
+
     func testFirstPhotoCompletionMarksLocalUserComplete() async {
         let userId = "onboarding-first-photo-complete-\(UUID().uuidString)"
         let previousUser = AuthManager.shared.currentUser


### PR DESCRIPTION
## Summary
- Prevent overlapping authenticated onboarding completion saves from being treated as already complete.
- Keep users on the first-photo/profile completion step until the durable profile update succeeds.
- Add a regression test for a suspended first-photo completion save plus a concurrent second completion attempt.

## Validation
- `swiftlint lint --strict apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift apps/ios/LogYourBodyTests/LogYourBodyTests.swift`
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/OnboardingFlowViewModelTests/testFirstPhotoStepDoesNotAdvanceDuringConcurrentCompletionSave`
- XcodeBuildMCP `test_sim -only-testing:LogYourBodyTests/OnboardingFlowViewModelTests` (34 passed)
- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- Grok CLI (`grok-composer-2.5-fast`) diff review: `NO BLOCKERS`
- `gt branch submit --dry-run` passed; real Graphite submit blocked by repo sync configuration.
