### PR TITLE
perf(ios): DEBUG performance instrumentation baseline (Phase 0)

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -138,6 +138,8 @@
 		ADA4B7532ED0E61600F4262A /* ErrorReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA4B7522ED0E61600F4262A /* ErrorReporter.swift */; };
 		ADA4B7542ED0E61600F4262A /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA4B7502ED0E61600F4262A /* AppError.swift */; };
 		ADA4B7552ED0E61600F4262A /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA4B7512ED0E61600F4262A /* AppLogger.swift */; };
+		AD9E000B2F20000100ABCDEF /* PerfSignpost.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9E000A2F20000100ABCDEF /* PerfSignpost.swift */; };
+		AD9E000D2F20000200ABCDEF /* FrameHitchMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9E000C2F20000200ABCDEF /* FrameHitchMonitor.swift */; };
 		ADA4B7582ED0E7D700F4262A /* DashboardFFMITile.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA4B7562ED0E7D700F4262A /* DashboardFFMITile.swift */; };
 		ADA4B7592ED0E7D700F4262A /* DashboardPrimaryMetricCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA4B7572ED0E7D700F4262A /* DashboardPrimaryMetricCard.swift */; };
 		ADA4B75B2ED10FFC00F4262A /* DashboardViewLiquid+MetricsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA4B75A2ED10FFC00F4262A /* DashboardViewLiquid+MetricsHelpers.swift */; };
@@ -553,6 +555,8 @@
 		ADA4B74E2ED0365100F4262A /* DashboardBodyScoreHeroCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DashboardBodyScoreHeroCard.swift; path = Components/DashboardBodyScoreHeroCard.swift; sourceTree = "<group>"; };
 		ADA4B7502ED0E61600F4262A /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		ADA4B7512ED0E61600F4262A /* AppLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogger.swift; sourceTree = "<group>"; };
+		AD9E000A2F20000100ABCDEF /* PerfSignpost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerfSignpost.swift; sourceTree = "<group>"; };
+		AD9E000C2F20000200ABCDEF /* FrameHitchMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameHitchMonitor.swift; sourceTree = "<group>"; };
 		ADA4B7522ED0E61600F4262A /* ErrorReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReporter.swift; sourceTree = "<group>"; };
 		ADA4B7562ED0E7D700F4262A /* DashboardFFMITile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DashboardFFMITile.swift; path = Components/DashboardFFMITile.swift; sourceTree = "<group>"; };
 		ADA4B7572ED0E7D700F4262A /* DashboardPrimaryMetricCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DashboardPrimaryMetricCard.swift; path = Components/DashboardPrimaryMetricCard.swift; sourceTree = "<group>"; };
@@ -983,6 +987,8 @@
 				ADF1F6BB2ED4C69F00745F33 /* UnitConversion.swift */,
 				ADA4B7502ED0E61600F4262A /* AppError.swift */,
 				ADA4B7512ED0E61600F4262A /* AppLogger.swift */,
+				AD9E000A2F20000100ABCDEF /* PerfSignpost.swift */,
+				AD9E000C2F20000200ABCDEF /* FrameHitchMonitor.swift */,
 				ADA4B7522ED0E61600F4262A /* ErrorReporter.swift */,
 				ADE6D39B2E24AD30001F82A8 /* LiquidGlassComponents.swift */,
 				ADE6D3962E24A96A001F82A8 /* ShakeDetector.swift */,
@@ -1759,6 +1765,8 @@
 				ADA6003A2ED2602F00088042 /* BodySpecAuthManager.swift in Sources */,
 				ADA4B7542ED0E61600F4262A /* AppError.swift in Sources */,
 				ADA4B7552ED0E61600F4262A /* AppLogger.swift in Sources */,
+				AD9E000B2F20000100ABCDEF /* PerfSignpost.swift in Sources */,
+				AD9E000D2F20000200ABCDEF /* FrameHitchMonitor.swift in Sources */,
 				43ED1CCFAE5CC7DA20E6DB3E /* BaseTextField.swift in Sources */,
 				F0451813784DE99328797E5F /* DSText.swift in Sources */,
 				ADA4B7392ECD44C800F4262A /* BodyScoreCache.swift in Sources */,

--- a/apps/ios/LogYourBody/Helpers/MetricChartDataHelper.swift
+++ b/apps/ios/LogYourBody/Helpers/MetricChartDataHelper.swift
@@ -416,7 +416,9 @@ struct MetricChartDataHelper {
             startDate: startDate
         )
 
-        return composeChartData(with: context)
+        return PerfSignpost.measure("chart_generate") {
+            composeChartData(with: context)
+        }
     }
 
     /// Async version for generating chart data using non-blocking Core Data fetches
@@ -448,7 +450,9 @@ struct MetricChartDataHelper {
             startDate: startDate
         )
 
-        return composeChartData(with: context)
+        return PerfSignpost.measure("chart_generate_async") {
+            composeChartData(with: context)
+        }
     }
 
     private struct ChartCompositionContext {

--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -20,7 +20,11 @@ struct LogYourBodyApp: App {
     let persistenceController = CoreDataManager.shared
 
     init() {
+        LaunchMetrics.begin()
         LogYourBodyAppShortcuts.updateAppShortcutParameters()
+        #if DEBUG
+        FrameHitchMonitor.shared.start()
+        #endif
     }
 
     var body: some Scene {

--- a/apps/ios/LogYourBody/Utils/FrameHitchMonitor.swift
+++ b/apps/ios/LogYourBody/Utils/FrameHitchMonitor.swift
@@ -1,0 +1,89 @@
+//
+// FrameHitchMonitor.swift
+// LogYourBody
+//
+// DEBUG-only frame hitch counter built on CADisplayLink. A "hitch" is any frame
+// whose render interval exceeds the display's nominal frame budget by more than
+// `hitchThresholdMultiplier`. Use it to capture an objective scroll/scrub
+// smoothness baseline and to confirm later optimization phases drive hitches → 0.
+//
+// It only runs when explicitly enabled (launch argument `-lybPerfHitchMonitor`
+// or env `LYB_PERF_HITCH_MONITOR=1`) so it never skews normal debug sessions and
+// never ships in release builds.
+//
+// Typical flow:
+//   FrameHitchMonitor.shared.start()          // app launch (guarded internally)
+//   FrameHitchMonitor.shared.flush(label: ...) // after a measured gesture
+//
+
+#if DEBUG
+import QuartzCore
+import UIKit
+
+@MainActor
+final class FrameHitchMonitor {
+    static let shared = FrameHitchMonitor()
+
+    private var displayLink: CADisplayLink?
+    private var lastTimestamp: CFTimeInterval = 0
+
+    private(set) var hitchCount = 0
+    private(set) var frameCount = 0
+    private(set) var worstFrameMs: Double = 0
+
+    /// A frame counts as a hitch when it takes longer than this multiple of the
+    /// nominal frame duration (e.g. > 1.5× of 8.3ms on a 120Hz display).
+    private let hitchThresholdMultiplier: Double = 1.5
+
+    private var isEnabled: Bool {
+        ProcessInfo.processInfo.arguments.contains("-lybPerfHitchMonitor") ||
+            ProcessInfo.processInfo.environment["LYB_PERF_HITCH_MONITOR"] == "1"
+    }
+
+    private init() {}
+
+    /// Start monitoring. No-op unless explicitly enabled.
+    func start() {
+        guard isEnabled, displayLink == nil else { return }
+        let link = CADisplayLink(target: self, selector: #selector(tick(_:)))
+        link.add(to: .main, forMode: .common)
+        displayLink = link
+        reset()
+        AppLogger.ui.info("FrameHitchMonitor started")
+    }
+
+    func stop() {
+        displayLink?.invalidate()
+        displayLink = nil
+    }
+
+    func reset() {
+        lastTimestamp = 0
+        hitchCount = 0
+        frameCount = 0
+        worstFrameMs = 0
+    }
+
+    /// Log the rolling counters and reset. Call at the end of a measured gesture.
+    func flush(label: String) {
+        guard isEnabled else { return }
+        let worst = String(format: "%.1f", worstFrameMs)
+        AppLogger.ui.info("hitches[\(label)] \(hitchCount)/\(frameCount) frames, worst \(worst) ms")
+        reset()
+    }
+
+    @objc private func tick(_ link: CADisplayLink) {
+        defer { lastTimestamp = link.timestamp }
+        guard lastTimestamp != 0 else { return }
+
+        let frameMs = (link.timestamp - lastTimestamp) * 1_000
+        let nominalMs = link.duration > 0 ? link.duration * 1_000 : 1_000.0 / 60.0
+
+        frameCount += 1
+        if frameMs > nominalMs * hitchThresholdMultiplier {
+            hitchCount += 1
+        }
+        worstFrameMs = max(worstFrameMs, frameMs)
+    }
+}
+#endif

--- a/apps/ios/LogYourBody/Utils/PerfSignpost.swift
+++ b/apps/ios/LogYourBody/Utils/PerfSignpost.swift
@@ -1,0 +1,107 @@
+//
+// PerfSignpost.swift
+// LogYourBody
+//
+// Lightweight performance signposts for profiling hot paths (launch, scrub,
+// chart generation) in Instruments. Active only in DEBUG builds — in release
+// every call compiles down to a no-op, so there is zero shipping overhead.
+//
+// Usage:
+//   PerfSignpost.measure("scrub_select_closest") { ... }   // time a sync block
+//   let token = PerfSignpost.begin("custom_span"); ...; PerfSignpost.end(token)
+//   PerfSignpost.event("launch_first_dashboard_frame", "123 ms")
+//
+
+import Foundation
+import os
+
+enum PerfSignpost {
+    #if DEBUG
+    private static let signposter = OSSignposter(
+        subsystem: Bundle.main.bundleIdentifier ?? "LogYourBody",
+        category: "perf"
+    )
+    #endif
+
+    /// Opaque handle for an in-flight interval. Pass it back to `end` to close it.
+    struct IntervalToken {
+        #if DEBUG
+        fileprivate let name: StaticString
+        fileprivate let state: OSSignpostIntervalState
+        #endif
+    }
+
+    /// Begin a named interval that will be closed later by `end`. Prefer `measure`
+    /// for spans that begin and end in the same scope.
+    static func begin(_ name: StaticString) -> IntervalToken {
+        #if DEBUG
+        return IntervalToken(name: name, state: signposter.beginInterval(name))
+        #else
+        return IntervalToken()
+        #endif
+    }
+
+    static func end(_ token: IntervalToken) {
+        #if DEBUG
+        signposter.endInterval(token.name, token.state)
+        #endif
+    }
+
+    /// Measure a synchronous block as a signpost interval and return its result.
+    static func measure<T>(_ name: StaticString, _ work: () throws -> T) rethrows -> T {
+        #if DEBUG
+        let state = signposter.beginInterval(name)
+        defer { signposter.endInterval(name, state) }
+        return try work()
+        #else
+        return try work()
+        #endif
+    }
+
+    /// Emit a one-shot point-of-interest event. The message autoclosure is only
+    /// evaluated in DEBUG builds.
+    static func event(_ name: StaticString, _ message: @autoclosure () -> String = "") {
+        #if DEBUG
+        let text = message()
+        if text.isEmpty {
+            signposter.emitEvent(name)
+        } else {
+            signposter.emitEvent(name, "\(text, privacy: .public)")
+        }
+        #endif
+    }
+}
+
+/// Tracks time-to-first-dashboard-frame as a launch performance baseline.
+/// `begin()` is called as early as possible (app `init`); `markFirstDashboardFrame()`
+/// is called when the dashboard first appears and logs the elapsed time once.
+enum LaunchMetrics {
+    #if DEBUG
+    private static var processStart: DispatchTime?
+    private static var firstFrameLogged = false
+    #endif
+
+    /// Record the launch start timestamp. Idempotent.
+    static func begin() {
+        #if DEBUG
+        if processStart == nil {
+            processStart = DispatchTime.now()
+        }
+        #endif
+    }
+
+    /// Log the launch → first dashboard frame duration exactly once.
+    static func markFirstDashboardFrame() {
+        #if DEBUG
+        guard !firstFrameLogged else { return }
+        firstFrameLogged = true
+
+        let start = processStart ?? DispatchTime.now()
+        let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds) / 1_000_000
+        let formatted = String(format: "%.1f", elapsedMs)
+
+        AppLogger.ui.info("launch→firstDashboardFrame \(formatted) ms")
+        PerfSignpost.event("launch_first_dashboard_frame", "\(formatted) ms")
+        #endif
+    }
+}

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
@@ -10,6 +10,9 @@ extension DashboardViewLiquid {
         guard index >= 0 && index < metrics.count else { return }
         let metric = metrics[index]
 
+        let interval = PerfSignpost.begin("scrub_update_animated_values")
+        defer { PerfSignpost.end(interval) }
+
         withAnimation(.easeOut(duration: 0.18)) {
             // Weight
             if let weightResult = metric.weight != nil ?

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -262,12 +262,14 @@ extension DashboardViewLiquid {
     }
 
     func selectClosestMetric(to date: Date) {
-        guard let index = nearestBodyMetricIndex(in: bodyMetrics, to: date) else {
-            return
-        }
+        PerfSignpost.measure("scrub_select_closest") {
+            guard let index = nearestBodyMetricIndex(in: bodyMetrics, to: date) else {
+                return
+            }
 
-        selectedIndex = index
-        updateAnimatedValues(for: index)
+            selectedIndex = index
+            updateAnimatedValues(for: index)
+        }
     }
 
     func formatHUDDate(_ date: Date) -> String {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -170,6 +170,7 @@ struct DashboardViewLiquid: View {
 
         let withLifecycle = base
             .onAppear {
+                LaunchMetrics.markFirstDashboardFrame()
                 Task { @MainActor in
                     await Task.yield()
                     handleOnAppear()
@@ -380,14 +381,16 @@ struct DashboardViewLiquid: View {
         Task { @MainActor in
             await Task.yield()
 
-            if rebuildDailyMetricsLookup {
-                rebuildDailyMetricsLookupCache()
-            }
+            PerfSignpost.measure("dashboard_derived_refresh") {
+                if rebuildDailyMetricsLookup {
+                    rebuildDailyMetricsLookupCache()
+                }
 
-            refreshGlobalTimelineStore()
+                refreshGlobalTimelineStore()
 
-            if let animatedIndex, !viewModel.bodyMetrics.isEmpty {
-                updateAnimatedValues(for: animatedIndex)
+                if let animatedIndex, !viewModel.bodyMetrics.isEmpty {
+                    updateAnimatedValues(for: animatedIndex)
+                }
             }
         }
     }

--- a/apps/ios/docs/development/PERFORMANCE_BASELINE.md
+++ b/apps/ios/docs/development/PERFORMANCE_BASELINE.md
@@ -1,0 +1,76 @@
+# iOS Performance Baseline & Instrumentation
+
+This document describes the DEBUG-only performance instrumentation added in the
+"rock solid & blazing fast" campaign (Phase 0) and how to capture the baseline
+numbers that later phases must not regress.
+
+All instrumentation is compiled out of release builds — it lives behind `#if DEBUG`
+and, for the frame monitor, an explicit launch flag. There is **zero shipping overhead**.
+
+## What's instrumented
+
+### `PerfSignpost` (`LogYourBody/Utils/PerfSignpost.swift`)
+Thin wrapper over `OSSignposter` (category `perf`). Use it to time hot paths so they
+show up as intervals in Instruments' **os_signpost** / **Points of Interest** track.
+
+| Signpost name                  | Where                                                            | Measures |
+|--------------------------------|-----------------------------------------------------------------|----------|
+| `launch_first_dashboard_frame` | `LaunchMetrics.markFirstDashboardFrame()`                       | Launch → first dashboard frame (point event) |
+| `scrub_select_closest`         | `selectClosestMetric(to:)`                                      | Timeline header cursor → metric selection |
+| `scrub_update_animated_values` | `updateAnimatedValues(for:)`                                    | Per-index hero value recompute (3× interpolation) |
+| `dashboard_derived_refresh`    | `scheduleDashboardDerivedStateRefresh(...)`                    | Derived-state rebuild on data/index change |
+| `chart_generate` / `_async`    | `MetricChartDataHelper.generateChartData[Async]`               | Sparkline/chart compute (cache miss cost) |
+
+API: `PerfSignpost.measure("name") { ... }`, `begin/end`, `event("name", "msg")`.
+
+### `LaunchMetrics` (`LogYourBody/Utils/PerfSignpost.swift`)
+- `LaunchMetrics.begin()` — called in `LogYourBodyApp.init()` (earliest hook).
+- `LaunchMetrics.markFirstDashboardFrame()` — called in `DashboardViewLiquid.onAppear`;
+  logs `launch→firstDashboardFrame <ms>` once via `AppLogger.ui`.
+
+### `FrameHitchMonitor` (`LogYourBody/Utils/FrameHitchMonitor.swift`)
+CADisplayLink-based hitch counter. A frame is a **hitch** if its render interval
+exceeds 1.5× the display's nominal frame budget. Only runs when explicitly enabled:
+
+- Launch argument: `-lybPerfHitchMonitor`, or
+- Environment variable: `LYB_PERF_HITCH_MONITOR=1`
+
+Call `FrameHitchMonitor.shared.flush(label:)` after a measured gesture to log
+`hitches[label] <hitches>/<frames> frames, worst <ms> ms` and reset counters.
+
+## How to capture the baseline
+
+### Launch → first frame
+1. Run the app (Debug) on a physical device (preferred) or simulator.
+2. Filter the Console / unified log for subsystem `co.logyourbody.*`, category `ui`.
+3. Read the `launch→firstDashboardFrame <ms>` line. Take the median of 3 cold launches.
+
+Or in Instruments: profile with the **os_signpost** instrument and read the
+`launch_first_dashboard_frame` point event.
+
+### Scrub / scroll hitches
+1. Launch with the hitch monitor enabled, e.g. in the scheme's Run arguments add
+   `-lybPerfHitchMonitor`, or run a UI test with that argument
+   (the `-lybUITestPhotoTimelineHUDFixture` fixture seeds timeline data).
+2. Perform a consistent gesture (e.g. drag the timeline scrubber end-to-end 3×).
+3. Read the `hitches[...]` log line, or use Instruments **Animation Hitches** /
+   **Time Profiler** alongside the `scrub_*` signpost intervals.
+
+### Recommended: Instruments
+Profile the **os_signpost**, **Time Profiler**, and **Animation Hitches** instruments
+on a physical device. The `scrub_*` and `chart_generate` intervals pinpoint the
+main-thread work to attack in Phase 2.
+
+## Baseline numbers (fill in from a real device run)
+
+> Capture on a fixed device (e.g. iPhone 15, iOS 26) with the
+> `-lybUITestPhotoTimelineHUDFixture` data set, and record here + in the PR.
+
+| Metric                              | Baseline | Target |
+|-------------------------------------|----------|--------|
+| Launch → first dashboard frame (ms) | _TBD_    | hold / ↓ |
+| Scrub hitches (end-to-end drag)     | _TBD_    | ~0 |
+| Cold scroll hitches (home)          | _TBD_    | ~0 |
+| Worst frame during scrub (ms)       | _TBD_    | < frame budget |
+
+These become the regression gate for Phases 2–4.


### PR DESCRIPTION
## Context

Phase 0 of the **"make the iOS app rock solid & blazing fast (0 jank)"** campaign — a phased, one-PR-per-phase effort. This first PR adds the *measurement baseline* so that "fast / 0 jank" is verified with numbers, not vibes. **No behavior changes**; all instrumentation is `#if DEBUG` and compiles to no-ops in release (zero shipping overhead).

Priorities for the campaign (from planning): **(1) zero crashes**, **(2) scroll/scrub smoothness on the default photo-timeline surface**, then launch speed and visual polish. This PR instruments exactly those hot paths.

## What's in this PR

**New — `LogYourBody/Utils/PerfSignpost.swift`**
- `PerfSignpost` — thin `OSSignposter` wrapper (`measure` / `begin` / `end` / `event`, category `perf`) for timing hot paths in Instruments.
- `LaunchMetrics` — records launch start in `App.init()` and logs `launch→firstDashboardFrame <ms>` once on first dashboard appearance.

**New — `LogYourBody/Utils/FrameHitchMonitor.swift`**
- CADisplayLink hitch counter (a frame is a "hitch" when its render interval exceeds 1.5× the display's nominal budget). Only runs when explicitly enabled via the `-lybPerfHitchMonitor` launch arg or `LYB_PERF_HITCH_MONITOR=1`, so it never skews normal debug sessions and never ships.

**Instrumented hot paths (default photo-timeline surface):**
| Signpost | Location |
|---|---|
| `launch_first_dashboard_frame` | `DashboardViewLiquid.onAppear` |
| `scrub_select_closest` | `selectClosestMetric(to:)` |
| `scrub_update_animated_values` | `updateAnimatedValues(for:)` |
| `dashboard_derived_refresh` | `scheduleDashboardDerivedStateRefresh(...)` |
| `chart_generate` / `chart_generate_async` | `MetricChartDataHelper.generateChartData[Async]` |

**New — `docs/development/PERFORMANCE_BASELINE.md`**
- How to capture launch time and scrub/scroll hitches; baseline table (to be filled from a physical-device run) that becomes the regression gate for Phases 2–4.

## Verification
- ✅ Full iOS Simulator build (`xcodebuild build -scheme LogYourBody`, Debug): **BUILD SUCCEEDED**, 0 errors, no warnings on the new files.
- ✅ SwiftLint clean on all changed files.
- ✅ `project.pbxproj` change is a surgical 8-line registration (validated with `plutil` + `xcodeproj`).

## Notes
- Release builds are unaffected — every call site is `#if DEBUG` or a release no-op.
- Baseline numbers are best captured on a physical device; the doc documents the exact procedure and leaves the table as `TBD` for that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)