### PR TITLE
fix: keep RevenueCat UI test fixtures debug-only

### DIFF
--- a/apps/ios/LogYourBody/Services/RevenueCatManager+Part01.swift
+++ b/apps/ios/LogYourBody/Services/RevenueCatManager+Part01.swift
@@ -544,6 +544,7 @@ func cachePaywallOfferingDisplay(_ display: CachedPaywallOfferingDisplay) {
         }
     }
 
+#if DEBUG
 func applyCachedPaywallOfferingUITestFixture() {
         shouldForceOfferingsUnavailableForUITests = true
         currentOffering = nil
@@ -628,6 +629,7 @@ func applyPaywallPlansUITestFixture() {
 func fixtureDecimal(_ value: String) -> Decimal {
         Decimal(string: value) ?? 0
     }
+#endif
 
 // MARK: - Private Helper Methods
 


### PR DESCRIPTION
## Summary
- keeps RevenueCat UI-test fixture helpers out of non-DEBUG builds
- fixes the post-merge iOS Release Loop archive failure from #436: `cannot find shouldForceOfferingsUnavailableForUITests in scope`

## Validation
- `swiftlint lint --strict` from `apps/ios`
- `xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -configuration Release -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
- source line-count scan: no tracked/untracked source files over 800 lines
- pre-push hook: `turbo run lint/typecheck/test --filter='...[origin/main]'` (no affected turbo tasks)