### PR TITLE
fix: enable waitlist funnel analytics

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
+import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Providers } from './providers';
 import { PWAInstallPrompt } from '@/components/PWAInstallPrompt';
@@ -140,6 +141,7 @@ export default function RootLayout({
           <PWAInstallPrompt />
           <ServiceWorkerUpdater />
         </Providers>
+        <Analytics />
         <SpeedInsights />
       </body>
     </html>

--- a/apps/web/src/lib/__tests__/vercelAnalyticsAdapter.test.ts
+++ b/apps/web/src/lib/__tests__/vercelAnalyticsAdapter.test.ts
@@ -1,0 +1,33 @@
+import { track } from '@vercel/analytics';
+import { createVercelAnalytics } from '../vercelAnalyticsAdapter';
+
+jest.mock('@vercel/analytics', () => ({
+  track: jest.fn(),
+}));
+
+describe('createVercelAnalytics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends custom funnel events without undefined metadata', () => {
+    createVercelAnalytics().track('web_waitlist_submitted', {
+      landing_id: 'minimal_waitlist_v1',
+      variant: 'waitlist_minimal',
+      omitted: undefined,
+    });
+
+    expect(track).toHaveBeenCalledWith('web_waitlist_submitted', {
+      landing_id: 'minimal_waitlist_v1',
+      variant: 'waitlist_minimal',
+    });
+  });
+
+  it('does not interrupt conversion when analytics throws', () => {
+    (track as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('analytics unavailable');
+    });
+
+    expect(() => createVercelAnalytics().track('web_waitlist_submitted')).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { createStatsigAnalytics, type StatsigAnalyticsConfig } from './statsigAnalyticsAdapter';
+import { createVercelAnalytics } from './vercelAnalyticsAdapter';
 
 export type AnalyticsEvent =
   | 'app_open'
@@ -35,6 +36,15 @@ const config: StatsigAnalyticsConfig = {
   environmentTier: process.env.NEXT_PUBLIC_STATSIG_ENV_TIER ?? 'development',
 };
 
-const implementation = createStatsigAnalytics(config);
+const statsig = createStatsigAnalytics(config);
+const vercel = createVercelAnalytics();
 
-export const analytics: AnalyticsPort = implementation;
+export const analytics: AnalyticsPort = {
+  identify: statsig.identify,
+  track(event, properties) {
+    statsig.track(event, properties);
+    vercel.track(event, properties);
+  },
+  reset: statsig.reset,
+  isFeatureEnabled: statsig.isFeatureEnabled,
+};

--- a/apps/web/src/lib/vercelAnalyticsAdapter.ts
+++ b/apps/web/src/lib/vercelAnalyticsAdapter.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { track as trackVercelEvent } from '@vercel/analytics';
+
+type AnalyticsProperties = Record<string, string | number | boolean | null | undefined>;
+
+export interface VercelAnalyticsPort {
+  track(event: string, properties?: AnalyticsProperties): void;
+}
+
+export function createVercelAnalytics(): VercelAnalyticsPort {
+  return {
+    track(event, properties) {
+      const safeProperties = Object.fromEntries(
+        Object.entries(properties ?? {}).filter(([, value]) => value !== undefined),
+      ) as Record<string, string | number | boolean | null>;
+
+      try {
+        trackVercelEvent(event, safeProperties);
+      } catch {
+        // Analytics must never interrupt the conversion path.
+      }
+    },
+  };
+}


### PR DESCRIPTION
## What changed

- enable Vercel Web Analytics page views in the root layout
- send the existing PII-free waitlist funnel taxonomy to Vercel custom events
- retain Statsig as an optional parallel adapter when a client key is configured
- fail open so analytics cannot interrupt email capture

## Why

The landing emitted conversion events, but production had no Statsig client key, making the adapter a no-op. Vercel Analytics is already installed and hosted with the deployed surface, so this closes the measurement loop without another credential.

## Validation

- `pnpm --filter logyourbody lint`
- `pnpm --filter logyourbody typecheck`
- focused adapter and waitlist tests
- `pnpm check:vendor-boundaries`
- production build: 143 kB first-load JS (budget: <=150 kB)