### PR TITLE
fix: replay entry deep links after auth restore

### DIFF
--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -60,6 +60,68 @@ enum LogYourBodyDeepLink {
     }
 }
 
+enum EntryDeepLinkRoutingPolicy {
+    struct PendingDestination: Equatable {
+        let destination: LogYourBodyDeepLink.Destination
+        let userId: String?
+        let receivedAt: Date
+    }
+
+    enum Action: Equatable {
+        case open(LogYourBodyDeepLink.Destination)
+        case store(LogYourBodyDeepLink.Destination)
+        case keepPending
+        case ignore
+    }
+
+    static let pendingLinkTTL: TimeInterval = 120
+
+    static func canStoreForLater(isClerkLoaded: Bool, isAuthenticated: Bool) -> Bool {
+        !isClerkLoaded || isAuthenticated
+    }
+
+    static func action(
+        for destination: LogYourBodyDeepLink.Destination?,
+        canOpenNow: Bool,
+        canStoreForLater: Bool
+    ) -> Action {
+        guard let destination else { return .ignore }
+
+        if canOpenNow {
+            return .open(destination)
+        }
+
+        return canStoreForLater ? .store(destination) : .ignore
+    }
+
+    static func actionForStoredDestination(
+        _ pendingDestination: PendingDestination?,
+        currentUserId: String?,
+        canOpenNow: Bool,
+        canStoreForLater: Bool,
+        now: Date,
+        ttl: TimeInterval = pendingLinkTTL
+    ) -> Action {
+        guard let pendingDestination else { return .ignore }
+
+        if now.timeIntervalSince(pendingDestination.receivedAt) > ttl {
+            return .ignore
+        }
+
+        if let pendingUserId = pendingDestination.userId,
+           let currentUserId,
+           pendingUserId != currentUserId {
+            return .ignore
+        }
+
+        if canOpenNow {
+            return .open(pendingDestination.destination)
+        }
+
+        return canStoreForLater ? .keepPending : .ignore
+    }
+}
+
 @main
 struct LogYourBodyApp: App {
     @StateObject private var authManager = AuthManager.shared
@@ -70,6 +132,7 @@ struct LogYourBodyApp: App {
     @State private var clerk = Clerk.shared
     @State private var showAddEntrySheet = false
     @State private var selectedEntryTab = 0
+    @State private var pendingEntryDeepLinkDestination: EntryDeepLinkRoutingPolicy.PendingDestination?
 
     let persistenceController = CoreDataManager.shared
 
@@ -110,6 +173,25 @@ struct LogYourBodyApp: App {
                 }
                 .task {
                     await performStartupSequence()
+                    resolvePendingEntryDeepLinkIfPossible()
+                }
+                .onChange(of: authManager.isClerkLoaded) { _, _ in
+                    resolvePendingEntryDeepLinkIfPossible()
+                }
+                .onChange(of: authManager.isAuthenticated) { _, _ in
+                    resolvePendingEntryDeepLinkIfPossible()
+                }
+                .onChange(of: authManager.currentUser?.id) { _, _ in
+                    resolvePendingEntryDeepLinkIfPossible()
+                }
+                .onChange(of: authManager.currentUser?.profile?.onboardingCompleted) { _, _ in
+                    resolvePendingEntryDeepLinkIfPossible()
+                }
+                .onChange(of: revenueCatManager.isSubscribed) { _, _ in
+                    resolvePendingEntryDeepLinkIfPossible()
+                }
+                .onReceive(NotificationCenter.default.publisher(for: OnboardingStateManager.onboardingStateDidChange)) { _ in
+                    resolvePendingEntryDeepLinkIfPossible()
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)) { _ in
                     // App entering background - ensure sync is complete
@@ -461,25 +543,73 @@ struct LogYourBodyApp: App {
 
     // MARK: - Deep Link Handling
 
+    @MainActor
     private func handleDeepLink(_ url: URL) {
         if LogYourBodyDeepLink.isOAuthCallback(url) {
             // Clerk SDK handles the OAuth callback automatically.
             return
         }
 
-        guard
-            let destination = LogYourBodyDeepLink.destination(for: url),
-            canOpenEntrySheetFromDeepLink
-        else {
+        guard let destination = LogYourBodyDeepLink.destination(for: url) else {
             return
         }
 
+        let action = EntryDeepLinkRoutingPolicy.action(
+            for: destination,
+            canOpenNow: canOpenEntrySheetFromDeepLink,
+            canStoreForLater: canStoreEntryDeepLinkForLater
+        )
+
+        applyEntryDeepLinkAction(action)
+    }
+
+    @MainActor
+    private func resolvePendingEntryDeepLinkIfPossible() {
+        let action = EntryDeepLinkRoutingPolicy.actionForStoredDestination(
+            pendingEntryDeepLinkDestination,
+            currentUserId: authManager.currentUser?.id,
+            canOpenNow: canOpenEntrySheetFromDeepLink,
+            canStoreForLater: canStoreEntryDeepLinkForLater,
+            now: Date()
+        )
+
+        applyEntryDeepLinkAction(action)
+    }
+
+    @MainActor
+    private func applyEntryDeepLinkAction(_ action: EntryDeepLinkRoutingPolicy.Action) {
+        switch action {
+        case .open(let destination):
+            pendingEntryDeepLinkDestination = nil
+            openEntryDeepLink(destination)
+        case .store(let destination):
+            pendingEntryDeepLinkDestination = EntryDeepLinkRoutingPolicy.PendingDestination(
+                destination: destination,
+                userId: authManager.currentUser?.id,
+                receivedAt: Date()
+            )
+        case .keepPending:
+            break
+        case .ignore:
+            pendingEntryDeepLinkDestination = nil
+        }
+    }
+
+    @MainActor
+    private func openEntryDeepLink(_ destination: LogYourBodyDeepLink.Destination) {
         switch destination {
         case .entry(let tab):
             selectedEntryTab = tab
             UserDefaults.standard.set(tab, forKey: "pendingEntryTab")
             showAddEntrySheet = true
         }
+    }
+
+    private var canStoreEntryDeepLinkForLater: Bool {
+        EntryDeepLinkRoutingPolicy.canStoreForLater(
+            isClerkLoaded: authManager.isClerkLoaded,
+            isAuthenticated: authManager.isAuthenticated
+        )
     }
 
     private var canOpenEntrySheetFromDeepLink: Bool {

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -159,6 +159,137 @@ final class LaunchSurfacePolicyTests: XCTestCase {
         XCTAssertNil(LogYourBodyDeepLink.destination(for: oauthURL))
     }
 
+    func testEntryDeepLinkRoutingStoresDuringStartupAndReplaysWhenEligible() {
+        let destination = LogYourBodyDeepLink.Destination.entry(tab: 2)
+        let receivedAt = Date()
+        let pending = EntryDeepLinkRoutingPolicy.PendingDestination(
+            destination: destination,
+            userId: nil,
+            receivedAt: receivedAt
+        )
+
+        XCTAssertEqual(
+            EntryDeepLinkRoutingPolicy.action(
+                for: destination,
+                canOpenNow: false,
+                canStoreForLater: true
+            ),
+            .store(destination)
+        )
+        XCTAssertEqual(
+            EntryDeepLinkRoutingPolicy.actionForStoredDestination(
+                pending,
+                currentUserId: "restored-user",
+                canOpenNow: true,
+                canStoreForLater: true,
+                now: receivedAt.addingTimeInterval(1)
+            ),
+            .open(destination)
+        )
+    }
+
+    func testEntryDeepLinkRoutingDropsKnownSignedOutUsers() {
+        let destination = LogYourBodyDeepLink.Destination.entry(tab: 0)
+        let receivedAt = Date()
+        let pending = EntryDeepLinkRoutingPolicy.PendingDestination(
+            destination: destination,
+            userId: nil,
+            receivedAt: receivedAt
+        )
+
+        XCTAssertFalse(
+            EntryDeepLinkRoutingPolicy.canStoreForLater(
+                isClerkLoaded: true,
+                isAuthenticated: false
+            )
+        )
+        XCTAssertEqual(
+            EntryDeepLinkRoutingPolicy.action(
+                for: destination,
+                canOpenNow: false,
+                canStoreForLater: false
+            ),
+            .ignore
+        )
+        XCTAssertEqual(
+            EntryDeepLinkRoutingPolicy.actionForStoredDestination(
+                pending,
+                currentUserId: nil,
+                canOpenNow: false,
+                canStoreForLater: false,
+                now: receivedAt.addingTimeInterval(1)
+            ),
+            .ignore
+        )
+    }
+
+    func testEntryDeepLinkRoutingKeepsAuthenticatedDeferredLinksUntilDownstreamGatesOpen() {
+        let destination = LogYourBodyDeepLink.Destination.entry(tab: 1)
+        let receivedAt = Date()
+        let pending = EntryDeepLinkRoutingPolicy.PendingDestination(
+            destination: destination,
+            userId: "user-a",
+            receivedAt: receivedAt
+        )
+
+        XCTAssertTrue(
+            EntryDeepLinkRoutingPolicy.canStoreForLater(
+                isClerkLoaded: true,
+                isAuthenticated: true
+            )
+        )
+        XCTAssertEqual(
+            EntryDeepLinkRoutingPolicy.actionForStoredDestination(
+                pending,
+                currentUserId: "user-a",
+                canOpenNow: false,
+                canStoreForLater: true,
+                now: receivedAt.addingTimeInterval(1)
+            ),
+            .keepPending
+        )
+    }
+
+    func testEntryDeepLinkRoutingExpiresStalePendingLinks() {
+        let receivedAt = Date()
+        let pending = EntryDeepLinkRoutingPolicy.PendingDestination(
+            destination: .entry(tab: 2),
+            userId: "user-a",
+            receivedAt: receivedAt
+        )
+
+        XCTAssertEqual(
+            EntryDeepLinkRoutingPolicy.actionForStoredDestination(
+                pending,
+                currentUserId: "user-a",
+                canOpenNow: true,
+                canStoreForLater: true,
+                now: receivedAt.addingTimeInterval(EntryDeepLinkRoutingPolicy.pendingLinkTTL + 1)
+            ),
+            .ignore
+        )
+    }
+
+    func testEntryDeepLinkRoutingClearsPendingLinksAcrossAccountSwitch() {
+        let receivedAt = Date()
+        let pending = EntryDeepLinkRoutingPolicy.PendingDestination(
+            destination: .entry(tab: 1),
+            userId: "user-a",
+            receivedAt: receivedAt
+        )
+
+        XCTAssertEqual(
+            EntryDeepLinkRoutingPolicy.actionForStoredDestination(
+                pending,
+                currentUserId: "user-b",
+                canOpenNow: true,
+                canStoreForLater: true,
+                now: receivedAt.addingTimeInterval(1)
+            ),
+            .ignore
+        )
+    }
+
     @MainActor
     func testEntryDeepLinkPolicyBlocksAccountSwitchWithPreviousOnboardingCompletion() {
         let suiteName = "entry-deeplink-\(UUID().uuidString)"


### PR DESCRIPTION
## Summary
- Preserve recognized entry deep links received before auth/session/onboarding/subscription state finishes restoring.
- Replay the pending link when the normal launch gate becomes eligible.
- Drop stale, signed-out, and account-switched pending links instead of opening the add-entry sheet for the wrong user.

## Validation
- `gbrain search "LogYourBody cold start deep link session restore entry dropped" --limit 8`
- `gbrain query "For LogYourBody iOS, are authenticated cold-start deep links or entry URLs dropped during Clerk/session restoration, and where is that handled?"`
- Subagent audit: confirmed cold-start/session-restore entry URLs could be dropped before launch gates restored.
- `git diff --check`
- `swiftlint lint --strict --config apps/ios/.swiftlint.yml apps/ios/LogYourBody/LogYourBodyApp.swift apps/ios/LogYourBodyTests/LogYourBodyTests.swift`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination "platform=iOS Simulator,name=iPhone 16" -only-testing:LogYourBodyTests/LaunchSurfacePolicyTests -parallel-testing-enabled NO COMPILER_INDEX_STORE_ENABLE=NO ONLY_ACTIVE_ARCH=YES test` (14 tests, 0 failures)
- `gt branch track`
- `gt branch submit --dry-run`

## Notes
- `gt branch submit --publish --no-edit` is still blocked by Graphite synced-repo settings: "You can only submit to repos synced with Graphite."
- Grok CLI with `grok-composer-2.5-fast` was attempted for review, but the local Grok environment spent the run bootstrapping MCP/skill state and exited at max turns without a useful review.