### PR TITLE
LYB tests: cover BodyScore engine

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		9B5611E2F8314E22A5BF7889 /* ImageCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75034CADEA1D4697BDCB5555 /* ImageCacheService.swift */; };
 		9BCEB21BE7B69676BCA5C211 /* HealthSyncCoordinatorPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDACB9E8EEAB1EBF446F0F02 /* HealthSyncCoordinatorPipelineTests.swift */; };
 		9EBBDD6AF2FF4E4FF8B9E3BC /* BodyCompositionMathGoldenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927B7D58E8E1756BB92364B6 /* BodyCompositionMathGoldenTests.swift */; };
+		B12671012F16000100ABCDEF /* BodyScoreEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12671002F16000100ABCDEF /* BodyScoreEngineTests.swift */; };
+		B12671032F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12671022F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift */; };
 		A4856A2B9E1FC174F9F1739F /* RevenueCatFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE602CA4F092CAB186EE952 /* RevenueCatFlowTests.swift */; };
 		A7876ACC0BAFED8A57643661 /* AccountDeletionAndShareCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8631504046C70A4EE432C9B8 /* AccountDeletionAndShareCardTests.swift */; };
 		AD0054EB2E2197600029E0FF /* privacy-policy.md in Resources */ = {isa = PBXBuildFile; fileRef = AD0054E82E2197600029E0FF /* privacy-policy.md */; };
@@ -487,6 +489,8 @@
 		8EA82A71E77423D56A70AA46 /* SupabaseProfilePayloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SupabaseProfilePayloadTests.swift; sourceTree = "<group>"; };
 		91C10C0E4F8B40568047DA88 /* AddEntrySheet+Part01.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AddEntrySheet+Part01.swift"; path = "AddEntrySheet+Part01.swift"; sourceTree = "<group>"; };
 		927B7D58E8E1756BB92364B6 /* BodyCompositionMathGoldenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyCompositionMathGoldenTests.swift; sourceTree = "<group>"; };
+		B12671002F16000100ABCDEF /* BodyScoreEngineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyScoreEngineTests.swift; sourceTree = "<group>"; };
+		B12671022F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyScoreHealthKitTriggerTests.swift; sourceTree = "<group>"; };
 		9C89CCE0BFAE9B2ACB9A017B /* UserHeaderSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserHeaderSection.swift; path = DesignSystem/Organisms/UserHeaderSection.swift; sourceTree = "<group>"; };
 		9ED9F05E697F00813F824903 /* LogoutButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LogoutButton.swift; path = DesignSystem/Molecules/LogoutButton.swift; sourceTree = "<group>"; };
 		9F0DAD82BAAEB27B75923381 /* FullMetricChartView+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "FullMetricChartView+Part02.swift"; path = "Components/FullMetricChartView+Part02.swift"; sourceTree = "<group>"; };
@@ -1070,6 +1074,8 @@
 				FBDA30F8A24DC3754F3CD216 /* AuthProfileBootstrapPolicyTests.swift */,
 				DA456B8668AB1B5DDFA6C5CA /* AuthSurfacePolicyTests.swift */,
 				927B7D58E8E1756BB92364B6 /* BodyCompositionMathGoldenTests.swift */,
+				B12671002F16000100ABCDEF /* BodyScoreEngineTests.swift */,
+				B12671022F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift */,
 				EB121088934BE398599BE39A /* BodyMetricContractTests.swift */,
 				776620205152E0A15A875703 /* BodyMetricLocalDateContractTests.swift */,
 				192238EEFD8161597A0B99AA /* BodyMetricLoggingAndInsightTests.swift */,
@@ -1891,6 +1897,8 @@
 				9528AB022858D682E801AC01 /* AuthProfileBootstrapPolicyTests.swift in Sources */,
 				BB64CACAE821CFB2A97F53BA /* AuthSurfacePolicyTests.swift in Sources */,
 				9EBBDD6AF2FF4E4FF8B9E3BC /* BodyCompositionMathGoldenTests.swift in Sources */,
+				B12671012F16000100ABCDEF /* BodyScoreEngineTests.swift in Sources */,
+				B12671032F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift in Sources */,
 				022D79AC5B1840BC58FB7D70 /* BodyMetricContractTests.swift in Sources */,
 				1564F129E1D9BAAC5F85C703 /* BodyMetricLocalDateContractTests.swift in Sources */,
 				8F1D82C327BC8A6B5FB2A6DB /* BodyMetricLoggingAndInsightTests.swift in Sources */,

--- a/apps/ios/LogYourBody/Services/BodyScoreCache.swift
+++ b/apps/ios/LogYourBody/Services/BodyScoreCache.swift
@@ -6,11 +6,15 @@ final class BodyScoreCache {
     static let shared = BodyScoreCache()
 
     private let userDefaults: UserDefaults
-    private let storageKey = "bodyScoreCache.latestResults"
+    private let storageKey: String
     private var cache: [String: BodyScoreResult] = [:]
 
-    private init(userDefaults: UserDefaults = .standard) {
+    init(
+        userDefaults: UserDefaults = .standard,
+        storageKey: String = "bodyScoreCache.latestResults"
+    ) {
         self.userDefaults = userDefaults
+        self.storageKey = storageKey
         loadFromDisk()
     }
 
@@ -23,6 +27,17 @@ final class BodyScoreCache {
         guard let userId else { return }
         cache[userId] = result
         persistToDisk()
+    }
+
+    func invalidate(for userId: String?) {
+        guard let userId else { return }
+        cache.removeValue(forKey: userId)
+        persistToDisk()
+    }
+
+    func removeAll() {
+        cache.removeAll()
+        userDefaults.removeObject(forKey: storageKey)
     }
 
     private func loadFromDisk() {

--- a/apps/ios/LogYourBody/Services/BodyScoreRecalculationService.swift
+++ b/apps/ios/LogYourBody/Services/BodyScoreRecalculationService.swift
@@ -6,29 +6,55 @@ import Foundation
 final class BodyScoreRecalculationService {
     static let shared = BodyScoreRecalculationService()
 
-    private let debounceInterval: TimeInterval = 0.4
+    private let debounceInterval: TimeInterval
     private var lastScheduledAt: Date?
+    private var pendingWorkItem: DispatchWorkItem?
     private let queue = DispatchQueue(label: "com.logyourbody.bodyScore.recalculation", qos: .userInitiated)
 
-    private init() {}
+    init(debounceInterval: TimeInterval = 0.4) {
+        self.debounceInterval = debounceInterval
+    }
 
     /// Schedule a background recalculation. Multiple calls in quick succession
     /// are coalesced to avoid redundant work.
-    func scheduleRecalculation() {
-        queue.async { [weak self] in
-            guard let self else { return }
+    @discardableResult
+    func scheduleRecalculation(now: Date = Date(), startTask: Bool = true) -> Bool {
+        queue.sync { [weak self] in
+            guard let self else { return false }
 
-            let now = Date()
-            if let last = self.lastScheduledAt, now.timeIntervalSince(last) < self.debounceInterval {
+            if let last = self.lastScheduledAt,
+               now >= last,
+               now.timeIntervalSince(last) < self.debounceInterval {
                 self.lastScheduledAt = now
-                return
+                self.scheduleTrailingRecalculation(startTask: startTask)
+                return false
             }
 
             self.lastScheduledAt = now
+            self.pendingWorkItem?.cancel()
+            self.startRecalculationIfNeeded(startTask: startTask)
 
-            Task.detached(priority: .userInitiated) {
-                await self.recalculateIfPossible()
-            }
+            return true
+        }
+    }
+
+    private func scheduleTrailingRecalculation(startTask: Bool) {
+        pendingWorkItem?.cancel()
+        guard startTask else { return }
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.startRecalculationIfNeeded(startTask: true)
+        }
+
+        pendingWorkItem = workItem
+        queue.asyncAfter(deadline: .now() + debounceInterval, execute: workItem)
+    }
+
+    private func startRecalculationIfNeeded(startTask: Bool) {
+        guard startTask else { return }
+
+        Task.detached(priority: .userInitiated) { [weak self] in
+            await self?.recalculateIfPossible()
         }
     }
 

--- a/apps/ios/LogYourBody/Services/CoreDataManager+Part02.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager+Part02.swift
@@ -261,9 +261,12 @@ func saveHKSamples(_ samples: [HKRawSample]) async {
                     try context.save()
                 }
 
-                let updated = cachedMetric.toBodyMetrics()
+                guard let updated = cachedMetric.toBodyMetrics() else {
+                    return nil
+                }
 
                 // Schedule background body score recalculation when weight/body fat entries change.
+                BodyScoreCache.shared.invalidate(for: updated.userId)
                 BodyScoreRecalculationService.shared.scheduleRecalculation()
 
                 return updated

--- a/apps/ios/LogYourBody/Services/HealthKitManager+Part02.swift
+++ b/apps/ios/LogYourBody/Services/HealthKitManager+Part02.swift
@@ -497,8 +497,11 @@ func processBatchHealthKitData(
             }
         }
 
-        // Trigger a background body score recalculation now that metrics have changed.
-        BodyScoreRecalculationService.shared.scheduleRecalculation()
+        if imported > 0 {
+            // Trigger a background body score recalculation now that metrics have changed.
+            BodyScoreCache.shared.invalidate(for: userId)
+            BodyScoreRecalculationService.shared.scheduleRecalculation()
+        }
 
         return (imported, skipped)
     }

--- a/apps/ios/LogYourBody/Views/AddEntrySheet+Part02.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet+Part02.swift
@@ -166,6 +166,7 @@ func saveWeight(userId: String) {
                 )
                 RealtimeSyncManager.shared.syncIfNeeded()
 
+                BodyScoreCache.shared.invalidate(for: userId)
                 BodyScoreRecalculationService.shared.scheduleRecalculation()
 
                 trackEntrySaved(
@@ -201,6 +202,7 @@ func saveBodyFat(userId: String) {
                 )
                 RealtimeSyncManager.shared.syncIfNeeded()
 
+                BodyScoreCache.shared.invalidate(for: userId)
                 BodyScoreRecalculationService.shared.scheduleRecalculation()
 
                 trackEntrySaved(type: "body_fat")

--- a/apps/ios/LogYourBodyTests/BodyScoreEngineTests.swift
+++ b/apps/ios/LogYourBodyTests/BodyScoreEngineTests.swift
@@ -1,0 +1,327 @@
+import XCTest
+@testable import LogYourBody
+
+final class BodyScoreEngineTests: XCTestCase {
+    func testCalculatorMatchesGoldenValuesAcrossBoundaryBandsAndUnits() throws {
+        let calculator = BodyScoreCalculator()
+
+        for testCase in bodyScoreGoldenCases {
+            try XCTContext.runActivity(named: testCase.name) { _ in
+                let result = try calculator.calculateScore(
+                    context: BodyScoreCalculationContext(input: testCase.input)
+                )
+
+                assert(result, matches: testCase)
+            }
+        }
+    }
+
+    func testCalculatorRejectsIncompleteInput() {
+        XCTAssertThrowsError(
+            try BodyScoreCalculator().calculateScore(
+                context: BodyScoreCalculationContext(input: BodyScoreInput())
+            )
+        ) { error in
+            XCTAssertEqual(error as? BodyScoreCalculationError, .missingRequiredInputs)
+        }
+    }
+
+    func testCachePersistsByUserKeyAndInvalidatesOnlyChangedUser() {
+        let suiteName = "BodyScoreCacheTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let storageKey = "bodyScoreCache.tests.\(UUID().uuidString)"
+        let cache = BodyScoreCache(userDefaults: defaults, storageKey: storageKey)
+        let first = makeBodyScoreResult(score: 81)
+        let second = makeBodyScoreResult(score: 68)
+
+        cache.store(first, for: "user-a")
+        cache.store(second, for: "user-b")
+        cache.store(makeBodyScoreResult(score: 1), for: nil)
+
+        XCTAssertEqual(cache.latestResult(for: "user-a"), first)
+        XCTAssertEqual(cache.latestResult(for: "user-b"), second)
+        XCTAssertNil(cache.latestResult(for: nil))
+
+        let reloaded = BodyScoreCache(userDefaults: defaults, storageKey: storageKey)
+        XCTAssertEqual(reloaded.latestResult(for: "user-a"), first)
+        XCTAssertEqual(reloaded.latestResult(for: "user-b"), second)
+
+        reloaded.invalidate(for: "user-a")
+
+        XCTAssertNil(reloaded.latestResult(for: "user-a"))
+        XCTAssertEqual(reloaded.latestResult(for: "user-b"), second)
+        XCTAssertNil(
+            BodyScoreCache(userDefaults: defaults, storageKey: storageKey)
+                .latestResult(for: "user-a")
+        )
+    }
+
+    func testRecalculationScheduleCoalescesRapidMetricChanges() {
+        let service = BodyScoreRecalculationService(debounceInterval: 0.4)
+        let firstChange = Date(timeIntervalSince1970: 1_783_100_000)
+
+        XCTAssertTrue(service.scheduleRecalculation(now: firstChange, startTask: false))
+        XCTAssertFalse(
+            service.scheduleRecalculation(
+                now: firstChange.addingTimeInterval(0.1),
+                startTask: false
+            )
+        )
+        XCTAssertTrue(
+            service.scheduleRecalculation(
+                now: firstChange.addingTimeInterval(1),
+                startTask: false
+            )
+        )
+        XCTAssertTrue(
+            service.scheduleRecalculation(
+                now: Date(timeIntervalSince1970: 1_783_100_002),
+                startTask: false
+            )
+        )
+    }
+
+    private func assert(
+        _ result: BodyScoreResult,
+        matches testCase: BodyScoreGoldenCase
+    ) {
+        XCTAssertEqual(result.score, testCase.expectedScore, testCase.name)
+        XCTAssertEqual(result.ffmi, testCase.expectedFFMI, accuracy: 0.05, testCase.name)
+        XCTAssertEqual(
+            result.leanPercentile,
+            testCase.expectedLeanPercentile,
+            accuracy: 0.05,
+            testCase.name
+        )
+        XCTAssertEqual(result.ffmiStatus, testCase.expectedFFMIStatus, testCase.name)
+        XCTAssertEqual(
+            result.statusTagline,
+            testCase.expectedStatusTagline,
+            testCase.name
+        )
+        XCTAssertEqual(result.targetBodyFat.label, "Lean", testCase.name)
+        XCTAssertEqual(
+            result.targetBodyFat.lowerBound,
+            testCase.targetBodyFatRange.lowerBound,
+            accuracy: 0.001,
+            testCase.name
+        )
+        XCTAssertEqual(
+            result.targetBodyFat.upperBound,
+            testCase.targetBodyFatRange.upperBound,
+            accuracy: 0.001,
+            testCase.name
+        )
+    }
+
+    private func makeBodyScoreResult(score: Int) -> BodyScoreResult {
+        BodyScoreResult(
+            score: score,
+            ffmi: Double(score) / 10,
+            leanPercentile: Double(score),
+            ffmiStatus: "Athletic",
+            targetBodyFat: .init(lowerBound: 8, upperBound: 12, label: "Lean"),
+            statusTagline: "Pinned cache fixture"
+        )
+    }
+}
+
+private struct BodyScoreGoldenCase {
+    let name: String
+    let sex: BiologicalSex
+    let age: Int
+    let heightCm: Double
+    let weightKg: Double
+    let bodyFat: Double
+    let units: BodyScoreFixtureUnits
+    let expectedScore: Int
+    let expectedFFMI: Double
+    let expectedLeanPercentile: Double
+    let expectedFFMIStatus: String
+    let expectedStatusTagline: String
+
+    var input: BodyScoreInput {
+        BodyScoreInput(
+            sex: sex,
+            birthYear: Calendar.current.component(.year, from: Date()) - age,
+            height: units.heightValue(fromCentimeters: heightCm),
+            weight: units.weightValue(fromKilograms: weightKg),
+            bodyFat: BodyFatValue(percentage: bodyFat, source: .manualValue),
+            measurementPreference: units.measurementSystem
+        )
+    }
+
+    var targetBodyFatRange: ClosedRange<Double> {
+        sex == .male
+            ? Constants.BodyComposition.BodyFat.maleOptimalRange
+            : Constants.BodyComposition.BodyFat.femaleOptimalRange
+    }
+}
+
+private enum BodyScoreFixtureUnits {
+    case metric
+    case imperial
+
+    var measurementSystem: MeasurementSystem {
+        switch self {
+        case .metric: return .metric
+        case .imperial: return .imperial
+        }
+    }
+
+    func heightValue(fromCentimeters heightCm: Double) -> HeightValue {
+        switch self {
+        case .metric:
+            return HeightValue(value: heightCm, unit: .centimeters)
+        case .imperial:
+            return HeightValue(value: heightCm / 2.54, unit: .inches)
+        }
+    }
+
+    func weightValue(fromKilograms weightKg: Double) -> WeightValue {
+        switch self {
+        case .metric:
+            return WeightValue(value: weightKg, unit: .kilograms)
+        case .imperial:
+            return WeightValue(value: weightKg / 0.45359237, unit: .pounds)
+        }
+    }
+}
+
+private struct BodyScoreGoldenCaseSeed {
+    let name: String
+    let sex: BiologicalSex
+    let metrics: Metrics
+    let expected: Expected
+
+    struct Metrics {
+        let age: Int
+        let heightCm: Double
+        let weightKg: Double
+        let bodyFat: Double
+        let units: BodyScoreFixtureUnits
+    }
+
+    struct Expected {
+        let score: Int
+        let ffmi: Double
+        let leanPercentile: Double
+        let ffmiStatus: String
+        let tagline: String
+    }
+}
+
+private let dialing = "Dialing it in."
+private let solidBase = "Solid base. Room to tighten up."
+private let earlyJourney = "Early in the journey. Huge upside."
+private let goodStart = "Good starting point. Big upside."
+
+private let bodyScoreGoldenCaseSeeds: [BodyScoreGoldenCaseSeed] = [
+    seed(
+        "male_underfat_peak", .male, metrics(23, 177.8, 80, 8, .metric),
+        expected(100, 23.4, 99.0, "Advanced", dialing)
+    ),
+    seed("male_peak_9", .male, metrics(30, 177.8, 82, 9, .metric), expected(100, 23.7, 98.0, "Advanced", dialing)),
+    seed("male_lean_11", .male, metrics(37, 180, 84, 11, .metric), expected(95, 23.1, 95.5, "Advanced", dialing)),
+    seed("male_mid_13", .male, metrics(44, 180, 82, 13, .metric), expected(87, 22.0, 89.0, "Athletic", dialing)),
+    seed("male_fit_15", .male, metrics(52, 175, 78, 15, .metric), expected(75, 22.0, 83.0, "Athletic", solidBase)),
+    seed(
+        "male_visible_18", .male, metrics(60, 175, 78, 18, .metric),
+        expected(58, 21.2, 69.0, "Athletic", earlyJourney)
+    ),
+    seed("male_soft_20", .male, metrics(35, 175, 85, 20, .metric), expected(47, 22.5, 65.0, "Advanced", earlyJourney)),
+    seed(
+        "male_boundary_25", .male, metrics(35, 175, 90, 25, .metric),
+        expected(30, 22.3, 40.0, "Athletic", earlyJourney)
+    ),
+    seed("male_high_30", .male, metrics(35, 175, 95, 30, .metric), expected(20, 22.0, 17.5, "Athletic", earlyJourney)),
+    seed(
+        "male_extreme_35", .male, metrics(35, 175, 100, 35, .metric),
+        expected(1, 21.5, 4.8, "Athletic", earlyJourney)
+    ),
+    seed("male_low_6", .male, metrics(23, 180, 75, 6, .metric), expected(92, 21.8, 99.0, "Athletic", dialing)),
+    seed("male_kg_metric", .male, metrics(40, 182, 88, 14, .metric), expected(81, 22.7, 87.0, "Advanced", solidBase)),
+    seed(
+        "male_lbs_inches_equiv", .male, metrics(40, 182, 88, 14, .imperial),
+        expected(81, 22.7, 87.0, "Advanced", solidBase)
+    ),
+    seed("female_low_17", .female, metrics(23, 165, 58, 17, .metric), expected(85, 18.6, 99.0, "Advanced", dialing)),
+    seed("female_18", .female, metrics(30, 165, 60, 18, .metric), expected(88, 19.0, 97.0, "Advanced", dialing)),
+    seed("female_peak_19", .female, metrics(37, 165, 62, 19, .metric), expected(90, 19.4, 95.5, "Elite", dialing)),
+    seed("female_peak_20", .female, metrics(44, 165, 62, 20, .metric), expected(90, 19.1, 91.0, "Elite", dialing)),
+    seed("female_21", .female, metrics(52, 165, 63, 21, .metric), expected(85, 19.2, 89.0, "Elite", dialing)),
+    seed("female_23", .female, metrics(60, 165, 64, 23, .metric), expected(75, 19.0, 80.0, "Elite", solidBase)),
+    seed("female_25", .female, metrics(35, 165, 65, 25, .metric), expected(60, 18.8, 78.5, "Advanced", earlyJourney)),
+    seed("female_28", .female, metrics(35, 165, 70, 28, .metric), expected(45, 19.4, 65.0, "Elite", earlyJourney)),
+    seed("female_30", .female, metrics(35, 165, 74, 30, .metric), expected(35, 19.9, 55.0, "Elite", earlyJourney)),
+    seed("female_35", .female, metrics(35, 165, 80, 35, .metric), expected(25, 20.0, 36.3, "Elite", earlyJourney)),
+    seed("female_40", .female, metrics(35, 165, 86, 40, .metric), expected(15, 19.9, 17.5, "Elite", earlyJourney)),
+    seed("female_45", .female, metrics(35, 165, 92, 45, .metric), expected(1, 19.5, 4.8, "Elite", earlyJourney)),
+    seed("female_metric", .female, metrics(42, 170, 68, 24, .metric), expected(68, 18.5, 79.0, "Advanced", goodStart)),
+    seed(
+        "female_imperial_equiv", .female, metrics(42, 170, 68, 24, .imperial),
+        expected(68, 18.5, 79.0, "Advanced", goodStart)
+    )
+]
+
+private let bodyScoreGoldenCases: [BodyScoreGoldenCase] = bodyScoreGoldenCaseSeeds.map { seed in
+    BodyScoreGoldenCase(
+        name: seed.name,
+        sex: seed.sex,
+        age: seed.metrics.age,
+        heightCm: seed.metrics.heightCm,
+        weightKg: seed.metrics.weightKg,
+        bodyFat: seed.metrics.bodyFat,
+        units: seed.metrics.units,
+        expectedScore: seed.expected.score,
+        expectedFFMI: seed.expected.ffmi,
+        expectedLeanPercentile: seed.expected.leanPercentile,
+        expectedFFMIStatus: seed.expected.ffmiStatus,
+        expectedStatusTagline: seed.expected.tagline
+    )
+}
+
+private func seed(
+    _ name: String,
+    _ sex: BiologicalSex,
+    _ metrics: BodyScoreGoldenCaseSeed.Metrics,
+    _ expected: BodyScoreGoldenCaseSeed.Expected
+) -> BodyScoreGoldenCaseSeed {
+    BodyScoreGoldenCaseSeed(name: name, sex: sex, metrics: metrics, expected: expected)
+}
+
+private func metrics(
+    _ age: Int,
+    _ heightCm: Double,
+    _ weightKg: Double,
+    _ bodyFat: Double,
+    _ units: BodyScoreFixtureUnits
+) -> BodyScoreGoldenCaseSeed.Metrics {
+    BodyScoreGoldenCaseSeed.Metrics(
+        age: age,
+        heightCm: heightCm,
+        weightKg: weightKg,
+        bodyFat: bodyFat,
+        units: units
+    )
+}
+
+private func expected(
+    _ score: Int,
+    _ ffmi: Double,
+    _ leanPercentile: Double,
+    _ ffmiStatus: String,
+    _ tagline: String
+) -> BodyScoreGoldenCaseSeed.Expected {
+    BodyScoreGoldenCaseSeed.Expected(
+        score: score,
+        ffmi: ffmi,
+        leanPercentile: leanPercentile,
+        ffmiStatus: ffmiStatus,
+        tagline: tagline
+    )
+}

--- a/apps/ios/LogYourBodyTests/BodyScoreHealthKitTriggerTests.swift
+++ b/apps/ios/LogYourBodyTests/BodyScoreHealthKitTriggerTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import LogYourBody
+
+@MainActor
+final class BodyScoreHealthKitTriggerTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        AuthManager.shared.currentUser = nil
+        BodyScoreCache.shared.removeAll()
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+    }
+
+    override func tearDown() async throws {
+        AuthManager.shared.currentUser = nil
+        BodyScoreCache.shared.removeAll()
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+        try await super.tearDown()
+    }
+
+    func testHealthKitNoOpBatchDoesNotInvalidateBodyScoreCache() async throws {
+        let userId = "healthkit_test_user_noop_cache_\(UUID().uuidString)"
+        let otherUserId = "healthkit_test_user_other_cache_\(UUID().uuidString)"
+        AuthManager.shared.currentUser = makeUser(id: userId, email: "hk_noop_cache@example.com")
+
+        let day = Calendar.current.startOfDay(for: Date())
+        let existingDate = Calendar.current.date(
+            byAdding: DateComponents(hour: 10, minute: 45),
+            to: day
+        ) ?? day
+        let skippedDate = Calendar.current.date(
+            byAdding: DateComponents(hour: 10, minute: 15),
+            to: day
+        ) ?? day
+
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(
+            makeBodyMetrics(userId: userId, date: existingDate),
+            userId: userId
+        )
+
+        let cachedScore = makeBodyScoreResult(score: 82)
+        let otherCachedScore = makeBodyScoreResult(score: 64)
+        BodyScoreCache.shared.store(cachedScore, for: userId)
+        BodyScoreCache.shared.store(otherCachedScore, for: otherUserId)
+
+        let result = await HealthKitManager.shared.processBatchHealthKitData(
+            weightHistory: [(weight: 81.0, date: skippedDate)],
+            bodyFatHistory: []
+        )
+
+        XCTAssertEqual(result.imported, 0)
+        XCTAssertEqual(result.skipped, 1)
+        XCTAssertEqual(BodyScoreCache.shared.latestResult(for: userId), cachedScore)
+        XCTAssertEqual(BodyScoreCache.shared.latestResult(for: otherUserId), otherCachedScore)
+    }
+
+    func testHealthKitImportInvalidatesOnlyAffectedBodyScoreCache() async {
+        let userId = "healthkit_test_user_import_cache_\(UUID().uuidString)"
+        let otherUserId = "healthkit_test_user_other_cache_\(UUID().uuidString)"
+        AuthManager.shared.currentUser = makeUser(id: userId, email: "hk_import_cache@example.com")
+
+        let cachedScore = makeBodyScoreResult(score: 91)
+        let otherCachedScore = makeBodyScoreResult(score: 73)
+        BodyScoreCache.shared.store(cachedScore, for: userId)
+        BodyScoreCache.shared.store(otherCachedScore, for: otherUserId)
+
+        let result = await HealthKitManager.shared.processBatchHealthKitData(
+            weightHistory: [(weight: 79.0, date: Date())],
+            bodyFatHistory: []
+        )
+
+        XCTAssertEqual(result.imported, 1)
+        XCTAssertEqual(result.skipped, 0)
+        XCTAssertNil(BodyScoreCache.shared.latestResult(for: userId))
+        XCTAssertEqual(BodyScoreCache.shared.latestResult(for: otherUserId), otherCachedScore)
+    }
+
+    private func makeUser(id: String, email: String) -> LocalUser {
+        LocalUser(
+            id: id,
+            email: email,
+            name: "HealthKit BodyScore Cache",
+            avatarUrl: nil,
+            profile: nil,
+            onboardingCompleted: false
+        )
+    }
+
+    private func makeBodyMetrics(userId: String, date: Date) -> BodyMetrics {
+        BodyMetrics(
+            id: UUID().uuidString,
+            userId: userId,
+            date: date,
+            weight: 80.0,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            waistCm: nil,
+            hipCm: nil,
+            waistUnit: nil,
+            notes: "existing-healthkit-cache",
+            photoUrl: nil,
+            dataSource: "Manual",
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+
+    private func makeBodyScoreResult(score: Int) -> BodyScoreResult {
+        BodyScoreResult(
+            score: score,
+            ffmi: Double(score) / 10,
+            leanPercentile: Double(score),
+            ffmiStatus: "Athletic",
+            targetBodyFat: .init(lowerBound: 8, upperBound: 12, label: "Lean"),
+            statusTagline: "HealthKit cache fixture"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 27 BodyScore golden cases covering sex, age bands, body-fat boundaries, FFMI/status/tagline outputs, and metric/imperial equivalent inputs.
- Adds BodyScore cache tests for per-user key persistence and invalidation.
- Adds HealthKit trigger tests proving skipped/no-op batches do not evict cached BodyScore data and successful imports invalidate only the affected user.
- Makes BodyScore recalculation scheduling testable and preserves trailing recalculation after bursty metric writes.
- Invalidates cached BodyScore results on manual, CoreData, and successful HealthKit metric changes.

Closes JovieInc/Jovie#12671

## Verification

```text
swiftlint lint --strict --config apps/ios/lint.json apps/ios/LogYourBodyTests/BodyScoreEngineTests.swift apps/ios/LogYourBodyTests/BodyScoreHealthKitTriggerTests.swift
Done linting! Found 0 violations, 0 serious in 2 files.
```

```text
xcodebuild test -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7EB60D3E-3637-43EA-969D-167ADC72BAEC' -only-testing:LogYourBodyTests/BodyScoreEngineTests -only-testing:LogYourBodyTests/BodyScoreHealthKitTriggerTests
** TEST SUCCEEDED **
BodyScoreEngineTests: 4 tests passed
BodyScoreHealthKitTriggerTests: 2 tests passed
```

```text
xcodebuild test -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody -destination 'platform=iOS Simulator,id=7EB60D3E-3637-43EA-969D-167ADC72BAEC' -only-testing:LogYourBodyTests
** TEST SUCCEEDED **
```

```text
git diff --check
exit 0
```

```text
coderabbit review --agent -c AGENTS.md -t uncommitted
Earlier completed rerun: review_completed, findings=0.
Final retry after singleton cleanup: errorType=rate_limit, message="Rate limit exceeded", recoverable=true, waitTime="47 minutes".
```

## Review Notes

- Required testing subagent: no blocking testing findings after HealthKit trigger coverage moved into a dedicated test file.
- Required review subagent: no blocking review findings.
- Required security subagent: no blocking security findings.

## Notes

The issue was filed in `JovieInc/Jovie`, but the referenced BodyScore implementation and iOS test target live in `JovieInc/LogYourBody`, so this PR lands in the repository that owns the code.
