### PR TITLE
refactor: extract main tab policies

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		AD7D30A72E1490810072AA5B /* LogYourBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7D30A62E1490810072AA5B /* LogYourBodyTests.swift */; };
 		AD7D30B12E1490810072AA5B /* LogYourBodyUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7D30B02E1490810072AA5B /* LogYourBodyUITests.swift */; };
 		AD7D30B32E1490810072AA5B /* LogYourBodyUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7D30B22E1490810072AA5B /* LogYourBodyUITestsLaunchTests.swift */; };
+		5DB1A0B114B3417EAE9E143B /* PaidWeightLoggerMVPPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBF4E377107434EA53A2F1B /* PaidWeightLoggerMVPPolicyTests.swift */; };
 		FE07A7A700000000000000B7 /* PhotoTimelineHUDPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE07A7A700000000000000F7 /* PhotoTimelineHUDPolicyTests.swift */; };
 		FE08A8A800000000000000B8 /* BodyScoreShareCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE08A8A800000000000000F8 /* BodyScoreShareCardTests.swift */; };
 		FE09A9A900000000000000B9 /* ProgressPhotoImagePipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE09A9A900000000000000F9 /* ProgressPhotoImagePipelineTests.swift */; };
@@ -259,6 +260,7 @@
 		ADDC47E82E2D89F3003C97E7 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD723B022E15FA5C002376C6 /* LoadingView.swift */; };
 		ADDC47E92E2D89F3003C97E7 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD723B032E15FA5C002376C6 /* LoginView.swift */; };
 		ADDC47EB2E2D89F3003C97E7 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD723B052E15FA5C002376C6 /* MainTabView.swift */; };
+		272AFFF5324345C4B93608F8 /* MainTabViewPolicies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3A26E632164AACAA5D77FD /* MainTabViewPolicies.swift */; };
 		ADDC47EC2E2D89F3003C97E7 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD723B062E15FA5C002376C6 /* PreferencesView.swift */; };
 		ADDC47EE2E2D89F3003C97E7 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD723B092E15FA5C002376C6 /* SignUpView.swift */; };
 		ADDC47F22E2D89F3003C97E7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD723B0E2E15FA5C002376C6 /* ContentView.swift */; };
@@ -483,6 +485,7 @@
 		AD723B022E15FA5C002376C6 /* LoadingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		AD723B032E15FA5C002376C6 /* LoginView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		AD723B052E15FA5C002376C6 /* MainTabView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		8E3A26E632164AACAA5D77FD /* MainTabViewPolicies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTabViewPolicies.swift; sourceTree = "<group>"; };
 		AD723B062E15FA5C002376C6 /* PreferencesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 		AD723B092E15FA5C002376C6 /* SignUpView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
 		AD723B0B2E15FA5C002376C6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -751,6 +754,7 @@
 		FE04A4A400000000000000F4 /* SyncIntervalAndChunkingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncIntervalAndChunkingTests.swift; sourceTree = "<group>"; };
 		FE05A5A500000000000000F5 /* Glp1DoseCardData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Glp1DoseCardData.swift; path = Components/Glp1DoseCardData.swift; sourceTree = "<group>"; };
 		FE06A6A600000000000000F6 /* Glp1CardAndCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glp1CardAndCatalogTests.swift; sourceTree = "<group>"; };
+		3CBF4E377107434EA53A2F1B /* PaidWeightLoggerMVPPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaidWeightLoggerMVPPolicyTests.swift; sourceTree = "<group>"; };
 		FE07A7A700000000000000F7 /* PhotoTimelineHUDPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTimelineHUDPolicyTests.swift; sourceTree = "<group>"; };
 		FE08A8A800000000000000F8 /* BodyScoreShareCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyScoreShareCardTests.swift; sourceTree = "<group>"; };
 		FE09A9A900000000000000F9 /* ProgressPhotoImagePipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressPhotoImagePipelineTests.swift; sourceTree = "<group>"; };
@@ -1148,6 +1152,7 @@
 				AD723B022E15FA5C002376C6 /* LoadingView.swift */,
 				AD723B032E15FA5C002376C6 /* LoginView.swift */,
 				AD723B052E15FA5C002376C6 /* MainTabView.swift */,
+				8E3A26E632164AACAA5D77FD /* MainTabViewPolicies.swift */,
 				AD723B062E15FA5C002376C6 /* PreferencesView.swift */,
 				AD3147A12F0B000100ABCDEF /* PreferenceGoalEditing.swift */,
 				AD3147A22F0B000200ABCDEF /* PreferenceGoalRows.swift */,
@@ -1254,6 +1259,7 @@
 				FE04A4A400000000000000F4 /* SyncIntervalAndChunkingTests.swift */,
 				FE02A2A200000000000000F2 /* DashboardMetricFormattingTests.swift */,
 				FE01A1A100000000000000F1 /* TimelineDataProviderScrubTests.swift */,
+				3CBF4E377107434EA53A2F1B /* PaidWeightLoggerMVPPolicyTests.swift */,
 				FE07A7A700000000000000F7 /* PhotoTimelineHUDPolicyTests.swift */,
 				FE08A8A800000000000000F8 /* BodyScoreShareCardTests.swift */,
 				FE09A9A900000000000000F9 /* ProgressPhotoImagePipelineTests.swift */,
@@ -1702,6 +1708,7 @@
 				FE04A4A400000000000000B4 /* SyncIntervalAndChunkingTests.swift in Sources */,
 				FE02A2A200000000000000B2 /* DashboardMetricFormattingTests.swift in Sources */,
 				FE01A1A100000000000000B1 /* TimelineDataProviderScrubTests.swift in Sources */,
+				5DB1A0B114B3417EAE9E143B /* PaidWeightLoggerMVPPolicyTests.swift in Sources */,
 				FE07A7A700000000000000B7 /* PhotoTimelineHUDPolicyTests.swift in Sources */,
 				FE08A8A800000000000000B8 /* BodyScoreShareCardTests.swift in Sources */,
 				FE09A9A900000000000000B9 /* ProgressPhotoImagePipelineTests.swift in Sources */,
@@ -1843,6 +1850,7 @@
 				AD050C4B2EC12E590082A313 /* PaywallView.swift in Sources */,
 				ADE146442EBF05E000B64DA0 /* TimelineMode.swift in Sources */,
 				ADDC47EB2E2D89F3003C97E7 /* MainTabView.swift in Sources */,
+				272AFFF5324345C4B93608F8 /* MainTabViewPolicies.swift in Sources */,
 				AD8872352EB4061F0041C426 /* BackgroundTaskMonitor.swift in Sources */,
 				ADDC47EC2E2D89F3003C97E7 /* PreferencesView.swift in Sources */,
 				AD3147B12F0B000100ABCDEF /* PreferenceGoalEditing.swift in Sources */,

--- a/apps/ios/LogYourBody/Views/MainTabView.swift
+++ b/apps/ios/LogYourBody/Views/MainTabView.swift
@@ -5,18 +5,6 @@
 import SwiftUI
 import CoreData
 
-enum PaidAppSurface: Equatable {
-    case weightLoggerMVP
-    case legacyFullDashboardBeta
-    case photoTimelineHUD
-}
-
-enum PaidAppSurfacePolicy {
-    static func surface() -> PaidAppSurface {
-        .photoTimelineHUD
-    }
-}
-
 struct MainTabView: View {
     @AppStorage("healthKitSyncEnabled") private var healthKitSyncEnabled = true
     @EnvironmentObject var authManager: AuthManager
@@ -64,45 +52,6 @@ struct MainTabView: View {
         selectedSurface = PaidAppSurfacePolicy.surface()
 
         HealthSyncCoordinator.shared.bootstrapIfNeeded(syncEnabled: healthKitSyncEnabled)
-    }
-}
-
-enum PaidWeightLoggerMVPPolicy {
-    static func validationMessage(weightText: String, unit: String) -> String? {
-        let trimmed = weightText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-
-        do {
-            _ = try ValidationService.shared.validateWeight(trimmed, unit: unit)
-            return nil
-        } catch {
-            return error.localizedDescription
-        }
-    }
-
-    static func canSaveWeight(weightText: String, unit: String, isSaving: Bool) -> Bool {
-        let trimmed = weightText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, !isSaving else { return false }
-        return validationMessage(weightText: trimmed, unit: unit) == nil
-    }
-
-    static func syncStatusText(status: RealtimeSyncManager.SyncStatus, pendingCount: Int) -> String {
-        switch status {
-        case .syncing:
-            return "Syncing"
-        case .success:
-            return "Synced"
-        case .error:
-            return "Sync needs retry"
-        case .offline:
-            return pendingCount > 0 ? "Saved offline" : "Offline"
-        case .idle:
-            return pendingCount > 0 ? "Pending sync" : "Synced"
-        }
-    }
-
-    static func savedConfirmationText(isOnline: Bool) -> String {
-        isOnline ? "Saved locally. Pending sync." : "Saved locally. Will sync when online."
     }
 }
 

--- a/apps/ios/LogYourBody/Views/MainTabViewPolicies.swift
+++ b/apps/ios/LogYourBody/Views/MainTabViewPolicies.swift
@@ -1,0 +1,56 @@
+//
+// MainTabViewPolicies.swift
+// LogYourBody
+//
+import Foundation
+
+enum PaidAppSurface: Equatable {
+    case weightLoggerMVP
+    case legacyFullDashboardBeta
+    case photoTimelineHUD
+}
+
+enum PaidAppSurfacePolicy {
+    static func surface() -> PaidAppSurface {
+        .photoTimelineHUD
+    }
+}
+
+enum PaidWeightLoggerMVPPolicy {
+    static func validationMessage(weightText: String, unit: String) -> String? {
+        let trimmed = weightText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        do {
+            _ = try ValidationService.shared.validateWeight(trimmed, unit: unit)
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    static func canSaveWeight(weightText: String, unit: String, isSaving: Bool) -> Bool {
+        let trimmed = weightText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isSaving else { return false }
+        return validationMessage(weightText: trimmed, unit: unit) == nil
+    }
+
+    static func syncStatusText(status: RealtimeSyncManager.SyncStatus, pendingCount: Int) -> String {
+        switch status {
+        case .syncing:
+            return "Syncing"
+        case .success:
+            return "Synced"
+        case .error:
+            return "Sync needs retry"
+        case .offline:
+            return pendingCount > 0 ? "Saved offline" : "Offline"
+        case .idle:
+            return pendingCount > 0 ? "Pending sync" : "Synced"
+        }
+    }
+
+    static func savedConfirmationText(isOnline: Bool) -> String {
+        isOnline ? "Saved locally. Pending sync." : "Saved locally. Will sync when online."
+    }
+}

--- a/scripts/ios/launch-ui-regression-audit.py
+++ b/scripts/ios/launch-ui-regression-audit.py
@@ -235,9 +235,10 @@ def main() -> int:
     )
 
     main_tab_view = app_dir / "Views/MainTabView.swift"
+    main_tab_view_policies = app_dir / "Views/MainTabViewPolicies.swift"
     require_token(
         root=root,
-        path=main_tab_view,
+        path=main_tab_view_policies,
         token="static func surface() -> PaidAppSurface {\n        .photoTimelineHUD",
         check="routing.timeline_hud_default",
         detail="Paid app default surface must route straight to the timeline HUD for v1.",
@@ -246,7 +247,7 @@ def main() -> int:
 
     add_pattern_violations(
         root=root,
-        paths=[main_tab_view],
+        paths=[main_tab_view, main_tab_view_policies],
         pattern=re.compile(r"AnalyticsService\.shared\.isFeatureEnabled|Statsig\.checkGate"),
         check="routing.no_feature_gate_default_surface",
         detail="The v1 paid-app default surface must not depend on a feature gate or legacy fallback.",


### PR DESCRIPTION
## Summary
- move MainTabView paid-surface and weight-logger policy helpers into MainTabViewPolicies.swift
- add the new policy source to the app target
- wire the existing PaidWeightLoggerMVPPolicyTests.swift file into the XCTest target so the extracted policy has real test execution

## Validation
- pnpm ios:bootstrap-local-config
- swiftlint lint --strict (from apps/ios)
- xcodebuild -project LogYourBody.xcodeproj -scheme LogYourBody -destination "platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74" -only-testing:LogYourBodyTests/PaidWeightLoggerMVPPolicyTests -only-testing:LogYourBodyTests/PhotoTimelineHUDPolicyTests test
- xcresult summary: 10 passed, 0 failed, 0 skipped on iPhone 17 / iOS 26.5

## Notes
- No product behavior changes, API changes, schema changes, or feature-gate changes.
- Pre-push Turbo lint/typecheck/test ran for the origin/main diff and had no package tasks for this iOS-only change.