### PR TITLE
ios timeline: horizontal swipe owns date navigation — stop stats page hijack

### DIFF
--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -82,7 +82,6 @@ extension DashboardViewLiquid {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .contentShape(Rectangle())
-            .simultaneousGesture(photoTimelineRootSwipeGesture)
         }
     }
 
@@ -129,27 +128,6 @@ extension DashboardViewLiquid {
         .accessibilityLabel(page.navigationTitle)
         .accessibilityAddTraits(selectedPhotoTimelineRootPage == page ? [.isSelected] : [])
         .accessibilityIdentifier(page.accessibilityIdentifier)
-    }
-
-    private var photoTimelineRootSwipeGesture: some Gesture {
-        DragGesture(minimumDistance: 12, coordinateSpace: .local)
-            .onEnded { value in
-                updatePhotoTimelineRootPage(from: value.translation)
-            }
-    }
-
-    private func updatePhotoTimelineRootPage(from translation: CGSize) {
-        let horizontal = translation.width
-        let vertical = translation.height
-        let threshold: CGFloat = 44
-        guard abs(horizontal) > abs(vertical), abs(horizontal) > threshold else { return }
-
-        let nextPage: PhotoTimelineRootPage = horizontal < 0 ? .analytics : .timeline
-        guard selectedPhotoTimelineRootPage != nextPage else { return }
-
-        withAnimation(.easeOut(duration: 0.2)) {
-            selectedPhotoTimelineRootPage = nextPage
-        }
     }
 
     var hudTimelineSection: some View {

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -264,6 +264,27 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertFalse(app.descendants(matching: .any)["dashboard_home_timeline_photo_stage"].exists)
     }
 
+    func testHorizontalSwipeOnTimelineHeroDoesNotOpenStatsPage() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["-lybUITestPhotoTimelineHUDFixture"]
+        app.launch()
+
+        let hero = app.descendants(matching: .any)["dashboard_home_timeline_hero"]
+        XCTAssertTrue(hero.waitForExistence(timeout: 12))
+
+        // Regression guard for JovieInc/Jovie#11350: a horizontal swipe on the
+        // home visual must own date navigation — it must NOT flip the root
+        // page to Stats/Analytics.
+        let start = hero.coordinate(withNormalizedOffset: CGVector(dx: 0.85, dy: 0.4))
+        let end = hero.coordinate(withNormalizedOffset: CGVector(dx: 0.15, dy: 0.4))
+        start.press(forDuration: 0.05, thenDragTo: end)
+
+        XCTAssertFalse(
+            app.descendants(matching: .any)["photo_timeline_root_page_analytics"].waitForExistence(timeout: 2)
+        )
+        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_root_page_timeline"].exists)
+    }
+
     func testMetricDetailOpensFromStatsAndShowsSharedTimelineContext() throws {
         let app = XCUIApplication()
         app.launchArguments = [


### PR DESCRIPTION
**Problem:** Horizontal swipe on the home timeline visual opened the Stats/Analytics page instead of advancing the photo timeline through dates (JovieInc/Jovie#11350, P1 regression from Tim device session 2026-06-21).

## What changed
- Removed the root-level `photoTimelineRootSwipeGesture` (and its `updatePhotoTimelineRootPage` helper) from `photoTimelineRoot` in `DashboardViewLiquid+PhotoTimelineHUD.swift`. It was attached via `.simultaneousGesture` across the entire page ZStack, so any horizontal drag > 44pt — including on the photo carousel — flipped the root page to `.analytics` ("the stats thing"), hijacking the `TabView` paging that already drives date navigation.
- The photo carousel (`ProgressPhotoCarouselView`, paging TabView bound to `selectedIndex`) now owns horizontal swipe. `selectedIndex` changes already propagate photo + hero metrics + date together via `scheduleDashboardDerivedStateRefresh(animatedIndex:)`.
- Stats/Analytics keeps its distinct, non-conflicting affordance: the existing Timeline/Stats nav tab buttons (`photo_timeline_root_nav`).
- Added regression UI test `testHorizontalSwipeOnTimelineHeroDoesNotOpenStatsPage` (fixture `-lybUITestPhotoTimelineHUDFixture`): horizontal swipe on `dashboard_home_timeline_hero` must not surface `photo_timeline_root_page_analytics`.

## Assumptions
- Swipe-to-switch between Timeline and Stats pages is intentionally dropped (not just re-scoped): the analytics page charts use their own horizontal `DragGesture(minimumDistance: 0)` scrub, so the root swipe conflicted on BOTH pages. Tab buttons remain the page-switch affordance. Conservative call; easy to re-add a scoped gesture later if wanted.
- Avatar-mode date-swipe (no TabView in avatar mode) is out of scope — issue repro is Photo mode. If avatar-mode swipe navigation is wanted, that is a follow-up.

## Verification
No Xcode toolchain in the build sandbox — **verification deferred to CI**. CI must run:

```
xcodebuild test -project apps/ios/LogYourBody.xcodeproj -scheme LogYourBody \
  -destination "platform=iOS Simulator,name=iPhone 16" \
  -only-testing:LogYourBodyUITests/LogYourBodyUITests/testHorizontalSwipeOnTimelineHeroDoesNotOpenStatsPage
```

Static checks done locally: removed symbols have zero remaining references (grep across repo); UI test uses existing fixture + accessibility identifiers only.

## Acceptance mapping
- "horizontal swipe advances photo + hero metrics + date together" -> TabView paging is no longer intercepted; `selectedIndex` binding drives all three (existing wiring).
- "stats no longer hijacks horizontal swipe" -> root swipe gesture removed; regression UI test added.

Fixes JovieInc/Jovie#11350
Dispatch: issue-11350

🤖 Generated with [Claude Code](https://claude.com/claude-code)