### PR TITLE
fix(ios): eliminate two confirmed crashes on the photo timeline (Phase 1)

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		42B0784EAF04F40C031D0186 /* DailyReminderPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D9694F1EA5B5091B0AE8B /* DailyReminderPolicyTests.swift */; };
 		43ED1CCFAE5CC7DA20E6DB3E /* BaseTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB074F9FFF63EE8FD17BA /* BaseTextField.swift */; };
 		46D2D60CC0C168272E5B0A14 /* BulkProgressPhotoImportPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060DD24271B0B2120CB0AA33 /* BulkProgressPhotoImportPolicyTests.swift */; };
+		AD9E00112F20001000ABCDEF /* ProgressPhotoCarouselPreloadRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9E00102F20001000ABCDEF /* ProgressPhotoCarouselPreloadRangeTests.swift */; };
+		AD9E00132F20001100ABCDEF /* BulkImportManagerBoundsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9E00122F20001100ABCDEF /* BulkImportManagerBoundsTests.swift */; };
 		4C2DA948F919366D436CEF26 /* DSIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458AAF24645E3634CCF88E16 /* DSIcon.swift */; };
 		4C64677ABA2986677DDE1389 /* LogWeightFormValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3ECAB100575E759C5A3D7A /* LogWeightFormValidatorTests.swift */; };
 		4DF78B8A5B5E0DBAF777CBC1 /* DSLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECEBC7B2B956D26BF45822F /* DSLogo.swift */; };
@@ -418,6 +420,8 @@
 		0401CF23AE214F20C7EB5886 /* DeveloperTapHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeveloperTapHandler.swift; path = DesignSystem/Molecules/DeveloperTapHandler.swift; sourceTree = "<group>"; };
 		05F19CFBFEA440516AFCE98B /* DSText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSText.swift; path = DesignSystem/Atoms/DSText.swift; sourceTree = "<group>"; };
 		060DD24271B0B2120CB0AA33 /* BulkProgressPhotoImportPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BulkProgressPhotoImportPolicyTests.swift; sourceTree = "<group>"; };
+		AD9E00102F20001000ABCDEF /* ProgressPhotoCarouselPreloadRangeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProgressPhotoCarouselPreloadRangeTests.swift; sourceTree = "<group>"; };
+		AD9E00122F20001100ABCDEF /* BulkImportManagerBoundsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BulkImportManagerBoundsTests.swift; sourceTree = "<group>"; };
 		07AFDB2060EF2522DE93E10D /* CachedPaywallOfferingDisplayTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CachedPaywallOfferingDisplayTests.swift; sourceTree = "<group>"; };
 		095D9694F1EA5B5091B0AE8B /* DailyReminderPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DailyReminderPolicyTests.swift; sourceTree = "<group>"; };
 		0AB2ACF16AEA86A36EDAD936 /* BiometricAuthView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BiometricAuthView.swift; path = DesignSystem/Organisms/BiometricAuthView.swift; sourceTree = "<group>"; };
@@ -1087,6 +1091,8 @@
 				3F2E34BC49376B87D43D81AD /* BodyMetricPhotoUpdateTests.swift */,
 				6EBD5BF3F1671BC8D17ABE5D /* BodyMetricSourceContractTests.swift */,
 				060DD24271B0B2120CB0AA33 /* BulkProgressPhotoImportPolicyTests.swift */,
+				AD9E00102F20001000ABCDEF /* ProgressPhotoCarouselPreloadRangeTests.swift */,
+				AD9E00122F20001100ABCDEF /* BulkImportManagerBoundsTests.swift */,
 				07AFDB2060EF2522DE93E10D /* CachedPaywallOfferingDisplayTests.swift */,
 				CA050E7DCEBA5BAF62341363 /* CoreDataAndPhotoPolicyTests.swift */,
 				095D9694F1EA5B5091B0AE8B /* DailyReminderPolicyTests.swift */,
@@ -1912,6 +1918,8 @@
 				D5F71D2685408ED4D599FC28 /* BodyMetricPhotoUpdateTests.swift in Sources */,
 				04EB1D7AD1947D32BDE7AD70 /* BodyMetricSourceContractTests.swift in Sources */,
 				46D2D60CC0C168272E5B0A14 /* BulkProgressPhotoImportPolicyTests.swift in Sources */,
+				AD9E00112F20001000ABCDEF /* ProgressPhotoCarouselPreloadRangeTests.swift in Sources */,
+				AD9E00132F20001100ABCDEF /* BulkImportManagerBoundsTests.swift in Sources */,
 				BC360577C7E72F397010D7B1 /* CachedPaywallOfferingDisplayTests.swift in Sources */,
 				04BF4BAC82CF6B37F817592F /* CoreDataAndPhotoPolicyTests.swift in Sources */,
 				42B0784EAF04F40C031D0186 /* DailyReminderPolicyTests.swift in Sources */,

--- a/apps/ios/LogYourBody/Services/BulkImportManager.swift
+++ b/apps/ios/LogYourBody/Services/BulkImportManager.swift
@@ -101,6 +101,17 @@ class BulkImportManager: ObservableObject {
 
     // MARK: - Private Methods
 
+    /// Safely mutate the import task at `index`, guarding against `importTasks`
+    /// being resized while an async import is still in flight. `importPhoto(at:)`
+    /// bounds-checks only once before its first `await`; if the user cancels and
+    /// starts a smaller import, the array shrinks and the still-suspended task
+    /// would otherwise index out of range. No-ops when the index is stale.
+    @MainActor
+    func updateImportTask(at index: Int, _ mutate: (inout ImportTask) -> Void) {
+        guard importTasks.indices.contains(index) else { return }
+        mutate(&importTasks[index])
+    }
+
     private func importPhoto(at index: Int) async {
         guard index < importTasks.count else { return }
 
@@ -109,7 +120,7 @@ class BulkImportManager: ObservableObject {
         dateFormatter.dateStyle = .medium
 
         await MainActor.run {
-            importTasks[index].status = .extracting
+            updateImportTask(at: index) { $0.status = .extracting }
             currentPhotoName = dateFormatter.string(from: photo.date)
         }
 
@@ -120,8 +131,10 @@ class BulkImportManager: ObservableObject {
             }
 
             await MainActor.run {
-                importTasks[index].status = .processing
-                importTasks[index].progress = 0.3
+                updateImportTask(at: index) {
+                    $0.status = .processing
+                    $0.progress = 0.3
+                }
             }
 
             // Step 2: Create body metrics entry for the photo date
@@ -167,8 +180,10 @@ class BulkImportManager: ObservableObject {
             }
 
             await MainActor.run {
-                importTasks[index].status = .uploading
-                importTasks[index].progress = 0.6
+                updateImportTask(at: index) {
+                    $0.status = .uploading
+                    $0.progress = 0.6
+                }
             }
 
             // Step 3: Upload photo
@@ -178,8 +193,10 @@ class BulkImportManager: ObservableObject {
             )
 
             await MainActor.run {
-                importTasks[index].status = .completed
-                importTasks[index].progress = 1.0
+                updateImportTask(at: index) {
+                    $0.status = .completed
+                    $0.progress = 1.0
+                }
             }
 
             // Trigger sync
@@ -189,8 +206,10 @@ class BulkImportManager: ObservableObject {
         } catch {
             // print("❌ Failed to import photo: \(error)")
             await MainActor.run {
-                importTasks[index].status = .failed
-                importTasks[index].error = error
+                updateImportTask(at: index) {
+                    $0.status = .failed
+                    $0.error = error
+                }
             }
         }
     }

--- a/apps/ios/LogYourBody/Views/ProgressPhotoCarouselView.swift
+++ b/apps/ios/LogYourBody/Views/ProgressPhotoCarouselView.swift
@@ -112,6 +112,25 @@ struct ProgressPhotoCarouselView: View {
 
     // MARK: - Photo Preloading for Smooth Experience
 
+    /// The clamped ±`window` index range to preload around `index` for a
+    /// collection of `count` items. Returns `nil` when there is nothing safe to
+    /// preload so callers never construct an inverted `ClosedRange` (which traps
+    /// with "Range requires lowerBound <= upperBound").
+    ///
+    /// `selectedMetricsIndex` is an externally-shared binding that can legitimately
+    /// exceed `displayMetrics.count` — the TabView tags in-flight processing
+    /// placeholders as `count + i`, and the index can go stale when metrics shrink
+    /// after a sync/delete. Clamping here keeps preloading crash-safe for those cases.
+    static func preloadIndexRange(around index: Int, count: Int, window: Int = 2) -> ClosedRange<Int>? {
+        let lastIndex = count - 1
+        guard lastIndex >= 0 else { return nil }
+        let clamped = min(max(index, 0), lastIndex)
+        let lower = max(0, clamped - window)
+        let upper = min(lastIndex, clamped + window)
+        guard lower <= upper else { return nil }
+        return lower...upper
+    }
+
     private func preloadAdjacentPhotos() {
         // Cancel previous preload task to prevent accumulation
         preloadTask?.cancel()
@@ -124,9 +143,12 @@ struct ProgressPhotoCarouselView: View {
             // Check if task was cancelled during sleep
             guard !Task.isCancelled else { return }
 
-            // Preload photos around current selection (±2 indices)
-            let currentIndex = selectedMetricsIndex
-            let range = max(0, currentIndex - 2)...min(displayMetrics.count - 1, currentIndex + 2)
+            // Preload photos around current selection (±2 indices), clamped so a
+            // stale/oversized index can never form an inverted range.
+            guard let range = Self.preloadIndexRange(
+                around: selectedMetricsIndex,
+                count: displayMetrics.count
+            ) else { return }
 
             let urlsToPreload = range.compactMap { index -> String? in
                 guard index < displayMetrics.count else { return nil }

--- a/apps/ios/LogYourBodyTests/BulkImportManagerBoundsTests.swift
+++ b/apps/ios/LogYourBodyTests/BulkImportManagerBoundsTests.swift
@@ -1,0 +1,32 @@
+//
+// BulkImportManagerBoundsTests.swift
+// LogYourBodyTests
+//
+// Regression coverage for a confirmed crash: `importPhoto(at:)` bounds-checks the
+// index only once, before its first `await`. If the user cancels an in-flight
+// bulk import and starts a smaller one, `importTasks` shrinks while the old task
+// is still suspended; on resume its captured index pointed past the array and
+// `importTasks[index]` trapped with "Index out of range". `updateImportTask`
+// re-validates the index on every mutation.
+//
+import XCTest
+@testable import LogYourBody
+
+@MainActor
+final class BulkImportManagerBoundsTests: XCTestCase {
+    func test_updateImportTask_indexPastEnd_isSafeNoOp() {
+        let manager = BulkImportManager.shared
+        let original = manager.importTasks
+        defer { manager.importTasks = original }
+
+        manager.importTasks = []
+
+        // Would previously crash: importTasks[5] on an empty array.
+        manager.updateImportTask(at: 5) { $0.status = .completed }
+        XCTAssertTrue(manager.importTasks.isEmpty)
+
+        // A negative index is also a safe no-op.
+        manager.updateImportTask(at: -1) { $0.status = .failed }
+        XCTAssertTrue(manager.importTasks.isEmpty)
+    }
+}

--- a/apps/ios/LogYourBodyTests/ProgressPhotoCarouselPreloadRangeTests.swift
+++ b/apps/ios/LogYourBodyTests/ProgressPhotoCarouselPreloadRangeTests.swift
@@ -1,0 +1,46 @@
+//
+// ProgressPhotoCarouselPreloadRangeTests.swift
+// LogYourBodyTests
+//
+// Regression coverage for a confirmed crash: the photo carousel built its
+// preload window as `max(0, i-2)...min(count-1, i+2)`, which trapped with
+// "Range requires lowerBound <= upperBound" whenever the shared selection index
+// exceeded the metric count (processing-placeholder tags `count + i`, or a stale
+// index after the metrics array shrank). `preloadIndexRange` clamps and guards.
+//
+import XCTest
+@testable import LogYourBody
+
+final class ProgressPhotoCarouselPreloadRangeTests: XCTestCase {
+    func test_emptyCollection_returnsNil() {
+        XCTAssertNil(ProgressPhotoCarouselView.preloadIndexRange(around: 0, count: 0))
+        XCTAssertNil(ProgressPhotoCarouselView.preloadIndexRange(around: 5, count: 0))
+    }
+
+    func test_midIndex_returnsClampedWindow() {
+        XCTAssertEqual(ProgressPhotoCarouselView.preloadIndexRange(around: 5, count: 10), 3...7)
+    }
+
+    func test_startIndex_clampsLowerBoundToZero() {
+        XCTAssertEqual(ProgressPhotoCarouselView.preloadIndexRange(around: 0, count: 10), 0...2)
+    }
+
+    func test_endIndex_clampsUpperBoundToLastIndex() {
+        XCTAssertEqual(ProgressPhotoCarouselView.preloadIndexRange(around: 9, count: 10), 7...9)
+    }
+
+    func test_negativeIndex_clampsToStart() {
+        XCTAssertEqual(ProgressPhotoCarouselView.preloadIndexRange(around: -4, count: 10), 0...2)
+    }
+
+    /// The crash case: an index beyond `count` must not form an inverted range.
+    func test_indexBeyondCount_doesNotTrap_andClampsToTail() {
+        // count = 5, index = 7 (== count + 2) → clamp to last index 4 → 2...4
+        XCTAssertEqual(ProgressPhotoCarouselView.preloadIndexRange(around: 7, count: 5), 2...4)
+    }
+
+    func test_singleItem_isAlwaysSafe() {
+        XCTAssertEqual(ProgressPhotoCarouselView.preloadIndexRange(around: 0, count: 1), 0...0)
+        XCTAssertEqual(ProgressPhotoCarouselView.preloadIndexRange(around: 3, count: 1), 0...0)
+    }
+}


### PR DESCRIPTION
## Context

Phase 1 of the **"rock solid & blazing fast, 0 jank"** campaign — priority: **zero crashes**. No feature changes.

Both fixes come from an **adversarially-verified crash-vector audit** of the *current* tree (6 parallel finders across force-unwrap / collection-bounds / `fatalError` / numeric-range / forced-construction / concurrency categories, then per-candidate verification). The audit confirmed the codebase is already well-hardened — only **2 genuine, high-severity, production-reachable crashes** survived verification, both on the default photo-timeline surface. Every other candidate (e.g. `AppVersionManager` caches `.first!`, several `Calendar.date(byAdding:)!`) was verified **SAFE** and deliberately left untouched to keep this diff to real crashes only.

## Crash 1 — `ProgressPhotoCarouselView` inverted `ClosedRange`

The preload window was built as `max(0, i-2)...min(count-1, i+2)`. When the shared `selectedMetricsIndex` exceeds `displayMetrics.count` — the `TabView` tags in-flight processing placeholders as `count + i`, and the index goes stale after the metrics array shrinks post sync/delete — `lowerBound` becomes greater than `upperBound` and constructing the range **traps** with *"Range requires lowerBound <= upperBound"*.

**Fix:** extract a pure `preloadIndexRange(around:count:window:)` that clamps the index and returns `nil` for anything unsafe, so an oversized/stale index can never form an inverted range.

**Repro:** with ≥1 existing metric, start importing ≥3 progress photos, swipe to the last processing placeholder (drives the index to `count+2`); after the 500ms debounce the range construction crashes.

## Crash 2 — `BulkImportManager` post-`await` out-of-bounds

`importPhoto(at:)` bounds-checks the index only once, before its first `await`. Cancelling an in-flight import and starting a **smaller** one reassigns the `@Published importTasks` array while the old task is still suspended (its awaits are non-cooperative). On resume, `importTasks[index]` indexes past the now-smaller array → *"Fatal error: Index out of range"*.

**Fix:** route every post-`await` mutation through a bounds-guarded `updateImportTask(at:_:)` that re-validates the index (`indices.contains`) on each access.

**Repro:** start a 10-photo import, tap Cancel in the background-task HUD mid-upload, immediately start a 2-photo import; the suspended task resumes and crashes.

## Tests (new, all passing)
- `ProgressPhotoCarouselPreloadRangeTests` — 7 cases including the inverted-range regression (`index == count+2` → clamps, no trap), empty/negative/boundary indices.
- `BulkImportManagerBoundsTests` — out-of-range mutation on a shrunk array is a safe no-op.

## Verification
- ✅ `xcodebuild test` (iPhone 17 Pro, iOS 26.1) — **TEST SUCCEEDED**; full app + test target compile clean; all 8 new tests pass.
- ✅ SwiftLint clean on changed files.
- ✅ `project.pbxproj` change is a surgical registration of the 2 test files (validated with `plutil` + `xcodeproj`).

Both fixes are behavior-preserving for the valid-index path — they only add guards for the previously-crashing out-of-range/inverted cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)