### PR TITLE
perf(ios): preload timeline photos with bounded concurrency (Phase 2)

### DIFF
--- a/apps/ios/LogYourBody/Services/ImageCacheService.swift
+++ b/apps/ios/LogYourBody/Services/ImageCacheService.swift
@@ -104,11 +104,27 @@ class ImageCacheService: ObservableObject {
         return image
     }
 
-    /// Preload images in background
+    /// Preload images in the background with bounded concurrency.
+    ///
+    /// Adjacent photos decode in parallel — so timeline scrubbing lands on an
+    /// already-cached image instead of stalling on a serial decode chain — while
+    /// the concurrency cap avoids firing every request at once. `loadImage`'s
+    /// per-URL deduplication still prevents redundant work.
     func preloadImages(_ urlStrings: [String]) {
+        let urls = urlStrings.filter { !$0.isEmpty }
+        guard !urls.isEmpty else { return }
+
         Task {
-            for urlString in urlStrings {
-                _ = await loadImage(from: urlString)
+            let maxConcurrent = min(4, urls.count)
+            await withTaskGroup(of: Void.self) { group in
+                for (offset, urlString) in urls.enumerated() {
+                    // Keep at most `maxConcurrent` decodes in flight: once the
+                    // window is full, wait for one to finish before starting the next.
+                    if offset >= maxConcurrent {
+                        await group.next()
+                    }
+                    group.addTask { _ = await self.loadImage(from: urlString) }
+                }
             }
         }
     }

--- a/apps/ios/LogYourBodyTests/ImageCacheServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/ImageCacheServiceTests.swift
@@ -74,6 +74,47 @@ final class ImageCacheServiceTests: XCTestCase {
         XCTAssertNil(service.cachedImage(for: url))
     }
 
+    func testPreloadImagesLoadsAllDistinctURLsWithBoundedConcurrency() async throws {
+        let loader = CountingImageLoader(image: makeImage(color: .systemGreen), delayNanoseconds: 0)
+        let service = ImageCacheService(imageLoader: loader, notificationCenter: NotificationCenter())
+        // More URLs than the concurrency cap (4) to prove the sliding window still
+        // covers every item rather than dropping the tail.
+        let urls = (0..<7).map { "https://example.com/preload-\($0).jpg" }
+
+        service.preloadImages(urls)
+
+        // preloadImages is fire-and-forget; poll until every distinct URL loaded.
+        try await waitUntil { await loader.loadCount() == urls.count }
+
+        let cachedCount = urls.filter { service.cachedImage(for: $0) != nil }.count
+        XCTAssertEqual(cachedCount, urls.count)
+    }
+
+    func testPreloadImagesSkipsEmptyURLs() async throws {
+        let loader = CountingImageLoader(image: makeImage(color: .systemOrange), delayNanoseconds: 0)
+        let service = ImageCacheService(imageLoader: loader, notificationCenter: NotificationCenter())
+
+        service.preloadImages(["https://example.com/a.jpg", "", "https://example.com/b.jpg", ""])
+
+        try await waitUntil { await loader.loadCount() == 2 }
+        // Give any erroneous empty-string load a chance to register before asserting.
+        try await Task.sleep(nanoseconds: 20_000_000)
+        let loadCount = await loader.loadCount()
+        XCTAssertEqual(loadCount, 2)
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 2.0,
+        _ condition: () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTFail("Condition not met within \(timeout)s")
+    }
+
     private func makeImage(color: UIColor) -> UIImage {
         let format = UIGraphicsImageRendererFormat()
         format.scale = 1


### PR DESCRIPTION
## Context

Phase 2 of the **"rock solid & blazing fast, 0 jank"** campaign — priority: **scroll/scrub smoothness on the default photo-timeline surface**. No feature changes.

`ImageCacheService.preloadImages` (called on every timeline selection change to warm the ±2 photos around the cursor) loaded its URLs in a **serial** `for … await` loop:

```swift
Task {
    for urlString in urlStrings { _ = await loadImage(from: urlString) }
}
```

So the preload took as long as the **sum** of each decode, and scrubbing frequently landed on a photo that hadn't finished decoding.

## Change

Load concurrently with a small in-flight cap (4) via a sliding-window `TaskGroup`:
- Adjacent photos decode **in parallel**, so a scrub lands on an already-cached image.
- The cap avoids firing every request at once (thrashing decode/network).
- Empty URLs are filtered up front.
- Per-URL **deduplication in `loadImage` is unchanged** — no redundant work; behavior is identical apart from concurrency.

## Tests
Two new `ImageCacheServiceTests` (injectable `CountingImageLoader` mock, no network):
- `testPreloadImagesLoadsAllDistinctURLsWithBoundedConcurrency` — 7 URLs (> cap) all load, proving the sliding window covers the tail rather than dropping it.
- `testPreloadImagesSkipsEmptyURLs` — empty strings are skipped.

Plus the existing `testConcurrentLoadsForSameURLShareSinglePipelineRequest` already guarantees concurrent loads still dedup to a single pipeline request — exactly what this change relies on.

## Verification
- ✅ `xcodebuild test` (iPhone 17 Pro, iOS 26.1) — **TEST SUCCEEDED**; all 5 `ImageCacheServiceTests` pass (3 existing + 2 new).
- ✅ SwiftLint clean.
- ✅ No `project.pbxproj` change (edited files already in target).

Stacked on Phases 0 (#462) and 1 (#463), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)