### PR TITLE
fix(ios): reject invalid Supabase upload hosts before URLSession

### DIFF
--- a/apps/ios/LogYourBody/Services/PhotoUploadManager.swift
+++ b/apps/ios/LogYourBody/Services/PhotoUploadManager.swift
@@ -49,17 +49,58 @@ class PhotoUploadManager: ObservableObject {
                 return "Please log in to upload photos"
             case .imageConversionFailed:
                 return "Failed to process the image"
-            case .uploadFailed:
-                return "Photo upload failed. Please try again."
-            case .processingFailed:
-                return "Photo processing failed. Please try again."
+            case .uploadFailed(let message):
+                return message
+            case .processingFailed(let message):
+                return message
             case .networkError:
-                return "Network connection error"
+                return "Network connection error. Check your connection and try again."
             }
         }
     }
 
     private init() {}
+
+    private func mapUploadEndpointError(_ error: Error, action: String) -> PhotoError {
+        if error is SupabaseError {
+            return .uploadFailed("\(action) is temporarily unavailable. Please try again.")
+        }
+
+        if let networkError = mapNetworkError(error) {
+            return networkError
+        }
+
+        return .uploadFailed("\(action) failed. Please try again.")
+    }
+
+    private func mapNetworkError(_ error: Error) -> PhotoError? {
+        if let urlError = error as? URLError {
+            return networkPhotoError(for: urlError.code)
+        }
+
+        let nsError = error as NSError
+        if let urlError = nsError.userInfo[NSUnderlyingErrorKey] as? URLError {
+            return networkPhotoError(for: urlError.code)
+        }
+
+        return nil
+    }
+
+    private func networkPhotoError(for code: URLError.Code) -> PhotoError? {
+        switch code {
+        case .cannotFindHost,
+             .dnsLookupFailed,
+             .notConnectedToInternet,
+             .networkConnectionLost,
+             .timedOut,
+             .cannotConnectToHost,
+             .internationalRoamingOff,
+             .dataNotAllowed:
+            return .networkError
+        default:
+            return nil
+        }
+    }
 
     private func authenticatedJWT() async throws -> String {
         guard let session = authManager.clerkSession else {
@@ -381,9 +422,13 @@ class PhotoUploadManager: ObservableObject {
 
         // print("📸 PhotoUploadManager: Got JWT token for storage upload")
 
-        guard let url = try? SupabaseURLBuilder.storageURL(bucket: "photos", path: fileName) else {
-            throw PhotoError.uploadFailed("Invalid upload URL")
+        let url: URL
+        do {
+            url = try SupabaseURLBuilder.storageURL(bucket: "photos", path: fileName)
+        } catch {
+            throw mapUploadEndpointError(error, action: "Photo upload")
         }
+
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue(Constants.supabaseAnonKey, forHTTPHeaderField: "apikey")
@@ -397,11 +442,17 @@ class PhotoUploadManager: ObservableObject {
         configuration.timeoutIntervalForResource = 120.0 // 2 minutes
         let uploadSession = URLSession(configuration: configuration)
 
-        let (data, response) = try await uploadSession.data(for: request)
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await uploadSession.data(for: request)
+        } catch {
+            throw mapUploadEndpointError(error, action: "Photo upload")
+        }
 
         guard let httpResponse = response as? HTTPURLResponse else {
             // print("❌ PhotoUploadManager: Invalid response type")
-            throw PhotoError.uploadFailed("Invalid response")
+            throw PhotoError.uploadFailed("Photo upload failed. Please try again.")
         }
 
         // print("📸 PhotoUploadManager: Storage upload response: \(httpResponse.statusCode)")
@@ -419,9 +470,19 @@ class PhotoUploadManager: ObservableObject {
     private func processImageWithCloudinary(storagePath: String, metricsId: String) async throws -> String {
         let token = try await authenticatedJWT()
 
-        guard let url = try? SupabaseURLBuilder.functionURL("process-progress-photo") else {
-            throw PhotoError.processingFailed("Invalid processing URL")
+        let url: URL
+        do {
+            url = try SupabaseURLBuilder.functionURL("process-progress-photo")
+        } catch {
+            if error is SupabaseError {
+                throw PhotoError.processingFailed("Photo processing is temporarily unavailable. Please try again.")
+            }
+            if let networkError = mapNetworkError(error) {
+                throw networkError
+            }
+            throw PhotoError.processingFailed("Photo processing failed. Please try again.")
         }
+
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue(Constants.supabaseAnonKey, forHTTPHeaderField: "apikey")
@@ -434,11 +495,20 @@ class PhotoUploadManager: ObservableObject {
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            if let networkError = mapNetworkError(error) {
+                throw networkError
+            }
+            throw PhotoError.processingFailed("Photo processing failed. Please try again.")
+        }
 
         guard let httpResponse = response as? HTTPURLResponse else {
             // print("❌ PhotoUploadManager: Invalid edge function response")
-            throw PhotoError.processingFailed("Invalid response")
+            throw PhotoError.processingFailed("Photo processing failed. Please try again.")
         }
 
         // print("📸 PhotoUploadManager: Edge function response: \(httpResponse.statusCode)")

--- a/apps/ios/LogYourBody/Services/SupabaseDataClient.swift
+++ b/apps/ios/LogYourBody/Services/SupabaseDataClient.swift
@@ -157,16 +157,60 @@ enum SupabaseError: LocalizedError, Equatable {
 
 enum SupabaseURLBuilder {
     static func restURL(table: String, query: String? = nil, baseURL: String = Constants.supabaseURL) throws -> URL {
+        let normalizedBase = try normalizedBaseURL(baseURL)
         let suffix = query.map { "/rest/v1/\(table)?\($0)" } ?? "/rest/v1/\(table)"
-        return try url(from: baseURL + suffix)
+        return try url(from: normalizedBase + suffix)
     }
 
     static func storageURL(bucket: String, path: String, baseURL: String = Constants.supabaseURL) throws -> URL {
-        try url(from: baseURL + "/storage/v1/object/\(bucket)/\(path)")
+        let normalizedBase = try normalizedBaseURL(baseURL)
+        return try url(from: normalizedBase + "/storage/v1/object/\(bucket)/\(path)")
     }
 
     static func functionURL(_ functionName: String, baseURL: String = Constants.supabaseURL) throws -> URL {
-        try url(from: baseURL + "/functions/v1/\(functionName)")
+        let normalizedBase = try normalizedBaseURL(baseURL)
+        return try url(from: normalizedBase + "/functions/v1/\(functionName)")
+    }
+
+    static func isValidServiceHost(_ host: String) -> Bool {
+        let normalized = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        guard
+            !normalized.isEmpty,
+            !normalized.contains("*"),
+            normalized.contains("."),
+            normalized.rangeOfCharacter(from: .whitespacesAndNewlines) == nil
+        else {
+            return false
+        }
+
+        return true
+    }
+
+    static func normalizedBaseURL(_ rawValue: String) throws -> String {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !Configuration.isPlaceholder(trimmed) else {
+            throw SupabaseError.invalidConfiguration
+        }
+
+        if let url = URL(string: trimmed),
+           let scheme = url.scheme?.lowercased(),
+           ["http", "https"].contains(scheme),
+           let host = url.host,
+           isValidServiceHost(host) {
+            return "\(scheme)://\(host)"
+        }
+
+        let candidate = "https://\(trimmed)"
+        if let url = URL(string: candidate),
+           url.scheme?.lowercased() == "https",
+           let host = url.host,
+           isValidServiceHost(host) {
+            return candidate
+        }
+
+        throw SupabaseError.invalidConfiguration
     }
 
     static func url(from absoluteString: String) throws -> URL {
@@ -174,7 +218,8 @@ enum SupabaseURLBuilder {
             let url = URL(string: absoluteString),
             let scheme = url.scheme?.lowercased(),
             ["http", "https"].contains(scheme),
-            url.host?.isEmpty == false
+            let host = url.host,
+            isValidServiceHost(host)
         else {
             throw SupabaseError.invalidConfiguration
         }

--- a/apps/ios/LogYourBody/Utils/Configuration.swift
+++ b/apps/ios/LogYourBody/Utils/Configuration.swift
@@ -96,17 +96,30 @@ enum Configuration {
         }
     }
 
-    private static func isPlaceholder(_ value: String) -> Bool {
+    static func isPlaceholder(_ value: String) -> Bool {
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
-        return normalized.isEmpty ||
+        if normalized.isEmpty ||
             normalized.contains("$(") ||
             normalized.contains("your-") ||
             normalized.contains("placeholder") ||
             normalized.contains("replace") ||
             normalized.contains("todo") ||
             normalized.contains("changeme") ||
-            normalized.contains("xxx")
+            normalized.contains("xxx") {
+            return true
+        }
+
+        // Corrupt/redacted xcconfig values (e.g. "***)") must not reach URLSession.
+        if normalized.contains("*") {
+            return true
+        }
+
+        if let host = URL(string: normalized)?.host ?? URL(string: "https://\(normalized)")?.host {
+            return !SupabaseURLBuilder.isValidServiceHost(host)
+        }
+
+        return true
     }
 
     // MARK: - API Configuration

--- a/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
+++ b/apps/ios/LogYourBodyTests/LogYourBodyTests.swift
@@ -52,4 +52,30 @@ final class SupabaseURLBuilderTests: XCTestCase {
             XCTAssertEqual(error as? SupabaseError, .invalidConfiguration)
         }
     }
+
+    func testRejectsRedactedSupabaseBaseURLBeforeNetwork() {
+        let corruptValues = ["***)", "https://***", "https://***.supabase.co"]
+
+        for corruptValue in corruptValues {
+            XCTAssertTrue(
+                Configuration.isPlaceholder(corruptValue),
+                "Expected placeholder rejection for \(corruptValue)"
+            )
+            XCTAssertThrowsError(
+                try SupabaseURLBuilder.storageURL(
+                    bucket: "photos",
+                    path: "user-123/photo.jpg",
+                    baseURL: corruptValue
+                )
+            ) { error in
+                XCTAssertEqual(error as? SupabaseError, .invalidConfiguration)
+            }
+        }
+    }
+
+    func testRejectsHostWithoutDomainSegment() {
+        XCTAssertFalse(SupabaseURLBuilder.isValidServiceHost("localhost"))
+        XCTAssertFalse(SupabaseURLBuilder.isValidServiceHost("***"))
+        XCTAssertTrue(SupabaseURLBuilder.isValidServiceHost("abc123.supabase.co"))
+    }
 }

--- a/apps/ios/Scripts/verify_upload_hosts.sh
+++ b/apps/ios/Scripts/verify_upload_hosts.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Preflight upload endpoint hosts before release builds or CI smoke.
+# Mirrors SupabaseURLBuilder.isValidServiceHost in LogYourBody.
+
+lowercase() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+is_invalid_service_host() {
+  local host
+  host="$(lowercase "$1")"
+
+  if [ -z "$host" ] || [[ "$host" == *"*"* ]] || [[ "$host" != *"."* ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+fail() {
+  echo "::error::$1" >&2
+  exit 1
+}
+
+require_https_service_url() {
+  local name="$1"
+  local value="$2"
+  local host
+
+  if [ -z "$value" ]; then
+    fail "$name must be set."
+  fi
+
+  if ! ruby -ruri -e 'uri = URI(ARGV.fetch(0)); exit(uri.is_a?(URI::HTTPS) && uri.host && !uri.host.empty? ? 0 : 1)' "$value"; then
+    fail "$name must be a valid HTTPS URL."
+  fi
+
+  host="$(ruby -ruri -e 'uri = URI(ARGV.fetch(0)); print(uri.host || "")' "$value")"
+  if is_invalid_service_host "$host"; then
+    fail "$name host '$host' is invalid for photo uploads."
+  fi
+}
+
+SUPABASE_URL="${SUPABASE_URL:-${NEXT_PUBLIC_SUPABASE_URL:-}}"
+API_BASE_URL="${API_BASE_URL:-https://www.logyourbody.com}"
+
+require_https_service_url "SUPABASE_URL" "$SUPABASE_URL"
+require_https_service_url "API_BASE_URL" "$API_BASE_URL"
+
+echo "Upload host preflight passed."

--- a/apps/ios/Scripts/write_release_config.sh
+++ b/apps/ios/Scripts/write_release_config.sh
@@ -16,7 +16,7 @@ is_placeholder() {
   value="$(lowercase "$1")"
 
   case "$value" in
-    ""|*"\$("*|*your-*|*placeholder*|*replace*|*todo*)
+    ""|*"\$("*|*your-*|*placeholder*|*replace*|*todo*|*changeme*|*xxx*|*"*"*)
       return 0
       ;;
     *)
@@ -94,6 +94,8 @@ esac
 require_https_url "SUPABASE_URL" "$SUPABASE_URL"
 require_https_url "CLERK_FRONTEND_API" "$CLERK_FRONTEND_API"
 require_https_url "API_BASE_URL" "$API_BASE_URL"
+
+bash "$SCRIPT_DIR/verify_upload_hosts.sh"
 
 case "$REVENUE_CAT_PUBLIC_KEY" in
   appl_*) ;;

--- a/scripts/ios/launch-quality-audit.sh
+++ b/scripts/ios/launch-quality-audit.sh
@@ -257,7 +257,8 @@ run_xcodebuild_test \
   "$ARTIFACT_DIR/launch-quality-unit-tests.xcresult" \
   "$ARTIFACT_DIR/launch-quality-unit-tests.log" \
   -only-testing:LogYourBodyTests/PhotoTimelineHUDPolicyTests \
-  -only-testing:LogYourBodyTests/BodyScoreShareCardTests
+  -only-testing:LogYourBodyTests/BodyScoreShareCardTests \
+  -only-testing:LogYourBodyTests/SupabaseURLBuilderTests
 assert_xcresult_has_test_cases \
   "launch-quality-unit-tests" \
   "$ARTIFACT_DIR/launch-quality-unit-tests.xcresult"


### PR DESCRIPTION
## Summary

Fixes JovieInc/Jovie#11346 — progress-photo upload failing with *"a server with the specified hostname could not be found"*.

**Root cause:** Corrupt/redacted `SUPABASE_URL` values in local `Config.xcconfig` (e.g. `***)`) passed shallow URL validation (`host?.isEmpty == false`), so `PhotoUploadManager` built `https://***/storage/v1/...` and URLSession failed at DNS lookup.

**Fix:** Reject placeholder/redacted/invalid hosts in `Configuration.isPlaceholder` + `SupabaseURLBuilder` before any network call; map errors to clear retriable messages; add release/CI upload-host preflight.

## Causal chain

1. `SUPABASE_URL = ***)` in gitignored `Config.xcconfig`
2. `SupabaseURLBuilder` accepted `https://***` as valid
3. URLSession DNS lookup for host `***` fails
4. iOS surfaces: *"a server with the specified hostname could not be found"*

## Changes

- `Configuration.isPlaceholder` — reject `*`, invalid hosts
- `SupabaseURLBuilder` — `isValidServiceHost`, `normalizedBaseURL`, stricter `url(from:)`
- `PhotoUploadManager` — propagate config errors; map `URLError.cannotFindHost` etc. to retriable network message
- `verify_upload_hosts.sh` — release preflight (wired into `write_release_config.sh`)
- `SupabaseURLBuilderTests` — regression for `***)` / star hosts; added to launch-quality CI lane

## Verification

```bash
xcodebuild -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody \
  -destination 'platform=iOS Simulator,name=iPhone 16' \
  -only-testing:LogYourBodyTests/SupabaseURLBuilderTests \
  CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO test
# ** TEST SUCCEEDED **

SUPABASE_URL='https://***' bash apps/ios/Scripts/verify_upload_hosts.sh
# ::error::SUPABASE_URL host '***' is invalid for photo uploads.
```

## Risks / follow-ups

- Local devs with corrupt `Config.xcconfig` will now see configuration error at upload time (not DNS mystery). Re-run `pnpm ios:bootstrap-local-config` or fix `SUPABASE_URL` manually.
- `placeholder.supabase.co` is already rejected by `isPlaceholder` — CI placeholder builds unaffected for compile; release path uses `write_release_config.sh` with real secrets.

Closes JovieInc/Jovie#11346