### PR TITLE
perf(ios): reuse interpolation contexts for hero values while scrubbing

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		AD050C512EC135360082A313 /* RevenueCatUI in Frameworks */ = {isa = PBXBuildFile; productRef = AD050C502EC135360082A313 /* RevenueCatUI */; };
 		AD0B7BF52EC552FA008B29E7 /* LogYourBody.storekit in Resources */ = {isa = PBXBuildFile; fileRef = AD0B7BF42EC552FA008B29E7 /* LogYourBody.storekit */; };
 		AD0B7BF72EC692ED008B29E7 /* MetricChartDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0B7BF62EC692ED008B29E7 /* MetricChartDataHelper.swift */; };
+		AD9E00212F20002000ABCDEF /* HeroMetricInterpolationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9E00202F20002000ABCDEF /* HeroMetricInterpolationCache.swift */; };
 		AD0B7BFB2EC6930D008B29E7 /* PeriodSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0B7BFA2EC6930D008B29E7 /* PeriodSelector.swift */; };
 		AD1036332F00000100ABCDEF /* BodyMetricAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1036322F00000100ABCDEF /* BodyMetricAppIntents.swift */; };
 		AD1036352F00000100ABCDEF /* BodyMetricLoggingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1036342F00000100ABCDEF /* BodyMetricLoggingService.swift */; };
@@ -379,6 +380,7 @@
 		FE09A9A900000000000000B9 /* ProgressPhotoImagePipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE09A9A900000000000000F9 /* ProgressPhotoImagePipelineTests.swift */; };
 		FE10B0B000000000000000BA /* DashboardTimelineProviderPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE10B0B000000000000000FA /* DashboardTimelineProviderPerformanceTests.swift */; };
 		FE11C1C100000000000000BB /* ImageCacheServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE11C1C100000000000000FB /* ImageCacheServiceTests.swift */; };
+		AD9E00312F20003000ABCDEF /* HeroMetricInterpolationCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9E00302F20003000ABCDEF /* HeroMetricInterpolationCacheTests.swift */; };
 		FE12D2D100000000000000BC /* GoldenPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE12D2D100000000000000FC /* GoldenPathTests.swift */; };
 		FFC041175CAD1871B45B8FE6 /* RevenueCatPurchaseRestoreFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F9119B26AB2A527AA6E344 /* RevenueCatPurchaseRestoreFlowTests.swift */; };
 /* End PBXBuildFile section */
@@ -521,6 +523,7 @@
 		AD050C4A2EC12E590082A313 /* PaywallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallView.swift; sourceTree = "<group>"; };
 		AD0B7BF42EC552FA008B29E7 /* LogYourBody.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = LogYourBody.storekit; sourceTree = "<group>"; };
 		AD0B7BF62EC692ED008B29E7 /* MetricChartDataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricChartDataHelper.swift; sourceTree = "<group>"; };
+		AD9E00202F20002000ABCDEF /* HeroMetricInterpolationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroMetricInterpolationCache.swift; sourceTree = "<group>"; };
 		AD0B7BFA2EC6930D008B29E7 /* PeriodSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PeriodSelector.swift; path = Components/PeriodSelector.swift; sourceTree = "<group>"; };
 		AD1036322F00000100ABCDEF /* BodyMetricAppIntents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyMetricAppIntents.swift; sourceTree = "<group>"; };
 		AD1036342F00000100ABCDEF /* BodyMetricLoggingService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodyMetricLoggingService.swift; sourceTree = "<group>"; };
@@ -883,6 +886,7 @@
 		FE09A9A900000000000000F9 /* ProgressPhotoImagePipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressPhotoImagePipelineTests.swift; sourceTree = "<group>"; };
 		FE10B0B000000000000000FA /* DashboardTimelineProviderPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTimelineProviderPerformanceTests.swift; sourceTree = "<group>"; };
 		FE11C1C100000000000000FB /* ImageCacheServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheServiceTests.swift; sourceTree = "<group>"; };
+		AD9E00302F20003000ABCDEF /* HeroMetricInterpolationCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroMetricInterpolationCacheTests.swift; sourceTree = "<group>"; };
 		FE12D2D100000000000000FC /* GoldenPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoldenPathTests.swift; sourceTree = "<group>"; };
 		FECEBC7B2B956D26BF45822F /* DSLogo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSLogo.swift; path = DesignSystem/Atoms/DSLogo.swift; sourceTree = "<group>"; };
 		FF0B649CA62200DAACE12AA8 /* AddEntrySheet+Part03.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AddEntrySheet+Part03.swift"; path = "AddEntrySheet+Part03.swift"; sourceTree = "<group>"; };
@@ -1450,6 +1454,7 @@
 				FE09A9A900000000000000F9 /* ProgressPhotoImagePipelineTests.swift */,
 				FE10B0B000000000000000FA /* DashboardTimelineProviderPerformanceTests.swift */,
 				FE11C1C100000000000000FB /* ImageCacheServiceTests.swift */,
+				AD9E00302F20003000ABCDEF /* HeroMetricInterpolationCacheTests.swift */,
 				FE12D2D100000000000000FC /* GoldenPathTests.swift */,
 			);
 			path = LogYourBodyTests;
@@ -1693,6 +1698,7 @@
 				ADA4B73D2ECFAB0B00F4262A /* TimelineCalculator.swift */,
 				AD4B1C7D2FFC0A4E00A3B9E1 /* LRUCache.swift */,
 				AD0B7BF62EC692ED008B29E7 /* MetricChartDataHelper.swift */,
+				AD9E00202F20002000ABCDEF /* HeroMetricInterpolationCache.swift */,
 				ADE1464A2EBF0BDF00B64DA0 /* TimelinePhotoSampler.swift */,
 				ADE1464B2EBF0BDF00B64DA0 /* TimelineZoomLevel.swift */,
 			);
@@ -1900,6 +1906,7 @@
 				FE09A9A900000000000000B9 /* ProgressPhotoImagePipelineTests.swift in Sources */,
 				FE10B0B000000000000000BA /* DashboardTimelineProviderPerformanceTests.swift in Sources */,
 				FE11C1C100000000000000BB /* ImageCacheServiceTests.swift in Sources */,
+				AD9E00312F20003000ABCDEF /* HeroMetricInterpolationCacheTests.swift in Sources */,
 				FE12D2D100000000000000BC /* GoldenPathTests.swift in Sources */,
 				A7876ACC0BAFED8A57643661 /* AccountDeletionAndShareCardTests.swift in Sources */,
 				5A5834631DA85239D455F320 /* AccountDeletionCleanupServiceTests.swift in Sources */,
@@ -2215,6 +2222,7 @@
 				AD050C412EBFD8160082A313 /* HapticManager.swift in Sources */,
 				AD4B1C7E2FFC0A4E00A3B9E1 /* LRUCache.swift in Sources */,
 				AD0B7BF72EC692ED008B29E7 /* MetricChartDataHelper.swift in Sources */,
+				AD9E00212F20002000ABCDEF /* HeroMetricInterpolationCache.swift in Sources */,
 				AD8F12F52ED7C987003C4559 /* BugReportManager.swift in Sources */,
 				AD8872D02EB946BE0041C426 /* MarkdownView.swift in Sources */,
 				AD8872D12EB946BE0041C426 /* StandardCard.swift in Sources */,

--- a/apps/ios/LogYourBody/Helpers/HeroMetricInterpolationCache.swift
+++ b/apps/ios/LogYourBody/Helpers/HeroMetricInterpolationCache.swift
@@ -1,0 +1,100 @@
+//
+// HeroMetricInterpolationCache.swift
+// LogYourBody
+//
+// Caches the reusable MetricsInterpolationService contexts used to compute the
+// dashboard hero's weight / body-fat / FFMI values while scrubbing the timeline.
+//
+// Previously `updateAnimatedValues(for:)` called
+// `MetricsInterpolationService.estimate{Weight,BodyFat,FFMI}` on every scrub index
+// change. Each call rebuilt an interpolation context (filter + sort), and FFMI
+// additionally walked an EMA "trend weight" day-by-day — so scrubbing recomputed
+// all of that per frame.
+//
+// The contexts depend only on the metrics array (plus height for FFMI), so we build
+// them once per data change — keyed by a content fingerprint — and reuse them across
+// scrubs. Reusing the same context instances also preserves their internal per-day
+// caches (notably the FFMI trend-weight cache), so revisiting an index is cheap.
+//
+// The values produced are identical to the previous per-call path — see
+// HeroMetricInterpolationCacheTests, which asserts value-exactness against
+// MetricsInterpolationService.estimate{Weight,BodyFat,FFMI} across many indices.
+//
+
+import Foundation
+
+final class HeroMetricInterpolationCache {
+    /// Raw interpolated values (kg / %, before any unit conversion). A `nil` field
+    /// means "no value available"; callers should leave the displayed value
+    /// unchanged, matching the prior behavior.
+    struct Values: Equatable {
+        var weight: Double?
+        var bodyFat: Double?
+        var ffmi: Double?
+    }
+
+    private let service: MetricsInterpolationService
+    private var fingerprint: Int?
+    private var weightContext: MetricsInterpolationService.WeightInterpolationContext?
+    private var bodyFatContext: MetricsInterpolationService.BodyFatInterpolationContext?
+    private var ffmiContext: MetricsInterpolationService.FFMIInterpolationContext?
+
+    init(service: MetricsInterpolationService = .shared) {
+        self.service = service
+    }
+
+    /// Interpolated values for `metric`, rebuilding the cached contexts only when
+    /// the underlying metrics/height change.
+    func values(for metric: BodyMetrics, in metrics: [BodyMetrics], heightInches: Double?) -> Values {
+        refreshContextsIfNeeded(metrics: metrics, heightInches: heightInches)
+
+        var result = Values()
+
+        // Weight & body fat prefer the metric's own recorded value (matching the
+        // previous logic), otherwise fall back to interpolation.
+        if let weight = metric.weight {
+            result.weight = weight
+        } else {
+            result.weight = weightContext?.estimate(for: metric.date)?.value
+        }
+
+        if let bodyFat = metric.bodyFatPercentage {
+            result.bodyFat = bodyFat
+        } else {
+            result.bodyFat = bodyFatContext?.estimate(for: metric.date)?.value
+        }
+
+        // FFMI is always interpolated (uses EMA trend weight), never the raw metric.
+        result.ffmi = ffmiContext?.estimate(for: metric.date)?.value
+
+        return result
+    }
+
+    private func refreshContextsIfNeeded(metrics: [BodyMetrics], heightInches: Double?) {
+        let newFingerprint = Self.fingerprint(metrics: metrics, heightInches: heightInches)
+        guard newFingerprint != fingerprint else { return }
+
+        fingerprint = newFingerprint
+        weightContext = service.makeWeightInterpolationContext(for: metrics)
+        bodyFatContext = service.makeBodyFatInterpolationContext(for: metrics)
+        if let heightInches, heightInches > 0 {
+            ffmiContext = service.makeFFMIInterpolationContext(for: metrics, heightInches: heightInches)
+        } else {
+            ffmiContext = nil
+        }
+    }
+
+    /// Content fingerprint over exactly the inputs that determine the contexts:
+    /// each metric's date, weight and body-fat, plus the height used for FFMI.
+    static func fingerprint(metrics: [BodyMetrics], heightInches: Double?) -> Int {
+        var hasher = Hasher()
+        hasher.combine(metrics.count)
+        for metric in metrics {
+            hasher.combine(metric.date)
+            hasher.combine(metric.weight)
+            hasher.combine(metric.bodyFatPercentage)
+        }
+        hasher.combine(heightInches)
+        return hasher.finalize()
+    }
+}

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
@@ -4,7 +4,12 @@ import Foundation
 extension DashboardViewLiquid {
     // MARK: - Animation Helpers
 
-    /// Update animated metric values with 180ms ease-out animation
+    /// Update animated metric values with 180ms ease-out animation.
+    ///
+    /// The interpolation contexts are cached and reused across scrubs (rebuilt only
+    /// when the metrics/height change), so a scrub reads precomputed contexts instead
+    /// of re-sorting and re-walking the EMA trend on every index change. The resulting
+    /// values are identical to the previous per-call estimate path.
     func updateAnimatedValues(for index: Int) {
         let metrics = viewModel.bodyMetrics
         guard index >= 0 && index < metrics.count else { return }
@@ -13,61 +18,28 @@ extension DashboardViewLiquid {
         let interval = PerfSignpost.begin("scrub_update_animated_values")
         defer { PerfSignpost.end(interval) }
 
+        let heightInches = convertHeightToInches(
+            height: authManager.currentUser?.profile?.height,
+            heightUnit: authManager.currentUser?.profile?.heightUnit
+        )
+        let values = heroInterpolationCache.values(
+            for: metric,
+            in: metrics,
+            heightInches: heightInches
+        )
+
         withAnimation(.easeOut(duration: 0.18)) {
-            // Weight
-            let weightResult: InterpolatedMetric?
-            if let weight = metric.weight {
-                weightResult = InterpolatedMetric(
-                    value: weight,
-                    isInterpolated: false,
-                    isLastKnown: false,
-                    confidenceLevel: nil
-                )
-            } else {
-                weightResult = MetricsInterpolationService.shared.estimateWeight(
-                    for: metric.date,
-                    metrics: viewModel.bodyMetrics
-                )
-            }
-
-            if let weightResult {
+            if let weight = values.weight {
                 let system = currentMeasurementSystem
-                animatedWeight = convertWeight(weightResult.value, to: system) ?? weightResult.value
+                animatedWeight = convertWeight(weight, to: system) ?? weight
             }
 
-            // Body Fat
-            let bodyFatResult: InterpolatedMetric?
-            if let bodyFatPercentage = metric.bodyFatPercentage {
-                bodyFatResult = InterpolatedMetric(
-                    value: bodyFatPercentage,
-                    isInterpolated: false,
-                    isLastKnown: false,
-                    confidenceLevel: nil
-                )
-            } else {
-                bodyFatResult = MetricsInterpolationService.shared.estimateBodyFat(
-                    for: metric.date,
-                    metrics: viewModel.bodyMetrics
-                )
+            if let bodyFat = values.bodyFat {
+                animatedBodyFat = bodyFat
             }
 
-            if let bodyFatResult {
-                animatedBodyFat = bodyFatResult.value
-            }
-
-            // FFMI
-            let heightInches = convertHeightToInches(
-                height: authManager.currentUser?.profile?.height,
-                heightUnit: authManager.currentUser?.profile?.heightUnit
-            )
-
-            if let heightInches,
-               let ffmiResult = MetricsInterpolationService.shared.estimateFFMI(
-                   for: metric.date,
-                   metrics: viewModel.bodyMetrics,
-                   heightInches: heightInches
-               ) {
-                animatedFFMI = ffmiResult.value
+            if let ffmi = values.ffmi {
+                animatedFFMI = ffmi
             }
         }
     }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -50,6 +50,12 @@ struct DashboardViewLiquid: View {
     @State var glp1Medications: [Glp1Medication] = []
     @State var dailyMetricsLookupCache: [Date: DailyMetrics] = [:]
 
+    // Reused interpolation contexts for the hero weight/body-fat/FFMI values so
+    // scrubbing doesn't rebuild them per index change. Reference type: mutating its
+    // internals does not invalidate the view. (Accessed from the +MetricsHelpers
+    // extension, so not file-private.)
+    @State var heroInterpolationCache = HeroMetricInterpolationCache()
+
     // Animated metric values for tweening
     @State var animatedWeight: Double = 0
     @State var animatedBodyFat: Double = 0

--- a/apps/ios/LogYourBodyTests/HeroMetricInterpolationCacheTests.swift
+++ b/apps/ios/LogYourBodyTests/HeroMetricInterpolationCacheTests.swift
@@ -1,0 +1,150 @@
+//
+// HeroMetricInterpolationCacheTests.swift
+// LogYourBodyTests
+//
+// Value-exactness guard for the scrub optimization: HeroMetricInterpolationCache
+// must produce EXACTLY the same weight / body-fat / FFMI values as the previous
+// per-call MetricsInterpolationService.estimate{Weight,BodyFat,FFMI} path it replaces.
+// Also verifies the cache rebuilds when the underlying metrics change.
+//
+import XCTest
+@testable import LogYourBody
+
+final class HeroMetricInterpolationCacheTests: XCTestCase {
+    private let service = MetricsInterpolationService.shared
+    private let heightInches: Double = 70
+
+    // MARK: - Reference (pre-optimization) computation
+
+    private func referenceWeight(for metric: BodyMetrics, in metrics: [BodyMetrics]) -> Double? {
+        if let weight = metric.weight { return weight }
+        return service.estimateWeight(for: metric.date, metrics: metrics)?.value
+    }
+
+    private func referenceBodyFat(for metric: BodyMetrics, in metrics: [BodyMetrics]) -> Double? {
+        if let bodyFat = metric.bodyFatPercentage { return bodyFat }
+        return service.estimateBodyFat(for: metric.date, metrics: metrics)?.value
+    }
+
+    private func referenceFFMI(for metric: BodyMetrics, in metrics: [BodyMetrics], heightInches: Double?) -> Double? {
+        service.estimateFFMI(for: metric.date, metrics: metrics, heightInches: heightInches)?.value
+    }
+
+    private func assertMatchesReference(
+        _ metrics: [BodyMetrics],
+        heightInches: Double?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let cache = HeroMetricInterpolationCache(service: service)
+        for (index, metric) in metrics.enumerated() {
+            let values = cache.values(for: metric, in: metrics, heightInches: heightInches)
+            XCTAssertEqual(values.weight, referenceWeight(for: metric, in: metrics),
+                           "weight mismatch at index \(index)", file: file, line: line)
+            XCTAssertEqual(values.bodyFat, referenceBodyFat(for: metric, in: metrics),
+                           "bodyFat mismatch at index \(index)", file: file, line: line)
+            XCTAssertEqual(values.ffmi, referenceFFMI(for: metric, in: metrics, heightInches: heightInches),
+                           "ffmi mismatch at index \(index)", file: file, line: line)
+        }
+    }
+
+    // MARK: - Tests
+
+    func testMatchesReferenceForMixedMetrics() {
+        assertMatchesReference(Self.mixedMetrics(), heightInches: heightInches)
+    }
+
+    func testMatchesReferenceWithoutHeight_ffmiAlwaysNil() {
+        let metrics = Self.mixedMetrics()
+        let cache = HeroMetricInterpolationCache(service: service)
+        for metric in metrics {
+            let values = cache.values(for: metric, in: metrics, heightInches: nil)
+            XCTAssertNil(values.ffmi)
+            XCTAssertEqual(values.weight, referenceWeight(for: metric, in: metrics))
+            XCTAssertEqual(values.bodyFat, referenceBodyFat(for: metric, in: metrics))
+        }
+    }
+
+    func testMatchesReferenceForSingleMetric() {
+        assertMatchesReference([Self.metric(daysAgo: 0, weight: 80, bodyFat: 18)], heightInches: heightInches)
+    }
+
+    func testMatchesReferenceWhenValuesSparse() {
+        // Only the endpoints carry weight/bf; the middle entries must interpolate.
+        let metrics = [
+            Self.metric(daysAgo: 40, weight: 84, bodyFat: 22),
+            Self.metric(daysAgo: 30, weight: nil, bodyFat: nil),
+            Self.metric(daysAgo: 20, weight: nil, bodyFat: nil),
+            Self.metric(daysAgo: 10, weight: nil, bodyFat: nil),
+            Self.metric(daysAgo: 0, weight: 79, bodyFat: 17)
+        ]
+        assertMatchesReference(metrics, heightInches: heightInches)
+    }
+
+    func testRepeatedCallsAreStable() {
+        let metrics = Self.mixedMetrics()
+        let cache = HeroMetricInterpolationCache(service: service)
+        let first = metrics.map { cache.values(for: $0, in: metrics, heightInches: heightInches) }
+        let second = metrics.map { cache.values(for: $0, in: metrics, heightInches: heightInches) }
+        XCTAssertEqual(first, second)
+    }
+
+    func testCacheInvalidatesWhenMetricsChange() {
+        let cache = HeroMetricInterpolationCache(service: service)
+
+        let metricsA = Self.mixedMetrics()
+        // Warm the cache on data set A.
+        _ = cache.values(for: metricsA[1], in: metricsA, heightInches: heightInches)
+
+        // Different data set (shifted values) — the cache must rebuild, not return A.
+        let metricsB = [
+            Self.metric(daysAgo: 30, weight: 90, bodyFat: 25),
+            Self.metric(daysAgo: 20, weight: nil, bodyFat: nil),
+            Self.metric(daysAgo: 10, weight: 88, bodyFat: 23),
+            Self.metric(daysAgo: 0, weight: 86, bodyFat: 21)
+        ]
+        for metric in metricsB {
+            let values = cache.values(for: metric, in: metricsB, heightInches: heightInches)
+            XCTAssertEqual(values.weight, referenceWeight(for: metric, in: metricsB))
+            XCTAssertEqual(values.bodyFat, referenceBodyFat(for: metric, in: metricsB))
+            XCTAssertEqual(values.ffmi, referenceFFMI(for: metric, in: metricsB, heightInches: heightInches))
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private static let baseDate = Date(timeIntervalSinceReferenceDate: 700_000_000)
+
+    private static func metric(daysAgo: Int, weight: Double?, bodyFat: Double?) -> BodyMetrics {
+        let date = baseDate.addingTimeInterval(TimeInterval(-daysAgo) * 86_400)
+        return BodyMetrics(
+            id: "metric-\(daysAgo)",
+            userId: "user",
+            date: date,
+            weight: weight,
+            weightUnit: "kg",
+            bodyFatPercentage: bodyFat,
+            bodyFatMethod: bodyFat == nil ? nil : "manual",
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: "manual",
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+
+    /// Oldest → newest, mixing recorded and missing weight/body-fat so weight, body
+    /// fat and FFMI each exercise actual, interpolated and last-known paths.
+    private static func mixedMetrics() -> [BodyMetrics] {
+        [
+            metric(daysAgo: 40, weight: 84, bodyFat: 22),
+            metric(daysAgo: 30, weight: nil, bodyFat: 20),
+            metric(daysAgo: 20, weight: 81, bodyFat: nil),
+            metric(daysAgo: 10, weight: nil, bodyFat: nil),
+            metric(daysAgo: 5, weight: 79, bodyFat: 18),
+            metric(daysAgo: 0, weight: 78, bodyFat: nil)
+        ]
+    }
+}


### PR DESCRIPTION
## Context

Continues the **"rock solid & blazing fast, 0 jank"** campaign — priority: **scrub smoothness on the default photo-timeline surface**. No feature/behavior change.

`updateAnimatedValues(for:)` runs on *every* timeline scrub (each `selectedIndex` change). It recomputed the hero's weight / body-fat / FFMI by calling `MetricsInterpolationService.estimate{Weight,BodyFat,FFMI}` — and each of those:
- filters + **sorts** the metrics array to build an interpolation context, and
- for FFMI, walks an **EMA "trend weight" day-by-day** from the first entry to the target date.

So a fast scrub re-sorted and re-walked all of that on the main thread, per frame.

## Change

New `HeroMetricInterpolationCache` builds the three reusable interpolation contexts **once**, keyed by a content fingerprint of the metrics (+ height), and reuses them across scrubs. Reusing the *same context instances* also preserves their internal per-day caches (notably the FFMI trend-weight cache), so revisiting an index is cheap. Contexts rebuild only when the metrics or height actually change.

`updateAnimatedValues` now reads from the cache; the `withAnimation` assignments are unchanged, so the 180ms ease animation behaves exactly as before.

## Why it's value-exact
The per-call `estimateWeight/estimateBodyFat` are literally `make…InterpolationContext(…)?.estimate(for:)`, and `estimateFFMI` → `estimateLeanMass` uses `weightContext.trendWeight` + body-fat context — the same path `FFMIInterpolationContext.estimate` takes. Caching the context therefore changes *nothing but the amount of recomputation*.

## Tests (new, all passing)
`HeroMetricInterpolationCacheTests` asserts the cache's output is **exactly equal** to `MetricsInterpolationService.estimate{Weight,BodyFat,FFMI}` for every index across:
- mixed metrics (actual / interpolated / last-known),
- sparse metrics (endpoints only → middle interpolated),
- single metric, and no-height (FFMI must be nil),
- repeated calls (stable), and
- **cache invalidation** when the metrics change.

> Note: the test initially failed — it caught an access-level bug (`private` cache unreachable from the `+MetricsHelpers` extension) before any value drift. Fixed and re-verified.

## Verification
- ✅ `xcodebuild test` (iPhone 17 Pro, iOS 26.1) — **TEST SUCCEEDED**; all 6 `HeroMetricInterpolationCacheTests` pass.
- ✅ SwiftLint clean; `project.pbxproj` surgically registers the 2 new files (`plutil` + `xcodeproj` validated).

Best measured with the Phase 0 `scrub_update_animated_values` signpost on device — the win is largest on scrub-back over the same data (contexts + EMA cache reused).

Stacked on the merged Phases 0 (#462) / 1 (#463) and the open preload PR (#464).

🤖 Generated with [Claude Code](https://claude.com/claude-code)