### PR TITLE
fix(ci): release-loop validate timeout must outlast the CI Summary gate

### DIFF
--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -49,7 +49,9 @@ jobs:
   validate-release:
     name: Validate Release
     runs-on: macos-26
-    timeout-minutes: 20
+    # Must exceed validate-release-source.sh's RELEASE_CHECK_TIMEOUT_SECONDS (2700s):
+    # CI Summary only completes after the ~30-minute iOS quality gate on iOS merges.
+    timeout-minutes: 50
     permissions:
       contents: read
       checks: read


### PR DESCRIPTION
## Bug

`ios-release-loop.yml` → Validate Release polls for the **CI Summary** check via `validate-release-source.sh` (own budget: 2700s). On iOS-touching merges, CI Summary only completes after the ~30-minute iOS Launch Quality Gate — but the job had `timeout-minutes: 20`.

Result: **every iOS merge since June 30 was cancelled at exactly ~20m and never reached TestFlight** (runs 28448561335, 28620735452 — both show the poll looping on "Required CI checks missing so far: CI Summary" until "The operation was canceled"). The June 28 run only succeeded because the quality gate finished faster that day.

## Fix

One line: `timeout-minutes: 20` → `50` (> the script's 2700s), with a comment tying the two numbers together.

## Why it matters

This is the pipeline that produces the TestFlight build needed for the paywall verification gating App Store submission of 1.2.0. With the timeout fixed, the Golden Path merge (#453) can be re-dispatched to TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)