### PR TITLE
feat: elevate waitlist landing art direction

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -22,6 +22,9 @@ NEXT_PUBLIC_VERSION=local-dev
 # Set to 1 locally or in preview to render the full System B marketing landing.
 NEXT_PUBLIC_LYB_FULL_LANDING=
 
+# Rollback gate for the art-directed minimal waitlist landing. Defaults off.
+NEXT_PUBLIC_LYB_LANDING_ART_DIRECTION_V2=
+
 # Pre-launch editorial waitlist v2. Defaults off; enable for preview/internal cohorts.
 NEXT_PUBLIC_LYB_WAITLIST_V2=
 

--- a/apps/web/src/app/LegacyMinimalWaitlistLanding.tsx
+++ b/apps/web/src/app/LegacyMinimalWaitlistLanding.tsx
@@ -1,0 +1,83 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { MarketingFooter } from '@/components/MarketingFooter';
+import { APP_CONFIG } from '@/constants/app';
+import { LANDING_BRAND_ASSET, LANDING_PRODUCT_PROOF } from '@/lib/marketing/landing-registry';
+import { WaitlistForm } from './WaitlistForm';
+import { waitlistLandingCopy } from './waitlist-copy';
+
+/** Stable waitlist surface retained as the rollback path for the art-direction gate. */
+export function LegacyMinimalWaitlistLanding() {
+  return (
+    <div className="min-h-screen overflow-x-hidden bg-[#06070a] text-[#f7f8f8]">
+      <a
+        href="#main-content"
+        className="sr-only z-50 rounded bg-white px-4 py-2 text-black focus:not-sr-only focus:fixed focus:left-4 focus:top-4"
+      >
+        Skip to content
+      </a>
+
+      <header className="mx-auto flex h-20 w-full max-w-7xl items-center px-5 sm:px-8">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-3 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/25"
+        >
+          <Image
+            src={LANDING_BRAND_ASSET.src}
+            alt=""
+            width={LANDING_BRAND_ASSET.width}
+            height={LANDING_BRAND_ASSET.height}
+            className="h-9 w-9 rounded-[11px]"
+            priority
+          />
+          <span className="text-base font-medium tracking-[-0.025em]">{APP_CONFIG.appName}</span>
+        </Link>
+      </header>
+
+      <main id="main-content" tabIndex={-1}>
+        <section
+          className="relative isolate border-b border-white/[0.07]"
+          aria-labelledby="legacy-landing-heading"
+        >
+          <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_72%_45%,rgba(48,91,167,0.14),transparent_36%)]" />
+          <div className="mx-auto grid min-h-[calc(100svh-5rem)] w-full max-w-7xl items-center gap-12 px-5 pb-16 pt-8 sm:px-8 lg:grid-cols-[minmax(0,1.06fr)_minmax(340px,0.62fr)] lg:gap-20 lg:pb-20 lg:pt-12">
+            <div className="max-w-3xl">
+              <p className="mb-5 text-sm font-medium tracking-[-0.01em] text-sky-300">
+                Private iPhone beta
+              </p>
+              <h1
+                id="legacy-landing-heading"
+                className="max-w-[11ch] text-balance text-[clamp(3.15rem,8vw,6.4rem)] font-semibold leading-[0.94] tracking-[-0.06em]"
+              >
+                {waitlistLandingCopy.headline}
+              </h1>
+              <p className="mt-7 max-w-2xl text-pretty text-lg leading-8 tracking-[-0.015em] text-white/60 sm:text-xl sm:leading-9">
+                {waitlistLandingCopy.subheading}
+              </p>
+              <WaitlistForm />
+            </div>
+
+            <div
+              className="relative mx-auto h-[430px] w-full max-w-[390px] overflow-hidden rounded-[2.2rem] border border-white/10 bg-black shadow-[0_28px_90px_rgba(0,0,0,0.55)] lg:h-[590px]"
+              aria-label="LogYourBody product preview"
+              data-testid="landing-product-proof"
+            >
+              <Image
+                src={LANDING_PRODUCT_PROOF.src}
+                alt={LANDING_PRODUCT_PROOF.alt}
+                width={LANDING_PRODUCT_PROOF.width}
+                height={LANDING_PRODUCT_PROOF.height}
+                sizes="(min-width: 1024px) 390px, calc(100vw - 40px)"
+                className="h-auto w-full"
+                priority
+              />
+              <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black to-transparent" />
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <MarketingFooter />
+    </div>
+  );
+}

--- a/apps/web/src/app/MinimalWaitlistLanding.module.css
+++ b/apps/web/src/app/MinimalWaitlistLanding.module.css
@@ -1,0 +1,140 @@
+.heroImage {
+  animation: hero-image-in 1.15s cubic-bezier(0.22, 1, 0.36, 1) both;
+  transform-origin: 65% 45%;
+}
+
+.heroEyebrow,
+.heroTitle,
+.heroBody,
+.heroForm {
+  animation: hero-copy-in 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.heroTitle {
+  animation-delay: 80ms;
+}
+
+.heroBody {
+  animation-delay: 160ms;
+}
+
+.heroForm {
+  animation-delay: 240ms;
+}
+
+.ambientOrb {
+  position: absolute;
+  top: 8%;
+  right: -12%;
+  width: min(62vw, 840px);
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(35, 112, 214, 0.12), transparent 67%);
+  filter: blur(18px);
+  pointer-events: none;
+}
+
+.reveal,
+.productReveal {
+  animation: section-reveal linear both;
+  animation-timeline: view();
+  animation-range: entry 8% cover 36%;
+}
+
+.productReveal {
+  animation-name: product-reveal;
+  animation-range: entry 3% cover 32%;
+}
+
+.finalGlow {
+  position: absolute;
+  inset: auto 50% -35% auto;
+  z-index: -20;
+  width: min(90vw, 1050px);
+  aspect-ratio: 1.25;
+  transform: translateX(50%);
+  border-radius: 999px;
+  background: radial-gradient(
+    ellipse,
+    rgba(22, 120, 255, 0.22),
+    rgba(22, 120, 255, 0.04) 46%,
+    transparent 70%
+  );
+  filter: blur(18px);
+}
+
+.finalArcs {
+  opacity: 0.72;
+  mask-image: linear-gradient(to bottom, transparent, black 42%);
+  animation: arcs-in linear both;
+  animation-timeline: view();
+  animation-range: entry 15% cover 58%;
+}
+
+@keyframes hero-image-in {
+  from {
+    opacity: 0;
+    transform: scale(1.045);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes hero-copy-in {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes section-reveal {
+  from {
+    opacity: 0.25;
+    transform: translateY(52px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes product-reveal {
+  from {
+    opacity: 0.3;
+    transform: translateY(70px) scale(0.965);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes arcs-in {
+  from {
+    opacity: 0.08;
+    transform: translateY(70px) scaleX(0.92);
+  }
+  to {
+    opacity: 0.72;
+    transform: translateY(0) scaleX(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .heroImage,
+  .heroEyebrow,
+  .heroTitle,
+  .heroBody,
+  .heroForm,
+  .reveal,
+  .productReveal,
+  .finalArcs {
+    animation: none;
+  }
+}

--- a/apps/web/src/app/MinimalWaitlistLanding.tsx
+++ b/apps/web/src/app/MinimalWaitlistLanding.tsx
@@ -2,76 +2,228 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { MarketingFooter } from '@/components/MarketingFooter';
 import { APP_CONFIG } from '@/constants/app';
-import { LANDING_BRAND_ASSET, LANDING_PRODUCT_PROOF } from '@/lib/marketing/landing-registry';
+import {
+  LANDING_BRAND_ASSET,
+  LANDING_MEDIA,
+  LANDING_PRODUCT_PROOF,
+} from '@/lib/marketing/landing-registry';
+import styles from './MinimalWaitlistLanding.module.css';
 import { WaitlistForm } from './WaitlistForm';
 import { waitlistLandingCopy } from './waitlist-copy';
 
+const signals = [
+  { index: '01', label: 'Weight', detail: 'The daily measure' },
+  { index: '02', label: 'Body fat', detail: 'The composition estimate' },
+  { index: '03', label: 'Lean mass', detail: 'The derived estimate' },
+  { index: '04', label: 'Photos', detail: 'The visual record' },
+] as const;
+
+function BrandMark() {
+  return (
+    <Link
+      href="/"
+      aria-label={`${APP_CONFIG.appName} home`}
+      className="inline-flex items-center gap-3 rounded-full text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+    >
+      <Image
+        src={LANDING_BRAND_ASSET.src}
+        alt=""
+        width={LANDING_BRAND_ASSET.width}
+        height={LANDING_BRAND_ASSET.height}
+        className="h-10 w-10 rounded-[12px] shadow-[0_10px_35px_rgba(0,0,0,0.35)] sm:h-11 sm:w-11"
+        priority
+      />
+      <span className="text-lg font-semibold tracking-[-0.035em] sm:text-xl">
+        {APP_CONFIG.appName}
+      </span>
+    </Link>
+  );
+}
+
 export function MinimalWaitlistLanding() {
   return (
-    <div className="min-h-screen overflow-x-hidden bg-[#06070a] text-[#f7f8f8]">
+    <div className="min-h-screen overflow-x-hidden bg-[#050608] text-[#f5f7f7]">
       <a
         href="#main-content"
-        className="sr-only z-50 rounded bg-white px-4 py-2 text-black focus:not-sr-only focus:fixed focus:left-4 focus:top-4"
+        className="sr-only z-50 rounded-full bg-white px-4 py-2 text-black focus:not-sr-only focus:fixed focus:left-4 focus:top-4"
       >
         Skip to content
       </a>
 
-      <header className="mx-auto flex h-20 w-full max-w-7xl items-center px-5 sm:px-8">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-3 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/25"
-        >
-          <Image
-            src={LANDING_BRAND_ASSET.src}
-            alt=""
-            width={LANDING_BRAND_ASSET.width}
-            height={LANDING_BRAND_ASSET.height}
-            className="h-9 w-9 rounded-[11px]"
-            priority
-          />
-          <span className="text-base font-medium tracking-[-0.025em]">{APP_CONFIG.appName}</span>
-        </Link>
+      <header className="pointer-events-none absolute inset-x-0 top-0 z-30">
+        <div className="mx-auto flex h-20 w-full max-w-[1480px] items-center justify-between px-5 sm:h-24 sm:px-8 lg:px-12">
+          <div className="pointer-events-auto">
+            <BrandMark />
+          </div>
+          <span className="hidden text-[11px] font-medium uppercase tracking-[0.18em] text-white/55 sm:block">
+            Private iPhone beta
+          </span>
+        </div>
       </header>
 
       <main id="main-content" tabIndex={-1}>
         <section
-          className="relative isolate border-b border-white/[0.07]"
+          className="relative isolate flex min-h-[100svh] items-end overflow-hidden border-b border-white/[0.08]"
           aria-labelledby="landing-heading"
         >
-          <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_72%_45%,rgba(48,91,167,0.14),transparent_36%)]" />
-          <div className="mx-auto grid min-h-[calc(100svh-5rem)] w-full max-w-7xl items-center gap-12 px-5 pb-16 pt-8 sm:px-8 lg:grid-cols-[minmax(0,1.06fr)_minmax(340px,0.62fr)] lg:gap-20 lg:pb-20 lg:pt-12">
-            <div className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 max-w-3xl motion-safe:duration-700">
-              <p className="mb-5 text-sm font-medium tracking-[-0.01em] text-sky-300">
-                Private iPhone beta
+          <div className={`${styles.heroImage} absolute inset-0 -z-20`} aria-hidden="true">
+            <Image
+              src={LANDING_MEDIA.men.src}
+              alt=""
+              fill
+              priority
+              sizes="100vw"
+              className="object-cover object-[64%_center] sm:object-[68%_center] lg:object-center"
+            />
+          </div>
+          <div className="absolute inset-0 -z-10 bg-[linear-gradient(90deg,rgba(3,4,6,0.98)_0%,rgba(3,4,6,0.9)_35%,rgba(3,4,6,0.34)_67%,rgba(3,4,6,0.14)_100%)] max-lg:bg-[linear-gradient(180deg,rgba(3,4,6,0.42)_0%,rgba(3,4,6,0.22)_26%,rgba(3,4,6,0.93)_72%,#030406_100%)]" />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 h-40 bg-gradient-to-t from-[#050608] to-transparent" />
+
+          <div className="mx-auto w-full max-w-[1480px] px-5 pb-6 pt-24 sm:px-8 sm:pb-16 sm:pt-32 lg:px-12 lg:pb-[8vh]">
+            <div className="max-w-[760px]">
+              <p
+                className={`${styles.heroEyebrow} text-xs font-medium uppercase tracking-[0.2em] text-white/65`}
+              >
+                Body composition, in context
               </p>
               <h1
                 id="landing-heading"
-                className="max-w-[11ch] text-balance text-[clamp(3.15rem,8vw,6.4rem)] font-semibold leading-[0.94] tracking-[-0.06em]"
+                className={`${styles.heroTitle} mt-4 max-w-[10.5ch] text-balance text-[clamp(3.25rem,9.5vw,8.5rem)] font-semibold leading-[0.88] tracking-[-0.07em] sm:mt-5`}
               >
                 {waitlistLandingCopy.headline}
               </h1>
-              <p className="mt-7 max-w-2xl text-pretty text-lg leading-8 tracking-[-0.015em] text-white/60 sm:text-xl sm:leading-9">
+              <p
+                className={`${styles.heroBody} text-white/66 mt-5 max-w-[620px] text-pretty text-base leading-7 tracking-[-0.02em] sm:mt-7 sm:text-xl sm:leading-9`}
+              >
                 {waitlistLandingCopy.subheading}
               </p>
-              <WaitlistForm />
+              <div id="early-access" className={styles.heroForm}>
+                <WaitlistForm />
+              </div>
+            </div>
+          </div>
+
+          <div
+            aria-hidden="true"
+            className="absolute bottom-8 right-8 hidden items-center gap-3 text-[10px] font-medium uppercase tracking-[0.18em] text-white/45 lg:flex"
+          >
+            <span className="h-px w-10 bg-white/25" />
+            Scroll to see the signal
+          </div>
+        </section>
+
+        <section className="relative overflow-hidden border-b border-white/[0.08] px-5 py-24 sm:px-8 sm:py-32 lg:px-12 lg:py-44">
+          <div aria-hidden="true" className={styles.ambientOrb} />
+          <div className="mx-auto w-full max-w-[1380px]">
+            <div className={`${styles.reveal} grid gap-10 lg:grid-cols-[0.85fr_1.15fr] lg:gap-24`}>
+              <p className="pt-2 text-xs font-medium uppercase tracking-[0.2em] text-sky-300">
+                The whole picture
+              </p>
+              <div>
+                <h2 className="max-w-[13ch] text-balance text-[clamp(3rem,7vw,7rem)] font-medium leading-[0.94] tracking-[-0.065em]">
+                  One number is a moment. The trend is the answer.
+                </h2>
+                <p className="mt-8 max-w-2xl text-pretty text-lg leading-8 text-white/55 sm:text-xl sm:leading-9">
+                  See the measures you already care about on one timeline, so today never has to
+                  explain everything.
+                </p>
+              </div>
             </div>
 
-            <div
-              className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-5 relative mx-auto h-[430px] w-full max-w-[390px] overflow-hidden rounded-[2.2rem] border border-white/10 bg-black shadow-[0_28px_90px_rgba(0,0,0,0.55)] motion-safe:duration-700 lg:h-[590px]"
-              aria-label="LogYourBody product preview"
-              data-testid="landing-product-proof"
-            >
-              <Image
-                src={LANDING_PRODUCT_PROOF.src}
-                alt={LANDING_PRODUCT_PROOF.alt}
-                width={LANDING_PRODUCT_PROOF.width}
-                height={LANDING_PRODUCT_PROOF.height}
-                sizes="(min-width: 1024px) 390px, calc(100vw - 40px)"
-                className="h-auto w-full"
-                priority
-              />
-              <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black to-transparent" />
+            <ol className={`${styles.reveal} mt-20 border-t border-white/[0.12] lg:mt-32`}>
+              {signals.map((signal) => (
+                <li
+                  key={signal.label}
+                  className="group grid gap-2 border-b border-white/[0.12] py-6 transition-colors hover:border-white/30 sm:grid-cols-[64px_1fr_auto] sm:items-baseline sm:gap-6 sm:py-7"
+                >
+                  <span className="text-xs tabular-nums text-white/30">{signal.index}</span>
+                  <span className="text-[clamp(1.75rem,4vw,3.6rem)] font-medium tracking-[-0.045em] text-white/90 transition-transform duration-300 group-hover:translate-x-2">
+                    {signal.label}
+                  </span>
+                  <span className="text-sm text-white/40 sm:text-base">{signal.detail}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        <section className="relative border-b border-white/[0.08] bg-[#08090c] px-5 py-24 sm:px-8 sm:py-32 lg:px-12 lg:py-44">
+          <div className="mx-auto grid w-full max-w-[1380px] gap-16 lg:grid-cols-[0.76fr_1.24fr] lg:items-start lg:gap-24">
+            <div className="lg:sticky lg:top-28">
+              <p className="text-xs font-medium uppercase tracking-[0.2em] text-sky-300">
+                Built for the check-in
+              </p>
+              <h2 className="mt-6 max-w-[10ch] text-balance text-[clamp(3rem,6vw,6.5rem)] font-medium leading-[0.92] tracking-[-0.065em]">
+                Your progress, in context.
+              </h2>
+              <p className="text-white/52 mt-7 max-w-md text-lg leading-8">
+                Log a measurement. Keep the record. Come back to the trend—not the noise around a
+                single day.
+              </p>
+              <div className="mt-12 flex items-center gap-4 text-sm text-white/50">
+                <span className="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_18px_rgba(52,211,153,0.7)]" />
+                Real iPhone product capture
+              </div>
             </div>
+
+            <div className={`${styles.productReveal} relative mx-auto w-full max-w-[720px]`}>
+              <div className="absolute -inset-x-8 top-[12%] h-[55%] rounded-full bg-sky-500/[0.08] blur-[90px]" />
+              <div
+                className="relative mx-auto max-h-[940px] w-full max-w-[570px] overflow-hidden rounded-[2.8rem] border border-white/[0.14] bg-black shadow-[0_50px_140px_rgba(0,0,0,0.75)]"
+                aria-label="LogYourBody product preview"
+                data-testid="landing-product-proof"
+              >
+                <Image
+                  src={LANDING_PRODUCT_PROOF.src}
+                  alt={LANDING_PRODUCT_PROOF.alt}
+                  width={LANDING_PRODUCT_PROOF.width}
+                  height={LANDING_PRODUCT_PROOF.height}
+                  sizes="(min-width: 1024px) 570px, calc(100vw - 40px)"
+                  className="h-auto w-full"
+                />
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-black via-black/85 to-transparent" />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="relative isolate overflow-hidden px-5 py-32 text-center sm:px-8 sm:py-40 lg:py-52">
+          <div aria-hidden="true" className={styles.finalGlow} />
+          <svg
+            aria-hidden="true"
+            className={`${styles.finalArcs} pointer-events-none absolute inset-x-0 bottom-0 -z-10 h-[72%] w-full`}
+            viewBox="0 0 1200 520"
+            preserveAspectRatio="xMidYMax slice"
+          >
+            {[90, 170, 260, 360, 480, 620].map((radius, index) => (
+              <ellipse
+                key={radius}
+                cx="600"
+                cy="610"
+                rx={radius}
+                ry={220 - index * 8}
+                fill="none"
+                stroke={index % 2 === 0 ? 'rgba(125,190,255,.62)' : 'rgba(255,255,255,.28)'}
+                strokeWidth={index < 2 ? 1.5 : 1}
+              />
+            ))}
+          </svg>
+          <div className={`${styles.reveal} mx-auto max-w-4xl`}>
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-sky-300">
+              TestFlight access
+            </p>
+            <h2 className="mt-6 text-balance text-[clamp(3.25rem,8vw,8rem)] font-medium leading-[0.9] tracking-[-0.07em]">
+              See what the work is doing.
+            </h2>
+            <p className="mx-auto mt-7 max-w-xl text-lg leading-8 text-white/55 sm:text-xl">
+              Join the waitlist. We’ll email you when a beta spot opens.
+            </p>
+            <a
+              href="#early-access"
+              className="mt-9 inline-flex min-h-14 items-center justify-center rounded-full bg-white px-9 text-base font-semibold text-black transition-[transform,background-color] duration-200 hover:-translate-y-0.5 hover:bg-sky-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-4 focus-visible:ring-offset-[#050608] active:translate-y-0"
+            >
+              Request early access
+            </a>
           </div>
         </section>
       </main>

--- a/apps/web/src/app/WaitlistForm.tsx
+++ b/apps/web/src/app/WaitlistForm.tsx
@@ -109,7 +109,7 @@ export function WaitlistForm() {
   }
 
   return (
-    <div className="mt-8 w-full max-w-xl">
+    <div className="mt-6 w-full max-w-[640px] sm:mt-9">
       <form
         className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]"
         onSubmit={handleSubmit}
@@ -135,7 +135,7 @@ export function WaitlistForm() {
           disabled={submitState === 'submitting' || submitState === 'success'}
           aria-invalid={Boolean(fieldError)}
           aria-describedby="waitlist-status waitlist-consent"
-          className="min-h-14 w-full rounded-full border border-white/15 bg-black/45 px-6 text-base text-white outline-none backdrop-blur-xl transition-colors placeholder:text-white/35 hover:border-white/25 focus:border-white/50 focus:ring-2 focus:ring-sky-400/30 disabled:opacity-60"
+          className="placeholder:text-white/38 min-h-[54px] w-full rounded-full border border-white/20 bg-black/55 px-6 text-base text-white shadow-[0_18px_60px_rgba(0,0,0,0.22)] outline-none backdrop-blur-xl transition-[border-color,background-color,box-shadow] hover:border-white/35 hover:bg-black/65 focus:border-white/60 focus:bg-black/70 focus:ring-2 focus:ring-sky-400/30 disabled:opacity-60 sm:min-h-[58px]"
         />
         <div className="pointer-events-none absolute -left-[10000px]" aria-hidden="true">
           <label htmlFor="waitlist-website">Website</label>
@@ -150,13 +150,13 @@ export function WaitlistForm() {
         <button
           type="submit"
           disabled={submitState === 'submitting' || submitState === 'success'}
-          className="inline-flex min-h-14 items-center justify-center rounded-full bg-white px-8 text-base font-semibold text-black transition-[background-color,transform] hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-black active:scale-[0.985] disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex min-h-[54px] items-center justify-center rounded-full bg-white px-8 text-base font-semibold text-black shadow-[0_18px_55px_rgba(0,0,0,0.24)] transition-[background-color,transform,box-shadow] hover:-translate-y-0.5 hover:bg-sky-50 hover:shadow-[0_22px_65px_rgba(0,0,0,0.34)] focus:outline-none focus:ring-2 focus:ring-sky-300 focus:ring-offset-2 focus:ring-offset-black active:translate-y-0 active:scale-[0.985] disabled:cursor-not-allowed disabled:opacity-60 sm:min-h-[58px]"
         >
           {submitState === 'submitting' ? 'Joining…' : waitlistLandingCopy.submitLabel}
         </button>
       </form>
 
-      <div id="waitlist-status" className="mt-3 min-h-6" aria-live="polite">
+      <div id="waitlist-status" className="mt-2 min-h-5 sm:mt-3 sm:min-h-6" aria-live="polite">
         {fieldError ? (
           <p className="text-sm text-rose-300" role="alert">
             {fieldError}
@@ -176,7 +176,10 @@ export function WaitlistForm() {
         ) : null}
       </div>
 
-      <p id="waitlist-consent" className="mt-2 max-w-lg text-xs leading-5 text-white/45">
+      <p
+        id="waitlist-consent"
+        className="text-white/48 mt-1 max-w-lg text-[11px] leading-4 sm:mt-2 sm:text-xs sm:leading-5"
+      >
         Join to receive early-access and TestFlight invitations. Unsubscribe anytime. See our{' '}
         <Link
           href="/privacy"

--- a/apps/web/src/app/__tests__/home-page.test.ts
+++ b/apps/web/src/app/__tests__/home-page.test.ts
@@ -19,6 +19,6 @@ describe('HomePage landing copy', () => {
 
   it('keeps waitlist hero copy separate from full-landing section headings', () => {
     expect(waitlistLandingCopy.headline).not.toEqual(landingSectionHeadings.hero);
-    expect(waitlistLandingCopy.submitLabel).toBe('Join the waitlist');
+    expect(waitlistLandingCopy.submitLabel).toBe('Request early access');
   });
 });

--- a/apps/web/src/app/__tests__/landing-flags.test.ts
+++ b/apps/web/src/app/__tests__/landing-flags.test.ts
@@ -1,10 +1,12 @@
 describe('landing flags', () => {
   const originalFlag = process.env.NEXT_PUBLIC_LYB_FULL_LANDING;
   const originalWaitlistV2Flag = process.env.NEXT_PUBLIC_LYB_WAITLIST_V2;
+  const originalArtDirectionFlag = process.env.NEXT_PUBLIC_LYB_LANDING_ART_DIRECTION_V2;
 
   afterEach(() => {
     process.env.NEXT_PUBLIC_LYB_FULL_LANDING = originalFlag;
     process.env.NEXT_PUBLIC_LYB_WAITLIST_V2 = originalWaitlistV2Flag;
+    process.env.NEXT_PUBLIC_LYB_LANDING_ART_DIRECTION_V2 = originalArtDirectionFlag;
     jest.resetModules();
   });
 
@@ -29,5 +31,16 @@ describe('landing flags', () => {
     process.env.NEXT_PUBLIC_LYB_WAITLIST_V2 = '1';
     flags = (await import('@/lib/flags/landing')).LANDING_FLAGS;
     expect(flags.WAITLIST_V2_ENABLED).toBe(true);
+  });
+
+  it('defaults the art direction to off and enables it only with an explicit flag', async () => {
+    delete process.env.NEXT_PUBLIC_LYB_LANDING_ART_DIRECTION_V2;
+    let flags = (await import('@/lib/flags/landing')).LANDING_FLAGS;
+    expect(flags.ART_DIRECTION_V2_ENABLED).toBe(false);
+
+    jest.resetModules();
+    process.env.NEXT_PUBLIC_LYB_LANDING_ART_DIRECTION_V2 = '1';
+    flags = (await import('@/lib/flags/landing')).LANDING_FLAGS;
+    expect(flags.ART_DIRECTION_V2_ENABLED).toBe(true);
   });
 });

--- a/apps/web/src/app/__tests__/marketing-discovery.test.tsx
+++ b/apps/web/src/app/__tests__/marketing-discovery.test.tsx
@@ -7,6 +7,10 @@ jest.mock('../MinimalWaitlistLanding', () => ({
   MinimalWaitlistLanding: () => <main data-testid="minimal-landing" />,
 }));
 
+jest.mock('../LegacyMinimalWaitlistLanding', () => ({
+  LegacyMinimalWaitlistLanding: () => <main data-testid="legacy-minimal-landing" />,
+}));
+
 describe('marketing discovery routes', () => {
   it('publishes a nonempty robots policy and sitemap URL', () => {
     const value = robots();

--- a/apps/web/src/app/__tests__/minimal-waitlist-landing.test.tsx
+++ b/apps/web/src/app/__tests__/minimal-waitlist-landing.test.tsx
@@ -20,6 +20,12 @@ describe('MinimalWaitlistLanding', () => {
       screen.getByRole('button', { name: waitlistLandingCopy.submitLabel }),
     ).toBeInTheDocument();
     expect(screen.getByTestId('landing-product-proof')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /one number is a moment/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /your progress/i })).toBeInTheDocument();
+    expect(screen.getByText('Weight')).toBeInTheDocument();
+    expect(screen.getByText('Body fat')).toBeInTheDocument();
     expect(screen.getByTestId('marketing-footer')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Privacy' })).toHaveAttribute('href', '/privacy');
     expect(screen.getByRole('link', { name: 'Terms' })).toHaveAttribute('href', '/terms');

--- a/apps/web/src/app/__tests__/waitlist-form.test.tsx
+++ b/apps/web/src/app/__tests__/waitlist-form.test.tsx
@@ -31,7 +31,7 @@ describe('WaitlistForm', () => {
     const email = screen.getByRole('textbox', { name: 'Email' });
     fireEvent.focus(email);
     fireEvent.change(email, { target: { value: 'person@example.com' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Join the waitlist' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Request early access' }));
 
     await screen.findByText(/TestFlight spot opens/i);
     expect(fetchMock).toHaveBeenCalledWith(
@@ -54,7 +54,7 @@ describe('WaitlistForm', () => {
 
   it('announces invalid email without making a request', async () => {
     render(<WaitlistForm />);
-    fireEvent.click(screen.getByRole('button', { name: 'Join the waitlist' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Request early access' }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Enter a valid email address.');
     expect(fetchMock).not.toHaveBeenCalled();

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,6 @@
 import { MinimalWaitlistLanding } from './MinimalWaitlistLanding';
+import { LegacyMinimalWaitlistLanding } from './LegacyMinimalWaitlistLanding';
+import { LANDING_FLAGS } from '@/lib/flags/landing';
 
 const landingStructuredData = {
   '@context': 'https://schema.org',
@@ -40,7 +42,11 @@ export default function HomePage() {
           __html: JSON.stringify(landingStructuredData).replace(/</g, '\\u003c'),
         }}
       />
-      <MinimalWaitlistLanding />
+      {LANDING_FLAGS.ART_DIRECTION_V2_ENABLED ? (
+        <MinimalWaitlistLanding />
+      ) : (
+        <LegacyMinimalWaitlistLanding />
+      )}
     </>
   );
 }

--- a/apps/web/src/app/waitlist-copy.ts
+++ b/apps/web/src/app/waitlist-copy.ts
@@ -4,7 +4,7 @@ export const waitlistLandingCopy = {
     'Weight, body fat, lean mass, and progress photos in one private timeline that shows the trend.',
   emailLabel: 'Email',
   emailPlaceholder: 'you@example.com',
-  submitLabel: 'Join the waitlist',
+  submitLabel: 'Request early access',
   successMessage: "You're on the list. We'll email you when a TestFlight spot opens.",
   duplicateMessage: "You're on the list. We'll email you when a TestFlight spot opens.",
   errorMessage: 'Something went wrong. Please try again.',

--- a/apps/web/src/lib/flags/landing.ts
+++ b/apps/web/src/lib/flags/landing.ts
@@ -5,8 +5,11 @@
  * waitlist hero until the iOS app is live and marketing claims are verified.
  * Set NEXT_PUBLIC_LYB_FULL_LANDING=1 locally or in preview to render the
  * full System B marketing page.
+ * ART_DIRECTION_V2_ENABLED is a separate rollback gate for the production
+ * waitlist redesign. It must be explicitly enabled per deployment environment.
  */
 export const LANDING_FLAGS = {
   FULL_LANDING_ENABLED: process.env.NEXT_PUBLIC_LYB_FULL_LANDING === '1',
   WAITLIST_V2_ENABLED: process.env.NEXT_PUBLIC_LYB_WAITLIST_V2 === '1',
+  ART_DIRECTION_V2_ENABLED: process.env.NEXT_PUBLIC_LYB_LANDING_ART_DIRECTION_V2 === '1',
 } as const;


### PR DESCRIPTION
## What changed

- Reframes the first viewport as a full-bleed product poster using the existing verified lifestyle asset
- Adds a cardless signal story for weight, body-fat estimates, lean-mass estimates, and progress photos
- Promotes the real iPhone capture into an immersive sticky product-proof section
- Adds restrained CSS-only entrance, view-timeline, hover, and final-CTA motion with reduced-motion fallbacks
- Keeps the canonical LogYourBody adaptation of Jovie's marketing footer and all legal links
- Adds `NEXT_PUBLIC_LYB_LANDING_ART_DIRECTION_V2` as an explicit rollback gate; production and this preview branch are enabled
- Preserves the existing Neon waitlist API and PII-free funnel instrumentation

## Why

The shipped waitlist page converted correctly but visually read as a boxed product demo. This gives LogYourBody one strong visual idea, clearer hierarchy, real product depth, and a memorable close without adding client-side animation weight or unverified claims.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 53 web suites / 369 tests, plus 37 shared tests
- `pnpm build`
- Root route: 143 KB first-load JS (budget: 150 KB)
- Playwright visual QA at 1440×1000 and iPhone 15 mobile viewport
- Full-page desktop and mobile scroll review
- Reduced-motion fallback included
