### PR TITLE
fix: discard failed photo placeholders

### DIFF
--- a/apps/ios/LogYourBody/Services/CoreDataManager.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager.swift
@@ -89,9 +89,11 @@ struct PendingBodyMetricSyncItem {
     let muscleMass: Double
     let boneMass: Double
     let photoUrl: String?
+    let originalPhotoUrl: String?
     let notes: String?
     let dataSource: String?
     let sourceMetadataJSON: String?
+    let syncStatus: String?
     let createdAt: Date
     let updatedAt: Date
     let isMarkedDeleted: Bool
@@ -177,6 +179,8 @@ struct PendingDexaResultSyncItem {
 
 class CoreDataManager: ObservableObject {
     static let shared = CoreDataManager()
+    static let photoUploadInFlightSyncStatus = "photo_upload_in_flight"
+    static let photoUploadStorageCommittedSyncStatus = "photo_upload_storage_committed"
 
     private let saveQueue = DispatchQueue(label: "com.logyourbody.coredata.save", qos: .utility)
     private var isSaving = false
@@ -750,6 +754,126 @@ class CoreDataManager: ObservableObject {
         }
     }
 
+    func createOrUpdatePhotoUploadMetricsPlaceholder(
+        for date: Date,
+        userId: String
+    ) async throws -> PhotoMetricsUpdateResult {
+        let context = viewContext
+        let startOfDay = Calendar.current.startOfDay(for: date)
+        let localDate = BodyMetricLocalDate.key(for: date)
+        let normalizedLocalDate = BodyMetricLocalDate.normalized(localDate, fallback: date)
+
+        return try await context.perform {
+            let fetchRequest: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+            fetchRequest.predicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
+                NSCompoundPredicate(andPredicateWithSubpredicates: [
+                    NSPredicate(format: "userId == %@", userId),
+                    NSPredicate(format: "isMarkedDeleted == %@", NSNumber(value: false)),
+                    NSPredicate(format: "localDate == %@", normalizedLocalDate)
+                ]),
+                Self.legacyBodyMetricDatePredicate(userId: userId, localDate: normalizedLocalDate)
+            ])
+            fetchRequest.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+            fetchRequest.fetchLimit = 1
+
+            let cached: CachedBodyMetrics
+            let createdNewEntry: Bool
+            let now = Date()
+
+            if let existing = try context.fetch(fetchRequest).first {
+                cached = existing
+                createdNewEntry = false
+            } else {
+                cached = CachedBodyMetrics(context: context)
+                cached.id = UUID().uuidString
+                cached.userId = userId
+                cached.date = startOfDay
+                cached.localDate = normalizedLocalDate
+                cached.weight = 0
+                cached.weightUnit = "kg"
+                cached.waistCircumference = 0
+                cached.hipCircumference = 0
+                cached.bodyFatPercentage = 0
+                cached.muscleMass = 0
+                cached.boneMass = 0
+                cached.dataSource = BodyMetricSource.photo.rawValue
+                cached.createdAt = now
+                cached.updatedAt = now
+                cached.lastModified = now
+                cached.isMarkedDeleted = false
+                cached.isSynced = false
+                createdNewEntry = true
+            }
+
+            if Self.isUploadPlaceholderCandidate(cached, userId: userId),
+               !Self.isPhotoUploadStorageCommittedSyncStatus(cached.syncStatus) {
+                cached.syncStatus = Self.photoUploadInFlightSyncStatus
+                cached.updatedAt = now
+                cached.lastModified = now
+                cached.isSynced = false
+            }
+
+            if context.hasChanges {
+                try context.save()
+            }
+
+            guard let metrics = cached.toBodyMetrics() else {
+                throw NSError(
+                    domain: "CoreDataManager",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Could not create photo upload metrics placeholder"]
+                )
+            }
+
+            return PhotoMetricsUpdateResult(metrics: metrics, createdNewEntry: createdNewEntry)
+        }
+    }
+
+    func prepareExistingPhotoUploadMetrics(id: String, userId: String) async throws -> BodyMetrics {
+        let context = viewContext
+
+        return try await context.perform {
+            let fetchRequest: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+            fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(format: "id == %@", id),
+                NSPredicate(format: "userId == %@", userId),
+                NSPredicate(format: "isMarkedDeleted == %@", NSNumber(value: false))
+            ])
+            fetchRequest.fetchLimit = 1
+
+            guard let cached = try context.fetch(fetchRequest).first else {
+                throw NSError(
+                    domain: "CoreDataManager",
+                    code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "Could not find selected photo upload metrics"]
+                )
+            }
+
+            if Self.isUploadPlaceholderCandidate(cached, userId: userId),
+               !Self.isPhotoUploadStorageCommittedSyncStatus(cached.syncStatus) {
+                let now = Date()
+                cached.syncStatus = Self.photoUploadInFlightSyncStatus
+                cached.updatedAt = now
+                cached.lastModified = now
+                cached.isSynced = false
+
+                if context.hasChanges {
+                    try context.save()
+                }
+            }
+
+            guard let metrics = cached.toBodyMetrics() else {
+                throw NSError(
+                    domain: "CoreDataManager",
+                    code: 3,
+                    userInfo: [NSLocalizedDescriptionKey: "Could not prepare selected photo upload metrics"]
+                )
+            }
+
+            return metrics
+        }
+    }
+
     // MARK: - Async Fetch Methods (Recommended for UI)
 
     /// Async version - does NOT block the main thread
@@ -801,7 +925,7 @@ class CoreDataManager: ObservableObject {
                     NSPredicate(format: "isMarkedDeleted == %@", NSNumber(value: false)),
                     NSPredicate(format: "localDate == %@", normalizedLocalDate)
                 ]),
-                self.legacyBodyMetricDatePredicate(userId: userId, localDate: normalizedLocalDate)
+                Self.legacyBodyMetricDatePredicate(userId: userId, localDate: normalizedLocalDate)
             ])
             fetchRequest.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
 
@@ -816,7 +940,7 @@ class CoreDataManager: ObservableObject {
         }
     }
 
-    private func legacyBodyMetricDatePredicate(userId: String, localDate: String) -> NSPredicate {
+    private static func legacyBodyMetricDatePredicate(userId: String, localDate: String) -> NSPredicate {
         guard let startOfDay = BodyMetricLocalDate.startOfDay(for: localDate),
               let endOfDay = Calendar.current.date(byAdding: .day, value: 1, to: startOfDay) else {
             return NSPredicate(value: false)
@@ -1061,6 +1185,91 @@ class CoreDataManager: ObservableObject {
         }
     }
 
+    @discardableResult
+    func markPhotoPlaceholderUploadInFlight(id: String, userId: String) async -> Bool {
+        let context = viewContext
+
+        return await context.perform {
+            let fetchRequest: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "id == %@ AND userId == %@", id, userId)
+            fetchRequest.fetchLimit = 1
+
+            do {
+                guard let cachedMetric = try context.fetch(fetchRequest).first,
+                      Self.isUploadPlaceholderCandidate(cachedMetric, userId: userId) else {
+                    return false
+                }
+
+                let now = Date()
+                cachedMetric.syncStatus = Self.photoUploadInFlightSyncStatus
+                cachedMetric.updatedAt = now
+                cachedMetric.lastModified = now
+                cachedMetric.isSynced = false
+
+                if context.hasChanges {
+                    try context.save()
+                }
+
+                return true
+            } catch {
+                #if DEBUG
+                let appError = AppError.coreData(operation: "markPhotoPlaceholderUploadInFlight", underlying: error)
+                let contextInfo = ErrorContext(
+                    feature: "coreData",
+                    operation: "markPhotoPlaceholderUploadInFlight",
+                    screen: nil,
+                    userId: userId
+                )
+                ErrorReporter.shared.capture(appError, context: contextInfo)
+                #endif
+                return false
+            }
+        }
+    }
+
+    @discardableResult
+    func markPhotoUploadStorageCommitted(id: String, userId: String, storagePath: String) async -> Bool {
+        let context = viewContext
+
+        return await context.perform {
+            let fetchRequest: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "id == %@ AND userId == %@", id, userId)
+            fetchRequest.fetchLimit = 1
+
+            do {
+                guard let cachedMetric = try context.fetch(fetchRequest).first,
+                      Self.isUploadPlaceholderCandidate(cachedMetric, userId: userId) else {
+                    return false
+                }
+
+                let now = Date()
+                cachedMetric.originalPhotoUrl = storagePath
+                cachedMetric.syncStatus = Self.photoUploadStorageCommittedSyncStatus
+                cachedMetric.updatedAt = now
+                cachedMetric.lastModified = now
+                cachedMetric.isSynced = false
+
+                if context.hasChanges {
+                    try context.save()
+                }
+
+                return true
+            } catch {
+                #if DEBUG
+                let appError = AppError.coreData(operation: "markPhotoUploadStorageCommitted", underlying: error)
+                let contextInfo = ErrorContext(
+                    feature: "coreData",
+                    operation: "markPhotoUploadStorageCommitted",
+                    screen: nil,
+                    userId: userId
+                )
+                ErrorReporter.shared.capture(appError, context: contextInfo)
+                #endif
+                return false
+            }
+        }
+    }
+
     func markBodyMetricDeleted(id: String) async -> Bool {
         let context = viewContext
 
@@ -1100,6 +1309,80 @@ class CoreDataManager: ObservableObject {
                 return false
             }
         }
+    }
+
+    func deleteEmptyPhotoPlaceholder(id: String, userId: String) async -> Bool {
+        let context = viewContext
+
+        return await context.perform {
+            let fetchRequest: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "id == %@ AND userId == %@", id, userId)
+            fetchRequest.fetchLimit = 1
+
+            do {
+                guard let cachedMetric = try context.fetch(fetchRequest).first,
+                      Self.isDeletableEmptyPhotoPlaceholder(cachedMetric, userId: userId) else {
+                    return false
+                }
+
+                context.delete(cachedMetric)
+
+                if context.hasChanges {
+                    try context.save()
+                }
+
+                return true
+            } catch {
+                #if DEBUG
+                let appError = AppError.coreData(operation: "deleteEmptyPhotoPlaceholder", underlying: error)
+                let contextInfo = ErrorContext(
+                    feature: "coreData",
+                    operation: "deleteEmptyPhotoPlaceholder",
+                    screen: nil,
+                    userId: userId
+                )
+                ErrorReporter.shared.capture(appError, context: contextInfo)
+                #endif
+                return false
+            }
+        }
+    }
+
+    private static func isDeletableEmptyPhotoPlaceholder(_ metric: CachedBodyMetrics, userId: String) -> Bool {
+        isUploadPlaceholderCandidate(metric, userId: userId) &&
+            !isPhotoUploadStorageCommittedSyncStatus(metric.syncStatus) &&
+            Self.isBlank(metric.notes) &&
+            Self.isBlank(metric.sourceMetadataJSON)
+    }
+
+    private static func isUploadPlaceholderCandidate(_ metric: CachedBodyMetrics, userId: String) -> Bool {
+        metric.userId == userId &&
+            !metric.isSynced &&
+            !metric.isMarkedDeleted &&
+            BodyMetricSource.normalizedRawValue(metric.dataSource) == BodyMetricSource.photo.rawValue &&
+            metric.weight <= 0 &&
+            metric.bodyFatPercentage <= 0 &&
+            metric.muscleMass <= 0 &&
+            metric.boneMass <= 0 &&
+            metric.waistCircumference <= 0 &&
+            metric.hipCircumference <= 0 &&
+            Self.isBlank(metric.photoUrl)
+    }
+
+    static func isPhotoUploadPlaceholderSyncStatus(_ value: String?) -> Bool {
+        isPhotoUploadInFlightSyncStatus(value) || isPhotoUploadStorageCommittedSyncStatus(value)
+    }
+
+    private static func isPhotoUploadInFlightSyncStatus(_ value: String?) -> Bool {
+        value == photoUploadInFlightSyncStatus
+    }
+
+    private static func isPhotoUploadStorageCommittedSyncStatus(_ value: String?) -> Bool {
+        value == photoUploadStorageCommittedSyncStatus
+    }
+
+    private static func isBlank(_ value: String?) -> Bool {
+        value?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true
     }
 
     // MARK: - Daily Metrics Operations
@@ -2697,9 +2980,11 @@ extension CachedBodyMetrics {
             muscleMass: muscleMass,
             boneMass: boneMass,
             photoUrl: photoUrl,
+            originalPhotoUrl: originalPhotoUrl,
             notes: notes,
             dataSource: dataSource,
             sourceMetadataJSON: sourceMetadataJSON,
+            syncStatus: syncStatus,
             createdAt: createdAt ?? date,
             updatedAt: updatedAt ?? createdAt ?? date,
             isMarkedDeleted: isMarkedDeleted

--- a/apps/ios/LogYourBody/Services/PhotoMetadataService.swift
+++ b/apps/ios/LogYourBody/Services/PhotoMetadataService.swift
@@ -7,6 +7,11 @@ import Photos
 import ImageIO
 import CoreData
 
+struct PhotoMetricsUpdateResult {
+    let metrics: BodyMetrics
+    let createdNewEntry: Bool
+}
+
 class PhotoMetadataService {
     static let shared = PhotoMetadataService()
 
@@ -103,6 +108,27 @@ class PhotoMetadataService {
         dataSource: String? = nil,
         preserveExistingMeasurements: Bool = false
     ) async -> BodyMetrics {
+        await createOrUpdateMetricsWithResult(
+            for: date,
+            photoUrl: photoUrl,
+            weight: weight,
+            bodyFatPercentage: bodyFatPercentage,
+            userId: userId,
+            dataSource: dataSource,
+            preserveExistingMeasurements: preserveExistingMeasurements
+        ).metrics
+    }
+
+    /// Create or update body metrics and report whether this call created a new local row.
+    func createOrUpdateMetricsWithResult(
+        for date: Date,
+        photoUrl: String? = nil,
+        weight: Double? = nil,
+        bodyFatPercentage: Double? = nil,
+        userId: String,
+        dataSource: String? = nil,
+        preserveExistingMeasurements: Bool = false
+    ) async -> PhotoMetricsUpdateResult {
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: date)
         let localDate = BodyMetricLocalDate.key(for: date)
@@ -141,7 +167,7 @@ class PhotoMetadataService {
             )
 
             CoreDataManager.shared.saveBodyMetrics(updated, userId: userId)
-            return updated
+            return PhotoMetricsUpdateResult(metrics: updated, createdNewEntry: false)
         } else {
             // Create new metrics
             let new = BodyMetrics(
@@ -168,8 +194,30 @@ class PhotoMetadataService {
             )
 
             CoreDataManager.shared.saveBodyMetrics(new, userId: userId)
-            return new
+            return PhotoMetricsUpdateResult(metrics: new, createdNewEntry: true)
         }
+    }
+
+    /// Create or reuse the metrics row for an upload and mark empty placeholders in flight atomically.
+    func createOrUpdateMetricsForPhotoUpload(
+        for date: Date,
+        userId: String
+    ) async throws -> PhotoMetricsUpdateResult {
+        try await CoreDataManager.shared.createOrUpdatePhotoUploadMetricsPlaceholder(
+            for: date,
+            userId: userId
+        )
+    }
+
+    func prepareExistingMetricsForPhotoUpload(
+        id: String,
+        userId: String
+    ) async throws -> PhotoMetricsUpdateResult {
+        let metrics = try await CoreDataManager.shared.prepareExistingPhotoUploadMetrics(
+            id: id,
+            userId: userId
+        )
+        return PhotoMetricsUpdateResult(metrics: metrics, createdNewEntry: false)
     }
 
     /// Estimate weight based on nearby entries

--- a/apps/ios/LogYourBody/Services/PhotoUploadManager.swift
+++ b/apps/ios/LogYourBody/Services/PhotoUploadManager.swift
@@ -138,6 +138,11 @@ class PhotoUploadManager: ObservableObject {
             // print("📸 PhotoUploadManager: Uploading to Supabase Storage with fileName: \(fileName)")
             _ = try await uploadToSupabase(imageData: imageData, fileName: fileName)
             let storagePath = fileName
+            await coreDataManager.markPhotoUploadStorageCommitted(
+                id: metrics.id,
+                userId: userId,
+                storagePath: storagePath
+            )
             // print("✅ PhotoUploadManager: Upload complete, storage path: \(storagePath)")
 
             updateUploadStatus(.uploading, progress: 0.5)
@@ -309,6 +314,11 @@ class PhotoUploadManager: ObservableObject {
             let fileName = "\(userId)/\(metrics.id)_\(Date().timeIntervalSince1970).jpg"
             _ = try await uploadToSupabase(imageData: finalImageData, fileName: fileName)
             let storagePath = fileName
+            await coreDataManager.markPhotoUploadStorageCommitted(
+                id: metrics.id,
+                userId: userId,
+                storagePath: storagePath
+            )
 
             updateUploadStatus(.uploading, progress: 0.5)
 

--- a/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
+++ b/apps/ios/LogYourBody/Services/RealtimeSyncManager.swift
@@ -357,9 +357,16 @@ class RealtimeSyncManager: ObservableObject {
     }
 
     nonisolated func syncLocalChanges(for userId: String?, token: String) async throws {
-        let unsynced = try await coreDataManager.fetchPendingLocalSyncSnapshot(for: userId)
+        var unsynced = try await coreDataManager.fetchPendingLocalSyncSnapshot(for: userId)
+        if unsynced.bodyMetrics.contains(where: \.isStaleEmptyPhotoPlaceholder) {
+            await discardEmptyPhotoPlaceholders(unsynced.bodyMetrics)
+            unsynced = try await coreDataManager.fetchPendingLocalSyncSnapshot(for: userId)
+        }
+
         let deletedBodyMetrics = unsynced.bodyMetrics.filter(\.isMarkedDeleted)
-        let bodyMetricsToUpsert = unsynced.bodyMetrics.filter { !$0.isMarkedDeleted }
+        let bodyMetricsToUpsert = unsynced.bodyMetrics.filter {
+            !$0.isMarkedDeleted && !$0.shouldSkipBodyMetricUpsert
+        }
         let deletedGlp1DoseLogs = unsynced.glp1DoseLogs.filter(\.isMarkedDeleted)
         let glp1DoseLogsToUpsert = unsynced.glp1DoseLogs.filter { !$0.isMarkedDeleted }
 
@@ -393,6 +400,15 @@ class RealtimeSyncManager: ObservableObject {
 
         if !unsynced.dexaResults.isEmpty {
             try await syncDexaResultsBatch(unsynced.dexaResults, token: token)
+        }
+    }
+
+    nonisolated private func discardEmptyPhotoPlaceholders(_ metrics: [PendingBodyMetricSyncItem]) async {
+        for metric in metrics where metric.isStaleEmptyPhotoPlaceholder {
+            _ = await coreDataManager.deleteEmptyPhotoPlaceholder(
+                id: metric.id,
+                userId: metric.userId
+            )
         }
     }
 
@@ -913,6 +929,37 @@ class RealtimeSyncManager: ObservableObject {
         if syncStatus == .error("") {
             syncStatus = .idle
         }
+    }
+}
+
+private extension PendingBodyMetricSyncItem {
+    var shouldSkipBodyMetricUpsert: Bool {
+        isEmptyPhotoPlaceholder ||
+            (
+                CoreDataManager.isPhotoUploadPlaceholderSyncStatus(syncStatus) &&
+                    Self.isBlank(photoUrl)
+            )
+    }
+
+    var isStaleEmptyPhotoPlaceholder: Bool {
+        isEmptyPhotoPlaceholder && !CoreDataManager.isPhotoUploadPlaceholderSyncStatus(syncStatus)
+    }
+
+    var isEmptyPhotoPlaceholder: Bool {
+        BodyMetricSource.normalizedRawValue(dataSource) == BodyMetricSource.photo.rawValue &&
+            weight <= 0 &&
+            waistCircumference <= 0 &&
+            hipCircumference <= 0 &&
+            bodyFatPercentage <= 0 &&
+            muscleMass <= 0 &&
+            boneMass <= 0 &&
+            Self.isBlank(photoUrl) &&
+            Self.isBlank(notes) &&
+            Self.isBlank(sourceMetadataJSON)
+    }
+
+    static func isBlank(_ value: String?) -> Bool {
+        value?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true
     }
 }
 

--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -980,6 +980,8 @@ struct AddEntrySheet: View {
         }
 
         for (index, item) in photosToUpload.enumerated() {
+            var placeholderMetricId: String?
+
             do {
                 defer {
                     processedCount = index + 1
@@ -1003,10 +1005,12 @@ struct AddEntrySheet: View {
                 let photoDate = PhotoMetadataService.shared.extractDate(from: data) ?? selectedDate
 
                 // Create or get metrics for this date
-                let metrics = await PhotoMetadataService.shared.createOrUpdateMetrics(
+                let metricsResult = try await PhotoMetadataService.shared.createOrUpdateMetricsForPhotoUpload(
                     for: photoDate,
                     userId: userId
                 )
+                let metrics = metricsResult.metrics
+                placeholderMetricId = metrics.id
 
                 // Upload the photo
                 _ = try await PhotoUploadManager.shared.uploadProgressPhoto(
@@ -1026,6 +1030,12 @@ struct AddEntrySheet: View {
                     userId: userId
                 )
                 ErrorReporter.shared.captureNonFatal(error, context: context)
+                if let placeholderMetricId {
+                    _ = await CoreDataManager.shared.deleteEmptyPhotoPlaceholder(
+                        id: placeholderMetricId,
+                        userId: userId
+                    )
+                }
                 failedPhotos.append(item)
             }
         }

--- a/apps/ios/LogYourBody/Views/ProgressPhotoAttachSheet.swift
+++ b/apps/ios/LogYourBody/Views/ProgressPhotoAttachSheet.swift
@@ -539,8 +539,12 @@ struct ProgressPhotoAttachSheet: View {
         attachStatus = .processing
 
         Task {
+            var placeholderMetricId: String?
+
             do {
-                let metrics = await targetMetrics(userId: userId)
+                let metricsResult = try await targetMetrics(userId: userId)
+                let metrics = metricsResult.metrics
+                placeholderMetricId = metrics.id
 
                 #if DEBUG
                 if usesProgressPhotoAttachFixture {
@@ -571,6 +575,12 @@ struct ProgressPhotoAttachSheet: View {
             } catch {
                 await MainActor.run {
                     attachStatus = .failed(error.localizedDescription)
+                }
+                if let placeholderMetricId {
+                    _ = await CoreDataManager.shared.deleteEmptyPhotoPlaceholder(
+                        id: placeholderMetricId,
+                        userId: userId
+                    )
                 }
             }
         }
@@ -638,12 +648,15 @@ struct ProgressPhotoAttachSheet: View {
     }
     #endif
 
-    private func targetMetrics(userId: String) async -> BodyMetrics {
+    private func targetMetrics(userId: String) async throws -> PhotoMetricsUpdateResult {
         if let targetMetric {
-            return targetMetric
+            return try await PhotoMetadataService.shared.prepareExistingMetricsForPhotoUpload(
+                id: targetMetric.id,
+                userId: userId
+            )
         }
 
-        return await PhotoMetadataService.shared.createOrUpdateMetrics(
+        return try await PhotoMetadataService.shared.createOrUpdateMetricsForPhotoUpload(
             for: selectedImageDate ?? fallbackDate,
             userId: userId
         )

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -2485,6 +2485,16 @@ final class BodyMetricPhotoUpdateTests: XCTestCase {
 }
 
 final class PhotoMetadataServiceTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+    }
+
+    override func tearDown() async throws {
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+        try await super.tearDown()
+    }
+
     func testCreateOrUpdateMetricsPreservesExistingMeasurementsForFirstPhotoBaseline() async throws {
         let userId = "photo_baseline_existing_\(UUID().uuidString)"
         let date = Date(timeIntervalSince1970: 1_764_000_000)
@@ -2578,6 +2588,303 @@ final class PhotoMetadataServiceTests: XCTestCase {
         XCTAssertEqual(photoEntry.dataSource, BodyMetricSource.photo.rawValue)
         XCTAssertNil(photoEntry.weight)
         XCTAssertNil(photoEntry.bodyFatPercentage)
+    }
+
+    func testCreateOrUpdateMetricsWithResultDistinguishesNewPhotoPlaceholderFromExistingMetric() async {
+        let userId = "photo_placeholder_result_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_300_000)
+
+        let first = await PhotoMetadataService.shared.createOrUpdateMetricsWithResult(
+            for: date,
+            userId: userId
+        )
+        let second = await PhotoMetadataService.shared.createOrUpdateMetricsWithResult(
+            for: date,
+            userId: userId
+        )
+
+        XCTAssertTrue(first.createdNewEntry)
+        XCTAssertFalse(second.createdNewEntry)
+        XCTAssertEqual(second.metrics.id, first.metrics.id)
+    }
+
+    func testDeleteEmptyPhotoPlaceholderRemovesUnsyncedPhotoOnlyMetric() async throws {
+        let userId = "photo_placeholder_cleanup_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_400_000)
+
+        let result = await PhotoMetadataService.shared.createOrUpdateMetricsWithResult(
+            for: date,
+            userId: userId
+        )
+
+        XCTAssertTrue(result.createdNewEntry)
+
+        let deleted = await CoreDataManager.shared.deleteEmptyPhotoPlaceholder(
+            id: result.metrics.id,
+            userId: userId
+        )
+
+        XCTAssertTrue(deleted)
+
+        let visibleMetrics = await CoreDataManager.shared.fetchBodyMetrics(for: userId)
+        XCTAssertFalse(visibleMetrics.contains { $0.id == result.metrics.id })
+
+        let pending = try await CoreDataManager.shared.fetchPendingLocalSyncSnapshot(for: userId)
+        XCTAssertFalse(pending.bodyMetrics.contains { $0.id == result.metrics.id })
+    }
+
+    func testDeleteEmptyPhotoPlaceholderCanRemoveExistingRetryPlaceholder() async throws {
+        let userId = "photo_placeholder_retry_cleanup_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_450_000)
+
+        let first = await PhotoMetadataService.shared.createOrUpdateMetricsWithResult(
+            for: date,
+            userId: userId
+        )
+        let retry = await PhotoMetadataService.shared.createOrUpdateMetricsWithResult(
+            for: date,
+            userId: userId
+        )
+
+        XCTAssertTrue(first.createdNewEntry)
+        XCTAssertFalse(retry.createdNewEntry)
+        XCTAssertEqual(retry.metrics.id, first.metrics.id)
+
+        let deleted = await CoreDataManager.shared.deleteEmptyPhotoPlaceholder(
+            id: retry.metrics.id,
+            userId: userId
+        )
+
+        XCTAssertTrue(deleted)
+        let cachedRetryMetric = await cachedMetric(id: retry.metrics.id)
+        XCTAssertNil(cachedRetryMetric)
+    }
+
+    func testDeleteEmptyPhotoPlaceholderRemovesOriginalOnlyFailedUploadMetric() async throws {
+        let userId = "photo_placeholder_original_only_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_475_000)
+
+        let result = await PhotoMetadataService.shared.createOrUpdateMetricsWithResult(
+            for: date,
+            userId: userId
+        )
+        try await setOriginalPhotoUrl(id: result.metrics.id, value: "\(userId)/failed-upload.png")
+
+        let deleted = await CoreDataManager.shared.deleteEmptyPhotoPlaceholder(
+            id: result.metrics.id,
+            userId: userId
+        )
+
+        XCTAssertTrue(deleted)
+        let cachedOriginalOnlyMetric = await cachedMetric(id: result.metrics.id)
+        XCTAssertNil(cachedOriginalOnlyMetric)
+    }
+
+    func testDeleteEmptyPhotoPlaceholderKeepsStorageCommittedUpload() async throws {
+        let userId = "photo_placeholder_committed_upload_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_485_000)
+        let storagePath = "\(userId)/committed-upload.png"
+
+        let result = await PhotoMetadataService.shared.createOrUpdateMetricsWithResult(
+            for: date,
+            userId: userId
+        )
+        let markedCommitted = await CoreDataManager.shared.markPhotoUploadStorageCommitted(
+            id: result.metrics.id,
+            userId: userId,
+            storagePath: storagePath
+        )
+
+        XCTAssertTrue(markedCommitted)
+
+        let deleted = await CoreDataManager.shared.deleteEmptyPhotoPlaceholder(
+            id: result.metrics.id,
+            userId: userId
+        )
+
+        XCTAssertFalse(deleted)
+        let cachedCommittedMetric = await cachedMetric(id: result.metrics.id)
+        XCTAssertEqual(cachedCommittedMetric?.originalPhotoUrl, storagePath)
+        XCTAssertEqual(
+            cachedCommittedMetric?.syncStatus,
+            CoreDataManager.photoUploadStorageCommittedSyncStatus
+        )
+    }
+
+    func testMarkPhotoPlaceholderUploadInFlightIsLocalOnly() async throws {
+        let userId = "photo_placeholder_in_flight_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_490_000)
+
+        let result = await PhotoMetadataService.shared.createOrUpdateMetricsWithResult(
+            for: date,
+            userId: userId
+        )
+        let markedInFlight = await CoreDataManager.shared.markPhotoPlaceholderUploadInFlight(
+            id: result.metrics.id,
+            userId: userId
+        )
+
+        XCTAssertTrue(markedInFlight)
+
+        let cachedInFlightMetric = await cachedMetric(id: result.metrics.id)
+        XCTAssertEqual(cachedInFlightMetric?.syncStatus, CoreDataManager.photoUploadInFlightSyncStatus)
+        XCTAssertNil(cachedInFlightMetric?.sourceMetadataJSON)
+    }
+
+    func testCreateOrUpdateMetricsForPhotoUploadMarksPlaceholderInFlightAtomically() async throws {
+        let userId = "photo_placeholder_atomic_upload_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_495_000)
+
+        let result = try await PhotoMetadataService.shared.createOrUpdateMetricsForPhotoUpload(
+            for: date,
+            userId: userId
+        )
+
+        XCTAssertTrue(result.createdNewEntry)
+
+        let pending = try await CoreDataManager.shared.fetchPendingLocalSyncSnapshot(for: userId)
+        let item = try XCTUnwrap(pending.bodyMetrics.first { $0.id == result.metrics.id })
+        XCTAssertEqual(item.syncStatus, CoreDataManager.photoUploadInFlightSyncStatus)
+    }
+
+    func testCreateOrUpdateMetricsForPhotoUploadDoesNotDowngradeCommittedStorageState() async throws {
+        let userId = "photo_placeholder_committed_retry_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_496_000)
+        let storagePath = "\(userId)/committed-retry.png"
+
+        let first = try await PhotoMetadataService.shared.createOrUpdateMetricsForPhotoUpload(
+            for: date,
+            userId: userId
+        )
+        let markedCommitted = await CoreDataManager.shared.markPhotoUploadStorageCommitted(
+            id: first.metrics.id,
+            userId: userId,
+            storagePath: storagePath
+        )
+        let retry = try await PhotoMetadataService.shared.createOrUpdateMetricsForPhotoUpload(
+            for: date,
+            userId: userId
+        )
+
+        XCTAssertTrue(markedCommitted)
+        XCTAssertEqual(retry.metrics.id, first.metrics.id)
+
+        let cachedRetryMetric = await cachedMetric(id: first.metrics.id)
+        XCTAssertEqual(cachedRetryMetric?.syncStatus, CoreDataManager.photoUploadStorageCommittedSyncStatus)
+        XCTAssertEqual(cachedRetryMetric?.originalPhotoUrl, storagePath)
+    }
+
+    func testPrepareExistingMetricsForPhotoUploadUsesSelectedMetricId() async throws {
+        let userId = "photo_placeholder_selected_id_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_497_000)
+        let first = BodyMetrics(
+            id: UUID().uuidString,
+            userId: userId,
+            date: date,
+            weight: nil,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.photo.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+        let selected = BodyMetrics(
+            id: UUID().uuidString,
+            userId: userId,
+            date: date,
+            weight: nil,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.photo.rawValue,
+            createdAt: date.addingTimeInterval(1),
+            updatedAt: date.addingTimeInterval(1)
+        )
+
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(first, userId: userId)
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(selected, userId: userId)
+
+        let prepared = try await PhotoMetadataService.shared.prepareExistingMetricsForPhotoUpload(
+            id: selected.id,
+            userId: userId
+        )
+
+        XCTAssertEqual(prepared.metrics.id, selected.id)
+        let firstCached = await cachedMetric(id: first.id)
+        let selectedCached = await cachedMetric(id: selected.id)
+        XCTAssertEqual(firstCached?.syncStatus, "pending")
+        XCTAssertEqual(selectedCached?.syncStatus, CoreDataManager.photoUploadInFlightSyncStatus)
+    }
+
+    func testDeleteEmptyPhotoPlaceholderKeepsExistingMeasurementMetric() async throws {
+        let userId = "photo_placeholder_keep_measurement_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_500_000)
+        let metric = BodyMetrics(
+            id: UUID().uuidString,
+            userId: userId,
+            date: date,
+            weight: 82.0,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.photo.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(metric, userId: userId, markAsSynced: false)
+
+        let deleted = await CoreDataManager.shared.deleteEmptyPhotoPlaceholder(
+            id: metric.id,
+            userId: userId
+        )
+
+        XCTAssertFalse(deleted)
+
+        let visibleMetrics = await CoreDataManager.shared.fetchBodyMetrics(for: userId)
+        XCTAssertTrue(visibleMetrics.contains { $0.id == metric.id })
+    }
+
+    private func cachedMetric(id: String) async -> CachedBodyMetrics? {
+        let context = CoreDataManager.shared.viewContext
+
+        return await context.perform {
+            let request: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id)
+            request.fetchLimit = 1
+
+            return try? context.fetch(request).first
+        }
+    }
+
+    private func setOriginalPhotoUrl(id: String, value: String) async throws {
+        let context = CoreDataManager.shared.viewContext
+
+        try await context.perform {
+            let request: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id)
+            request.fetchLimit = 1
+
+            let metric = try XCTUnwrap(context.fetch(request).first)
+            metric.originalPhotoUrl = value
+
+            if context.hasChanges {
+                try context.save()
+            }
+        }
     }
 }
 
@@ -5523,6 +5830,159 @@ final class SyncIntegrationTests: XCTestCase {
         let unsynced = await coreData.fetchUnsyncedEntries()
         let unsyncedForUser = unsynced.bodyMetrics.filter { $0.userId == userId }
         XCTAssertTrue(unsyncedForUser.isEmpty)
+    }
+
+    func testSyncLocalChangesDiscardsEmptyPhotoPlaceholdersInsteadOfUpserting() async throws {
+        let coreData = CoreDataManager.shared
+        let userId = "sync_test_user_empty_photo_placeholder_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_600_000)
+
+        let result = await PhotoMetadataService.shared.createOrUpdateMetricsWithResult(
+            for: date,
+            userId: userId
+        )
+
+        XCTAssertTrue(result.createdNewEntry)
+
+        let snapshot = try await coreData.fetchPendingLocalSyncSnapshot(for: userId)
+        XCTAssertEqual(snapshot.bodyMetrics.map(\.id), [result.metrics.id])
+
+        let stubSupabase = StubSupabaseManager()
+        let manager = RealtimeSyncManager(
+            coreDataManager: coreData,
+            authManager: AuthManager.shared,
+            supabaseManager: stubSupabase
+        )
+
+        try await manager.syncLocalChanges(token: "test-token")
+
+        XCTAssertTrue(stubSupabase.bodyMetricsBatches.isEmpty)
+        XCTAssertTrue(stubSupabase.deletedRecords.isEmpty)
+        let cachedMetric = await cachedBodyMetric(id: result.metrics.id)
+        XCTAssertNil(cachedMetric)
+
+        let pending = try await coreData.fetchPendingLocalSyncSnapshot(for: userId)
+        XCTAssertTrue(pending.bodyMetrics.isEmpty)
+    }
+
+    func testSyncLocalChangesSkipsInFlightPhotoPlaceholderWithoutDeleting() async throws {
+        let coreData = CoreDataManager.shared
+        let userId = "sync_test_user_in_flight_photo_placeholder_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_610_000)
+
+        let result = await PhotoMetadataService.shared.createOrUpdateMetricsWithResult(
+            for: date,
+            userId: userId
+        )
+        let markedInFlight = await coreData.markPhotoPlaceholderUploadInFlight(
+            id: result.metrics.id,
+            userId: userId
+        )
+
+        XCTAssertTrue(markedInFlight)
+
+        let stubSupabase = StubSupabaseManager()
+        let manager = RealtimeSyncManager(
+            coreDataManager: coreData,
+            authManager: AuthManager.shared,
+            supabaseManager: stubSupabase
+        )
+
+        try await manager.syncLocalChanges(token: "test-token")
+
+        XCTAssertTrue(stubSupabase.bodyMetricsBatches.isEmpty)
+        XCTAssertTrue(stubSupabase.deletedRecords.isEmpty)
+        let cachedMetric = await cachedBodyMetric(id: result.metrics.id)
+        XCTAssertEqual(cachedMetric?.syncStatus, CoreDataManager.photoUploadInFlightSyncStatus)
+
+        let pending = try await coreData.fetchPendingLocalSyncSnapshot(for: userId)
+        XCTAssertEqual(pending.bodyMetrics.map(\.id), [result.metrics.id])
+    }
+
+    func testSyncLocalChangesSkipsStorageCommittedPhotoPlaceholderWithoutDeleting() async throws {
+        let coreData = CoreDataManager.shared
+        let userId = "sync_test_user_committed_photo_placeholder_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_620_000)
+        let storagePath = "\(userId)/committed-upload.png"
+
+        let result = await PhotoMetadataService.shared.createOrUpdateMetricsWithResult(
+            for: date,
+            userId: userId
+        )
+        let markedCommitted = await coreData.markPhotoUploadStorageCommitted(
+            id: result.metrics.id,
+            userId: userId,
+            storagePath: storagePath
+        )
+
+        XCTAssertTrue(markedCommitted)
+
+        let stubSupabase = StubSupabaseManager()
+        let manager = RealtimeSyncManager(
+            coreDataManager: coreData,
+            authManager: AuthManager.shared,
+            supabaseManager: stubSupabase
+        )
+
+        try await manager.syncLocalChanges(token: "test-token")
+
+        XCTAssertTrue(stubSupabase.bodyMetricsBatches.isEmpty)
+        XCTAssertTrue(stubSupabase.deletedRecords.isEmpty)
+        let cachedMetric = await cachedBodyMetric(id: result.metrics.id)
+        XCTAssertEqual(cachedMetric?.syncStatus, CoreDataManager.photoUploadStorageCommittedSyncStatus)
+        XCTAssertEqual(cachedMetric?.originalPhotoUrl, storagePath)
+
+        let pending = try await coreData.fetchPendingLocalSyncSnapshot(for: userId)
+        XCTAssertEqual(pending.bodyMetrics.map(\.id), [result.metrics.id])
+    }
+
+    func testSyncLocalChangesUpsertsCompletedPhotoAfterStorageCommit() async throws {
+        let coreData = CoreDataManager.shared
+        let userId = "sync_test_user_completed_photo_placeholder_\(UUID().uuidString)"
+        let date = Date(timeIntervalSince1970: 1_765_630_000)
+        let storagePath = "\(userId)/completed-upload.png"
+        let processedUrl = "https://res.cloudinary.com/logyourbody/image/upload/completed.png"
+
+        let result = try await PhotoMetadataService.shared.createOrUpdateMetricsForPhotoUpload(
+            for: date,
+            userId: userId
+        )
+        let markedCommitted = await coreData.markPhotoUploadStorageCommitted(
+            id: result.metrics.id,
+            userId: userId,
+            storagePath: storagePath
+        )
+        let didUpdatePhoto = try await coreData.updateBodyMetricPhoto(
+            id: result.metrics.id,
+            userId: userId,
+            storagePath: storagePath,
+            processedUrl: processedUrl
+        )
+
+        XCTAssertTrue(markedCommitted)
+        XCTAssertTrue(didUpdatePhoto)
+
+        let cachedBeforeSync = await cachedBodyMetric(id: result.metrics.id)
+        XCTAssertEqual(cachedBeforeSync?.photoUrl, processedUrl)
+        XCTAssertEqual(cachedBeforeSync?.syncStatus, "pending")
+
+        let stubSupabase = StubSupabaseManager()
+        let manager = RealtimeSyncManager(
+            coreDataManager: coreData,
+            authManager: AuthManager.shared,
+            supabaseManager: stubSupabase
+        )
+
+        try await manager.syncLocalChanges(token: "test-token")
+
+        XCTAssertEqual(stubSupabase.bodyMetricsBatches.count, 1)
+        let payload = try XCTUnwrap(stubSupabase.bodyMetricsBatches.first?.first)
+        XCTAssertEqual(payload["id"] as? String, result.metrics.id)
+        XCTAssertEqual(payload["photo_url"] as? String, processedUrl)
+
+        let cachedAfterSync = await cachedBodyMetric(id: result.metrics.id)
+        XCTAssertEqual(cachedAfterSync?.syncStatus, "synced")
+        XCTAssertEqual(cachedAfterSync?.photoUrl, processedUrl)
     }
 
     func testSyncLocalChanges_UsesSupabaseAndMarksDailyMetricSynced() async throws {


### PR DESCRIPTION
## Summary
- prevent failed Add Entry and Progress Photo attach uploads from leaving blank photo-only body metric rows
- mark photo upload placeholders with local-only in-flight/storage-committed sync states so background sync cannot delete an active upload row
- discard stale empty photo placeholders before sync while preserving storage-committed rows and syncing completed photos normally
- keep attach-to-existing flows bound to the exact selected metric id

## Validation
- `gbrain search "failed photo upload phantom blank body metric row LogYourBody" --limit 8`
- `gbrain query "LogYourBody iOS failed photo uploads can leave phantom blank body metric rows; where is the relevant Add Entry photo upload body metrics flow?"`
- Grok composer 2.5 fast blocker review: `NO BLOCKERS`
- `swiftlint lint --strict --config apps/ios/.swiftlint.yml apps/ios/LogYourBody/Services/PhotoMetadataService.swift apps/ios/LogYourBody/Services/CoreDataManager.swift apps/ios/LogYourBody/Services/RealtimeSyncManager.swift apps/ios/LogYourBody/Services/PhotoUploadManager.swift apps/ios/LogYourBody/Views/AddEntrySheet.swift apps/ios/LogYourBody/Views/ProgressPhotoAttachSheet.swift apps/ios/LogYourBodyTests/LogYourBodyTests.swift`
- `git diff --check`
- XcodeBuildMCP focused simulator tests on `LYB Golden iPhone 16`: 20 passed / 0 failed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Graphite
- `gt branch track`
- `gt branch submit --dry-run`
- real `gt branch submit` is blocked by synced-repo account settings: https://app.graphite.com/settings/synced-repos
