### PR TITLE
feat: unify iOS Jovie experience

### DIFF
--- a/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
+++ b/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
@@ -1,6 +1,35 @@
 import SwiftUI
 import UIKit
 
+/// Controls precisely which personal details leave the app in a rendered card.
+/// The private default keeps the card to the Body Score until the person opts in.
+struct BodyScoreShareOptions: Equatable {
+    var includeWeight = false
+    var includeBodyFat = false
+    var includeFFMI = false
+    var includeVisual = false
+
+    static let all = BodyScoreShareOptions(
+        includeWeight: true,
+        includeBodyFat: true,
+        includeFFMI: true,
+        includeVisual: true
+    )
+
+    var hasMetrics: Bool {
+        includeWeight || includeBodyFat || includeFFMI
+    }
+
+    var includedSummary: String {
+        var items = ["Body Score"]
+        if includeWeight { items.append("weight") }
+        if includeBodyFat { items.append("body fat") }
+        if includeFFMI { items.append("FFMI") }
+        if includeVisual { items.append("visual") }
+        return items.joined(separator: ", ")
+    }
+}
+
 struct BodyScoreSharePayload {
     let score: Int
     let scoreText: String
@@ -20,8 +49,9 @@ struct BodyScoreSharePayload {
         AvatarBodyFatCatalog.match(bodyFatPercentage: bodyFatPercentage, gender: gender)
     }
 
-    var visualBadgeText: String {
-        photoImage == nil ? avatarMatch.badgeText : "Progress photo"
+    func visualBadgeText(includeVisual: Bool) -> String {
+        guard includeVisual else { return "Private summary" }
+        return photoImage == nil ? avatarMatch.badgeText : "Progress photo"
     }
 }
 
@@ -79,10 +109,21 @@ enum BodyScoreShareAspect: String, CaseIterable, Identifiable {
 struct BodyScoreShareCardView: View {
     let payload: BodyScoreSharePayload
     let aspect: BodyScoreShareAspect
+    let options: BodyScoreShareOptions
+
+    init(
+        payload: BodyScoreSharePayload,
+        aspect: BodyScoreShareAspect,
+        options: BodyScoreShareOptions = .all
+    ) {
+        self.payload = payload
+        self.aspect = aspect
+        self.options = options
+    }
 
     var body: some View {
         GeometryReader { geometry in
-            let layout = ShareCardLayout(size: geometry.size, aspect: aspect)
+            let layout = ShareCardLayout(size: geometry.size, aspect: aspect, includesMetrics: options.hasMetrics)
 
             ZStack {
                 Color.black
@@ -108,6 +149,7 @@ struct BodyScoreShareCardView: View {
         .clipped()
         .dynamicTypeSize(.medium)
         .accessibilityElement(children: .contain)
+        .accessibilityLabel("Body Score share card. Includes \(options.includedSummary).")
         .accessibilityIdentifier("body_score_share_card")
     }
 
@@ -119,7 +161,7 @@ struct BodyScoreShareCardView: View {
 
     private func visualStage(layout: ShareCardLayout) -> some View {
         Group {
-            if let photoImage = payload.photoImage {
+            if options.includeVisual, let photoImage = payload.photoImage {
                 Image(uiImage: photoImage)
                     .resizable()
                     .scaledToFit()
@@ -127,7 +169,7 @@ struct BodyScoreShareCardView: View {
                     .clipped()
                     .accessibilityLabel("Progress photo")
                     .accessibilityIdentifier("body_score_share_photo_visual")
-            } else {
+            } else if options.includeVisual {
                 VStack(spacing: 0) {
                     Spacer(minLength: layout.visualTopOffset)
 
@@ -163,7 +205,7 @@ struct BodyScoreShareCardView: View {
                     .minimumScaleFactor(0.78)
                     .accessibilityIdentifier("body_score_share_brand")
 
-                Text(payload.visualBadgeText)
+                Text(payload.visualBadgeText(includeVisual: options.includeVisual))
                     .font(.system(size: layout.badgeFontSize, weight: .medium))
                     .foregroundColor(Color.white.opacity(0.62))
                     .lineLimit(1)
@@ -219,28 +261,8 @@ struct BodyScoreShareCardView: View {
                 Spacer(minLength: 0)
             }
 
-            ViewThatFits(in: .horizontal) {
-                HStack(spacing: layout.metricSpacing) {
-                    shareMetric("Weight", payload.weightValue, payload.weightCaption, identifier: "weight", layout: layout)
-                    shareMetric("Body Fat", payload.bodyFatValue, payload.bodyFatCaption, identifier: "body_fat", layout: layout)
-                    shareMetric("FFMI", payload.ffmiValue, payload.ffmiCaption, identifier: "ffmi", layout: layout)
-                }
-                .accessibilityIdentifier("body_score_share_metrics")
-
-                VStack(spacing: layout.metricSpacing * 0.55) {
-                    HStack(spacing: layout.metricSpacing) {
-                        shareMetric("Weight", payload.weightValue, payload.weightCaption, identifier: "weight", layout: layout)
-                        shareMetric(
-                            "Body Fat",
-                            payload.bodyFatValue,
-                            payload.bodyFatCaption,
-                            identifier: "body_fat",
-                            layout: layout
-                        )
-                    }
-                    shareMetric("FFMI", payload.ffmiValue, payload.ffmiCaption, identifier: "ffmi", layout: layout)
-                }
-                .accessibilityIdentifier("body_score_share_metrics_stacked")
+            if options.hasMetrics {
+                shareMetrics(layout: layout)
             }
 
             Text("Shared from LogYourBody")
@@ -317,11 +339,49 @@ struct BodyScoreShareCardView: View {
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("body_score_share_metric_\(identifier)")
     }
+
+    @ViewBuilder
+    private func shareMetrics(layout: ShareCardLayout) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: layout.metricSpacing) {
+                if options.includeWeight {
+                    shareMetric("Weight", payload.weightValue, payload.weightCaption, identifier: "weight", layout: layout)
+                }
+                if options.includeBodyFat {
+                    shareMetric("Body Fat", payload.bodyFatValue, payload.bodyFatCaption, identifier: "body_fat", layout: layout)
+                }
+                if options.includeFFMI {
+                    shareMetric("FFMI", payload.ffmiValue, payload.ffmiCaption, identifier: "ffmi", layout: layout)
+                }
+            }
+            .accessibilityIdentifier("body_score_share_metrics")
+
+            VStack(alignment: .leading, spacing: layout.metricSpacing * 0.55) {
+                if options.includeWeight {
+                    shareMetric("Weight", payload.weightValue, payload.weightCaption, identifier: "weight", layout: layout)
+                }
+                if options.includeBodyFat {
+                    shareMetric("Body Fat", payload.bodyFatValue, payload.bodyFatCaption, identifier: "body_fat", layout: layout)
+                }
+                if options.includeFFMI {
+                    shareMetric("FFMI", payload.ffmiValue, payload.ffmiCaption, identifier: "ffmi", layout: layout)
+                }
+            }
+            .accessibilityIdentifier("body_score_share_metrics_stacked")
+        }
+    }
 }
 
 struct ShareCardLayout {
     let size: CGSize
     let aspect: BodyScoreShareAspect
+    let includesMetrics: Bool
+
+    init(size: CGSize, aspect: BodyScoreShareAspect, includesMetrics: Bool = true) {
+        self.size = size
+        self.aspect = aspect
+        self.includesMetrics = includesMetrics
+    }
 
     var scale: CGFloat {
         let reference = referenceSize
@@ -396,7 +456,8 @@ struct ShareCardLayout {
         let scoreLabelStack = scoreLabelFontSize + taglineFontSize * 2.6 + deltaFontSize + scoreLabelSpacing * 3
         let scoreRow = max(scoreFontSize * 1.02, scoreLabelStack)
         let metricRow = metricTitleFontSize + metricValueFontSize + metricCaptionFontSize + metricTextSpacing * 2
-        return scoreRow + summarySpacing + metricRow * 1.12 + summarySpacing + footerFontSize * 1.2
+        let metricHeight = includesMetrics ? summarySpacing + metricRow * 1.12 : 0
+        return scoreRow + metricHeight + summarySpacing + footerFontSize * 1.2
     }
 
     var summaryTopY: CGFloat {
@@ -442,11 +503,15 @@ struct ShareCardLayout {
 
 struct BodyScoreShareSheet: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.theme) private var theme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     let payload: BodyScoreSharePayload
     let onClose: (() -> Void)?
 
     @State private var selectedAspect: BodyScoreShareAspect
+    @State private var shareOptions = BodyScoreShareOptions()
+    @State private var areContentControlsExpanded = true
     @State private var renderedImage: UIImage?
     @State private var isRendering = false
     @State private var showSystemShareSheet = false
@@ -458,49 +523,17 @@ struct BodyScoreShareSheet: View {
     }
 
     var body: some View {
-        VStack(spacing: 18) {
-            sheetHeader
-
-            Picker("Format", selection: $selectedAspect) {
-                ForEach(BodyScoreShareAspect.allCases) { aspect in
-                    Text(aspect.displayName).tag(aspect)
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                ScrollView(showsIndicators: false) {
+                    shareSheetContent(previewHeight: 360)
+                        .padding(.vertical, JovieTokens.itemGap)
                 }
+            } else {
+                shareSheetContent(previewHeight: nil)
             }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, 20)
-
-            GeometryReader { geometry in
-                let verticalInset = previewVerticalInset
-                let availableSize = CGSize(
-                    width: geometry.size.width,
-                    height: max(0, geometry.size.height - verticalInset * 2)
-                )
-                let size = fittedSize(for: availableSize, target: selectedAspect.pixelSize)
-
-                BodyScoreShareCardView(payload: payload, aspect: selectedAspect)
-                    .frame(width: size.width, height: size.height)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-                    .padding(.vertical, verticalInset)
-            }
-            .frame(maxWidth: .infinity)
-
-            HStack(spacing: 12) {
-                GlassPillButton(icon: "square.and.arrow.down", title: "Save") {
-                    Task { await saveToPhotos() }
-                }
-                .accessibilityIdentifier("body_score_share_save_button")
-
-                GlassPillButton(icon: "square.and.arrow.up", title: "Share") {
-                    Task { await shareImage() }
-                }
-                .accessibilityIdentifier("body_score_share_system_button")
-            }
-            .padding(.horizontal, 20)
-            .padding(.bottom, 16)
-            .disabled(isRendering)
         }
-        .padding(.top, 62)
-        .background(Color.appBackground.ignoresSafeArea())
+        .background(Color.jovieCanvas.ignoresSafeArea())
         .overlay {
             if isRendering {
                 ZStack {
@@ -521,6 +554,9 @@ struct BodyScoreShareSheet: View {
         .onChange(of: selectedAspect) { _, _ in
             renderedImage = nil
         }
+        .onChange(of: shareOptions) { _, _ in
+            renderedImage = nil
+        }
     }
 
     private var sheetHeader: some View {
@@ -532,16 +568,15 @@ struct BodyScoreShareSheet: View {
                     dismiss()
                 }
             }
-            .buttonStyle(.bordered)
-            .controlSize(.regular)
-            .tint(.white.opacity(0.12))
-            .foregroundColor(.white)
+            .font(theme.typography.labelMedium)
+            .foregroundColor(theme.colors.text)
+            .jovieTouchTarget()
 
             Spacer()
 
             Text("Share Body Score")
-                .font(.headline.weight(.semibold))
-                .foregroundColor(.white)
+                .font(theme.typography.headlineSmall)
+                .foregroundColor(theme.colors.text)
                 .lineLimit(1)
 
             Spacer()
@@ -549,10 +584,115 @@ struct BodyScoreShareSheet: View {
             Color.clear
                 .frame(width: 72, height: 1)
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, JovieTokens.screenInset)
     }
 
     private var previewVerticalInset: CGFloat { 8 }
+
+    private func shareSheetContent(previewHeight: CGFloat?) -> some View {
+        VStack(spacing: JovieTokens.itemGap) {
+            sheetHeader
+
+            Picker("Format", selection: $selectedAspect) {
+                ForEach(BodyScoreShareAspect.allCases) { aspect in
+                    Text(aspect.displayName).tag(aspect)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, JovieTokens.screenInset)
+            .accessibilityLabel("Card format")
+
+            contentControls
+
+            cardPreview(height: previewHeight)
+
+            shareActions
+                .disabled(isRendering)
+        }
+        .padding(.top, JovieTokens.itemGap)
+        .padding(.bottom, JovieTokens.compactInset)
+    }
+
+    private var contentControls: some View {
+        DisclosureGroup(isExpanded: $areContentControlsExpanded) {
+            VStack(spacing: 0) {
+                Toggle("Weight", isOn: $shareOptions.includeWeight)
+                Toggle("Body fat", isOn: $shareOptions.includeBodyFat)
+                Toggle("FFMI", isOn: $shareOptions.includeFFMI)
+                Toggle(payload.photoImage == nil ? "Body visual" : "Progress photo", isOn: $shareOptions.includeVisual)
+            }
+            .font(theme.typography.bodyMedium)
+            .tint(theme.colors.info)
+            .padding(.top, theme.spacing.xs)
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Included on card")
+                    .font(theme.typography.labelLarge)
+                    .foregroundColor(theme.colors.text)
+
+                Text(shareOptions.includedSummary)
+                    .font(theme.typography.captionLarge)
+                    .foregroundColor(theme.colors.textSecondary)
+                    .lineLimit(2)
+            }
+        }
+        .padding(theme.spacing.sm)
+        .background(theme.colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: theme.radius.input, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: theme.radius.input, style: .continuous)
+                .stroke(theme.colors.border, lineWidth: 1)
+        )
+        .padding(.horizontal, JovieTokens.screenInset)
+        .accessibilityIdentifier("body_score_share_content_controls")
+    }
+
+    private func cardPreview(height: CGFloat?) -> some View {
+        GeometryReader { geometry in
+            let verticalInset = previewVerticalInset
+            let availableSize = CGSize(
+                width: geometry.size.width,
+                height: max(0, geometry.size.height - verticalInset * 2)
+            )
+            let size = fittedSize(for: availableSize, target: selectedAspect.pixelSize)
+
+            BodyScoreShareCardView(payload: payload, aspect: selectedAspect, options: shareOptions)
+                .frame(width: size.width, height: size.height)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                .padding(.vertical, verticalInset)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(height: height)
+        .padding(.horizontal, JovieTokens.screenInset)
+    }
+
+    private var shareActions: some View {
+        HStack(spacing: JovieTokens.itemGap) {
+            shareActionButton(title: "Save", icon: "square.and.arrow.down") {
+                Task { await saveToPhotos() }
+            }
+            .accessibilityIdentifier("body_score_share_save_button")
+
+            shareActionButton(title: "Share", icon: "square.and.arrow.up") {
+                Task { await shareImage() }
+            }
+            .accessibilityIdentifier("body_score_share_system_button")
+        }
+        .padding(.horizontal, JovieTokens.screenInset)
+    }
+
+    private func shareActionButton(title: String, icon: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: icon)
+                .font(theme.typography.labelLarge)
+                .frame(maxWidth: .infinity, minHeight: JovieTokens.compactControlHeight)
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(Color.jovieActionText)
+        .background(theme.colors.interactive)
+        .clipShape(Capsule())
+        .accessibilityHint("Renders a card containing \(shareOptions.includedSummary)")
+    }
 
     private func fittedSize(for container: CGSize, target: CGSize) -> CGSize {
         guard container.width > 0, container.height > 0 else {
@@ -571,7 +711,7 @@ struct BodyScoreShareSheet: View {
         let size = selectedAspect.pixelSize
         let renderer = ImageRenderer(
             content:
-                BodyScoreShareCardView(payload: payload, aspect: selectedAspect)
+                BodyScoreShareCardView(payload: payload, aspect: selectedAspect, options: shareOptions)
                 .frame(width: size.width, height: size.height)
                 .environment(\.colorScheme, .dark)
         )

--- a/apps/ios/LogYourBody/Components/DashboardHeaderCompact.swift
+++ b/apps/ios/LogYourBody/Components/DashboardHeaderCompact.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct DashboardHeaderCompact: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     let scrollProgress: CGFloat
     let avatarURL: URL?
     let userFirstName: String
@@ -13,10 +15,12 @@ struct DashboardHeaderCompact: View {
     let onShowSyncDetails: () -> Void
     let onAddEntry: () -> Void
 
-    @State private var isSyncIndicatorExpanded = false
-
     private var clampedScrollProgress: CGFloat {
         min(max(scrollProgress, 0), 1)
+    }
+
+    private var shouldShowPersistentSyncStatus: Bool {
+        isSyncError || syncStatusTitle == "Offline"
     }
 
     var body: some View {
@@ -25,7 +29,9 @@ struct DashboardHeaderCompact: View {
                 NavigationLink(destination: PreferencesView()) {
                     avatarView
                 }
-                .buttonStyle(PlainButtonStyle())
+                .buttonStyle(.plain)
+                .frame(width: 44, height: 44)
+                .accessibilityLabel("Open profile and settings")
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Welcome back")
@@ -41,11 +47,12 @@ struct DashboardHeaderCompact: View {
                         .lineLimit(1)
                         .offset(y: -3 * clampedScrollProgress)
                 }
-                .animation(.easeOut(duration: 0.2), value: clampedScrollProgress)
+                .animation(
+                    reduceMotion ? nil : .easeOut(duration: 0.2),
+                    value: clampedScrollProgress
+                )
 
                 Spacer(minLength: 8)
-
-                syncIndicator
 
                 Button {
                     onAddEntry()
@@ -59,8 +66,15 @@ struct DashboardHeaderCompact: View {
                                 .fill(Color.appPrimary)
                         )
                 }
-                .buttonStyle(PlainButtonStyle())
+                .frame(width: 44, height: 44)
+                .contentShape(Circle())
+                .buttonStyle(.plain)
                 .accessibilityLabel("New Entry")
+                .accessibilityHint("Opens a new body metric entry")
+            }
+
+            if shouldShowPersistentSyncStatus {
+                syncStatusNotice
             }
 
             if !hasAge || !hasHeight {
@@ -79,7 +93,10 @@ struct DashboardHeaderCompact: View {
                                 .foregroundColor(Color.liquidTextPrimary.opacity(0.8))
                                 .clipShape(Capsule())
                         }
-                        .buttonStyle(PlainButtonStyle())
+                        .buttonStyle(.plain)
+                        .frame(minHeight: 44)
+                        .contentShape(Capsule())
+                        .accessibilityLabel("Add your age")
                     }
 
                     if !hasHeight {
@@ -96,7 +113,10 @@ struct DashboardHeaderCompact: View {
                                 .foregroundColor(Color.liquidTextPrimary.opacity(0.8))
                                 .clipShape(Capsule())
                         }
-                        .buttonStyle(PlainButtonStyle())
+                        .buttonStyle(.plain)
+                        .frame(minHeight: 44)
+                        .contentShape(Capsule())
+                        .accessibilityLabel("Add your height")
                     }
                 }
             }
@@ -140,69 +160,69 @@ struct DashboardHeaderCompact: View {
         }
     }
 
-    private var syncIndicator: some View {
+    private var syncStatusNotice: some View {
         Button {
             onShowSyncDetails()
         } label: {
-            HStack(spacing: 8) {
-                if isSyncIndicatorExpanded, isSyncError {
-                    Text(syncIndicatorLabelText)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(Color.liquidTextPrimary.opacity(0.7))
-                        .lineLimit(1)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(Color.white.opacity(0.06))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 999)
-                            .stroke(Color.white.opacity(0.18), lineWidth: 1)
-                    )
-                    .clipShape(Capsule())
-                    .transition(
-                        .move(edge: .trailing)
-                            .combined(with: .opacity)
-                    )
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: syncStatusSymbolName)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(syncStatusColor)
+                    .frame(width: 20, height: 20)
+                    .padding(.top, 1)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(syncStatusTitle)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(Color.liquidTextPrimary)
+
+                    Text(syncStatusDetailText)
+                        .font(.footnote)
+                        .foregroundColor(Color.liquidTextPrimary.opacity(0.72))
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
-                Circle()
-                    .fill(syncStatusColor)
-                    .frame(width: 6, height: 6)
+                Spacer(minLength: 8)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(Color.liquidTextPrimary.opacity(0.55))
+                    .padding(.top, 3)
             }
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color.white.opacity(0.06))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(syncStatusColor.opacity(0.42), lineWidth: 1)
+            )
         }
-        .buttonStyle(PlainButtonStyle())
-        .fixedSize(horizontal: false, vertical: true)
-        .onAppear {
-            handleSyncIndicatorStatusChange()
-        }
-        .onChange(of: isSyncError) { _, _ in
-            handleSyncIndicatorStatusChange()
-        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(syncStatusTitle). \(syncStatusDetailText)")
+        .accessibilityHint("Opens sync details and recovery options")
+        .accessibilityIdentifier("dashboard_sync_status")
     }
 
-    private var syncIndicatorLabelText: String {
-        guard isSyncError else {
-            return syncStatusTitle
+    private var syncStatusSymbolName: String {
+        if isSyncError {
+            return "exclamationmark.triangle.fill"
         }
 
-        return "Sync paused (tap for details)"
+        return "icloud.slash.fill"
     }
 
-    private func handleSyncIndicatorStatusChange() {
-        guard isSyncError else {
-            withAnimation(.easeOut(duration: 0.25)) {
-                isSyncIndicatorExpanded = false
-            }
-            return
+    private var syncStatusDetailText: String {
+        if let syncStatusDetail, !syncStatusDetail.isEmpty {
+            return syncStatusDetail
         }
 
-        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-            isSyncIndicatorExpanded = true
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            withAnimation(.easeOut(duration: 0.25)) {
-                isSyncIndicatorExpanded = false
-            }
-        }
+        return isSyncError
+            ? "Tap for sync details and retry options."
+            : "Changes are queued until you are back online."
     }
 }

--- a/apps/ios/LogYourBody/Components/FullMetricChartView+Part01.swift
+++ b/apps/ios/LogYourBody/Components/FullMetricChartView+Part01.swift
@@ -210,23 +210,31 @@ var timeRangeSelector: some View {
             HStack {
                 HStack(spacing: 4) {
                     ForEach(TimeRange.allCases, id: \.self) { range in
+                        let isSelected = selectedTimeRange == range
+
                         Button {
                             selectedTimeRange = range
                         } label: {
                             Text(range.rawValue)
-                                .font(.system(size: 13, weight: .semibold))
+                                .font(.subheadline.weight(.semibold))
                                 .foregroundColor(
-                                    selectedTimeRange == range ? Color.black : Color.metricTextPrimary
+                                    isSelected ? Color.black : Color.metricTextPrimary
                                 )
                                 .padding(.vertical, 8)
                                 .padding(.horizontal, 14)
-                                .frame(minWidth: 44, minHeight: 36)
+                                .frame(minWidth: 44, minHeight: 44)
                                 .background(
                                     Capsule()
-                                        .fill(selectedTimeRange == range ? Color.white : Color.clear)
+                                        .fill(isSelected ? Color.white : Color.clear)
                                 )
                         }
                         .buttonStyle(.plain)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel(range.accessibilityLabel)
+                        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+                        .accessibilityHint("Shows \(range.accessibilityLabel.lowercased()) of data")
+                        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+                        .accessibilityIdentifier("metric_detail_range_\(range.rawValue)")
                     }
                 }
                 .padding(.horizontal, 6)
@@ -266,19 +274,41 @@ var chartCard: some View {
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(.white)
 
-                LazyVGrid(
-                    columns: [
-                        GridItem(.flexible(), spacing: 10),
-                        GridItem(.flexible(), spacing: 10)
-                    ],
-                    spacing: 10
-                ) {
-                    ForEach(relatedMetrics) { metric in
-                        relatedMetricTile(metric)
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(spacing: 10) {
+                        ForEach(relatedMetrics) { metric in
+                            relatedMetricTile(metric)
+                        }
+                    }
+                } else {
+                    VStack(spacing: 10) {
+                        ForEach(relatedMetricRows.indices, id: \.self) { index in
+                            let row = relatedMetricRows[index]
+
+                            HStack(spacing: 10) {
+                                ForEach(row) { metric in
+                                    relatedMetricTile(metric)
+                                }
+
+                                if row.count == 1 {
+                                    Color.clear
+                                        .frame(maxWidth: .infinity)
+                                        .accessibilityHidden(true)
+                                }
+                            }
+                        }
                     }
                 }
             }
+            .accessibilityElement(children: .contain)
             .accessibilityIdentifier("metric_detail_related_metrics")
+        }
+    }
+
+    private var relatedMetricRows: [[MetricDetailRelatedMetric]] {
+        stride(from: 0, to: relatedMetrics.count, by: 2).map { start in
+            let end = min(start + 2, relatedMetrics.count)
+            return Array(relatedMetrics[start..<end])
         }
     }
 
@@ -364,6 +394,10 @@ var chartHeader: some View {
                 Spacer()
             }
 
+            if let goalValue {
+                goalLegend(goalValue)
+            }
+
             if shouldShowPresenceLegend {
                 chartPresenceLegend
             }
@@ -401,28 +435,60 @@ var chartPresenceLegend: some View {
         }
     }
 
-var chartModeToggle: some View {
+    var chartModeToggle: some View {
         HStack(spacing: 8) {
             ForEach(ChartMode.allCases, id: \.self) { mode in
+                let isSelected = chartMode == mode
+
                 Button {
                     chartMode = mode
                 } label: {
                     Text(mode.label)
-                        .font(.system(size: 13, weight: .semibold))
+                        .font(.subheadline.weight(.semibold))
                         .foregroundColor(
-                            chartMode == mode ? Color.metricAccent : Color.metricTextSecondary
+                            isSelected ? Color.metricAccent : Color.metricTextSecondary
                         )
                         .padding(.vertical, 8)
                         .padding(.horizontal, 14)
-                        .frame(minWidth: 44, minHeight: 36)
+                        .frame(minWidth: 44, minHeight: 44)
                         .background(
                             RoundedRectangle(cornerRadius: 12)
-                                .fill(chartMode == mode ? Color.metricAccent.opacity(0.18) : Color.clear)
+                                .fill(isSelected ? Color.metricAccent.opacity(0.18) : Color.clear)
                         )
                 }
                 .buttonStyle(.plain)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(mode.label)
+                .accessibilityValue(isSelected ? "Selected" : "Not selected")
+                .accessibilityHint("Changes the chart to \(mode.label.lowercased()) values")
+                .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+                .accessibilityIdentifier("metric_detail_mode_\(mode.label.lowercased())")
             }
         }
+    }
+
+    func goalLegend(_ goalValue: Double) -> some View {
+        let value = formatHeadlineValue(goalValue)
+        let displayValue = unit.isEmpty ? value : "\(value) \(unit)"
+
+        return HStack(spacing: 7) {
+            Circle()
+                .fill(Color.metricAccent.opacity(0.8))
+                .frame(width: 7, height: 7)
+
+            Text("Goal \(displayValue)")
+                .font(.footnote.weight(.semibold))
+                .foregroundColor(Color.metricTextSecondary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(
+            Capsule()
+                .fill(Color.white.opacity(0.06))
+        )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Goal \(displayValue)")
+        .accessibilityIdentifier("metric_detail_goal_legend")
     }
 
 var chartView: some View {
@@ -460,7 +526,7 @@ var chartView: some View {
                     .symbolSize(chartPointSymbolSize(for: point.presence))
                     .foregroundStyle(chartPointColor(for: point.presence))
                     .opacity(chartPointOpacity(for: point.presence))
-                    .accessibilityLabel("\(presenceLabel(for: point.presence)) point")
+                    .accessibilityLabel(chartPointAccessibilityLabel(for: point))
 
                     if chartMode == .trend {
                         AreaMark(
@@ -484,22 +550,6 @@ var chartView: some View {
                 RuleMark(y: .value("Goal", goalValue))
                     .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
                     .foregroundStyle(Color.metricAccent.opacity(0.45))
-                    .annotation(position: .topTrailing, alignment: .trailing) {
-                        HStack(spacing: 4) {
-                            Circle()
-                                .fill(Color.metricAccent.opacity(0.7))
-                                .frame(width: 6, height: 6)
-                            Text("Goal")
-                                .font(.system(size: 10, weight: .semibold))
-                                .foregroundColor(Color.metricTextSecondary)
-                        }
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 4)
-                        .background(
-                            Capsule()
-                                .fill(Color.black.opacity(0.35))
-                        )
-                    }
             }
 
             if let stats = computeSeriesStats(for: activeSeries) {
@@ -524,36 +574,37 @@ var chartView: some View {
                 }
                 .symbol(CircleSymbol())
                 .foregroundStyle(Color.metricChartLine)
-                .accessibilityLabel("Selected point")
+                .accessibilityLabel("Selected \(chartPointAccessibilityLabel(for: focus))")
             }
         }
         .chartXAxis {
-            if selectedTimeRange == .week1 {
-                AxisMarks(values: .stride(by: .day)) { _ in
-                    AxisValueLabel()
+            if selectedTimeRange == .week1 || selectedTimeRange == .month1 {
+                AxisMarks(values: .automatic(desiredCount: xAxisTickCount)) { _ in
+                    AxisGridLine(centered: true, stroke: StrokeStyle(lineWidth: 0.5))
+                        .foregroundStyle(Color.metricGridMajor.opacity(0.25))
+                    AxisTick()
+                    AxisValueLabel(format: .dateTime.month(.abbreviated).day())
                         .foregroundStyle(Color.metricTextSecondary)
-                        .font(.system(size: 10, weight: .medium))
+                        .font(.caption2.weight(.medium))
                 }
             } else {
                 AxisMarks(values: .automatic(desiredCount: xAxisTickCount)) { _ in
-                    AxisValueLabel()
+                    AxisGridLine(centered: true, stroke: StrokeStyle(lineWidth: 0.5))
+                        .foregroundStyle(Color.metricGridMajor.opacity(0.25))
+                    AxisTick()
+                    AxisValueLabel(format: .dateTime.month(.abbreviated))
                         .foregroundStyle(Color.metricTextSecondary)
-                        .font(.system(size: 10, weight: .medium))
+                        .font(.caption2.weight(.medium))
                 }
             }
         }
         .chartYAxis {
             AxisMarks(position: .leading, values: .automatic(desiredCount: 4)) { _ in
-                AxisValueLabel()
-                    .foregroundStyle(Color.metricTextSecondary)
-                    .font(.system(size: 10, weight: .medium))
-            }
-            AxisMarks(position: .trailing, values: .automatic(desiredCount: 4)) { _ in
                 AxisGridLine(centered: true, stroke: StrokeStyle(lineWidth: 0.5))
                     .foregroundStyle(Color.metricGridMajor.opacity(0.4))
                 AxisValueLabel()
                     .foregroundStyle(Color.metricTextSecondary)
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.caption2.weight(.medium))
             }
         }
         .chartYScale(domain: .automatic(includesZero: false))
@@ -588,7 +639,15 @@ var chartView: some View {
                     )
             }
         }
-        .animation(.easeInOut(duration: 0.25), value: activeSeries.count)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(title) chart")
+        .accessibilityValue(chartAccessibilityValue)
+        .accessibilityHint(chartAccessibilityHint)
+        .accessibilityAdjustableAction { direction in
+            adjustChartFocus(for: direction)
+        }
+        .accessibilityIdentifier("metric_detail_chart_plot")
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: activeSeries.count)
     }
 
 func selectedPointCallout(for point: MetricChartDataPoint) -> some View {

--- a/apps/ios/LogYourBody/Components/FullMetricChartView+Part02.swift
+++ b/apps/ios/LogYourBody/Components/FullMetricChartView+Part02.swift
@@ -29,8 +29,12 @@ var historyBlock: some View {
                                     .fill(Color.white.opacity(0.08))
                             )
                     }
+                    .frame(width: 44, height: 44)
+                    .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                     .buttonStyle(.plain)
                     .accessibilityLabel("Add Entry")
+                    .accessibilityHint("Opens a new \(title.lowercased()) entry")
+                    .accessibilityIdentifier("metric_detail_history_add_button")
                 }
             }
 
@@ -214,7 +218,10 @@ func historyScrubber(proxy: ScrollViewProxy) -> some View {
                             .opacity(isHistoryScrubbing ? 1 : 0)
                     }
                     .padding(.trailing, 4)
-                    .animation(.easeInOut(duration: 0.2), value: isHistoryScrubbing)
+                    .animation(
+                        reduceMotion ? nil : .easeInOut(duration: 0.2),
+                        value: isHistoryScrubbing
+                    )
                     .contentShape(Rectangle())
                     .gesture(
                         DragGesture(minimumDistance: 0)
@@ -229,8 +236,12 @@ func historyScrubber(proxy: ScrollViewProxy) -> some View {
                                         isHistoryScrubbing = true
                                     }
                                     let sectionId = displayedHistorySections[index].id
-                                    withAnimation(.easeInOut(duration: 0.15)) {
+                                    if reduceMotion {
                                         proxy.scrollTo(sectionId, anchor: .top)
+                                    } else {
+                                        withAnimation(.easeInOut(duration: 0.15)) {
+                                            proxy.scrollTo(sectionId, anchor: .top)
+                                        }
                                     }
                                     HapticManager.shared.selection()
                                 }
@@ -313,13 +324,42 @@ var headlineDateText: String {
         return currentDate
     }
 
-var selectedFocusPoint: MetricChartDataPoint? {
+    var selectedFocusPoint: MetricChartDataPoint? {
         if let activePoint {
             return activePoint
         }
 
         guard let selectedTimelineDate else { return nil }
         return nearestPoint(to: selectedTimelineDate)
+    }
+
+    var chartAccessibilityValue: String {
+        guard let first = activeSeries.first, let last = activeSeries.last else {
+            return "No data in this range"
+        }
+
+        let firstDate = first.date.formatted(.dateTime.month().day().year())
+        let lastDate = last.date.formatted(.dateTime.month().day().year())
+        let latest = selectedFocusPoint ?? last
+        let latestValue = formattedChartValue(latest.value)
+
+        var parts = [
+            "\(activeSeries.count) data points",
+            "from \(firstDate) to \(lastDate)",
+            "current selection \(latestValue) on \(latest.date.formatted(.dateTime.month().day().year()))"
+        ]
+
+        if let goalValue {
+            parts.append("goal \(formattedChartValue(goalValue))")
+        }
+
+        return parts.joined(separator: ", ")
+    }
+
+    var chartAccessibilityHint: String {
+        activeSeries.count > 1
+            ? "Swipe up or down to move between dates, or drag across the chart to inspect a value."
+            : "The chart has one logged value."
     }
 
 var chartDataFingerprint: String {
@@ -361,6 +401,42 @@ func formatStatValue(_ value: Double) -> String {
             return String(format: "%.1f%%", value)
         }
         return String(format: value < 10 ? "%.2f" : "%.1f", value)
+    }
+
+    func formattedChartValue(_ value: Double) -> String {
+        let formatted = formatHeadlineValue(value)
+        return unit.isEmpty ? formatted : "\(formatted) \(unit)"
+    }
+
+    func chartPointAccessibilityLabel(for point: MetricChartDataPoint) -> String {
+        let date = point.date.formatted(.dateTime.month().day().year())
+        return "\(date), \(formattedChartValue(point.value)), \(presenceLabel(for: point.presence))"
+    }
+
+    func adjustChartFocus(for direction: AccessibilityAdjustmentDirection) {
+        let points = activeSeries.sorted { $0.date < $1.date }
+        guard !points.isEmpty else { return }
+
+        let currentIndex = selectedFocusPoint.flatMap { selected in
+            points.firstIndex(where: { $0.id == selected.id })
+        }
+        let nextIndex: Int
+
+        switch direction {
+        case .increment:
+            nextIndex = currentIndex.map { min($0 + 1, points.count - 1) } ?? 0
+        case .decrement:
+            nextIndex = currentIndex.map { max($0 - 1, 0) } ?? (points.count - 1)
+        @unknown default:
+            return
+        }
+
+        let next = points[nextIndex]
+        guard selectedFocusPoint?.id != next.id else { return }
+
+        activePoint = next
+        selectedTimelineDate = next.date
+        HapticManager.shared.selection()
     }
 
 func formattedValue(_ value: Double) -> String {
@@ -549,19 +625,11 @@ var isStepsMetric: Bool {
         unit.lowercased() == "steps"
     }
 
-var xAxisTickCount: Int {
-        switch selectedTimeRange {
-        case .week1:
-            return 7
-        case .month1:
-            return 8
-        case .month3:
-            return 6
-        case .month6:
-            return 6
-        case .year1, .all:
-            return 6
-        }
+    var xAxisTickCount: Int {
+        MetricChartLayoutPolicy.xAxisTickCount(
+            for: selectedTimeRange,
+            isAccessibilitySize: dynamicTypeSize.isAccessibilitySize
+        )
     }
 
 @MainActor

--- a/apps/ios/LogYourBody/Components/FullMetricChartView.swift
+++ b/apps/ios/LogYourBody/Components/FullMetricChartView.swift
@@ -43,6 +43,39 @@ enum TimeRange: String, CaseIterable {
             return nil
         }
     }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .week1:
+            return "1 week"
+        case .month1:
+            return "1 month"
+        case .month3:
+            return "3 months"
+        case .month6:
+            return "6 months"
+        case .year1:
+            return "1 year"
+        case .all:
+            return "All time"
+        }
+    }
+}
+
+enum MetricChartLayoutPolicy {
+    static func xAxisTickCount(
+        for range: TimeRange,
+        isAccessibilitySize: Bool
+    ) -> Int {
+        guard !isAccessibilitySize else { return 3 }
+
+        switch range {
+        case .week1, .month1, .month3, .month6:
+            return 4
+        case .year1, .all:
+            return 3
+        }
+    }
 }
 
 struct MetricChartDataPoint: Identifiable, Sendable {
@@ -278,6 +311,9 @@ struct ChartPresenceLegendItem: Identifiable {
 // MARK: - Full Metric Chart View
 
 struct FullMetricChartView: View {
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
+
     let title: String
     let icon: String
     let iconColor: Color
@@ -308,7 +344,9 @@ struct FullMetricChartView: View {
 
     @ScaledMetric(relativeTo: .largeTitle) var headlineValueFontSize: CGFloat = 56
 
-    let chartHeight: CGFloat = 320
+    var chartHeight: CGFloat {
+        dynamicTypeSize.isAccessibilitySize ? 360 : 320
+    }
 
     init(
         title: String,

--- a/apps/ios/LogYourBody/Components/GlobalTimelineHeader.swift
+++ b/apps/ios/LogYourBody/Components/GlobalTimelineHeader.swift
@@ -28,7 +28,7 @@ struct GlobalTimelineHeader: View {
 
             Button(action: onTodayTap) {
                 Text("Today")
-                    .font(.caption)
+                    .font(.subheadline.weight(.semibold))
                     .padding(.horizontal, 10)
                     .padding(.vertical, 4)
                     .background(
@@ -37,6 +37,10 @@ struct GlobalTimelineHeader: View {
                     )
             }
             .buttonStyle(.plain)
+            .frame(minHeight: 44)
+            .contentShape(Capsule())
+            .accessibilityLabel("Jump to today")
+            .accessibilityHint("Selects the most recent timeline period")
         }
     }
 
@@ -46,37 +50,58 @@ struct GlobalTimelineHeader: View {
             zoneView(buckets: monthlyBuckets)
             zoneView(buckets: yearlyBuckets)
         }
-        .frame(height: 24)
+        .frame(minHeight: 44)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Timeline periods")
     }
 
     private func zoneView(buckets: [GlobalTimelineBucket]) -> some View {
         GeometryReader { geometry in
+            let width = geometry.size.width
+            let visualHeight: CGFloat = 24
+
             ZStack(alignment: .leading) {
                 RoundedRectangle(cornerRadius: 3)
                     .fill(Color.white.opacity(0.10))
+                    .frame(height: visualHeight)
 
-                let width = geometry.size.width
-                let segmentWidth = buckets.isEmpty ? width : max(width / CGFloat(buckets.count), 2)
+                if !buckets.isEmpty {
+                    let totalSpacing = CGFloat(max(buckets.count - 1, 0))
+                    let segmentWidth = max((width - totalSpacing) / CGFloat(buckets.count), 2)
 
-                HStack(spacing: 1) {
-                    ForEach(buckets) { bucket in
-                        let isSelected = bucket.id == cursor?.bucketId
-                        Rectangle()
-                            .fill(isSelected ? Color.liquidAccent : Color.white.opacity(0.25))
-                            .frame(width: segmentWidth)
-                            .onTapGesture {
-                                let newCursor = GlobalTimelineCursor(
-                                    date: bucket.endDate,
-                                    scale: bucket.scale,
-                                    bucketId: bucket.id
-                                )
-                                onCursorChange(newCursor)
-                            }
+                    HStack(spacing: 1) {
+                        ForEach(buckets) { bucket in
+                            let isSelected = bucket.id == cursor?.bucketId
+
+                            Rectangle()
+                                .fill(isSelected ? Color.liquidAccent : Color.white.opacity(0.25))
+                                .frame(width: segmentWidth, height: visualHeight)
+                        }
                     }
+                    .frame(width: width, height: 44, alignment: .leading)
+                    .accessibilityHidden(true)
                 }
-                .frame(width: width, alignment: .leading)
+
+                Color.clear
+                    .contentShape(Rectangle())
+                    .gesture(
+                        SpatialTapGesture()
+                            .onEnded { value in
+                                selectBucket(in: buckets, at: value.location.x, width: width)
+                            }
+                    )
             }
+            .frame(width: width, height: 44, alignment: .leading)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(zoneAccessibilityLabel(for: buckets))
+            .accessibilityValue(zoneAccessibilityValue(for: buckets))
+            .accessibilityHint("Tap to select a period. Swipe up or down to move between periods.")
+            .accessibilityAdjustableAction { direction in
+                adjustBucketSelection(in: buckets, direction: direction)
+            }
+            .accessibilityIdentifier(zoneAccessibilityIdentifier(for: buckets))
         }
+        .frame(maxWidth: .infinity, minHeight: 44)
     }
 
     private var currentLabel: String {
@@ -89,5 +114,90 @@ struct GlobalTimelineHeader: View {
         case .year:
             return "Past years"
         }
+    }
+
+    private func accessibilityLabel(for bucket: GlobalTimelineBucket) -> String {
+        let start = bucket.startDate.formatted(.dateTime.month(.abbreviated).day().year())
+        let end = bucket.endDate.formatted(.dateTime.month(.abbreviated).day().year())
+        return "\(scaleName(for: bucket.scale)), \(start) to \(end)"
+    }
+
+    private func scaleName(for scale: GlobalTimelineScale) -> String {
+        switch scale {
+        case .week:
+            return "Week"
+        case .month:
+            return "Month"
+        case .year:
+            return "Year"
+        }
+    }
+
+    private func zoneAccessibilityLabel(for buckets: [GlobalTimelineBucket]) -> String {
+        guard let scale = buckets.first?.scale else {
+            return "Timeline"
+        }
+        return "\(scaleName(for: scale)) timeline"
+    }
+
+    private func zoneAccessibilityValue(for buckets: [GlobalTimelineBucket]) -> String {
+        guard let selected = buckets.first(where: { $0.id == cursor?.bucketId }) else {
+            return buckets.isEmpty ? "No periods" : "No period selected"
+        }
+        return accessibilityLabel(for: selected)
+    }
+
+    private func zoneAccessibilityIdentifier(for buckets: [GlobalTimelineBucket]) -> String {
+        guard let scale = buckets.first?.scale else {
+            return "timeline_zone_empty"
+        }
+        return "timeline_zone_\(scale.rawValue)"
+    }
+
+    private func selectBucket(
+        in buckets: [GlobalTimelineBucket],
+        at location: CGFloat,
+        width: CGFloat
+    ) {
+        guard !buckets.isEmpty else { return }
+
+        let normalizedPosition = min(max(location / max(width, 1), 0), 0.999999)
+        let index = min(Int(normalizedPosition * CGFloat(buckets.count)), buckets.count - 1)
+        let bucket = buckets[index]
+        onCursorChange(
+            GlobalTimelineCursor(
+                date: bucket.endDate,
+                scale: bucket.scale,
+                bucketId: bucket.id
+            )
+        )
+    }
+
+    private func adjustBucketSelection(
+        in buckets: [GlobalTimelineBucket],
+        direction: AccessibilityAdjustmentDirection
+    ) {
+        guard !buckets.isEmpty else { return }
+
+        let currentIndex = buckets.firstIndex(where: { $0.id == cursor?.bucketId })
+        let nextIndex: Int
+
+        switch direction {
+        case .increment:
+            nextIndex = currentIndex.map { min($0 + 1, buckets.count - 1) } ?? 0
+        case .decrement:
+            nextIndex = currentIndex.map { max($0 - 1, 0) } ?? (buckets.count - 1)
+        @unknown default:
+            return
+        }
+
+        let bucket = buckets[nextIndex]
+        onCursorChange(
+            GlobalTimelineCursor(
+                date: bucket.endDate,
+                scale: bucket.scale,
+                bucketId: bucket.id
+            )
+        )
     }
 }

--- a/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
+++ b/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct ProgressTimelineView: View {
     // MARK: - Properties
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     let bodyMetrics: [BodyMetrics]
     @Binding var selectedIndex: Int
     @Binding var mode: TimelineMode
@@ -66,6 +68,7 @@ struct ProgressTimelineView: View {
                         anchors: renderData.anchors,
                         zoomLevel: renderData.zoomLevel
                     )
+                    .accessibilityHidden(true)
 
                     // Scrubber handle
                     scrubberHandle
@@ -95,7 +98,7 @@ struct ProgressTimelineView: View {
 
     private var dateLabel: some View {
         Text(currentDateLabel)
-            .font(.system(size: 13, weight: .medium))
+            .font(.footnote.weight(.medium))
             .foregroundColor(Color.liquidTextPrimary)
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
@@ -108,6 +111,7 @@ struct ProgressTimelineView: View {
                     )
             )
             .padding(.bottom, 4)
+            .accessibilityHidden(true)
     }
 
     private var timelineTrack: some View {
@@ -119,6 +123,7 @@ struct ProgressTimelineView: View {
             )
             .frame(height: 6)
             .padding(.vertical, (timelineHeight - 6) / 2)
+            .accessibilityHidden(true)
     }
 
     private func anchorsView(
@@ -199,18 +204,23 @@ struct ProgressTimelineView: View {
     }
 
     private var scrubberHandle: some View {
-        VStack(spacing: 2) {
-            // Pill handle
+        ZStack {
             Capsule()
                 .fill(Color.liquidAccent)
                 .frame(width: 4, height: 24)
                 .shadow(color: Color.liquidAccent.opacity(0.5), radius: 4, x: 0, y: 2)
 
-            // Touch target (invisible but tappable)
             Color.clear
-                .frame(width: scrubberHandleSize, height: scrubberHandleSize)
         }
         .frame(width: scrubberHandleSize, height: scrubberHandleSize)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Timeline scrubber")
+        .accessibilityValue(accessibilityTimelineValue)
+        .accessibilityHint("Swipe up or down to move between logged dates")
+        .accessibilityAdjustableAction { direction in
+            adjustSelection(for: direction)
+        }
         .accessibilityIdentifier("dashboard_timeline_scrubber_handle")
     }
 
@@ -258,11 +268,11 @@ struct ProgressTimelineView: View {
         // Update selected index to nearest entry
         if let photo = result.photo {
             if let index = bodyMetrics.firstIndex(where: { $0.id == photo.bodyMetrics.id }) {
-                selectedIndex = index
+                updateSelectedIndex(index)
             }
         } else if let metrics = result.metrics {
             if let index = bodyMetrics.firstIndex(where: { $0.id == metrics.bodyMetrics.id }) {
-                selectedIndex = index
+                updateSelectedIndex(index)
             }
         }
     }
@@ -278,18 +288,62 @@ struct ProgressTimelineView: View {
         // Update selected index
         if let metric = provider.getMetric(for: nearestDate),
            let index = bodyMetrics.firstIndex(where: { $0.id == metric.id }) {
-            selectedIndex = index
+            updateSelectedIndex(index)
         }
     }
 
     private func handleDragEnd() {
-        withAnimation(.easeOut(duration: 0.2)) {
+        if reduceMotion {
             isDragging = false
+        } else {
+            withAnimation(.easeOut(duration: 0.2)) {
+                isDragging = false
+            }
         }
 
         // Haptic feedback
         let impact = UIImpactFeedbackGenerator(style: .light)
         impact.impactOccurred()
+    }
+
+    private var accessibilityTimelineValue: String {
+        guard !bodyMetrics.isEmpty else {
+            return "No logged dates"
+        }
+
+        let clampedIndex = min(max(selectedIndex, 0), bodyMetrics.count - 1)
+        let date = bodyMetrics[clampedIndex].date
+        let formattedDate = TimelineDateFormatterCache.string(from: date, style: .mediumDate)
+        return "\(formattedDate), \(clampedIndex + 1) of \(bodyMetrics.count)"
+    }
+
+    private func adjustSelection(for direction: AccessibilityAdjustmentDirection) {
+        guard !bodyMetrics.isEmpty else { return }
+
+        let current = min(max(selectedIndex, 0), bodyMetrics.count - 1)
+        let nextIndex: Int
+
+        switch direction {
+        case .increment:
+            nextIndex = min(current + 1, bodyMetrics.count - 1)
+        case .decrement:
+            nextIndex = max(current - 1, 0)
+        @unknown default:
+            return
+        }
+
+        guard nextIndex != current else { return }
+        updateSelectedIndex(nextIndex)
+        currentDateLabel = TimelineDateFormatterCache.string(
+            from: bodyMetrics[nextIndex].date,
+            style: .mediumDate
+        )
+        HapticManager.shared.selection()
+    }
+
+    private func updateSelectedIndex(_ index: Int) {
+        guard bodyMetrics.indices.contains(index), selectedIndex != index else { return }
+        selectedIndex = index
     }
 
     private func refreshRenderDataIfNeeded(for signature: TimelineRenderSignature) {

--- a/apps/ios/LogYourBody/DesignSystem/Atoms/BaseButton.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Atoms/BaseButton.swift
@@ -28,7 +28,7 @@ struct ButtonConfiguration {
 
         var backgroundColor: Color {
             switch self {
-            case .primary: return .appPrimary
+            case .primary: return .jovieAction
             case .secondary: return .appCard
             case .tertiary: return .appCard
             case .destructive: return .red
@@ -40,7 +40,7 @@ struct ButtonConfiguration {
 
         var foregroundColor: Color {
             switch self {
-            case .primary: return .white
+            case .primary: return .jovieActionText
             case .secondary: return .appText
             case .tertiary: return .appText
             case .destructive: return .white
@@ -107,6 +107,7 @@ struct ButtonConfiguration {
 
 struct BaseButton<Label: View>: View {
     @Environment(\.isEnabled) private var isEnvironmentEnabled
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let configuration: ButtonConfiguration
     let action: () -> Void
@@ -119,22 +120,37 @@ struct BaseButton<Label: View>: View {
     }
 
     private var cornerRadius: CGFloat {
-        configuration.cornerRadius ?? 10
+        configuration.cornerRadius ?? JovieTokens.controlRadius
+    }
+
+    private var labelTextStyle: Font.TextStyle {
+        switch configuration.size {
+        case .small:
+            return .subheadline
+        case .medium, .custom:
+            return .body
+        case .large:
+            return .headline
+        }
+    }
+
+    private var minimumHeight: CGFloat {
+        max(configuration.size.height, JovieTokens.minimumHitTarget)
     }
 
     var body: some View {
         Button(action: handleTap, label: {
             buttonContent
                 .frame(maxWidth: configuration.fullWidth ? .infinity : nil)
-                .frame(height: configuration.size.height)
-                .padding(configuration.size.padding)
+                .frame(minHeight: minimumHeight)
+                .padding(.horizontal, configuration.size.padding.leading)
                 .background(backgroundView)
                 .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
                 .overlay(borderOverlay)
-                .scaleEffect(isPressed || configuration.isLoading ? 0.98 : 1.0)
+                .scaleEffect(reduceMotion ? 1 : (isPressed || configuration.isLoading ? 0.98 : 1.0))
                 .opacity(isEnabled ? 1.0 : 0.6)
-                .animation(.easeInOut(duration: 0.15), value: isPressed)
-                .animation(.easeInOut(duration: 0.15), value: configuration.isLoading)
+                .animation(reduceMotion ? nil : .easeInOut(duration: JovieTokens.subtleDuration), value: isPressed)
+                .animation(reduceMotion ? nil : .easeInOut(duration: JovieTokens.subtleDuration), value: configuration.isLoading)
         })
         .buttonStyle(PlainButtonStyle())
         .disabled(!isEnabled)
@@ -158,8 +174,9 @@ struct BaseButton<Label: View>: View {
                 .scaleEffect(0.8)
         } else {
             label()
-                .font(.system(size: configuration.size.fontSize, weight: .semibold))
+                .font(.system(labelTextStyle, design: .default).weight(.semibold))
                 .foregroundColor(configuration.style.foregroundColor)
+                .multilineTextAlignment(.center)
         }
     }
 
@@ -228,6 +245,7 @@ struct BaseIconButton: View {
 
     @State private var isPressed = false
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     enum IconButtonStyle {
         case filled
@@ -256,9 +274,9 @@ struct BaseIconButton: View {
             action()
         }, label: {
             Image(systemName: icon)
-                .font(.system(size: size, weight: .medium))
+                .font(.system(.body, design: .default).weight(.medium))
                 .foregroundColor(.appText)
-                .frame(width: size * 2, height: size * 2)
+                .frame(width: max(size * 2, 32), height: max(size * 2, 32))
                 .background(
                     Circle()
                         .fill(style.backgroundColor)
@@ -268,9 +286,10 @@ struct BaseIconButton: View {
                             }
                         )
                 )
-                .scaleEffect(isPressed ? 0.9 : 1.0)
+                .frame(minWidth: JovieTokens.minimumHitTarget, minHeight: JovieTokens.minimumHitTarget)
+                .scaleEffect(reduceMotion ? 1 : (isPressed ? 0.9 : 1.0))
                 .opacity(isEnabled ? 1.0 : 0.6)
-                .animation(.easeInOut(duration: 0.1), value: isPressed)
+                .animation(reduceMotion ? nil : .easeInOut(duration: JovieTokens.subtleDuration), value: isPressed)
         })
         .buttonStyle(PlainButtonStyle())
         .disabled(!isEnabled)

--- a/apps/ios/LogYourBody/DesignSystem/Atoms/BaseTextField.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Atoms/BaseTextField.swift
@@ -15,8 +15,11 @@ struct TextFieldConfiguration {
     var errorMessage: String?
     var helperText: String?
     var characterLimit: Int?
-    var cornerRadius: CGFloat = 10
-    var padding = EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16)
+    var cornerRadius: CGFloat = JovieTokens.controlRadius
+    var padding = EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
+    var accessibilityLabel: String?
+    var accessibilityIdentifier: String?
+    var messageAccessibilityIdentifier: String?
 
     enum TextFieldStyle {
         case `default`
@@ -26,7 +29,7 @@ struct TextFieldConfiguration {
 
         var backgroundColor: Color {
             switch self {
-            case .default: return Color(.systemGray6)
+            case .default: return .jovieSurfaceElevated
             case .outlined, .underlined: return .clear
             case .custom(let bg, _): return bg
             }
@@ -61,6 +64,7 @@ struct BaseTextField: View {
     @State private var isSecureTextVisible = false
     @FocusState private var isFocused: Bool
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var hasError: Bool {
         configuration.errorMessage != nil
@@ -70,7 +74,7 @@ struct BaseTextField: View {
         if hasError {
             return .appError
         } else if isFocused {
-            return .appPrimary
+            return .jovieAction
         } else {
             return configuration.style.borderColor ?? .clear
         }
@@ -95,7 +99,7 @@ struct BaseTextField: View {
                         TextField(placeholder, text: $text)
                     }
                 }
-                .font(.system(size: 16))
+                .font(.body)
                 .foregroundColor(.appText)
                 .keyboardType(keyboardType)
                 .textContentType(textContentType)
@@ -105,16 +109,19 @@ struct BaseTextField: View {
                 .onSubmit {
                     onSubmit?()
                 }
-                .onChange(of: text) { newValue in
+                .onChange(of: text) { _, newValue in
                     if let limit = configuration.characterLimit, newValue.count > limit {
                         text = String(newValue.prefix(limit))
                     }
                     onChange?(newValue)
                 }
                 .focused($isFocused)
-                .onChange(of: isFocused) { isFocused in
+                .onChange(of: isFocused) { _, isFocused in
                     onEditingChanged?(isFocused)
                 }
+                .accessibilityLabel(configuration.accessibilityLabel ?? placeholder)
+                .accessibilityHint(configuration.helperText ?? "")
+                .accessibilityIdentifier(configuration.accessibilityIdentifier ?? "")
 
                 // Trailing elements
                 HStack(spacing: 8) {
@@ -135,6 +142,8 @@ struct BaseTextField: View {
                                 .foregroundColor(.appTextSecondary)
                         })
                         .buttonStyle(PlainButtonStyle())
+                        .frame(minWidth: 44, minHeight: 44)
+                        .accessibilityLabel(isSecureTextVisible ? "Hide password" : "Show password")
                     }
 
                     // Error icon
@@ -146,11 +155,12 @@ struct BaseTextField: View {
                 }
             }
             .padding(configuration.padding)
+            .frame(minHeight: JovieTokens.controlHeight)
             .background(fieldBackground)
             .overlay(fieldOverlay)
             .opacity(isEnabled ? 1.0 : 0.6)
-            .animation(.easeInOut(duration: 0.2), value: isFocused)
-            .animation(.easeInOut(duration: 0.2), value: hasError)
+            .animation(reduceMotion ? nil : .easeInOut(duration: JovieTokens.subtleDuration), value: isFocused)
+            .animation(reduceMotion ? nil : .easeInOut(duration: JovieTokens.subtleDuration), value: hasError)
 
             // Helper/Error text
             if let errorMessage = configuration.errorMessage {
@@ -158,6 +168,8 @@ struct BaseTextField: View {
                     .font(.caption)
                     .foregroundColor(.appError)
                     .padding(.horizontal, 4)
+                    .accessibilityAddTraits(.isStaticText)
+                    .accessibilityIdentifier(configuration.messageAccessibilityIdentifier ?? "")
             } else if let helperText = configuration.helperText {
                 Text(helperText)
                     .font(.caption)

--- a/apps/ios/LogYourBody/DesignSystem/Atoms/DSAuthLink.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Atoms/DSAuthLink.swift
@@ -17,10 +17,12 @@ struct DSAuthLink: View {
         Button(action: action) {
             Text(title)
                 .font(theme.typography.labelMedium)
-                .foregroundColor(theme.colors.primary)
+                .foregroundColor(.jovieText)
                 .underline()
         }
         .buttonStyle(PlainButtonStyle())
+        .frame(minWidth: 44, minHeight: 44)
+        .contentShape(Rectangle())
     }
 }
 
@@ -37,10 +39,12 @@ struct DSAuthNavigationLink<Destination: View>: View {
         NavigationLink(destination: destination) {
             Text(title)
                 .font(theme.typography.labelMedium)
-                .foregroundColor(theme.colors.primary)
+                .foregroundColor(.jovieText)
                 .underline()
         }
         .buttonStyle(PlainButtonStyle())
+        .frame(minWidth: 44, minHeight: 44)
+        .contentShape(Rectangle())
     }
 }
 

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/AuthConsentCheckbox.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/AuthConsentCheckbox.swift
@@ -33,40 +33,48 @@ struct AuthConsentCheckbox: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            // Checkbox
+        HStack(alignment: .center, spacing: 8) {
             Button(action: { isChecked.toggle() }, label: {
-                Image(systemName: isChecked ? "checkmark.square.fill" : "square")
-                    .font(.system(size: 20))
-                    .foregroundColor(isChecked ? theme.colors.primary : theme.colors.border)
+                Image(systemName: isChecked ? "checkmark" : "square")
+                    .font(.system(.body, design: .default).weight(.semibold))
+                    .foregroundColor(isChecked ? .jovieActionText : theme.colors.textSecondary)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        RoundedRectangle(cornerRadius: 9, style: .continuous)
+                            .fill(isChecked ? Color.jovieAction : Color.jovieSurfaceElevated)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 9, style: .continuous)
+                            .stroke(isChecked ? Color.clear : Color.jovieHairline, lineWidth: 1)
+                    )
+                    .frame(width: 44, height: 44)
             })
-            .buttonStyle(PlainButtonStyle())
+            .buttonStyle(.plain)
+            .accessibilityLabel("Agree to \(linkText)")
+            .accessibilityValue(isChecked ? "Selected" : "Not selected")
+            .accessibilityHint("Required to create an account.")
 
-            // Text with link
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 4) {
-                    Text("I agree to the")
-                        .font(theme.typography.bodySmall)
-                        .foregroundColor(theme.colors.textSecondary)
+            VStack(alignment: .leading, spacing: 0) {
+                Text("I agree to the")
+                    .font(theme.typography.bodySmall)
+                    .foregroundColor(theme.colors.textSecondary)
+                    .accessibilityHidden(true)
 
-                    Button(action: handleLinkTap) {
-                        Text(linkText)
-                            .font(theme.typography.labelMedium)
-                            .foregroundColor(theme.colors.primary)
-                            .underline()
-                    }
-                    .buttonStyle(PlainButtonStyle())
+                Button(action: handleLinkTap) {
+                    Text(linkText)
+                        .font(theme.typography.labelMedium)
+                        .foregroundColor(.jovieText)
+                        .underline()
+                        .multilineTextAlignment(.leading)
                 }
-                .multilineTextAlignment(.leading)
-
-                Text(text)
-                    .font(theme.typography.captionMedium)
-                    .foregroundColor(theme.colors.textTertiary)
-                    .multilineTextAlignment(.leading)
+                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                .accessibilityLabel("Read \(linkText)")
+                .accessibilityHint(text)
             }
-
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     private func handleLinkTap() {

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/AuthFormField.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/AuthFormField.swift
@@ -18,6 +18,11 @@ struct AuthFormField: View {
     var textContentType: UITextContentType?
     var autocapitalization: TextInputAutocapitalization = .sentences
     var isDisabled: Bool = false
+    var validationMessage: String?
+    var helperText: String?
+    var submitLabel: SubmitLabel = .done
+    var onSubmit: (() -> Void)?
+    var accessibilityIdentifier: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -25,6 +30,7 @@ struct AuthFormField: View {
             Text(label)
                 .font(theme.typography.captionLarge)
                 .foregroundColor(theme.colors.textSecondary)
+                .accessibilityHidden(true)
 
             // Input Field
             BaseTextField(
@@ -34,21 +40,40 @@ struct AuthFormField: View {
                     style: .custom(background: .clear, border: nil),
                     isSecure: isSecure,
                     showToggle: isSecure,
-                    cornerRadius: theme.radius.input
+                    errorMessage: validationMessage,
+                    helperText: helperText,
+                    cornerRadius: theme.radius.input,
+                    accessibilityLabel: label,
+                    accessibilityIdentifier: accessibilityIdentifier,
+                    messageAccessibilityIdentifier: accessibilityIdentifier.map { "\($0)_validation_message" }
                 ),
                 keyboardType: keyboardType,
                 textContentType: textContentType,
-                autocapitalization: autocapitalization
+                autocapitalization: autocapitalization,
+                submitLabel: submitLabel,
+                onSubmit: onSubmit
             )
             .systemBGlassSurface(
                 cornerRadius: theme.radius.input,
                 tint: theme.colors.text,
                 tintOpacity: 0.03,
-                borderColor: theme.colors.border,
-                borderOpacity: 0.65
+                borderColor: validationMessage == nil ? theme.colors.border : theme.colors.error,
+                borderOpacity: validationMessage == nil ? 0.65 : 0.8
             )
             .disabled(isDisabled)
         }
+    }
+}
+
+// MARK: - Auth input validation
+
+enum AuthEmailValidator {
+    static func isValid(_ email: String) -> Bool {
+        let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+
+        let pattern = "^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+        return trimmed.range(of: pattern, options: .regularExpression) != nil
     }
 }
 

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/AuthHeader.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/AuthHeader.swift
@@ -19,10 +19,11 @@ struct AuthHeader: View {
     }
 
     var body: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 8) {
             Text(title)
                 .font(theme.typography.displayMedium)
                 .foregroundColor(theme.colors.text)
+                .multilineTextAlignment(.center)
 
             if let subtitle = subtitle {
                 Text(subtitle)
@@ -32,6 +33,68 @@ struct AuthHeader: View {
             }
         }
         .padding(.horizontal)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+// MARK: - Auth service status
+
+/// A single recovery surface for authentication-provider availability. Keeping this
+/// shared prevents Login and Sign Up from drifting into different failure states.
+struct AuthServiceStatusBanner: View {
+    @Environment(\.theme)
+    private var theme
+
+    let errorMessage: String?
+    let isRetrying: Bool
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let errorMessage {
+                Label("Connection unavailable", systemImage: "exclamationmark.triangle.fill")
+                    .font(theme.typography.labelMedium)
+                    .foregroundColor(theme.colors.text)
+                    .accessibilityLabel("Connection unavailable")
+
+                Text(errorMessage)
+                    .font(theme.typography.captionLarge)
+                    .foregroundColor(theme.colors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                BaseButton(
+                    isRetrying ? "Retrying connection" : "Retry connection",
+                    configuration: ButtonConfiguration(
+                        style: .custom(background: .jovieSurfaceElevated, foreground: .jovieText),
+                        isLoading: isRetrying,
+                        fullWidth: true,
+                        cornerRadius: JovieTokens.controlRadius
+                    ),
+                    action: onRetry
+                )
+                .accessibilityHint("Tries to reconnect to the sign-in service.")
+            } else {
+                HStack(spacing: 10) {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: theme.colors.info))
+                        .accessibilityHidden(true)
+
+                    Text("Connecting to sign-in service")
+                        .font(theme.typography.captionLarge)
+                        .foregroundColor(theme.colors.textSecondary)
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Connecting to sign-in service")
+            }
+        }
+        .padding(16)
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.cardRadius,
+            tint: errorMessage == nil ? theme.colors.info : theme.colors.error,
+            tintOpacity: 0.08,
+            borderColor: errorMessage == nil ? theme.colors.info : theme.colors.error,
+            borderOpacity: 0.3
+        )
     }
 }
 

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/LiquidGlassCTAButton.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/LiquidGlassCTAButton.swift
@@ -126,18 +126,20 @@ struct LiquidGlassSecondaryCTAButton: View {
 
 struct LiquidGlassCTAModifier: ViewModifier {
     @Environment(\.theme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let isEnabled: Bool
 
     func body(content: Content) -> some View {
         content
-            .font(.system(size: 17, weight: .semibold))
+            .font(.system(.headline, design: .default).weight(.semibold))
             .frame(maxWidth: .infinity)
-            .frame(height: 56)
+            .frame(minHeight: 56)
             .foregroundColor(isEnabled ? .black : .white.opacity(0.5))
             .background(backgroundView)
             .overlay(overlayView)
             .clipShape(RoundedRectangle(cornerRadius: 28))
+            .animation(reduceMotion ? nil : theme.animation.fast, value: isEnabled)
     }
 
     @ViewBuilder private var backgroundView: some View {

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/OTPField.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/OTPField.swift
@@ -28,12 +28,19 @@ struct OTPField: View {
 
     var body: some View {
         ZStack {
-            // Hidden TextField
+            // Keep one real, labelled text field in the accessibility tree. The
+            // six visual cells are a presentation of that field, not six separate
+            // controls a VoiceOver user has to navigate.
             TextField("", text: $code)
                 .keyboardType(.numberPad)
                 .textContentType(.oneTimeCode)
                 .focused($isFieldFocused)
-                .opacity(0)
+                .opacity(0.01)
+                .frame(maxWidth: .infinity, minHeight: 56)
+                .accessibilityLabel("Verification code")
+                .accessibilityValue("\(code.count) of \(length) digits entered")
+                .accessibilityHint("Enter the \(length)-digit code we emailed you.")
+                .accessibilityIdentifier(accessibilityIdentifier ?? "otp_field")
                 .onChange(of: code) { newValue in
                     // Limit to specified length
                     if newValue.count > length {
@@ -55,12 +62,9 @@ struct OTPField: View {
                     )
                 }
             }
-            .onTapGesture {
-                isFieldFocused = true
-            }
+            .allowsHitTesting(false)
         }
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier(accessibilityIdentifier ?? "otp_field")
+        .contentShape(Rectangle())
     }
 
     private func digitAt(_ index: Int) -> String {
@@ -77,11 +81,12 @@ struct OTPField: View {
 private struct OTPDigitBox: View {
     let digit: String
     let isActive: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 8)
-                .fill(Color(.systemGray6))
+                .fill(Color.appCard)
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
                         .stroke(isActive ? Color.appPrimary : Color.appBorder, lineWidth: 1)
@@ -89,7 +94,7 @@ private struct OTPDigitBox: View {
                 .frame(width: 46, height: 56)
 
             Text(digit)
-                .font(.system(size: 24, weight: .semibold))
+                .font(.system(.title2, design: .rounded).weight(.semibold))
                 .foregroundColor(.appText)
 
             if isActive {
@@ -99,7 +104,7 @@ private struct OTPDigitBox: View {
                     .opacity(digit.isEmpty ? 1 : 0)
             }
         }
-        .animation(.easeInOut(duration: 0.1), value: isActive)
+        .animation(reduceMotion ? nil : .easeInOut(duration: JovieTokens.subtleDuration), value: isActive)
     }
 }
 

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/BiometricAuthView.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/BiometricAuthView.swift
@@ -1,10 +1,10 @@
 //
-// BiometricAuthView.swift
-// LogYourBody
+//  BiometricAuthView.swift
+//  LogYourBody
+//
+//  Focused recovery state for the app lock.
 //
 import SwiftUI
-
-// MARK: - BiometricAuthView Organism
 
 struct BiometricAuthView: View {
     enum BiometricType {
@@ -13,19 +13,22 @@ struct BiometricAuthView: View {
 
         var icon: String {
             switch self {
-            case .faceID:
-                return "faceid"
-            case .touchID:
-                return "touchid"
+            case .faceID: "faceid"
+            case .touchID: "touchid"
             }
         }
 
         var title: String {
             switch self {
-            case .faceID:
-                return "Face ID"
-            case .touchID:
-                return "Touch ID"
+            case .faceID: "Face ID"
+            case .touchID: "Touch ID"
+            }
+        }
+
+        var recoveryGuidance: String {
+            switch self {
+            case .faceID: "Keep the TrueDepth camera visible, then try again."
+            case .touchID: "Keep your finger on the sensor, then try again."
             }
         }
     }
@@ -34,113 +37,74 @@ struct BiometricAuthView: View {
     let onAuthenticate: () -> Void
     let onUsePassword: () -> Void
 
-    @State private var pulse = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        VStack(spacing: 32) {
-            VStack(spacing: 4) {
-                Text("Need help unlocking?")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.linearTextSecondary)
+        VStack(spacing: JovieTokens.sectionGap) {
+            Image(systemName: biometricType.icon)
+                .font(.system(.largeTitle, design: .default).weight(.medium))
+                .foregroundStyle(Color.jovieText)
+                .frame(width: 72, height: 72)
+                .background(Color.jovieSurfaceElevated, in: Circle())
+                .overlay(Circle().stroke(Color.jovieHairline, lineWidth: 1))
+                .symbolEffect(.pulse, options: reduceMotion ? .nonRepeating : .repeating)
+                .accessibilityHidden(true)
 
+            VStack(spacing: 8) {
                 Text("\(biometricType.title) didn’t complete")
-                    .font(.system(size: 24, weight: .bold))
-                    .foregroundColor(.linearText)
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(Color.jovieText)
+                    .multilineTextAlignment(.center)
+
+                Text(biometricType.recoveryGuidance)
+                    .font(.body)
+                    .foregroundStyle(Color.jovieTextSecondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
-            VStack(spacing: 26) {
-                ZStack {
-                    Circle()
-                        .fill(Color.linearBorder.opacity(0.25))
-                        .frame(width: 130, height: 130)
-
-                    Circle()
-                        .stroke(
-                            LinearGradient(
-                                gradient: Gradient(colors: [Color.appPrimary, Color.linearBlue]),
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            ),
-                            lineWidth: 12
-                        )
-                        .frame(width: 130, height: 130)
-
-                    Image(systemName: biometricType.icon)
-                        .font(.system(size: 40))
-                        .foregroundColor(Color.linearText)
-                        .scaleEffect(pulse ? 1.05 : 0.95)
-                        .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: pulse)
-                }
-                .onAppear {
-                    pulse = true
-                }
-
-                VStack(spacing: 6) {
-                    Text("Try \(biometricType.title) again")
-                        .font(.system(size: 18, weight: .semibold))
-                        .foregroundColor(.linearText)
-
-                    Text("Make sure the TrueDepth camera is clean and visible.")
-                        .font(.system(size: 15))
-                        .foregroundColor(.linearTextSecondary)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 12)
-                }
-
+            VStack(spacing: JovieTokens.itemGap) {
                 BaseButton(
-                    "Retry \(biometricType.title)",
+                    "Try \(biometricType.title) again",
                     configuration: ButtonConfiguration(
-                        style: .primary,
+                        style: .custom(background: .jovieAction, foreground: .jovieActionText),
                         fullWidth: true,
                         icon: biometricType.icon
                     ),
                     action: onAuthenticate
                 )
-            }
-            .padding(28)
-            .background(
-                RoundedRectangle(cornerRadius: 28, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .background(
-                        RoundedRectangle(cornerRadius: 28, style: .continuous)
-                            .fill(Color.liquidBg.opacity(0.85))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 28, style: .continuous)
-                            .stroke(Color.appPrimary.opacity(0.2), lineWidth: 1)
-                    )
-                    .shadow(color: Color.linearBlue.opacity(0.35), radius: 25, x: 0, y: 15)
-            )
+                .accessibilityHint("Starts \(biometricType.title) authentication again")
 
-            VStack(spacing: 8) {
-                Text("If \(biometricType.title) keeps failing, you can continue without it.")
-                    .font(.system(size: 13))
-                    .foregroundColor(.linearTextTertiary)
-                    .multilineTextAlignment(.center)
-
-                DSAuthLink(
-                    title: "Continue without \(biometricType.title)",
-                    action: onUsePassword
-                )
+                Button(action: onUsePassword) {
+                    Text("Continue without \(biometricType.title)")
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(Color.jovieTextSecondary)
+                        .frame(maxWidth: .infinity, minHeight: JovieTokens.minimumHitTarget)
+                }
+                .buttonStyle(.plain)
+                .jovieTouchTarget()
+                .accessibilityHint("Closes the biometric lock")
             }
         }
-        .padding(.horizontal, 20)
+        .padding(JovieTokens.sectionGap)
+        .frame(maxWidth: 440)
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.cardRadius,
+            tint: .white,
+            tintOpacity: 0.025,
+            borderColor: .jovieHairline
+        )
+        .accessibilityElement(children: .contain)
     }
 }
 
-// MARK: - Preview
-
 #Preview {
-    VStack {
-        Spacer()
-
-        BiometricAuthView(
-            biometricType: .faceID,
-            onAuthenticate: {},
-            onUsePassword: {}
-        )
-
-        Spacer()
-    }
-    .background(Color.appBackground)
+    BiometricAuthView(
+        biometricType: .faceID,
+        onAuthenticate: {},
+        onUsePassword: {}
+    )
+    .padding()
+    .background(Color.jovieCanvas)
+    .preferredColorScheme(.dark)
 }

--- a/apps/ios/LogYourBody/DesignSystem/Organisms/VerificationForm.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Organisms/VerificationForm.swift
@@ -7,6 +7,7 @@ import SwiftUI
 // MARK: - VerificationForm Organism
 
 struct VerificationForm: View {
+    @Environment(\.theme) private var theme
     @Binding var verificationCode: String
     @Binding var isLoading: Bool
 
@@ -23,13 +24,13 @@ struct VerificationForm: View {
         VStack(spacing: 32) {
             // Instructions
             VStack(spacing: 8) {
-                Text("We've sent a verification code to")
-                    .font(.system(size: 16))
-                    .foregroundColor(.appTextSecondary)
+                Text("We sent a 6-digit code to")
+                    .font(theme.typography.bodySmall)
+                    .foregroundColor(theme.colors.textSecondary)
 
                 Text(email)
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.appText)
+                    .font(theme.typography.labelLarge)
+                    .foregroundColor(theme.colors.text)
                     .accessibilityIdentifier("email_verification_pending_email")
             }
             .multilineTextAlignment(.center)
@@ -63,14 +64,14 @@ struct VerificationForm: View {
             VStack(spacing: 4) {
                 if timerActive && timeRemaining > 0 {
                     Text("Resend code in \(timeRemaining)s")
-                        .font(.system(size: 14))
-                        .foregroundColor(.appTextSecondary)
+                        .font(theme.typography.bodySmall)
+                        .foregroundColor(theme.colors.textSecondary)
                         .accessibilityIdentifier("email_verification_resend_timer")
                 } else {
                     HStack(spacing: 4) {
                         Text("Didn't receive code?")
-                            .font(.system(size: 14))
-                            .foregroundColor(.appTextSecondary)
+                            .font(theme.typography.bodySmall)
+                            .foregroundColor(theme.colors.textSecondary)
 
                         DSAuthLink(title: "Resend") {
                             onResend()

--- a/apps/ios/LogYourBody/DesignSystem/Theme.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Theme.swift
@@ -5,6 +5,23 @@
 import SwiftUI
 import UIKit
 
+/// The single set of geometry and interaction values for production iPhone UI.
+/// Keep these semantic values at the shared boundary instead of creating another
+/// screen-specific spacing or control system.
+enum JovieTokens {
+    static let screenInset: CGFloat = 20
+    static let compactInset: CGFloat = 16
+    static let sectionGap: CGFloat = 24
+    static let itemGap: CGFloat = 12
+    static let minimumHitTarget: CGFloat = 44
+    static let controlHeight: CGFloat = 48
+    static let compactControlHeight: CGFloat = 44
+    static let cardRadius: CGFloat = 20
+    static let controlRadius: CGFloat = 16
+    static let subtleDuration: Double = 0.15
+    static let cinematicDuration: Double = 0.42
+}
+
 protocol Theme {
     var colors: ColorTheme { get }
     var materials: MaterialTheme { get }
@@ -123,7 +140,7 @@ struct SpacingTheme {
     // Semantic spacing
     let elementSpacing: CGFloat = 8
     let sectionSpacing: CGFloat = 24
-    let screenPadding: CGFloat = 16
+    let screenPadding: CGFloat = JovieTokens.screenInset
     let cardPadding: CGFloat = 16
     let listItemSpacing: CGFloat = 12
 }
@@ -134,16 +151,16 @@ struct RadiusTheme {
     let none: CGFloat = 0
     let xs: CGFloat = 2
     let sm: CGFloat = 4
-    let md: CGFloat = 10
-    let lg: CGFloat = 14
+    let md: CGFloat = 12
+    let lg: CGFloat = 16
     let xl: CGFloat = 48
     let xxl: CGFloat = 48
     let full: CGFloat = 48
 
     // Semantic radius
     let button: CGFloat = 48
-    let card: CGFloat = 14
-    let input: CGFloat = 10
+    let card: CGFloat = JovieTokens.cardRadius
+    let input: CGFloat = JovieTokens.controlRadius
     let chip: CGFloat = 48
     let avatar: CGFloat = 48
 }
@@ -151,13 +168,13 @@ struct RadiusTheme {
 // MARK: - Animation Theme
 
 struct AnimationTheme {
-    let subtle: Animation = .easeInOut(duration: 0.15)
-    let cinematic: Animation = .easeInOut(duration: 0.42)
+    let subtle: Animation = .easeInOut(duration: JovieTokens.subtleDuration)
+    let cinematic: Animation = .easeInOut(duration: JovieTokens.cinematicDuration)
 
-    let ultraFast: Animation = .easeInOut(duration: 0.15)
-    let fast: Animation = .easeInOut(duration: 0.15)
-    let medium: Animation = .easeInOut(duration: 0.42)
-    let slow: Animation = .easeInOut(duration: 0.42)
+    let ultraFast: Animation = .easeInOut(duration: JovieTokens.subtleDuration)
+    let fast: Animation = .easeInOut(duration: JovieTokens.subtleDuration)
+    let medium: Animation = .easeInOut(duration: JovieTokens.cinematicDuration)
+    let slow: Animation = .easeInOut(duration: JovieTokens.cinematicDuration)
 
     let spring: Animation = .spring(response: 0.42, dampingFraction: 0.8)
     let springBouncy: Animation = .spring(response: 0.42, dampingFraction: 0.7)
@@ -203,9 +220,9 @@ struct DefaultTheme: Theme {
         surfaceTertiary: Color(hex: "#1f1f1f"),
 
         // Primary
-        primary: Color(hex: "#2563FF"),
-        primaryMuted: Color(hex: "#2563FF").opacity(0.8),
-        primarySubtle: Color(hex: "#2563FF").opacity(0.3),
+        primary: .jovieAction,
+        primaryMuted: .jovieAction.opacity(0.82),
+        primarySubtle: .jovieAction.opacity(0.12),
 
         // Accents
         accentViolet: Color(hex: "#8b1eff"),
@@ -221,53 +238,53 @@ struct DefaultTheme: Theme {
         textQuaternary: Color(hex: "#4A4D52"),
 
         // Borders
-        border: Color(hex: "#1f1f1f"),
-        borderSecondary: Color(hex: "#141414"),
-        borderFocused: Color(hex: "#2563FF"),
+        border: .jovieHairline,
+        borderSecondary: Color(hex: "#1A1A1C"),
+        borderFocused: .jovieAction.opacity(0.72),
 
         // States
         success: Color(hex: "#2F9E44"),
         warning: Color(hex: "#ff9800"),
         error: Color(hex: "#F3122D"),
-        info: Color(hex: "#2563FF"),
+        info: .jovieMetricAccent,
 
         // Interactive
-        interactive: Color(hex: "#2563FF"),
-        interactiveHover: Color(hex: "#3b74ff"),
-        interactivePressed: Color(hex: "#1d4ed8"),
-        interactiveDisabled: Color(hex: "#2563FF").opacity(0.4)
+        interactive: .jovieAction,
+        interactiveHover: .jovieAction,
+        interactivePressed: .jovieAction.opacity(0.82),
+        interactiveDisabled: .jovieAction.opacity(0.35)
     )
 
     let materials = MaterialTheme()
     let typography = TypographyTheme(
         // Display
-        displayLarge: .system(size: 48, weight: .bold, design: .rounded),
-        displayMedium: .system(size: 36, weight: .bold, design: .rounded),
-        displaySmall: .system(size: 32, weight: .semibold, design: .rounded),
+        displayLarge: .system(.largeTitle, design: .rounded).weight(.bold),
+        displayMedium: .system(.title, design: .rounded).weight(.bold),
+        displaySmall: .system(.title2, design: .rounded).weight(.semibold),
 
         // Headline
-        headlineLarge: .system(size: 28, weight: .semibold, design: .rounded),
-        headlineMedium: .system(size: 24, weight: .semibold, design: .rounded),
-        headlineSmall: .system(size: 20, weight: .semibold, design: .rounded),
+        headlineLarge: .system(.title2, design: .default).weight(.semibold),
+        headlineMedium: .system(.title3, design: .default).weight(.semibold),
+        headlineSmall: .system(.headline, design: .default).weight(.semibold),
 
         // Body
-        bodyLarge: .system(size: 18, weight: .regular, design: .rounded),
-        bodyMedium: .system(size: 16, weight: .regular, design: .rounded),
-        bodySmall: .system(size: 14, weight: .regular, design: .rounded),
+        bodyLarge: .system(.body, design: .default),
+        bodyMedium: .system(.callout, design: .default),
+        bodySmall: .system(.subheadline, design: .default),
 
         // Label
-        labelLarge: .system(size: 16, weight: .medium, design: .rounded),
-        labelMedium: .system(size: 14, weight: .medium, design: .rounded),
-        labelSmall: .system(size: 12, weight: .medium, design: .rounded),
+        labelLarge: .system(.body, design: .default).weight(.semibold),
+        labelMedium: .system(.subheadline, design: .default).weight(.semibold),
+        labelSmall: .system(.footnote, design: .default).weight(.semibold),
 
         // Caption
-        captionLarge: .system(size: 13, weight: .regular, design: .rounded),
-        captionMedium: .system(size: 12, weight: .regular, design: .rounded),
-        captionSmall: .system(size: 11, weight: .regular, design: .rounded),
+        captionLarge: .system(.footnote, design: .default),
+        captionMedium: .system(.caption, design: .default),
+        captionSmall: .system(.caption2, design: .default),
 
         // Special
-        monospace: .system(size: 16, weight: .regular, design: .monospaced),
-        monospaceLarge: .system(size: 24, weight: .semibold, design: .monospaced)
+        monospace: .system(.body, design: .monospaced),
+        monospaceLarge: .system(.title3, design: .monospaced).weight(.semibold)
     )
 
     let spacing = SpacingTheme()
@@ -332,6 +349,16 @@ extension View {
                 shadowY: shadowY
             )
         )
+    }
+
+    /// Expands a visual control to Apple's minimum recommended hit target without
+    /// forcing surrounding layout to use a one-off frame.
+    func jovieTouchTarget() -> some View {
+        contentShape(Rectangle())
+            .frame(
+                minWidth: JovieTokens.minimumHitTarget,
+                minHeight: JovieTokens.minimumHitTarget
+            )
     }
 }
 

--- a/apps/ios/LogYourBody/Extensions/Color+Theme.swift
+++ b/apps/ios/LogYourBody/Extensions/Color+Theme.swift
@@ -5,6 +5,20 @@
 import SwiftUI
 
 public extension Color {
+    // MARK: - Jovie canonical surface tokens
+    //
+    // These are intentionally neutral. Accent colour is reserved for metric meaning
+    // and system state; primary actions use the high-contrast white-on-black pair.
+    static let jovieCanvas = Color(hex: "#000000")
+    static let jovieSurface = Color(hex: "#141414")
+    static let jovieSurfaceElevated = Color(hex: "#1C1C1E")
+    static let jovieHairline = Color(hex: "#2A2A2C")
+    static let jovieText = Color(hex: "#F7F7F8")
+    static let jovieTextSecondary = Color(hex: "#A7A7AD")
+    static let jovieAction = Color.white
+    static let jovieActionText = Color.black
+    static let jovieMetricAccent = Color(hex: "#1EB4EA")
+
     // MARK: - Primary Colors
     static let linearPurple = Color(hex: "#5B63D3")
     static let linearBlue = Color(hex: "#3B82F6")
@@ -57,14 +71,14 @@ public extension Color {
     static let linearDisabledText = Color(hex: "#5A5A5A")
 
     // MARK: - App Specific (Aliases for consistency)
-    static let appBackground = linearBg
-    static let appCard = linearCard
-    static let appBorder = linearBorder
-    static let appPrimary = metricAccent  // Note: linearPurple is the canonical name
-    static let appSurfaceSecondary = linearCard
-    static let appText = linearText
-    static let appTextPrimary = linearText
-    static let appTextSecondary = linearTextSecondary
+    static let appBackground = jovieCanvas
+    static let appCard = jovieSurface
+    static let appBorder = jovieHairline
+    static let appPrimary = jovieMetricAccent
+    static let appSurfaceSecondary = jovieSurface
+    static let appText = jovieText
+    static let appTextPrimary = jovieText
+    static let appTextSecondary = jovieTextSecondary
     static let appTextTertiary = linearTextTertiary
     static let appDisabled = linearDisabled
     static let appDisabledText = linearDisabledText

--- a/apps/ios/LogYourBody/Features/Onboarding/BodyScoreCalculator.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/BodyScoreCalculator.swift
@@ -36,9 +36,11 @@ struct BodyScoreCalculator: BodyScoreCalculating {
     }
 
     private func calculateFFMI(weightKg: Double, bodyFatPercentage: Double, heightCm: Double) -> Double {
-        let heightM = heightCm / 100.0
-        let leanMassKg = weightKg * (1 - bodyFatPercentage / 100)
-        return (leanMassKg / (heightM * heightM)) + 6.1 * (1.8 - heightM)
+        UnitConversion.calculateFFMI(
+            weightKg: weightKg,
+            bodyFatPercentage: bodyFatPercentage,
+            heightCm: heightCm
+        ) ?? 0
     }
 
     private func bodyFatReferenceRange(for sex: BiologicalSex) -> BodyScoreResult.ReferenceRange {

--- a/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingAtoms.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingAtoms.swift
@@ -64,13 +64,13 @@ struct OnboardingPrimaryButtonStyle: ButtonStyle {
     private var theme
 
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
             .font(theme.typography.labelLarge)
             .frame(maxWidth: .infinity)
-            .frame(minHeight: 56)
-            .padding(.vertical, 2)
+            .frame(minHeight: JovieTokens.controlHeight)
             .foregroundStyle(isEnabled ? theme.colors.background : theme.colors.background.opacity(0.55))
             .background(
                 Capsule(style: .continuous)
@@ -81,7 +81,7 @@ struct OnboardingPrimaryButtonStyle: ButtonStyle {
                     .stroke(theme.colors.text.opacity(0.16))
             )
             .opacity(configuration.isPressed ? 0.85 : 1)
-            .animation(theme.animation.fast, value: configuration.isPressed)
+            .animation(reduceMotion ? nil : theme.animation.fast, value: configuration.isPressed)
     }
 
     private func buttonOpacity(isPressed: Bool) -> Double {
@@ -93,12 +93,13 @@ struct OnboardingPrimaryButtonStyle: ButtonStyle {
 struct OnboardingSecondaryButtonStyle: ButtonStyle {
     @Environment(\.theme)
     private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
             .font(theme.typography.labelLarge)
             .frame(maxWidth: .infinity)
-            .padding(.vertical, 14)
+            .frame(minHeight: JovieTokens.compactControlHeight)
             .foregroundStyle(theme.colors.text)
             .systemBGlassSurface(
                 cornerRadius: theme.radius.button,
@@ -107,7 +108,7 @@ struct OnboardingSecondaryButtonStyle: ButtonStyle {
                 borderColor: theme.colors.border,
                 borderOpacity: 0.65
             )
-            .animation(theme.animation.fast, value: configuration.isPressed)
+            .animation(reduceMotion ? nil : theme.animation.fast, value: configuration.isPressed)
     }
 }
 
@@ -125,6 +126,7 @@ struct OnboardingTextButton: View {
                 .foregroundStyle(theme.colors.primary)
                 .padding(.vertical, 8)
         }
+        .jovieTouchTarget()
     }
 }
 
@@ -145,7 +147,7 @@ struct OnboardingIconBullet: View {
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: item.iconName)
-                .font(.system(size: 16, weight: .semibold))
+                .font(.system(.body, design: .rounded).weight(.semibold))
                 .foregroundStyle(theme.colors.primary)
                 .frame(width: 24, height: 24)
                 .background(
@@ -195,7 +197,7 @@ struct OnboardingCard<Content: View>: View {
         content
             .padding(20)
             .systemBGlassSurface(
-                cornerRadius: 20,
+                cornerRadius: theme.radius.card,
                 tint: theme.colors.text,
                 tintOpacity: 0.04,
                 borderColor: theme.colors.border,
@@ -231,6 +233,9 @@ struct FFMIInfoContent: View {
 }
 
 struct FFMIInfoLink: View {
+    @Environment(\.theme)
+    private var theme
+
     @State private var isPresenting = false
 
     var body: some View {
@@ -242,11 +247,11 @@ struct FFMIInfoLink: View {
             label: {
                 HStack(spacing: 6) {
                     Image(systemName: "questionmark.circle")
-                        .font(.system(size: 14, weight: .semibold))
+                        .font(.system(.footnote, design: .default).weight(.semibold))
                     Text("What's FFMI?")
-                        .font(.system(size: 14, weight: .medium))
+                        .font(theme.typography.labelMedium)
                 }
-                .foregroundStyle(Color.appPrimary)
+                .foregroundStyle(Color.jovieAction)
                 .padding(.vertical, 4)
             }
         )
@@ -257,13 +262,13 @@ struct FFMIInfoLink: View {
                     FFMIInfoContent()
                         .padding(24)
                 }
-                .background(Color.appBackground.ignoresSafeArea())
+                .background(Color.jovieCanvas.ignoresSafeArea())
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Done") {
                             isPresenting = false
                         }
-                        .foregroundStyle(Color.appPrimary)
+                        .foregroundStyle(Color.jovieAction)
                     }
                 }
             }

--- a/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingMolecules.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingMolecules.swift
@@ -62,6 +62,10 @@ struct OnboardingOptionButton: View {
             )
         })
         .buttonStyle(.plain)
+        .jovieTouchTarget()
+        .accessibilityLabel(title)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }
 
@@ -81,7 +85,7 @@ struct OnboardingSegmentedControl<Option: Hashable & CustomStringConvertible>: V
                     Text(option.description)
                         .font(theme.typography.labelMedium)
                         .frame(maxWidth: .infinity)
-                        .padding(.vertical, 10)
+                        .frame(minHeight: JovieTokens.compactControlHeight)
                         .foregroundStyle(selection == option ? theme.colors.text : theme.colors.textSecondary)
                         .systemBGlassSurface(
                             cornerRadius: 14,
@@ -92,6 +96,8 @@ struct OnboardingSegmentedControl<Option: Hashable & CustomStringConvertible>: V
                         )
                 })
                 .buttonStyle(.plain)
+                .accessibilityValue(selection == option ? "Selected" : "Not selected")
+                .accessibilityAddTraits(selection == option ? .isSelected : [])
             }
         }
         .padding(4)
@@ -151,7 +157,7 @@ struct OnboardingTextFieldRow: View {
                 .textInputAutocapitalization(.never)
                 .focused($isFocused)
                 .padding(.horizontal, 14)
-                .padding(.vertical, 12)
+                .frame(minHeight: JovieTokens.compactControlHeight)
                 .systemBGlassSurface(
                     cornerRadius: theme.radius.input,
                     tint: isFocused ? theme.colors.primary : theme.colors.text,
@@ -200,6 +206,7 @@ struct OnboardingValueRow: View {
                         .foregroundStyle(theme.colors.primary)
                 })
                 .buttonStyle(.plain)
+                .jovieTouchTarget()
             }
         }
         .padding(20)
@@ -268,7 +275,7 @@ struct OnboardingProgressIndicator: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Step \(context.currentIndex) of \(context.totalCount)")
+            Text("\(context.label) · \(Int((context.fractionComplete * 100).rounded()))% complete")
                 .font(theme.typography.labelSmall)
                 .foregroundStyle(theme.colors.textSecondary)
 
@@ -324,7 +331,7 @@ struct OnboardingScaffold<Content: View, CTA: View>: View {
             ScrollView {
                 content
                     .frame(maxWidth: .infinity, alignment: .topLeading)
-                    .padding(.horizontal, 24)
+                    .padding(.horizontal, JovieTokens.screenInset)
                     .padding(.top, 16)
                     .padding(.bottom, showsCTA ? 24 : 40)
             }
@@ -348,7 +355,7 @@ struct OnboardingScaffold<Content: View, CTA: View>: View {
                 .frame(height: 1)
 
             cta
-                .padding(.horizontal, 24)
+                .padding(.horizontal, JovieTokens.screenInset)
                 .padding(.top, 14)
                 .padding(.bottom, 12)
         }
@@ -429,6 +436,7 @@ struct OnboardingPageTemplate<Content: View, Footer: View>: View {
                         )
                 })
                 .buttonStyle(.plain)
+                .jovieTouchTarget()
             }
 
             if let progress {

--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel+Part01.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel+Part01.swift
@@ -238,39 +238,40 @@ func trackStepTransition(from: Step, to: Step) {
     }
 
 func progress(for step: Step) -> ProgressContext? {
-        let steps = activeProgressSteps
-        guard let index = steps.firstIndex(of: step) else { return nil }
+        guard let milestone = progressMilestone(for: step) else { return nil }
+        let plan = progressMilestonePlan
+        guard let index = plan.firstIndex(of: milestone) else { return nil }
         return ProgressContext(
             currentIndex: index + 1,
-            totalCount: steps.count,
-            label: step.progressLabel
+            totalCount: plan.count,
+            label: milestone.label
         )
     }
 
-var activeProgressSteps: [Step] {
-        Step.progressSequence.filter { shouldIncludeInProgress($0) }
+var progressMilestonePlan: [ProgressMilestone] {
+        includesFirstPhotoStep
+            ? ProgressMilestone.allCases
+            : ProgressMilestone.allCases.filter { $0 != .photo }
     }
 
-func shouldIncludeInProgress(_ step: Step) -> Bool {
+func progressMilestone(for step: Step) -> ProgressMilestone? {
         switch step {
-        case .hook, .basics, .height, .healthConnect, .bodyScore, .defaultHomeMode, .profileDetails:
-            return true
+        case .hook:
+            return .welcome
+        case .basics, .height:
+            return .basics
+        case .healthConnect, .healthConfirmation, .manualWeight, .bodyFatChoice, .bodyFatNumeric, .bodyFatVisual:
+            return .measurements
+        case .bodyScore:
+            return .score
+        case .defaultHomeMode:
+            return .home
+        case .emailCapture, .account, .profileDetails:
+            return .profile
         case .firstPhoto:
-            return includesFirstPhotoStep
-        case .emailCapture, .account:
-            return !hasAuthenticatedAccountEmail
-        case .healthConfirmation:
-            return healthKitManager.isAuthorized
-        case .manualWeight:
-            return !hasWeightEntry
-        case .bodyFatChoice:
-            return !hasBodyFatEntry
-        case .bodyFatNumeric:
-            return bodyScoreInput.bodyFat.source == .manualValue
-        case .bodyFatVisual:
-            return bodyScoreInput.bodyFat.source == .visualEstimate
+            return includesFirstPhotoStep ? .photo : nil
         case .loading, .paywall:
-            return false
+            return nil
         }
     }
 

--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -74,8 +74,32 @@ final class OnboardingFlowViewModel: ObservableObject {
         let label: String
 
         var fractionComplete: Double {
-            guard totalCount > 0 else { return 0 }
-            return min(max(Double(currentIndex) / Double(totalCount), 0), 1)
+            guard totalCount > 1 else { return 1 }
+            return min(max(Double(currentIndex - 1) / Double(totalCount - 1), 0), 1)
+        }
+    }
+
+    /// A stable, user-facing plan. Branch-specific input screens belong to a
+    /// milestone instead of changing the visible progress denominator mid-flow.
+    enum ProgressMilestone: CaseIterable {
+        case welcome
+        case basics
+        case measurements
+        case score
+        case home
+        case profile
+        case photo
+
+        var label: String {
+            switch self {
+            case .welcome: return "Welcome"
+            case .basics: return "Basics"
+            case .measurements: return "Measurements"
+            case .score: return "Your Score"
+            case .home: return "Home"
+            case .profile: return "Profile"
+            case .photo: return "Photo"
+            }
         }
     }
 

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreAccountCreationView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreAccountCreationView.swift
@@ -6,6 +6,7 @@ struct BodyScoreAccountCreationView: View {
 
     @EnvironmentObject var authManager: AuthManager
     @ObservedObject var viewModel: OnboardingFlowViewModel
+    @AccessibilityFocusState private var accountCreationErrorFocused: Bool
 
     var body: some View {
         OnboardingPageTemplate(
@@ -14,7 +15,7 @@ struct BodyScoreAccountCreationView: View {
             onBack: { viewModel.goBack() },
             progress: viewModel.progress(for: .account),
             content: {
-                VStack(spacing: 20) {
+                VStack(alignment: .leading, spacing: JovieTokens.itemGap) {
                     OnboardingTextFieldRow(
                         title: "Email address",
                         placeholder: "you@domain.com",
@@ -24,38 +25,38 @@ struct BodyScoreAccountCreationView: View {
                         ),
                         keyboardType: .emailAddress
                     )
+
+                    OnboardingCaptionText(
+                        text: "We’ll send a verification code to this address.",
+                        alignment: .leading
+                    )
+
+                    if let error = viewModel.accountCreationError {
+                        Text(error)
+                            .font(OnboardingTypography.caption)
+                            .foregroundStyle(theme.colors.error)
+                            .accessibilityFocused($accountCreationErrorFocused)
+                    }
                 }
             },
             footer: {
                 Button(action: submit) {
-                    if viewModel.isCreatingAccount {
-                        VStack(spacing: 8) {
+                    HStack(spacing: 8) {
+                        if viewModel.isCreatingAccount {
                             ProgressView()
                                 .progressViewStyle(CircularProgressViewStyle(tint: theme.colors.background))
-                            if let status = viewModel.accountCreationStatusMessage {
-                                Text(status)
-                                    .font(OnboardingTypography.caption)
-                                    .foregroundStyle(theme.colors.background.opacity(0.65))
-                            }
                         }
-                    } else {
-                        Text("Create account")
-                            .font(.system(size: 18, weight: .semibold))
+                        Text(viewModel.isCreatingAccount ? "Creating account…" : "Create account")
                     }
                 }
                 .buttonStyle(OnboardingPrimaryButtonStyle())
                 .disabled(!viewModel.canContinueAccountCreation || viewModel.isCreatingAccount)
-                .opacity(viewModel.canContinueAccountCreation ? 1 : 0.85)
-
-                if let error = viewModel.accountCreationError {
-                    Text(error)
-                        .font(OnboardingTypography.caption)
-                        .foregroundStyle(theme.colors.error)
-                        .multilineTextAlignment(.center)
-                        .padding(.top, 8)
-                }
+                .accessibilityValue(viewModel.isCreatingAccount ? "Creating account" : "")
             }
         )
+        .onChange(of: viewModel.accountCreationError) { _, error in
+            accountCreationErrorFocused = error != nil
+        }
     }
 
     private func submit() {

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBasicsView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBasicsView.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 
 struct BodyScoreBasicsView: View {
+    @Environment(\.theme)
+    private var theme
+
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @State private var showWhyWeAsk = false
 
@@ -11,7 +17,7 @@ struct BodyScoreBasicsView: View {
             onBack: { viewModel.goBack() },
             progress: viewModel.progress(for: .basics),
             content: {
-                VStack(spacing: 24) {
+                VStack(spacing: JovieTokens.sectionGap) {
                     OnboardingFormSection {
                         VStack(spacing: 12) {
                             ForEach(BiologicalSex.allCases, id: \.self) { sex in
@@ -27,19 +33,19 @@ struct BodyScoreBasicsView: View {
                         }
 
                         Button {
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                showWhyWeAsk.toggle()
-                            }
+                            toggleWhyWeAsk()
                         } label: {
                             HStack(spacing: 6) {
                                 Image(systemName: "questionmark.circle")
-                                    .font(.system(size: 13, weight: .semibold))
+                                    .font(.system(.footnote, design: .default).weight(.semibold))
                                 Text("Why we ask")
                                     .font(OnboardingTypography.caption)
                             }
-                            .foregroundStyle(Color.appPrimary)
+                            .foregroundStyle(theme.colors.primary)
                         }
                         .buttonStyle(.plain)
+                        .jovieTouchTarget()
+                        .accessibilityValue(showWhyWeAsk ? "Expanded" : "Collapsed")
 
                         if showWhyWeAsk {
                             OnboardingInfoRow(
@@ -55,11 +61,9 @@ struct BodyScoreBasicsView: View {
                     viewModel.goToNextStep()
                 } label: {
                     Text("Continue")
-                        .font(.system(size: 18, weight: .semibold))
                 }
                 .buttonStyle(OnboardingPrimaryButtonStyle())
                 .disabled(!viewModel.canContinueBasics)
-                .opacity(viewModel.canContinueBasics ? 1 : 0.4)
             }
         )
     }
@@ -67,6 +71,16 @@ struct BodyScoreBasicsView: View {
     private func handleSexSelection(_ sex: BiologicalSex) {
         viewModel.updateSex(sex)
         HapticManager.shared.selection()
+    }
+
+    private func toggleWhyWeAsk() {
+        if reduceMotion {
+            showWhyWeAsk.toggle()
+        } else {
+            withAnimation(theme.animation.fast) {
+                showWhyWeAsk.toggle()
+            }
+        }
     }
 }
 

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatChoiceView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatChoiceView.swift
@@ -28,22 +28,24 @@ struct BodyScoreBodyFatChoiceView: View {
                         } label: {
                             HStack(alignment: .center, spacing: 12) {
                                 Image(systemName: option.icon)
-                                    .font(.system(size: 24, weight: .semibold))
-                                    .foregroundStyle(Color.appPrimary)
+                                    .font(.system(.title3, design: .rounded).weight(.semibold))
+                                    .foregroundStyle(theme.colors.primary)
+                                    .frame(width: JovieTokens.minimumHitTarget)
 
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text(option.title)
                                         .font(OnboardingTypography.headline)
-                                        .foregroundStyle(Color.appText)
+                                        .foregroundStyle(theme.colors.text)
 
                                     Text(option.subtitle)
                                         .font(OnboardingTypography.caption)
-                                        .foregroundStyle(Color.appTextSecondary)
+                                        .foregroundStyle(theme.colors.textSecondary)
+                                        .fixedSize(horizontal: false, vertical: true)
                                 }
 
                                 Spacer()
                                 Image(systemName: "chevron.right")
-                                    .foregroundStyle(Color.appTextSecondary)
+                                    .foregroundStyle(theme.colors.textSecondary)
                             }
                             .padding(20)
                             .systemBGlassSurface(
@@ -55,6 +57,9 @@ struct BodyScoreBodyFatChoiceView: View {
                             )
                         }
                         .buttonStyle(.plain)
+                        .jovieTouchTarget()
+                        .accessibilityLabel("\(option.title). \(option.subtitle)")
+                        .accessibilityHint("Continues to the next step.")
                     }
 
                     Button("Skip for now") {
@@ -69,6 +74,7 @@ struct BodyScoreBodyFatChoiceView: View {
                             .foregroundStyle(theme.colors.error)
                             .multilineTextAlignment(.center)
                             .frame(maxWidth: .infinity)
+                            .accessibilityAddTraits(.isStaticText)
                     }
                 }
             }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatNumericView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatNumericView.swift
@@ -4,8 +4,12 @@ struct BodyScoreBodyFatNumericView: View {
     @Environment(\.theme)
     private var theme
 
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @FocusState private var percentageFieldFocused: Bool
+    @AccessibilityFocusState private var bodyFatErrorFocused: Bool
     @State private var bodyFatError: String?
     @State private var showHelp = false
 
@@ -20,7 +24,7 @@ struct BodyScoreBodyFatNumericView: View {
                     VStack(alignment: .leading, spacing: 16) {
                         Text("Body fat %")
                             .font(OnboardingTypography.caption)
-                            .foregroundStyle(Color.appTextSecondary)
+                            .foregroundStyle(theme.colors.textSecondary)
 
                         TextField("14.5", text: Binding(
                             get: { viewModel.bodyFatPercentageText },
@@ -36,7 +40,7 @@ struct BodyScoreBodyFatNumericView: View {
                             validateBodyFat(newValue)
                         }
                         .padding(.horizontal, 20)
-                        .padding(.vertical, 16)
+                        .frame(minHeight: JovieTokens.controlHeight)
                         .systemBGlassSurface(
                             cornerRadius: 20,
                             tint: percentageFieldFocused ? theme.colors.primary : theme.colors.text,
@@ -44,11 +48,14 @@ struct BodyScoreBodyFatNumericView: View {
                             borderColor: percentageFieldStrokeColor,
                             borderOpacity: 1
                         )
+                        .accessibilityLabel("Body fat percentage")
+                        .accessibilityHint("Enter a value between 4 and 60 percent.")
 
                         if let error = bodyFatError {
                             Text(error)
                                 .font(OnboardingTypography.caption)
                                 .foregroundStyle(theme.colors.error)
+                                .accessibilityFocused($bodyFatErrorFocused)
                         } else {
                             OnboardingCaptionText(
                                 text: "Most people fall between 4–60% body fat.",
@@ -59,24 +66,24 @@ struct BodyScoreBodyFatNumericView: View {
 
                     VStack(alignment: .leading, spacing: 8) {
                         Button {
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                showHelp.toggle()
-                            }
+                            toggleHelp()
                         } label: {
                             HStack(spacing: 6) {
                                 Image(systemName: "questionmark.circle")
-                                    .font(.system(size: 13, weight: .semibold))
+                                    .font(.system(.footnote, design: .default).weight(.semibold))
                                 Text("Not sure your %?")
                                     .font(OnboardingTypography.caption)
                             }
-                            .foregroundStyle(Color.appPrimary)
+                            .foregroundStyle(theme.colors.primary)
                         }
                         .buttonStyle(.plain)
+                        .jovieTouchTarget()
+                        .accessibilityValue(showHelp ? "Expanded" : "Collapsed")
 
                         if showHelp {
                             Text("You can go back and choose visual estimate instead. We’ll guide you with reference photos.")
                                 .font(OnboardingTypography.body)
-                                .foregroundStyle(Color.appTextSecondary)
+                                .foregroundStyle(theme.colors.textSecondary)
                                 .transition(.opacity.combined(with: .move(edge: .top)))
                         }
                     }
@@ -88,11 +95,9 @@ struct BodyScoreBodyFatNumericView: View {
                     viewModel.goToNextStep()
                 } label: {
                     Text("Continue")
-                        .font(.system(size: 18, weight: .semibold))
                 }
                 .buttonStyle(OnboardingPrimaryButtonStyle())
                 .disabled(!viewModel.canContinueBodyFatNumeric)
-                .opacity(continueButtonOpacity)
             }
         )
         .onAppear {
@@ -110,6 +115,9 @@ struct BodyScoreBodyFatNumericView: View {
                 }
             }
         }
+        .onChange(of: bodyFatError) { _, error in
+            bodyFatErrorFocused = error != nil
+        }
     }
 }
 
@@ -119,15 +127,21 @@ struct BodyScoreBodyFatNumericView: View {
 }
 
 private extension BodyScoreBodyFatNumericView {
-    var continueButtonOpacity: Double {
-        viewModel.canContinueBodyFatNumeric ? 1 : 0.4
-    }
-
     var percentageFieldStrokeColor: Color {
         if percentageFieldFocused {
-            return Color.appPrimary
+            return theme.colors.primary
         }
-        return Color.appBorder.opacity(0.4)
+        return theme.colors.border.opacity(0.65)
+    }
+
+    private func toggleHelp() {
+        if reduceMotion {
+            showHelp.toggle()
+        } else {
+            withAnimation(theme.animation.fast) {
+                showHelp.toggle()
+            }
+        }
     }
 
     private func validateBodyFat(_ value: String) {

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatVisualView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatVisualView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct BodyScoreBodyFatVisualView: View {
+    @Environment(\.theme)
+    private var theme
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
 
     private struct VisualEstimate: Identifiable {
@@ -51,7 +54,7 @@ struct BodyScoreBodyFatVisualView: View {
             onBack: { viewModel.goBack() },
             progress: viewModel.progress(for: .bodyFatVisual),
             content: {
-                VStack(spacing: 8) {
+                VStack(spacing: JovieTokens.itemGap) {
                     ForEach(Self.visualEstimates) { estimate in
                         Button {
                             handleSelection(estimate)
@@ -60,35 +63,47 @@ struct BodyScoreBodyFatVisualView: View {
                                 HStack(spacing: 8) {
                                     Text("\(Int(estimate.percentage))% \(estimate.label)")
                                         .font(OnboardingTypography.headline)
-                                        .foregroundStyle(Color.appText)
+                                        .foregroundStyle(theme.colors.text)
+                                        .lineLimit(1)
+                                        .minimumScaleFactor(0.8)
 
                                     Spacer()
 
                                     Image(
                                         systemName: isSelected(estimate) ? "largecircle.fill.circle" : "circle"
                                     )
-                                    .font(.system(size: 20, weight: .semibold))
+                                    .font(.system(.title3, design: .default).weight(.semibold))
                                     .foregroundStyle(
                                         isSelected(estimate)
-                                            ? Color.appPrimary
-                                            : Color.appTextSecondary.opacity(0.6)
+                                            ? theme.colors.primary
+                                            : theme.colors.textSecondary.opacity(0.6)
                                     )
                                 }
 
                                 if isSelected(estimate) {
                                     Text(estimate.description)
                                         .font(OnboardingTypography.caption)
-                                        .foregroundStyle(Color.appTextSecondary)
+                                        .foregroundStyle(theme.colors.textSecondary)
+                                        .fixedSize(horizontal: false, vertical: true)
                                 }
                             }
-                            .padding(.vertical, 8)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 12)
+                            .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
+                            .systemBGlassSurface(
+                                cornerRadius: theme.radius.card,
+                                tint: isSelected(estimate) ? theme.colors.primary : theme.colors.text,
+                                tintOpacity: isSelected(estimate) ? 0.13 : 0.035,
+                                borderColor: isSelected(estimate) ? theme.colors.primary : theme.colors.border,
+                                borderOpacity: isSelected(estimate) ? 0.85 : 0.65,
+                                borderWidth: isSelected(estimate) ? 2 : 1
+                            )
                         }
                         .buttonStyle(.plain)
-
-                        if estimate.percentage != Self.visualEstimates.last?.percentage {
-                            Divider()
-                                .overlay(Color.appBorder.opacity(0.4))
-                        }
+                        .jovieTouchTarget()
+                        .accessibilityLabel("\(Int(estimate.percentage)) percent, \(estimate.label). \(estimate.description)")
+                        .accessibilityValue(isSelected(estimate) ? "Selected" : "Not selected")
+                        .accessibilityAddTraits(isSelected(estimate) ? .isSelected : [])
                     }
                 }
             },
@@ -97,24 +112,15 @@ struct BodyScoreBodyFatVisualView: View {
                     viewModel.goToNextStep()
                 } label: {
                     Text("Continue")
-                        .font(.system(size: 18, weight: .semibold))
                 }
                 .buttonStyle(OnboardingPrimaryButtonStyle())
                 .disabled(!viewModel.canContinueBodyFatVisual)
-                .opacity(continueButtonOpacity)
             }
         )
     }
 }
 
 extension BodyScoreBodyFatVisualView {
-    private var continueButtonOpacity: Double {
-        if viewModel.canContinueBodyFatVisual {
-            return 1
-        }
-        return 0.4
-    }
-
     private func isSelected(_ estimate: VisualEstimate) -> Bool {
         viewModel.selectedVisualBodyFat == estimate.percentage
     }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreEmailCaptureView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreEmailCaptureView.swift
@@ -1,8 +1,15 @@
 import SwiftUI
 
 struct BodyScoreEmailCaptureView: View {
+    @Environment(\.theme)
+    private var theme
+
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @FocusState private var emailFieldFocused: Bool
+    @AccessibilityFocusState private var emailErrorFocused: Bool
     @State private var emailError: String?
     @State private var showWhyEmail = false
 
@@ -32,27 +39,28 @@ struct BodyScoreEmailCaptureView: View {
                         if let error = emailError {
                             Text(error)
                                 .font(OnboardingTypography.caption)
-                                .foregroundStyle(Color.appError)
+                                .foregroundStyle(theme.colors.error)
+                                .accessibilityFocused($emailErrorFocused)
                         } else {
                             Button {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    showWhyEmail.toggle()
-                                }
+                                toggleWhyEmail()
                             } label: {
                                 HStack(spacing: 6) {
                                     Image(systemName: "info.circle")
-                                        .font(.system(size: 13, weight: .semibold))
+                                        .font(.system(.footnote, design: .default).weight(.semibold))
                                     Text("No spam. Only to save your progress.")
                                         .font(OnboardingTypography.caption)
                                 }
-                                .foregroundStyle(Color.appTextSecondary)
+                                .foregroundStyle(theme.colors.textSecondary)
                             }
                             .buttonStyle(.plain)
+                            .jovieTouchTarget()
+                            .accessibilityValue(showWhyEmail ? "Expanded" : "Collapsed")
 
                             if showWhyEmail {
                                 Text("We'll only use this email to save your Body Score and keep progress in sync.")
                                     .font(OnboardingTypography.body)
-                                    .foregroundStyle(Color.appTextSecondary)
+                                    .foregroundStyle(theme.colors.textSecondary)
                                     .transition(.opacity.combined(with: .move(edge: .top)))
                             }
                         }
@@ -65,11 +73,9 @@ struct BodyScoreEmailCaptureView: View {
                     viewModel.goToNextStep()
                 } label: {
                     Text("Continue")
-                        .font(.system(size: 18, weight: .semibold))
                 }
                 .buttonStyle(OnboardingPrimaryButtonStyle())
                 .disabled(!viewModel.canContinueEmailCapture)
-                .opacity(continueButtonOpacity)
             }
         )
         .onAppear {
@@ -88,14 +94,13 @@ struct BodyScoreEmailCaptureView: View {
                 }
             }
         }
+        .onChange(of: emailError) { _, error in
+            emailErrorFocused = error != nil
+        }
     }
 }
 
 private extension BodyScoreEmailCaptureView {
-    var continueButtonOpacity: Double {
-        viewModel.canContinueEmailCapture ? 1 : 0.4
-    }
-
     private func updateEmailError() {
         let trimmed = viewModel.emailAddress.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
@@ -107,6 +112,16 @@ private extension BodyScoreEmailCaptureView {
             emailError = nil
         } else {
             emailError = "Enter a valid email address."
+        }
+    }
+
+    private func toggleWhyEmail() {
+        if reduceMotion {
+            showWhyEmail.toggle()
+        } else {
+            withAnimation(theme.animation.fast) {
+                showWhyEmail.toggle()
+            }
         }
     }
 }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
@@ -39,30 +39,30 @@ struct BodyScoreFirstProgressPhotoView: View {
     private var previewCard: some View {
         VStack(alignment: .leading, spacing: 16) {
             Image(systemName: "camera.metering.center.weighted")
-                .font(.system(size: 34, weight: .semibold))
+                .font(.system(.title, design: .rounded).weight(.semibold))
                 .foregroundStyle(theme.colors.text.opacity(0.82))
 
             VStack(alignment: .leading, spacing: 6) {
                 Text("Photos make the timeline useful.")
-                    .font(.system(size: 20, weight: .bold))
-                    .foregroundStyle(Color.appText)
+                    .font(theme.typography.headlineSmall)
+                    .foregroundStyle(theme.colors.text)
 
                 Text(
                     "We attach the photo to the baseline metrics you just entered, so Home opens with your first visual check-in."
                 )
                     .font(OnboardingTypography.body)
-                    .foregroundStyle(Color.appTextSecondary)
+                    .foregroundStyle(theme.colors.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             HStack(alignment: .top, spacing: 10) {
                 Image(systemName: "lock.shield")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(Color.appPrimary)
+                    .font(.system(.footnote, design: .default).weight(.semibold))
+                    .foregroundStyle(theme.colors.text)
 
-                Text("Camera and photo library access are optional. You can skip this and add a photo later.")
+                Text("Camera and photo library access are optional. You choose what to add, and can skip this for now.")
                     .font(OnboardingTypography.caption)
-                    .foregroundStyle(Color.appTextTertiary)
+                    .foregroundStyle(theme.colors.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
@@ -113,9 +113,9 @@ struct BodyScoreFirstProgressPhotoView: View {
             .disabled(viewModel.isCompletingOnboarding)
             .accessibilityIdentifier("onboarding_first_photo_skip_button")
 
-            Text("You can add progress photos later from Home.")
-                .font(OnboardingTypography.caption)
-                .foregroundStyle(Color.appTextTertiary)
+                Text("You can add progress photos later from Home.")
+                    .font(OnboardingTypography.caption)
+                .foregroundStyle(theme.colors.textTertiary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
 

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHealthConfirmationView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHealthConfirmationView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct BodyScoreHealthConfirmationView: View {
+    @Environment(\.theme)
+    private var theme
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
 
     private struct Metric: Identifiable {
@@ -18,62 +21,69 @@ struct BodyScoreHealthConfirmationView: View {
             onBack: { viewModel.goBack() },
             progress: viewModel.progress(for: .healthConfirmation),
             content: {
-                VStack(spacing: 24) {
-                    VStack(alignment: .leading, spacing: 16) {
-                        if let status = viewModel.healthKitConnectionStatusText {
-                            HStack(spacing: 8) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .font(.system(size: 14, weight: .semibold))
-                                    .foregroundStyle(Color.green)
+                VStack(spacing: JovieTokens.sectionGap) {
+                    OnboardingCard {
+                        VStack(alignment: .leading, spacing: 16) {
+                            if let status = viewModel.healthKitConnectionStatusText {
+                                HStack(spacing: 8) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .font(.system(.body, design: .default).weight(.semibold))
+                                        .foregroundStyle(theme.colors.success)
 
-                                Text(status)
-                                    .font(OnboardingTypography.caption)
-                                    .foregroundStyle(Color.appTextSecondary)
-
-                                Spacer()
-                            }
-
-                            Divider()
-                                .overlay(Color.appBorder.opacity(0.4))
-                        }
-
-                        ForEach(metrics) { metric in
-                            HStack(alignment: .top, spacing: 12) {
-                                Image(systemName: metric.icon)
-                                    .font(.system(size: 20, weight: .semibold))
-                                    .foregroundStyle(Color.appPrimary)
-
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text(metric.title.uppercased())
+                                    Text(status)
                                         .font(OnboardingTypography.caption)
-                                        .foregroundStyle(Color.appTextSecondary)
+                                        .foregroundStyle(theme.colors.textSecondary)
 
-                                    Text(metric.value)
-                                        .font(OnboardingTypography.title)
-                                        .foregroundStyle(Color.appText)
-
-                                    Text(metric.subtitle)
-                                        .font(OnboardingTypography.body)
-                                        .foregroundStyle(Color.appTextSecondary)
+                                    Spacer()
                                 }
 
-                                Spacer()
-
-                                if metric.title != "No data" {
-                                    Button {
-                                        edit(metric: metric)
-                                    } label: {
-                                        Image(systemName: "square.and.pencil")
-                                            .font(.system(size: 16, weight: .medium))
-                                            .foregroundStyle(Color.appPrimary)
-                                    }
-                                    .buttonStyle(.plain)
-                                }
+                                Divider()
+                                    .overlay(theme.colors.border.opacity(0.65))
                             }
 
-                            if metric.id != metrics.last?.id {
-                                Divider()
-                                    .overlay(Color.appBorder.opacity(0.4))
+                            ForEach(metrics) { metric in
+                                HStack(alignment: .top, spacing: 12) {
+                                    Image(systemName: metric.icon)
+                                        .font(.system(.title3, design: .rounded).weight(.semibold))
+                                        .foregroundStyle(theme.colors.primary)
+                                        .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
+
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(metric.title.uppercased())
+                                            .font(OnboardingTypography.caption)
+                                            .foregroundStyle(theme.colors.textSecondary)
+
+                                        Text(metric.value)
+                                            .font(theme.typography.headlineLarge)
+                                            .foregroundStyle(theme.colors.text)
+                                            .fixedSize(horizontal: false, vertical: true)
+
+                                        Text(metric.subtitle)
+                                            .font(OnboardingTypography.body)
+                                            .foregroundStyle(theme.colors.textSecondary)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+
+                                    Spacer()
+
+                                    if metric.title != "No data" {
+                                        Button {
+                                            edit(metric: metric)
+                                        } label: {
+                                            Image(systemName: "square.and.pencil")
+                                                .font(.system(.body, design: .default).weight(.medium))
+                                                .foregroundStyle(theme.colors.primary)
+                                                .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
+                                        }
+                                        .buttonStyle(.plain)
+                                        .accessibilityLabel("Edit \(metric.title)")
+                                    }
+                                }
+
+                                if metric.id != metrics.last?.id {
+                                    Divider()
+                                        .overlay(theme.colors.border.opacity(0.65))
+                                }
                             }
                         }
                     }
@@ -90,7 +100,6 @@ struct BodyScoreHealthConfirmationView: View {
                         viewModel.goToNextStep()
                     } label: {
                         Text("Continue")
-                            .font(.system(size: 18, weight: .semibold))
                     }
                     .buttonStyle(OnboardingPrimaryButtonStyle())
 

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHealthConnectView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHealthConnectView.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 
 struct BodyScoreHealthConnectView: View {
+    @Environment(\.theme)
+    private var theme
+
+    @Environment(\.openURL)
+    private var openURL
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
 
     private var pageTitle: String {
@@ -35,10 +41,6 @@ struct BodyScoreHealthConnectView: View {
         return "Connect Apple Health"
     }
 
-    private var connectButtonOpacity: Double {
-        viewModel.isRequestingHealthImport ? 0.6 : 1.0
-    }
-
     var body: some View {
         OnboardingPageTemplate(
             title: pageTitle,
@@ -46,49 +48,56 @@ struct BodyScoreHealthConnectView: View {
             onBack: { viewModel.goBack() },
             progress: viewModel.progress(for: .healthConnect),
             content: {
-                VStack(spacing: 24) {
-                    VStack(alignment: .leading, spacing: 16) {
-                        HStack(alignment: .center, spacing: 12) {
-                            Image(systemName: "heart.text.square")
-                                .font(.system(size: 28, weight: .semibold))
-                                .foregroundStyle(.pink)
+                VStack(spacing: JovieTokens.sectionGap) {
+                    OnboardingCard {
+                        VStack(alignment: .leading, spacing: 16) {
+                            HStack(alignment: .center, spacing: 12) {
+                                Image(systemName: "heart.text.square")
+                                    .font(.system(.title2, design: .rounded).weight(.semibold))
+                                    .foregroundStyle(theme.colors.accentPink)
+                                    .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
 
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(cardTitle)
-                                    .font(OnboardingTypography.headline)
-                                    .foregroundStyle(Color.appText)
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(cardTitle)
+                                        .font(OnboardingTypography.headline)
+                                        .foregroundStyle(theme.colors.text)
 
-                                Text(cardSubtitle)
-                                    .font(OnboardingTypography.body)
-                                    .foregroundStyle(Color.appTextSecondary)
-                            }
-                        }
-
-                        if let status = viewModel.healthKitConnectionStatusText {
-                            HStack(spacing: 8) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .font(.system(size: 14, weight: .semibold))
-                                    .foregroundStyle(Color.green)
-
-                                Text(status)
-                                    .font(OnboardingTypography.caption)
-                                    .foregroundStyle(Color.appTextSecondary)
-
-                                Spacer()
-                            }
-                        }
-
-                        if viewModel.isHealthKitConnected {
-                            Button {
-                                if let url = URL(string: UIApplication.openSettingsURLString) {
-                                    UIApplication.shared.open(url)
+                                    Text(cardSubtitle)
+                                        .font(OnboardingTypography.body)
+                                        .foregroundStyle(theme.colors.textSecondary)
+                                        .fixedSize(horizontal: false, vertical: true)
                                 }
-                            } label: {
-                                Text("Adjust in Settings")
-                                    .font(OnboardingTypography.caption)
-                                    .foregroundStyle(Color.appPrimary)
                             }
-                            .buttonStyle(.plain)
+
+                            if let status = viewModel.healthKitConnectionStatusText {
+                                HStack(spacing: 8) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .font(.system(.body, design: .default).weight(.semibold))
+                                        .foregroundStyle(theme.colors.success)
+
+                                    Text(status)
+                                        .font(OnboardingTypography.caption)
+                                        .foregroundStyle(theme.colors.textSecondary)
+
+                                    Spacer()
+                                }
+                                .accessibilityLabel("Apple Health status: \(status)")
+                            }
+
+                            if viewModel.isHealthKitConnected {
+                                Button {
+                                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                                        openURL(url)
+                                    }
+                                } label: {
+                                    Text("Adjust in Settings")
+                                        .font(OnboardingTypography.caption)
+                                        .foregroundStyle(theme.colors.primary)
+                                }
+                                .buttonStyle(.plain)
+                                .jovieTouchTarget()
+                                .accessibilityHint("Opens the app’s Settings page.")
+                            }
                         }
                     }
                 }
@@ -101,15 +110,14 @@ struct BodyScoreHealthConnectView: View {
                         HStack {
                             if viewModel.isRequestingHealthImport {
                                 ProgressView()
-                                    .tint(.black)
+                                    .tint(theme.colors.background)
                             }
                             Text(connectButtonTitle)
-                                .font(OnboardingTypography.headline)
                         }
                     }
                     .buttonStyle(OnboardingPrimaryButtonStyle())
                     .disabled(viewModel.isRequestingHealthImport)
-                    .opacity(connectButtonOpacity)
+                    .accessibilityLabel(connectButtonTitle)
 
                     OnboardingTextButton(title: "Enter manually instead") {
                         viewModel.skipHealthKit()

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHeightView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHeightView.swift
@@ -4,8 +4,12 @@ struct BodyScoreHeightView: View {
     @Environment(\.theme)
     private var theme
 
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @FocusState private var centimetersFocused: Bool
+    @AccessibilityFocusState private var heightErrorFocused: Bool
     @State private var heightError: String?
     @State private var showWhyWeAsk = false
 
@@ -34,11 +38,9 @@ struct BodyScoreHeightView: View {
                     viewModel.goToNextStep()
                 } label: {
                     Text("Continue")
-                        .font(.system(size: 18, weight: .semibold))
                 }
                 .buttonStyle(OnboardingPrimaryButtonStyle())
                 .disabled(!viewModel.canContinueHeight)
-                .opacity(continueButtonOpacity)
             }
         )
         .toolbar {
@@ -51,6 +53,9 @@ struct BodyScoreHeightView: View {
                 }
             }
         }
+        .onChange(of: heightError) { _, error in
+            heightErrorFocused = error != nil
+        }
     }
 
     private var heightUnitBinding: Binding<HeightUnit> {
@@ -58,10 +63,6 @@ struct BodyScoreHeightView: View {
             get: { viewModel.heightUnit },
             set: { viewModel.setHeightUnit($0) }
         )
-    }
-
-    private var continueButtonOpacity: Double {
-        viewModel.canContinueHeight ? 1 : 0.4
     }
 
     private func validateHeightCentimeters(_ value: String) {
@@ -82,7 +83,7 @@ struct BodyScoreHeightView: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Enter centimeters")
                 .font(OnboardingTypography.caption)
-                .foregroundStyle(Color.appTextSecondary)
+                .foregroundStyle(theme.colors.textSecondary)
 
             TextField("175", text: Binding(
                 get: { viewModel.heightCentimetersText },
@@ -98,7 +99,7 @@ struct BodyScoreHeightView: View {
                 validateHeightCentimeters(newValue)
             }
             .padding(.horizontal, 18)
-            .padding(.vertical, 14)
+            .frame(minHeight: JovieTokens.controlHeight)
             .systemBGlassSurface(
                 cornerRadius: theme.radius.input,
                 tint: centimetersFocused ? theme.colors.primary : theme.colors.text,
@@ -111,15 +112,19 @@ struct BodyScoreHeightView: View {
                     self.centimetersFocused = true
                 }
             }
+            .accessibilityLabel("Height in centimeters")
+            .accessibilityHint("Enter a height between 100 and 250 centimeters.")
 
             if let error = heightError {
                 Text(error)
                     .font(OnboardingTypography.caption)
                     .foregroundStyle(theme.colors.error)
+                    .accessibilityFocused($heightErrorFocused)
+                    .accessibilityAddTraits(.isStaticText)
             } else {
                 Text("Most adults fall between 100–250 cm.")
                     .font(OnboardingTypography.caption)
-                    .foregroundStyle(Color.appTextTertiary)
+                    .foregroundStyle(theme.colors.textTertiary)
             }
         }
     }
@@ -166,7 +171,7 @@ struct BodyScoreHeightView: View {
 
             Text("We’ll convert everything into centimeters automatically.")
                 .font(OnboardingTypography.caption)
-                .foregroundStyle(Color.appTextSecondary)
+                .foregroundStyle(theme.colors.textSecondary)
                 .multilineTextAlignment(.center)
         }
     }
@@ -174,30 +179,40 @@ struct BodyScoreHeightView: View {
     private var helperCard: some View {
         VStack(alignment: .leading, spacing: 8) {
             Button {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    showWhyWeAsk.toggle()
-                }
+                toggleWhyWeAsk()
             } label: {
                 HStack(spacing: 6) {
                     Image(systemName: "questionmark.circle")
-                        .font(.system(size: 13, weight: .semibold))
+                        .font(.system(.footnote, design: .default).weight(.semibold))
                     Text("Why we ask")
                         .font(OnboardingTypography.caption)
                 }
-                .foregroundStyle(Color.appPrimary)
+                .foregroundStyle(theme.colors.primary)
             }
             .buttonStyle(.plain)
+            .jovieTouchTarget()
+            .accessibilityValue(showWhyWeAsk ? "Expanded" : "Collapsed")
 
             if showWhyWeAsk {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Height anchors lean mass so taller frames stay comparable.")
-                        .font(OnboardingTypography.body)
-                        .foregroundStyle(Color.appTextSecondary)
+                        Text("Height anchors lean mass so taller frames stay comparable.")
+                            .font(OnboardingTypography.body)
+                            .foregroundStyle(theme.colors.textSecondary)
 
                     FFMIInfoLink()
                         .padding(.top, 2)
                 }
                 .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+    }
+
+    private func toggleWhyWeAsk() {
+        if reduceMotion {
+            showWhyWeAsk.toggle()
+        } else {
+            withAnimation(theme.animation.fast) {
+                showWhyWeAsk.toggle()
             }
         }
     }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHookView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHookView.swift
@@ -17,9 +17,7 @@ struct BodyScoreHookView: View {
             showsBackButton: false,
             progress: viewModel.progress(for: .hook)
         ) {
-            VStack(spacing: 24) {
-                OnboardingBadge(text: "Body Score Early Access")
-
+            VStack(spacing: JovieTokens.sectionGap) {
                 OnboardingBulletList(items: bulletItems)
             }
         } footer: {
@@ -28,7 +26,6 @@ struct BodyScoreHookView: View {
                     viewModel.goToNextStep()
                 } label: {
                     Text("Start my 60-sec Body Score")
-                        .font(.system(size: 18, weight: .semibold))
                 }
                 .buttonStyle(OnboardingPrimaryButtonStyle())
                 .accessibilityIdentifier("body_score_onboarding_start_button")

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreLoadingView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreLoadingView.swift
@@ -8,23 +8,23 @@ struct BodyScoreLoadingView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(
-                colors: [theme.colors.background, theme.colors.backgroundSecondary],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
+            theme.colors.background
                 .ignoresSafeArea()
 
-            VStack(spacing: 24) {
+            VStack(spacing: JovieTokens.sectionGap) {
                 ProgressView()
                     .progressViewStyle(CircularProgressViewStyle(tint: theme.colors.text))
-                    .scaleEffect(1.3)
+                    .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
+                    .accessibilityHidden(true)
 
                 OnboardingTitleText(text: "Crunching your numbers…", alignment: .center)
 
                 OnboardingSubtitleText(text: "Pulling lean mass, FFMI, and percentile bands.", alignment: .center)
             }
-            .padding()
+            .padding(JovieTokens.screenInset)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Calculating your Body Score")
+            .accessibilityValue("Please wait")
         }
         .task {
             await viewModel.calculateScoreIfNeeded()

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreManualWeightView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreManualWeightView.swift
@@ -4,8 +4,12 @@ struct BodyScoreManualWeightView: View {
     @Environment(\.theme)
     private var theme
 
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @FocusState private var weightFieldFocused: Bool
+    @AccessibilityFocusState private var weightErrorFocused: Bool
     @State private var weightError: String?
     @State private var showWhyWeAsk = false
 
@@ -16,14 +20,14 @@ struct BodyScoreManualWeightView: View {
             onBack: { viewModel.goBack() },
             progress: viewModel.progress(for: .manualWeight),
             content: {
-                VStack(spacing: 28) {
+                VStack(spacing: JovieTokens.sectionGap) {
                     VStack(alignment: .leading, spacing: 16) {
                         OnboardingSegmentedControl(options: WeightUnit.allCases, selection: weightUnitBinding)
 
                         VStack(alignment: .leading, spacing: 12) {
                             Text(viewModel.weightFieldTitle)
                                 .font(OnboardingTypography.caption)
-                                .foregroundStyle(Color.appTextSecondary)
+                                .foregroundStyle(theme.colors.textSecondary)
 
                             TextField(viewModel.weightPlaceholder, text: Binding(
                                 get: { viewModel.manualWeightText },
@@ -39,7 +43,7 @@ struct BodyScoreManualWeightView: View {
                                 validateWeight(newValue)
                             }
                             .padding(.horizontal, 18)
-                            .padding(.vertical, 14)
+                            .frame(minHeight: JovieTokens.controlHeight)
                             .systemBGlassSurface(
                                 cornerRadius: theme.radius.input,
                                 tint: weightFieldFocused ? theme.colors.primary : theme.colors.text,
@@ -52,19 +56,21 @@ struct BodyScoreManualWeightView: View {
                                     Spacer()
                                     Text(viewModel.weightUnit == .kilograms ? "kg" : "lb")
                                         .font(OnboardingTypography.caption)
-                                        .foregroundStyle(Color.appTextSecondary)
+                                        .foregroundStyle(theme.colors.textSecondary)
                                         .padding(.trailing, 20)
                                 }
                             )
+                            .accessibilityLabel(viewModel.weightFieldTitle)
+                            .accessibilityHint("Enter your most recent weight.")
 
                             HStack(spacing: 12) {
                                 Button {
                                     nudgeWeight(by: -stepAmount)
                                 } label: {
                                     Image(systemName: "minus")
-                                        .font(.system(size: 14, weight: .medium))
+                                        .font(.system(.body, design: .default).weight(.medium))
                                         .foregroundStyle(theme.colors.text)
-                                        .frame(width: 32, height: 32)
+                                        .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
                                         .systemBGlassSurface(
                                             cornerRadius: 16,
                                             tint: theme.colors.text,
@@ -74,14 +80,15 @@ struct BodyScoreManualWeightView: View {
                                         )
                                 }
                                 .buttonStyle(.plain)
+                                .accessibilityLabel("Decrease weight by \(stepDescription)")
 
                                 Button {
                                     nudgeWeight(by: stepAmount)
                                 } label: {
                                     Image(systemName: "plus")
-                                        .font(.system(size: 14, weight: .medium))
+                                        .font(.system(.body, design: .default).weight(.medium))
                                         .foregroundStyle(theme.colors.text)
-                                        .frame(width: 32, height: 32)
+                                        .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
                                         .systemBGlassSurface(
                                             cornerRadius: 16,
                                             tint: theme.colors.text,
@@ -91,6 +98,7 @@ struct BodyScoreManualWeightView: View {
                                         )
                                 }
                                 .buttonStyle(.plain)
+                                .accessibilityLabel("Increase weight by \(stepDescription)")
                             }
                         }
 
@@ -98,28 +106,29 @@ struct BodyScoreManualWeightView: View {
                             Text(error)
                                 .font(OnboardingTypography.caption)
                                 .foregroundStyle(theme.colors.error)
+                                .accessibilityFocused($weightErrorFocused)
                         }
 
                         Button {
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                showWhyWeAsk.toggle()
-                            }
+                            toggleWhyWeAsk()
                         } label: {
                             HStack(spacing: 6) {
                                 Image(systemName: "questionmark.circle")
-                                    .font(.system(size: 13, weight: .semibold))
+                                    .font(.system(.footnote, design: .default).weight(.semibold))
                                 Text("Why we ask")
                                     .font(OnboardingTypography.caption)
                             }
-                            .foregroundStyle(Color.appPrimary)
+                            .foregroundStyle(theme.colors.primary)
                         }
                         .buttonStyle(.plain)
+                        .jovieTouchTarget()
+                        .accessibilityValue(showWhyWeAsk ? "Expanded" : "Collapsed")
 
                         if showWhyWeAsk {
                             VStack(alignment: .leading, spacing: 8) {
                                 Text("Weight plus body fat unlocks lean-mass insights for your Body Score.")
                                     .font(OnboardingTypography.body)
-                                    .foregroundStyle(Color.appTextSecondary)
+                                    .foregroundStyle(theme.colors.textSecondary)
 
                                 FFMIInfoLink()
                                     .padding(.top, 2)
@@ -135,11 +144,9 @@ struct BodyScoreManualWeightView: View {
                     viewModel.goToNextStep()
                 } label: {
                     Text("Continue")
-                        .font(.system(size: 18, weight: .semibold))
                 }
                 .buttonStyle(OnboardingPrimaryButtonStyle())
                 .disabled(!viewModel.canContinueWeight)
-                .opacity(continueButtonOpacity)
             }
         )
         .onAppear {
@@ -157,6 +164,9 @@ struct BodyScoreManualWeightView: View {
                 }
             }
         }
+        .onChange(of: weightError) { _, error in
+            weightErrorFocused = error != nil
+        }
     }
 
     private var weightUnitBinding: Binding<WeightUnit> {
@@ -164,10 +174,6 @@ struct BodyScoreManualWeightView: View {
             get: { viewModel.weightUnit },
             set: { viewModel.setWeightUnit($0) }
         )
-    }
-
-    private var continueButtonOpacity: Double {
-        viewModel.canContinueWeight ? 1 : 0.4
     }
 
     private var stepAmount: Double {
@@ -205,9 +211,27 @@ struct BodyScoreManualWeightView: View {
 
     private var weightFieldBorderColor: Color {
         if weightFieldFocused {
-            return Color.appPrimary
+            return theme.colors.primary
         }
-        return Color.appBorder.opacity(0.4)
+        return theme.colors.border.opacity(0.65)
+    }
+
+    private var stepDescription: String {
+        "\(BodyScoreManualWeightView.format(stepAmount)) \(viewModel.weightUnit == .kilograms ? "kilograms" : "pounds")"
+    }
+
+    private func toggleWhyWeAsk() {
+        if reduceMotion {
+            showWhyWeAsk.toggle()
+        } else {
+            withAnimation(theme.animation.fast) {
+                showWhyWeAsk.toggle()
+            }
+        }
+    }
+
+    private static func format(_ value: Double) -> String {
+        value.rounded() == value ? String(Int(value)) : String(format: "%.1f", value)
     }
 
     private func nudgeWeight(by amount: Double) {

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreProfileDetailsView.swift
@@ -4,12 +4,17 @@ struct BodyScoreProfileDetailsView: View {
     @Environment(\.theme)
     private var theme
 
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
     @EnvironmentObject var authManager: AuthManager
     @ObservedObject var viewModel: OnboardingFlowViewModel
 
     @State private var isSaving: Bool = false
     @State private var errorMessage: String?
     @FocusState private var focusedNameField: NameField?
+    @FocusState private var heightFieldFocused: Bool
+    @AccessibilityFocusState private var saveErrorFocused: Bool
 
     private var trimmedFirstName: String {
         viewModel.profileFirstName.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -127,26 +132,18 @@ struct BodyScoreProfileDetailsView: View {
                 case .firstName:
                     viewModel.goBack()
                 case .lastName:
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                        viewModel.profileDetailsActiveSubstep = .firstName
-                    }
+                    transition(to: .firstName)
                 case .dateOfBirth:
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                        viewModel.profileDetailsActiveSubstep = .lastName
-                    }
+                    transition(to: .lastName)
                 case .sex:
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                        viewModel.profileDetailsActiveSubstep = .dateOfBirth
-                    }
+                    transition(to: .dateOfBirth)
                 case .height:
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                        viewModel.profileDetailsActiveSubstep = viewModel.profileShouldAskSex ? .sex : .dateOfBirth
-                    }
+                    transition(to: viewModel.profileShouldAskSex ? .sex : .dateOfBirth)
                 }
             },
             progress: viewModel.progress(for: .profileDetails),
             content: {
-                VStack(spacing: 24) {
+                VStack(spacing: JovieTokens.sectionGap) {
                     switch viewModel.profileDetailsActiveSubstep {
                     case .firstName, .lastName:
                         nameSection
@@ -164,21 +161,20 @@ struct BodyScoreProfileDetailsView: View {
                     Button(action: handlePrimaryAction) {
                         if isSaving {
                             ProgressView()
-                                .progressViewStyle(CircularProgressViewStyle(tint: .black))
+                                .progressViewStyle(CircularProgressViewStyle(tint: theme.colors.background))
                         } else {
                             Text(primaryButtonTitle)
-                                .font(.system(size: 18, weight: .semibold))
                         }
                     }
                     .buttonStyle(OnboardingPrimaryButtonStyle())
                     .disabled(!canContinue || isSaving)
-                    .opacity(canContinue ? 1 : 0.4)
 
                     if let errorMessage {
                         Text(errorMessage)
                             .font(OnboardingTypography.caption)
                             .foregroundStyle(theme.colors.error)
                             .multilineTextAlignment(.center)
+                            .accessibilityFocused($saveErrorFocused)
                     }
                 }
             }
@@ -194,6 +190,20 @@ struct BodyScoreProfileDetailsView: View {
                 focusNameFieldIfNeeded(newValue)
             }
         }
+        .onChange(of: errorMessage) { _, error in
+            saveErrorFocused = error != nil
+        }
+        .toolbar {
+            ToolbarItem(placement: .keyboard) {
+                HStack {
+                    Spacer()
+                    Button("Done") {
+                        focusedNameField = nil
+                        heightFieldFocused = false
+                    }
+                }
+            }
+        }
     }
 
     private var nameSection: some View {
@@ -203,7 +213,7 @@ struct BodyScoreProfileDetailsView: View {
                 case .firstName:
                     Text("First name")
                         .font(OnboardingTypography.caption)
-                        .foregroundStyle(Color.appTextSecondary)
+                        .foregroundStyle(theme.colors.textSecondary)
 
                     TextField("First name", text: $viewModel.profileFirstName)
                         .textInputAutocapitalization(.words)
@@ -211,7 +221,7 @@ struct BodyScoreProfileDetailsView: View {
                         .submitLabel(.next)
                         .focused($focusedNameField, equals: .firstName)
                         .padding(.horizontal, 14)
-                        .padding(.vertical, 12)
+                        .frame(minHeight: JovieTokens.controlHeight)
                         .systemBGlassSurface(
                             cornerRadius: theme.radius.input,
                             tint: focusedNameField == .firstName ? theme.colors.primary : theme.colors.text,
@@ -227,16 +237,16 @@ struct BodyScoreProfileDetailsView: View {
                     if isFirstNameValid {
                         Text("Nice to meet you,")
                             .font(OnboardingTypography.caption)
-                            .foregroundStyle(Color.appTextSecondary)
+                            .foregroundStyle(theme.colors.textSecondary)
 
                         Text(trimmedFirstName)
-                            .font(.system(size: 24, weight: .semibold))
-                            .foregroundStyle(Color.appText)
+                            .font(theme.typography.headlineLarge)
+                            .foregroundStyle(theme.colors.text)
                     }
 
                     Text("What's your last name?")
                         .font(OnboardingTypography.headline)
-                        .foregroundStyle(Color.appText)
+                        .foregroundStyle(theme.colors.text)
 
                     TextField("Last name", text: $viewModel.profileLastName)
                         .textInputAutocapitalization(.words)
@@ -244,7 +254,7 @@ struct BodyScoreProfileDetailsView: View {
                         .submitLabel(.next)
                         .focused($focusedNameField, equals: .lastName)
                         .padding(.horizontal, 14)
-                        .padding(.vertical, 12)
+                        .frame(minHeight: JovieTokens.controlHeight)
                         .systemBGlassSurface(
                             cornerRadius: theme.radius.input,
                             tint: focusedNameField == .lastName ? theme.colors.primary : theme.colors.text,
@@ -272,6 +282,12 @@ struct BodyScoreProfileDetailsView: View {
             )
             .datePickerStyle(.wheel)
             .labelsHidden()
+
+            OnboardingCaptionText(
+                text: "You must be 16–80 years old to continue.",
+                alignment: .leading
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
@@ -296,12 +312,10 @@ struct BodyScoreProfileDetailsView: View {
     private var heightSection: some View {
         OnboardingFormSection(title: nil, caption: "You can update this later in Settings.") {
             VStack(alignment: .leading, spacing: 18) {
-                Picker("Height unit", selection: $viewModel.profileHeightUnit) {
-                    ForEach(HeightUnit.allCases, id: \.self) { unit in
-                        Text(unit.description).tag(unit)
-                    }
-                }
-                .pickerStyle(.segmented)
+                OnboardingSegmentedControl(
+                    options: HeightUnit.allCases,
+                    selection: $viewModel.profileHeightUnit
+                )
                 .onChange(of: viewModel.profileHeightUnit) { oldValue, newValue in
                     convertHeightFields(from: oldValue, to: newValue)
                 }
@@ -310,10 +324,11 @@ struct BodyScoreProfileDetailsView: View {
                 case .centimeters:
                     TextField("178", text: $viewModel.profileHeightCentimetersText)
                         .keyboardType(.decimalPad)
-                        .font(theme.typography.displayMedium)
+                        .font(theme.typography.headlineLarge)
                         .multilineTextAlignment(.center)
+                        .focused($heightFieldFocused)
                         .padding(.horizontal, 14)
-                        .padding(.vertical, 12)
+                        .frame(minHeight: JovieTokens.controlHeight)
                         .systemBGlassSurface(
                             cornerRadius: theme.radius.input,
                             tint: theme.colors.text,
@@ -322,10 +337,11 @@ struct BodyScoreProfileDetailsView: View {
                             borderOpacity: 0.65
                         )
                         .accessibilityLabel("Height in centimeters")
+                        .accessibilityHint("Enter a height between 100 and 250 centimeters.")
 
                     Text("Enter a height from 100 to 250 cm.")
                         .font(OnboardingTypography.caption)
-                        .foregroundStyle(Color.appTextSecondary)
+                        .foregroundStyle(theme.colors.textSecondary)
 
                 case .inches:
                     HStack(spacing: 12) {
@@ -352,7 +368,7 @@ struct BodyScoreProfileDetailsView: View {
 
                     Text("Enter a height from 4'0\" to 8'0\".")
                         .font(OnboardingTypography.caption)
-                        .foregroundStyle(Color.appTextSecondary)
+                        .foregroundStyle(theme.colors.textSecondary)
                 }
             }
         }
@@ -441,13 +457,9 @@ private extension BodyScoreProfileDetailsView {
         case .lastName:
             handleLastNameContinue()
         case .dateOfBirth:
-            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                viewModel.profileDetailsActiveSubstep = viewModel.profileShouldAskSex ? .sex : .height
-            }
+            transition(to: viewModel.profileShouldAskSex ? .sex : .height)
         case .sex:
-            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                viewModel.profileDetailsActiveSubstep = .height
-            }
+            transition(to: .height)
         case .height:
             submit()
         }
@@ -456,17 +468,13 @@ private extension BodyScoreProfileDetailsView {
     func handleFirstNameContinue() {
         guard isFirstNameValid else { return }
         HapticManager.shared.selection()
-        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-            viewModel.profileDetailsActiveSubstep = .lastName
-        }
+        transition(to: .lastName)
     }
 
     func handleLastNameContinue() {
         guard isLastNameValid else { return }
         HapticManager.shared.selection()
-        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-            viewModel.profileDetailsActiveSubstep = .dateOfBirth
-        }
+        transition(to: .dateOfBirth)
     }
 
     func focusNameFieldIfNeeded(_ step: OnboardingFlowViewModel.ProfileDetailsSubstep? = nil) {
@@ -494,6 +502,16 @@ private extension BodyScoreProfileDetailsView {
             viewModel.profileHeightCentimetersText = String(format: "%.0f", totalInches * 2.54)
         default:
             break
+        }
+    }
+
+    func transition(to substep: OnboardingFlowViewModel.ProfileDetailsSubstep) {
+        if reduceMotion {
+            viewModel.profileDetailsActiveSubstep = substep
+        } else {
+            withAnimation(theme.animation.springSmooth) {
+                viewModel.profileDetailsActiveSubstep = substep
+            }
         }
     }
 }

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreRevealView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreRevealView.swift
@@ -4,11 +4,15 @@ struct BodyScoreRevealView: View {
     @Environment(\.theme)
     private var theme
 
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @State private var animateScore = false
     @State private var isSharePresented = false
     @State private var sharePayload: BodyScoreSharePayload?
     @State private var featureGateRefreshToken = UUID()
+    @AccessibilityFocusState private var scoreFocused: Bool
 
     private var percentileGroupLabel: String {
         let sex = viewModel.bodyScoreInput.sex
@@ -43,17 +47,24 @@ struct BodyScoreRevealView: View {
                         scoreHero(result: result)
                             .scaleEffect(animateScore ? 1 : 0.9)
                             .opacity(animateScore ? 1 : 0)
-                            .animation(.spring(response: 0.6, dampingFraction: 0.75), value: animateScore)
+                            .animation(reduceMotion ? nil : theme.animation.spring, value: animateScore)
+                            .accessibilityFocused($scoreFocused)
 
                         statRow(result: result, groupLabel: percentileGroupLabel)
                             .opacity(animateScore ? 1 : 0)
                             .offset(y: animateScore ? 0 : 12)
-                            .animation(.easeOut(duration: 0.4).delay(0.1), value: animateScore)
+                            .animation(
+                                reduceMotion ? nil : theme.animation.fast.delay(0.1),
+                                value: animateScore
+                            )
 
                         referencePill(result: result)
                             .opacity(animateScore ? 1 : 0)
                             .offset(y: animateScore ? 0 : 16)
-                            .animation(.easeOut(duration: 0.4).delay(0.15), value: animateScore)
+                            .animation(
+                                reduceMotion ? nil : theme.animation.fast.delay(0.15),
+                                value: animateScore
+                            )
                     }
                 } footer: {
                     VStack(spacing: 12) {
@@ -100,7 +111,8 @@ struct BodyScoreRevealView: View {
     private func scoreHero(result: BodyScoreResult) -> some View {
         VStack(spacing: 8) {
             Text("\(result.score)")
-                .font(.system(size: 56, weight: .bold, design: .default))
+                .font(theme.typography.displayLarge)
+                .monospacedDigit()
                 .foregroundStyle(theme.colors.text)
 
             Text("Starting point")
@@ -109,39 +121,46 @@ struct BodyScoreRevealView: View {
 
             Text("Based on FFMI, body fat %, and trends.")
                 .font(OnboardingTypography.caption)
-                .foregroundStyle(Color.appTextSecondary)
+                .foregroundStyle(theme.colors.textSecondary)
         }
         .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Body Score \(result.score). \(result.statusTagline)")
     }
 
-    private func statRow(result: BodyScoreResult, groupLabel _: String) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 16) {
-            Text("FFMI \(String(format: "%.1f", result.ffmi)) — \(result.ffmiStatus)")
-                .font(OnboardingTypography.body)
-                .foregroundStyle(Color.appText)
+    private func statRow(result: BodyScoreResult, groupLabel: String) -> some View {
+        OnboardingCard {
+            VStack(alignment: .leading, spacing: 8) {
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .firstTextBaseline, spacing: 16) {
+                        ffmiLabel(result: result)
+                        Spacer()
+                        percentileLabel(result: result)
+                    }
 
-            Spacer()
+                    VStack(alignment: .leading, spacing: 8) {
+                        ffmiLabel(result: result)
+                        percentileLabel(result: result)
+                    }
+                }
 
-            Text("Lean %ile \(String(format: "%.0f", result.leanPercentile))")
-                .font(OnboardingTypography.body)
-                .foregroundStyle(Color.appTextSecondary)
+                Text("Compared with \(groupLabel).")
+                    .font(OnboardingTypography.caption)
+                    .foregroundStyle(theme.colors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 
     private func referencePill(result: BodyScoreResult) -> some View {
         HStack(spacing: 8) {
             Image(systemName: "info.circle")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(Color.appPrimary)
+                .font(.system(.body, design: .default).weight(.semibold))
+                .foregroundStyle(theme.colors.primary)
 
-            Text(
-                "\(usesIndividualizedAestheticGoals ? "Reference" : "Target"): " +
-                    "\(Int(result.bodyFatReferenceRange.lowerBound))–" +
-                    "\(Int(result.bodyFatReferenceRange.upperBound))% " +
-                    "(\(result.bodyFatReferenceRange.label))"
-            )
+            Text(referenceText(result: result))
                 .font(OnboardingTypography.caption)
-                .foregroundStyle(Color.appTextSecondary)
+                .foregroundStyle(theme.colors.textSecondary)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -152,6 +171,22 @@ struct BodyScoreRevealView: View {
             borderColor: theme.colors.border,
             borderOpacity: 0.55
         )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(referenceAccessibilityText(result: result))
+    }
+
+    private func referenceText(result: BodyScoreResult) -> String {
+        let label = usesIndividualizedAestheticGoals ? "Reference" : "Target"
+        let lowerBound = Int(result.bodyFatReferenceRange.lowerBound)
+        let upperBound = Int(result.bodyFatReferenceRange.upperBound)
+        return "\(label): \(lowerBound)–\(upperBound)% (\(result.bodyFatReferenceRange.label))"
+    }
+
+    private func referenceAccessibilityText(result: BodyScoreResult) -> String {
+        let label = usesIndividualizedAestheticGoals ? "Reference" : "Target"
+        let lowerBound = Int(result.bodyFatReferenceRange.lowerBound)
+        let upperBound = Int(result.bodyFatReferenceRange.upperBound)
+        return "\(label) body fat: \(lowerBound) to \(upperBound) percent. \(result.bodyFatReferenceRange.label)."
     }
 
     private func makeSharePayload(from result: BodyScoreResult) -> BodyScoreSharePayload? {
@@ -202,10 +237,29 @@ struct BodyScoreRevealView: View {
     }
 
     private func triggerRevealFeedback() {
-        withAnimation(.spring(response: 0.6, dampingFraction: 0.75)) {
+        if reduceMotion {
             animateScore = true
+        } else {
+            withAnimation(theme.animation.spring) {
+                animateScore = true
+            }
+        }
+        DispatchQueue.main.async {
+            scoreFocused = true
         }
         HapticManager.shared.successAction()
+    }
+
+    private func ffmiLabel(result: BodyScoreResult) -> some View {
+        Text("FFMI \(String(format: "%.1f", result.ffmi)) — \(result.ffmiStatus)")
+            .font(OnboardingTypography.body)
+            .foregroundStyle(theme.colors.text)
+    }
+
+    private func percentileLabel(result: BodyScoreResult) -> some View {
+        Text("Lean percentile \(String(format: "%.0f", result.leanPercentile))")
+            .font(OnboardingTypography.body)
+            .foregroundStyle(theme.colors.textSecondary)
     }
 }
 

--- a/apps/ios/LogYourBody/Helpers/MetricChartDataHelper.swift
+++ b/apps/ios/LogYourBody/Helpers/MetricChartDataHelper.swift
@@ -351,10 +351,11 @@ struct MetricChartDataHelper {
     /// Calculate Fat Free Mass Index
     /// FFMI = (weight × (1 - body fat %)) / height² + 6.1 × (1.8 - height)
     private static func calculateFFMI(weightKg: Double, bodyFatPercentage: Double, heightCm: Double) -> Double {
-        let heightM = heightCm / 100.0
-        let fatFreeMassKg = weightKg * (1 - bodyFatPercentage / 100)
-        let ffmi = (fatFreeMassKg / (heightM * heightM)) + 6.1 * (1.8 - heightM)
-        return ffmi
+        UnitConversion.calculateFFMI(
+            weightKg: weightKg,
+            bodyFatPercentage: bodyFatPercentage,
+            heightCm: heightCm
+        ) ?? 0
     }
 
     // MARK: - Data Downsampling

--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -408,6 +408,11 @@ struct LogYourBodyApp: App {
             MeasurementSystem.imperial.rawValue,
             forKey: Constants.preferredMeasurementSystemKey
         )
+        // UI fixtures must not inherit a goal saved by a prior test process. The
+        // weight-goal editor intentionally starts empty in this fixture so its
+        // validation and disabled-save state remain reproducible.
+        UserDefaults.standard.removeObject(forKey: Constants.goalWeightKilogramsKey)
+        UserDefaults.standard.removeObject(forKey: Constants.goalWeightKey)
         OnboardingStateManager.shared.updateCompletionStatus(!usesBodyScoreOnboardingFixture)
 
         realtimeSyncManager.isOnline = false

--- a/apps/ios/LogYourBody/Models/Glp1Medication.swift
+++ b/apps/ios/LogYourBody/Models/Glp1Medication.swift
@@ -371,3 +371,119 @@ enum Glp1MedicationCatalog {
         )
     }
 }
+
+enum Glp1DoseDraftSource: Equatable {
+    case latestLog
+    case catalogDefault
+}
+
+struct Glp1DoseDraft: Equatable {
+    let doseText: String
+    let doseUnit: String
+    let selectedDoseIndex: Int?
+    let usesCustomDose: Bool
+    let source: Glp1DoseDraftSource
+    let lastLoggedDoseText: String?
+}
+
+/// Resolves the initial dose shown when someone starts a new GLP-1 log.
+///
+/// A matching medication ID is authoritative. Brand matching is a fallback for
+/// legacy or re-created medication records.
+enum Glp1DoseDraftResolver {
+    static func resolve(
+        for medication: Glp1Medication,
+        doseLogs: [Glp1DoseLog]
+    ) -> Glp1DoseDraft {
+        let config = Glp1MedicationCatalog.doseConfig(for: medication)
+
+        guard let latestLog = latestCompatibleLog(for: medication, in: doseLogs),
+              let amount = latestLog.doseAmount else {
+            return catalogDefault(using: config)
+        }
+
+        let unit = nonEmptyString(latestLog.doseUnit) ?? config.unit
+        let matchesCatalogUnit = normalized(unit) == normalized(config.unit)
+        let selectedDoseIndex = matchesCatalogUnit
+            ? config.doses.firstIndex(where: { abs($0 - amount) < 0.0001 })
+            : nil
+
+        return Glp1DoseDraft(
+            doseText: Glp1DoseHistoryFormatter.numberText(amount),
+            doseUnit: unit,
+            selectedDoseIndex: selectedDoseIndex,
+            usesCustomDose: selectedDoseIndex == nil,
+            source: .latestLog,
+            lastLoggedDoseText: "\(Glp1DoseHistoryFormatter.numberText(amount)) \(unit)"
+        )
+    }
+
+    private static func catalogDefault(using config: Glp1MedicationDoseConfig) -> Glp1DoseDraft {
+        guard let firstDose = config.doses.first else {
+            return Glp1DoseDraft(
+                doseText: "",
+                doseUnit: config.unit,
+                selectedDoseIndex: nil,
+                usesCustomDose: true,
+                source: .catalogDefault,
+                lastLoggedDoseText: nil
+            )
+        }
+
+        return Glp1DoseDraft(
+            doseText: Glp1DoseHistoryFormatter.numberText(firstDose),
+            doseUnit: config.unit,
+            selectedDoseIndex: 0,
+            usesCustomDose: false,
+            source: .catalogDefault,
+            lastLoggedDoseText: nil
+        )
+    }
+
+    private static func latestCompatibleLog(
+        for medication: Glp1Medication,
+        in doseLogs: [Glp1DoseLog]
+    ) -> Glp1DoseLog? {
+        let doseLogsWithAmounts = doseLogs.filter { ($0.doseAmount ?? 0) > 0 }
+        let matchingIDs = doseLogsWithAmounts.filter { $0.medicationId == medication.id }
+
+        if let latestIDMatch = latestLog(in: matchingIDs) {
+            return latestIDMatch
+        }
+
+        let medicationNames = Set(
+            [medication.brand, medication.displayName]
+                .compactMap(normalized)
+        )
+        let matchingBrands = doseLogsWithAmounts.filter { log in
+            guard let brand = normalized(log.brand) else { return false }
+            return medicationNames.contains(brand)
+        }
+
+        return latestLog(in: matchingBrands)
+    }
+
+    private static func latestLog(in logs: [Glp1DoseLog]) -> Glp1DoseLog? {
+        logs.max { lhs, rhs in
+            if lhs.takenAt != rhs.takenAt {
+                return lhs.takenAt < rhs.takenAt
+            }
+
+            if lhs.updatedAt != rhs.updatedAt {
+                return lhs.updatedAt < rhs.updatedAt
+            }
+
+            return lhs.createdAt < rhs.createdAt
+        }
+    }
+
+    private static func nonEmptyString(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        nonEmptyString(value)?.lowercased()
+    }
+}

--- a/apps/ios/LogYourBody/Services/BulkImportManager.swift
+++ b/apps/ios/LogYourBody/Services/BulkImportManager.swift
@@ -66,7 +66,7 @@ class BulkImportManager: ObservableObject {
             overallProgress = 0
         }
 
-        currentTask = Task {
+        let task = Task {
             for index in photos.indices {
                 if Task.isCancelled { break }
 
@@ -88,6 +88,8 @@ class BulkImportManager: ObservableObject {
                 // Completion notification will be shown by the caller
             }
         }
+        currentTask = task
+        await task.value
     }
 
     func cancelImport() {

--- a/apps/ios/LogYourBody/Services/LoadingManager.swift
+++ b/apps/ios/LogYourBody/Services/LoadingManager.swift
@@ -56,7 +56,6 @@ class LoadingManager: ObservableObject {
     private var usesUITestAuthFixture: Bool {
         let arguments = ProcessInfo.processInfo.arguments
         return arguments.contains("-lybUITestSignedOutFixture")
-            || arguments.contains("-lybUITestEmailVerificationFixture")
             || arguments.contains("-lybUITestPaidMVPFixture")
             || arguments.contains("-lybUITestPaywallFixture")
             || arguments.contains("-lybUITestPaywallPlansFixture")

--- a/apps/ios/LogYourBody/Services/MetricsInterpolationService.swift
+++ b/apps/ios/LogYourBody/Services/MetricsInterpolationService.swift
@@ -329,19 +329,42 @@ class MetricsInterpolationService {
         }
 
         func estimate(for date: Date) -> InterpolatedMetric? {
-            guard let leanMassResult = estimateLeanMass(for: date) else {
+            guard let weightResult = weightContext.trendWeight(for: date),
+                  let bodyFatResult = bodyFatContext.estimate(for: date),
+                  let ffmi = UnitConversion.calculateFFMI(
+                    weightKg: weightResult.value,
+                    bodyFatPercentage: bodyFatResult.value,
+                    heightCm: heightInches * 2.54
+                  ) else {
                 return nil
             }
 
-            let heightMeters = heightInches * 0.0254
-            let ffmi = leanMassResult.value / (heightMeters * heightMeters)
+            let isInterpolated = weightResult.isInterpolated || bodyFatResult.isInterpolated
+            let isLastKnown = weightResult.isLastKnown || bodyFatResult.isLastKnown
+            let confidence = lowestConfidence(
+                weightResult.confidenceLevel,
+                bodyFatResult.confidenceLevel,
+                isInterpolated: isInterpolated
+            )
 
             return InterpolatedMetric(
                 value: round(ffmi * 10) / 10,
-                isInterpolated: leanMassResult.isInterpolated,
-                isLastKnown: leanMassResult.isLastKnown,
-                confidenceLevel: leanMassResult.confidenceLevel
+                isInterpolated: isInterpolated,
+                isLastKnown: isLastKnown,
+                confidenceLevel: confidence
             )
+        }
+
+        private func lowestConfidence(
+            _ first: InterpolatedMetric.ConfidenceLevel?,
+            _ second: InterpolatedMetric.ConfidenceLevel?,
+            isInterpolated: Bool
+        ) -> InterpolatedMetric.ConfidenceLevel? {
+            guard isInterpolated else { return nil }
+            let levels: [InterpolatedMetric.ConfidenceLevel] = [.high, .medium, .low]
+            let firstIndex = first.flatMap { levels.firstIndex(of: $0) } ?? 0
+            let secondIndex = second.flatMap { levels.firstIndex(of: $0) } ?? 0
+            return levels[max(firstIndex, secondIndex)]
         }
 
         private func estimateLeanMass(for date: Date) -> InterpolatedMetric? {
@@ -587,25 +610,39 @@ class MetricsInterpolationService {
     // MARK: - FFMI Calculation
 
     /// Calculate or estimate FFMI for a given date
-    /// FFMI = lean_mass_kg / (height_meters^2)
+    /// FFMI follows the canonical normalized formula in `UnitConversion` so
+    /// Home, Stats, charts, and Body Score agree for the same selected date.
     /// Requires height to be provided
     func estimateFFMI(for date: Date, metrics: [BodyMetrics], heightInches: Double?) -> InterpolatedMetric? {
         guard let heightInches = heightInches, heightInches > 0 else { return nil }
 
-        // Get lean mass (actual or interpolated)
-        guard let leanMassResult = estimateLeanMass(for: date, metrics: metrics) else {
+        guard let weightResult = estimateTrendWeight(for: date, metrics: metrics),
+              let bodyFatResult = estimateBodyFat(for: date, metrics: metrics),
+              let ffmi = UnitConversion.calculateFFMI(
+                weightKg: weightResult.value,
+                bodyFatPercentage: bodyFatResult.value,
+                heightCm: heightInches * 2.54
+              ) else {
             return nil
         }
 
-        // Calculate FFMI
-        let heightMeters = heightInches * 0.0254
-        let ffmi = leanMassResult.value / (heightMeters * heightMeters)
+        let isInterpolated = weightResult.isInterpolated || bodyFatResult.isInterpolated
+        let isLastKnown = weightResult.isLastKnown || bodyFatResult.isLastKnown
+        let confidence: InterpolatedMetric.ConfidenceLevel?
+        if isInterpolated {
+            let levels: [InterpolatedMetric.ConfidenceLevel] = [.high, .medium, .low]
+            let weightIndex = weightResult.confidenceLevel.flatMap { levels.firstIndex(of: $0) } ?? 0
+            let bodyFatIndex = bodyFatResult.confidenceLevel.flatMap { levels.firstIndex(of: $0) } ?? 0
+            confidence = levels[max(weightIndex, bodyFatIndex)]
+        } else {
+            confidence = nil
+        }
 
         return InterpolatedMetric(
             value: round(ffmi * 10) / 10,
-            isInterpolated: leanMassResult.isInterpolated,
-            isLastKnown: leanMassResult.isLastKnown,
-            confidenceLevel: leanMassResult.confidenceLevel
+            isInterpolated: isInterpolated,
+            isLastKnown: isLastKnown,
+            confidenceLevel: confidence
         )
     }
 

--- a/apps/ios/LogYourBody/SettingsComponents.swift
+++ b/apps/ios/LogYourBody/SettingsComponents.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 
 private enum SettingsLayout {
-    static let rowMinHeight: CGFloat = 50
+    static let rowMinHeight: CGFloat = max(52, JovieTokens.minimumHitTarget)
     static let iconSize: CGFloat = 20
     static let iconFrame: CGFloat = 24
 }
@@ -72,6 +72,8 @@ struct SettingsSection<Content: View>: View {
 struct SettingsRow: View {
     @Environment(\.theme)
     private var theme
+    @Environment(\.dynamicTypeSize)
+    private var dynamicTypeSize
 
     let icon: String?
     let title: String
@@ -100,8 +102,58 @@ struct SettingsRow: View {
     }
 
     var body: some View {
+        Group {
+            if usesStackedValueLayout, let value {
+                VStack(alignment: .leading, spacing: theme.spacing.xs) {
+                    HStack(spacing: theme.spacing.sm) {
+                        leadingContent
+
+                        Spacer(minLength: theme.spacing.xs)
+
+                        disclosureIndicator
+                    }
+
+                    Text(value)
+                        .font(theme.typography.captionLarge)
+                        .foregroundColor(theme.colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.leading, valueLeadingInset)
+                }
+            } else {
+                HStack(spacing: theme.spacing.sm) {
+                    leadingContent
+
+                    Spacer(minLength: theme.spacing.xs)
+
+                    if let value {
+                        Text(value)
+                            .font(theme.typography.captionLarge)
+                            .foregroundColor(theme.colors.textSecondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+                    }
+
+                    disclosureIndicator
+                }
+            }
+        }
+        .padding(.horizontal, theme.spacing.md)
+        .padding(.vertical, theme.spacing.sm)
+        .frame(minHeight: SettingsLayout.rowMinHeight)
+        .contentShape(Rectangle())
+    }
+
+    private var usesStackedValueLayout: Bool {
+        dynamicTypeSize.isAccessibilitySize && value != nil
+    }
+
+    private var valueLeadingInset: CGFloat {
+        icon == nil ? 0 : SettingsLayout.iconFrame + theme.spacing.sm
+    }
+
+    private var leadingContent: some View {
         HStack(spacing: theme.spacing.sm) {
-            if let icon = icon {
+            if let icon {
                 Image(systemName: icon)
                     .font(theme.typography.headlineSmall)
                     .foregroundColor(resolvedTint)
@@ -112,37 +164,28 @@ struct SettingsRow: View {
                 Text(title)
                     .font(theme.typography.labelLarge)
                     .foregroundColor(resolvedTint)
-                    .lineLimit(2)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
                     .fixedSize(horizontal: false, vertical: true)
 
-                if let subtitle = subtitle {
+                if let subtitle {
                     Text(subtitle)
                         .font(theme.typography.captionLarge)
                         .foregroundColor(theme.colors.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-
-            Spacer()
-
-            if let value = value {
-                Text(value)
-                    .font(theme.typography.captionLarge)
-                    .foregroundColor(theme.colors.textSecondary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.82)
-            }
-
-            if showChevron {
-                Image(systemName: isExternal ? "arrow.up.right.square" : "chevron.right")
-                    .font(.caption2.weight(.semibold))
-                    .foregroundColor(theme.colors.textTertiary)
-            }
+            .layoutPriority(1)
         }
-        .padding(.horizontal, theme.spacing.md)
-        .padding(.vertical, theme.spacing.sm)
-        .frame(minHeight: SettingsLayout.rowMinHeight)
-        .contentShape(Rectangle())
+        .layoutPriority(1)
+    }
+
+    @ViewBuilder
+    private var disclosureIndicator: some View {
+        if showChevron {
+            Image(systemName: isExternal ? "arrow.up.right.square" : "chevron.right")
+                .font(.caption2.weight(.semibold))
+                .foregroundColor(theme.colors.textTertiary)
+        }
     }
 
     private var resolvedTint: Color {
@@ -190,11 +233,45 @@ struct SettingsNavigationLink<Destination: View>: View {
     }
 }
 
+// MARK: - Detail Screen
+
+struct SettingsDetailScreen<Content: View>: View {
+    @Environment(\.theme)
+    private var theme
+
+    let title: String
+    @ViewBuilder let content: Content
+
+    init(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: theme.spacing.sectionSpacing) {
+                content
+            }
+            .padding(.horizontal, theme.spacing.screenPadding)
+            .padding(.vertical, theme.spacing.md)
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .settingsBackground()
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
 // MARK: - Toggle Row
 
 struct SettingsToggleRow: View {
     @Environment(\.theme)
     private var theme
+    @Environment(\.dynamicTypeSize)
+    private var dynamicTypeSize
 
     let icon: String?
     let title: String
@@ -220,8 +297,35 @@ struct SettingsToggleRow: View {
     }
 
     var body: some View {
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(alignment: .leading, spacing: theme.spacing.sm) {
+                    toggleLabel
+
+                    toggle
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+            } else {
+                HStack(spacing: theme.spacing.sm) {
+                    toggleLabel
+
+                    Spacer(minLength: theme.spacing.xs)
+
+                    toggle
+                }
+            }
+        }
+        .padding(.horizontal, theme.spacing.md)
+        .padding(.vertical, theme.spacing.sm)
+        .frame(minHeight: SettingsLayout.rowMinHeight)
+        .onChange(of: isOn) { _, newValue in
+            onToggle?(newValue)
+        }
+    }
+
+    private var toggleLabel: some View {
         HStack(spacing: theme.spacing.sm) {
-            if let icon = icon {
+            if let icon {
                 Image(systemName: icon)
                     .font(theme.typography.headlineSmall)
                     .foregroundColor(resolvedTint)
@@ -232,29 +336,26 @@ struct SettingsToggleRow: View {
                 Text(title)
                     .font(theme.typography.labelLarge)
                     .foregroundColor(resolvedTint)
-                    .lineLimit(2)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
                     .fixedSize(horizontal: false, vertical: true)
 
-                if let subtitle = subtitle {
+                if let subtitle {
                     Text(subtitle)
                         .font(theme.typography.captionLarge)
                         .foregroundColor(theme.colors.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-
-            Spacer()
-
-            Toggle("", isOn: $isOn)
-                .labelsHidden()
-                .tint(theme.colors.primary)
         }
-        .padding(.horizontal, theme.spacing.md)
-        .padding(.vertical, theme.spacing.sm)
-        .frame(minHeight: SettingsLayout.rowMinHeight)
-        .onChange(of: isOn) { _, newValue in
-            onToggle?(newValue)
-        }
+        .layoutPriority(1)
+    }
+
+    private var toggle: some View {
+        Toggle(title, isOn: $isOn)
+            .labelsHidden()
+            .accessibilityLabel(title)
+            .accessibilityHint(subtitle ?? "")
+            .tint(theme.colors.primary)
     }
 
     private var resolvedTint: Color {

--- a/apps/ios/LogYourBody/Utils/Constants.swift
+++ b/apps/ios/LogYourBody/Utils/Constants.swift
@@ -69,6 +69,9 @@ struct Constants {
     static let goalBodyFatPercentageKey = "goalBodyFatPercentage"
     static let goalFFMIKey = "goalFFMI"
     static let goalWeightKey = "goalWeight"
+    /// Canonical storage for the user's weight target. The legacy `goalWeight`
+    /// value was a display-unit value and could be converted twice.
+    static let goalWeightKilogramsKey = "goalWeightKilograms"
 
     // Timeline Keys
     static let timelineModeKey = "timelineMode"

--- a/apps/ios/LogYourBody/Utils/UnitConversion.swift
+++ b/apps/ios/LogYourBody/Utils/UnitConversion.swift
@@ -40,6 +40,43 @@ enum MeasurementSystem: String, Codable, CaseIterable {
     }
 }
 
+/// A weight target is persisted in kilograms and converted only at the display
+/// boundary. This prevents a user-entered pound goal from being interpreted as
+/// kilograms later in Home, Stats, or chart detail.
+struct WeightGoal: Equatable, Codable, Sendable {
+    let kilograms: Double
+
+    init?(displayValue: Double, measurementSystem: MeasurementSystem) {
+        guard displayValue.isFinite, displayValue > 0 else { return nil }
+        kilograms = measurementSystem == .imperial
+            ? UnitConversion.lbsToKg(displayValue)
+            : displayValue
+    }
+
+    init?(kilograms: Double) {
+        guard kilograms.isFinite, kilograms > 0 else { return nil }
+        self.kilograms = kilograms
+    }
+
+    func displayValue(in measurementSystem: MeasurementSystem) -> Double {
+        measurementSystem == .imperial ? UnitConversion.kgToLbs(kilograms) : kilograms
+    }
+
+    func displayText(in measurementSystem: MeasurementSystem) -> String {
+        String(format: "%.1f %@", displayValue(in: measurementSystem), measurementSystem.weightUnit)
+    }
+
+    /// The original app stored an untyped display value. Its migration is kept
+    /// pure so Settings and Home can apply the exact same conversion once.
+    static func migrateLegacy(
+        _ legacyDisplayValue: Double?,
+        measurementSystem: MeasurementSystem
+    ) -> WeightGoal? {
+        guard let legacyDisplayValue else { return nil }
+        return WeightGoal(displayValue: legacyDisplayValue, measurementSystem: measurementSystem)
+    }
+}
+
 // MARK: - Unit Conversion Helper
 
 struct UnitConversion {

--- a/apps/ios/LogYourBody/Views/AddEntrySheet+Part01.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet+Part01.swift
@@ -219,7 +219,9 @@ var body: some View {
 
                     if glp1SelectedMedication != nil {
                         let options = glp1DoseOptions
-                        let unit = glp1UnitForSelectedMedication ?? glp1DoseUnit
+                        let unit = glp1DoseUnit.isEmpty
+                            ? (glp1UnitForSelectedMedication ?? "mg")
+                            : glp1DoseUnit
 
                         VStack(alignment: .leading, spacing: 12) {
                             HStack {
@@ -253,7 +255,7 @@ var body: some View {
                                 Text("Record this date as a planned no-dose day.")
                                     .font(.appBodySmall)
                                     .foregroundColor(.appTextTertiary)
-                            } else if !options.isEmpty {
+                            } else if !glp1UseCustomDose && !options.isEmpty {
                                 Picker("Dose", selection: $selectedGlp1DoseIndex) {
                                     ForEach(options.indices, id: \.self) { index in
                                         Text(String(format: "%.2f", options[index]))
@@ -267,6 +269,10 @@ var body: some View {
                                 .onChange(of: selectedGlp1DoseIndex) { _, _ in
                                     updateGlp1DoseFromSelection()
                                 }
+                                .accessibilityLabel("GLP-1 dose")
+                                .accessibilityValue(glp1SelectedDoseAccessibilityValue)
+                                .accessibilityHint("Selected dose for this log.")
+                                .accessibilityIdentifier("glp1_dose_picker")
 
                                 HStack {
                                     Text(unit)
@@ -274,6 +280,14 @@ var body: some View {
                                         .foregroundColor(.appTextSecondary)
                                     Spacer()
                                 }
+                            }
+
+                            if let lastLoggedDoseText = glp1LastLoggedDoseText {
+                                Text("Last logged: \(lastLoggedDoseText)")
+                                    .font(.appBodySmall)
+                                    .foregroundColor(.appTextSecondary)
+                                    .accessibilityLabel("Last logged dose: \(lastLoggedDoseText)")
+                                    .accessibilityIdentifier("glp1_last_logged_dose_status")
                             }
 
                             if !glp1IsRestDay {
@@ -296,6 +310,7 @@ var body: some View {
                                         .frame(maxWidth: .infinity)
                                         .modernTextFieldStyle()
                                         .accessibilityLabel("GLP-1 custom dose value")
+                                        .accessibilityIdentifier("glp1_custom_dose_field")
                                         .submitLabel(.done)
                                         .onChange(of: glp1Dose) { _, newValue in
                                             validateGlp1Dose(newValue)
@@ -331,8 +346,8 @@ var body: some View {
                         .onAppear {
                             if glp1Dose.isEmpty {
                                 updateGlp1DoseFromSelection()
+                                glp1DoseUnit = unit
                             }
-                            glp1DoseUnit = unit
                         }
                     }
                 }
@@ -345,11 +360,11 @@ var body: some View {
         .padding(.horizontal)
         .sheet(isPresented: $isPresentingGlp1AddMedication) {
             if let userId = glp1UserId {
-                Glp1AddMedicationView(userId: userId) { medication in
-                    glp1Medications.append(medication)
-                    selectedGlp1MedicationId = medication.id
-                    applyDefaultDoseConfig(for: medication)
-                }
+                    Glp1AddMedicationView(userId: userId) { medication in
+                        glp1Medications.append(medication)
+                        selectedGlp1MedicationId = medication.id
+                        applyResolvedGlp1DoseDraft(for: medication)
+                    }
             }
         }
         .confirmationDialog(

--- a/apps/ios/LogYourBody/Views/AddEntrySheet+Part02.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet+Part02.swift
@@ -252,7 +252,7 @@ func saveGlp1Dose(userId: String) {
                 takenAt: takenDate,
                 medicationId: medication.id,
                 doseAmount: dose,
-                doseUnit: glp1IsRestDay ? nil : medication.doseUnit ?? glp1DoseUnit,
+                doseUnit: glp1IsRestDay ? nil : glp1DoseUnit,
                 drugClass: medication.drugClass,
                 brand: medication.brand ?? medication.displayName,
                 isCompounded: medication.isCompounded,
@@ -275,7 +275,7 @@ func saveGlp1Dose(userId: String) {
                     type: "glp1",
                     properties: [
                         "medication_id": medication.id,
-                        "dose_unit": medication.doseUnit ?? glp1DoseUnit
+                        "dose_unit": glp1DoseUnit
                     ]
                 )
                 dismiss()
@@ -492,6 +492,12 @@ var glp1UnitForSelectedMedication: String? {
         return config.unit
     }
 
+var glp1SelectedDoseAccessibilityValue: String {
+        guard !glp1IsRestDay else { return "Rest day" }
+        guard let amount = Double(glp1Dose) else { return "No dose selected" }
+        return "\(Glp1DoseHistoryFormatter.numberText(amount)) \(glp1DoseUnit)"
+    }
+
 var recentGlp1DoseLogs: [Glp1DoseLog] {
         Array(glp1DoseLogs.sorted(by: { $0.takenAt > $1.takenAt }).prefix(5))
     }
@@ -527,16 +533,19 @@ var glp1DeleteConfirmationBinding: Binding<Bool> {
 @MainActor
     func loadGlp1Medications(userId: String) async {
         glp1IsLoadingMedications = true
+        let shouldPrefillInitialDraft = selectedGlp1MedicationId == nil && editingGlp1DoseLogId == nil
+        var automaticallySelectedMedicationID: String?
         let cached = await CoreDataManager.shared.fetchGlp1Medications(for: userId)
         await loadGlp1DoseLogs(userId: userId)
 
         if !cached.isEmpty {
             glp1Medications = cached.sorted { $0.startedAt < $1.startedAt }
 
-            if selectedGlp1MedicationId == nil,
+            if shouldPrefillInitialDraft,
                let active = glp1Medications.last(where: { $0.endedAt == nil }) ?? glp1Medications.last {
                 selectedGlp1MedicationId = active.id
-                applyDefaultDoseConfig(for: active)
+                automaticallySelectedMedicationID = active.id
+                applyResolvedGlp1DoseDraft(for: active)
             }
         }
 
@@ -556,10 +565,16 @@ var glp1DeleteConfirmationBinding: Binding<Bool> {
             CoreDataManager.shared.saveGlp1DoseLogs(doseLogs, userId: userId)
             glp1DoseLogs = doseLogs.sorted(by: { $0.takenAt < $1.takenAt })
 
-            if selectedGlp1MedicationId == nil,
-               let active = glp1Medications.last(where: { $0.endedAt == nil }) ?? glp1Medications.last {
-                selectedGlp1MedicationId = active.id
-                applyDefaultDoseConfig(for: active)
+            if shouldPrefillInitialDraft {
+                if let automaticallySelectedMedicationID,
+                   selectedGlp1MedicationId == automaticallySelectedMedicationID,
+                   let medication = glp1Medications.first(where: { $0.id == automaticallySelectedMedicationID }) {
+                    applyResolvedGlp1DoseDraft(for: medication)
+                } else if selectedGlp1MedicationId == nil,
+                          let active = glp1Medications.last(where: { $0.endedAt == nil }) ?? glp1Medications.last {
+                    selectedGlp1MedicationId = active.id
+                    applyResolvedGlp1DoseDraft(for: active)
+                }
             }
         } catch {
         }
@@ -583,25 +598,28 @@ func loadGlp1MedicationsIfNeeded() {
         }
     }
 
-func applyDefaultDoseConfig(for medication: Glp1Medication) {
-        let config = Glp1MedicationCatalog.doseConfig(for: medication)
-        glp1DoseUnit = config.unit
-        selectedGlp1DoseIndex = 0
-        glp1UseCustomDose = false
+func applyResolvedGlp1DoseDraft(for medication: Glp1Medication) {
+        applyGlp1DoseDraft(
+            Glp1DoseDraftResolver.resolve(
+                for: medication,
+                doseLogs: glp1DoseLogs
+            )
+        )
+    }
+
+func applyGlp1DoseDraft(_ draft: Glp1DoseDraft) {
+        glp1DoseUnit = draft.doseUnit
+        selectedGlp1DoseIndex = draft.selectedDoseIndex ?? 0
+        glp1UseCustomDose = draft.usesCustomDose
         glp1IsRestDay = false
-
-        if let first = config.doses.first {
-            glp1Dose = String(first)
-        } else {
-            glp1Dose = ""
-        }
-
+        glp1Dose = draft.doseText
+        glp1LastLoggedDoseText = draft.lastLoggedDoseText
         glp1Error = nil
     }
 
 func selectGlp1Medication(_ medication: Glp1Medication) {
         selectedGlp1MedicationId = medication.id
-        applyDefaultDoseConfig(for: medication)
+        applyResolvedGlp1DoseDraft(for: medication)
     }
 
 func editGlp1Dose(_ log: Glp1DoseLog) {
@@ -609,6 +627,7 @@ func editGlp1Dose(_ log: Glp1DoseLog) {
         editingGlp1DoseCreatedAt = log.createdAt
         selectedDate = log.takenAt
         glp1DoseNotes = log.notes ?? ""
+        glp1LastLoggedDoseText = nil
         glp1IsRestDay = Glp1DoseHistoryFormatter.isRestDay(log)
 
         if let medicationId = log.medicationId,

--- a/apps/ios/LogYourBody/Views/AddEntrySheet+Part03.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet+Part03.swift
@@ -25,7 +25,7 @@ func resetGlp1DoseEditing() {
         glp1IsRestDay = false
 
         if let medication = glp1SelectedMedication {
-            applyDefaultDoseConfig(for: medication)
+            applyResolvedGlp1DoseDraft(for: medication)
         } else {
             glp1Dose = ""
             glp1Error = nil

--- a/apps/ios/LogYourBody/Views/AddEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/AddEntrySheet.swift
@@ -92,6 +92,7 @@ struct AddEntrySheet: View {
     @State var glp1IsRestDay = false
     @State var glp1UserId: String?
     @State var glp1DoseLogs: [Glp1DoseLog] = []
+    @State var glp1LastLoggedDoseText: String?
     @State var glp1DoseNotes: String = ""
     @State var editingGlp1DoseLogId: String?
     @State var editingGlp1DoseCreatedAt: Date?

--- a/apps/ios/LogYourBody/Views/BiometricLockView.swift
+++ b/apps/ios/LogYourBody/Views/BiometricLockView.swift
@@ -1,18 +1,18 @@
 //
-// BiometricLockView.swift
-// LogYourBody
-//
-// Refactored using Atomic Design principles
+//  BiometricLockView.swift
+//  LogYourBody
 //
 import SwiftUI
 
 struct BiometricLockView: View {
     @Binding var isUnlocked: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     @State private var isAuthenticating = false
     @State private var hasAttemptedOnce = false
-    @State private var authenticationTimer: Timer?
-    @State private var haloRotation: Double = 0
-    @State private var haloPulse = false
+
     private let biometricAuthenticator: BiometricAuthenticating = LocalBiometricAuthenticationAdapter.shared
 
     private var biometricType: BiometricAuthView.BiometricType {
@@ -21,215 +21,107 @@ struct BiometricLockView: View {
 
     private var biometricScanningText: String {
         switch biometricType {
-        case .faceID:
-            return "Scanning your face…"
-        case .touchID:
-            return "Reading your fingerprint…"
+        case .faceID: "Scanning your face…"
+        case .touchID: "Reading your fingerprint…"
         }
-    }
-
-    private var biometricReadyText: String {
-        "\(biometricType.title) is ready"
     }
 
     private var biometricPromptText: String {
         switch biometricType {
-        case .faceID:
-            return "Look at your iPhone to continue"
-        case .touchID:
-            return "Touch the sensor to continue"
+        case .faceID: "Look at your iPhone to continue."
+        case .touchID: "Touch the sensor to continue."
         }
-    }
-
-    private var biometricProtectionText: String {
-        "Your data stays encrypted on this device. \(biometricType.title) adds another lock on LogYourBody."
     }
 
     var body: some View {
         ZStack {
-            Color.liquidBg
-                .ignoresSafeArea()
+            Color.jovieCanvas.ignoresSafeArea()
 
-            LinearGradient(
-                colors: [
-                    Color.linearPurple.opacity(0.35),
-                    Color.linearBlue.opacity(0.25),
-                    Color.liquidBg
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            .blendMode(.screen)
-            .ignoresSafeArea()
-
-            Circle()
-                .fill(
-                    RadialGradient(
-                        gradient: Gradient(colors: [Color.liquidAccent.opacity(0.35), Color.clear]),
-                        center: .center,
-                        startRadius: 0,
-                        endRadius: 220
-                    )
-                )
-                .frame(width: 360, height: 360)
-                .blur(radius: 30)
-                .offset(x: -80, y: -120)
-
-            Circle()
-                .fill(
-                    RadialGradient(
-                        gradient: Gradient(colors: [Color.appPrimary.opacity(0.25), Color.clear]),
-                        center: .center,
-                        startRadius: 0,
-                        endRadius: 220
-                    )
-                )
-                .frame(width: 320, height: 320)
-                .blur(radius: 30)
-                .offset(x: 120, y: 180)
-
-            if hasAttemptedOnce && !isAuthenticating {
-                BiometricAuthView(
-                    biometricType: biometricType,
-                    onAuthenticate: authenticate,
-                    onUsePassword: {
-                        withAnimation(.easeOut(duration: 0.3)) {
-                            isUnlocked = true
-                        }
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    ScrollView {
+                        lockContent
+                            .padding(.vertical, JovieTokens.sectionGap)
                     }
-                )
-                .padding(.horizontal, 16)
-            } else {
-                lockSurface
-                    .padding(.horizontal, 24)
+                } else {
+                    lockContent
+                }
             }
+            .padding(.horizontal, JovieTokens.screenInset)
         }
-        .onAppear {
-            withAnimation(Animation.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
-                haloPulse.toggle()
-            }
-
-            withAnimation(Animation.linear(duration: 1.5).repeatForever(autoreverses: false)) {
-                haloRotation = 360
-            }
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                authenticate()
-            }
-        }
+        .onAppear(perform: authenticate)
         .onDisappear {
-            authenticationTimer?.invalidate()
             biometricAuthenticator.cancelCurrentAuthentication()
         }
     }
 
+    @ViewBuilder
+    private var lockContent: some View {
+        if hasAttemptedOnce && !isAuthenticating {
+            BiometricAuthView(
+                biometricType: biometricType,
+                onAuthenticate: authenticate,
+                onUsePassword: unlock
+            )
+        } else {
+            lockSurface
+        }
+    }
+
     private var lockSurface: some View {
-        VStack(spacing: 32) {
-            VStack(spacing: 6) {
-                Text("Secure Access")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.linearTextSecondary)
+        VStack(spacing: JovieTokens.sectionGap) {
+            VStack(spacing: 8) {
+                Text("Secure access")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.jovieTextSecondary)
 
                 Text("Unlock with \(biometricType.title)")
-                    .font(.system(size: 28, weight: .bold))
-                    .foregroundColor(.linearText)
+                    .font(.title.weight(.bold))
+                    .foregroundStyle(Color.jovieText)
+                    .multilineTextAlignment(.center)
             }
 
-            ZStack {
-                Circle()
-                    .stroke(Color.appPrimary.opacity(0.15), lineWidth: 18)
-                    .frame(width: 190, height: 190)
-
-                Circle()
-                    .trim(from: 0, to: 0.25)
-                    .stroke(
-                        AngularGradient(
-                            gradient: Gradient(colors: [Color.appPrimary, Color.linearBlue, Color.appPrimary]),
-                            center: .center
-                        ),
-                        style: StrokeStyle(lineWidth: 18, lineCap: .round)
-                    )
-                    .rotationEffect(.degrees(haloRotation))
-                    .frame(width: 190, height: 190)
-
-                Circle()
-                    .fill(
-                        .ultraThinMaterial
-                    )
-                    .frame(width: 140, height: 140)
-                    .overlay(
-                        Image(systemName: biometricType.icon)
-                            .font(.system(size: 54))
-                            .foregroundColor(.linearText)
-                    )
-                    .scaleEffect(haloPulse ? 1.02 : 0.98)
-                    .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: haloPulse)
-            }
+            Image(systemName: biometricType.icon)
+                .font(.system(size: 48, weight: .medium))
+                .foregroundStyle(Color.jovieText)
+                .frame(width: 120, height: 120)
+                .background(Color.jovieSurfaceElevated, in: Circle())
+                .overlay(Circle().stroke(Color.jovieHairline, lineWidth: 1))
+                .accessibilityHidden(true)
 
             VStack(spacing: 6) {
-                Text(isAuthenticating ? biometricScanningText : biometricReadyText)
-                    .font(.system(size: 18, weight: .semibold))
-                    .foregroundColor(.linearText)
+                Text(isAuthenticating ? biometricScanningText : "\(biometricType.title) is ready")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(Color.jovieText)
 
                 Text(biometricPromptText)
-                    .font(.system(size: 15))
-                    .foregroundColor(.linearTextSecondary)
+                    .font(.body)
+                    .foregroundStyle(Color.jovieTextSecondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             }
+            .accessibilityElement(children: .combine)
 
-            HStack {
-                Capsule()
-                    .fill(Color.appPrimary.opacity(0.2))
-                    .frame(width: 50, height: 6)
-
-                Capsule()
-                    .fill(Color.appPrimary.opacity(0.5))
-                    .frame(width: 140, height: 6)
-
-                Capsule()
-                    .fill(Color.appPrimary.opacity(0.2))
-                    .frame(width: 50, height: 6)
-            }
-            .opacity(isAuthenticating ? 1 : 0.4)
-
-            Text(biometricProtectionText)
-                .font(.system(size: 14))
+            Label("Your data stays encrypted on this device.", systemImage: "lock.fill")
+                .font(.footnote)
+                .foregroundStyle(Color.jovieTextSecondary)
                 .multilineTextAlignment(.center)
-                .foregroundColor(.linearTextTertiary)
-                .padding(.horizontal, 10)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityElement(children: .combine)
         }
-        .padding(30)
-        .background(
-            RoundedRectangle(cornerRadius: 34, style: .continuous)
-                .fill(.ultraThinMaterial)
-                .background(
-                    RoundedRectangle(cornerRadius: 34, style: .continuous)
-                        .fill(Color.liquidBg.opacity(0.85))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 34, style: .continuous)
-                        .stroke(Color.appPrimary.opacity(0.2), lineWidth: 1)
-                )
-                .shadow(color: Color.appPrimary.opacity(0.25), radius: 30, x: 0, y: 20)
+        .padding(JovieTokens.sectionGap)
+        .frame(maxWidth: 440)
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.cardRadius,
+            tint: .white,
+            tintOpacity: 0.025,
+            borderColor: .jovieHairline
         )
-        .overlay(
-            VStack {
-                Spacer()
-
-                HStack {
-                    Image(systemName: "lock.shield")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(.linearTextSecondary)
-                    Text("Protected by \(biometricType.title)")
-                        .font(.system(size: 14))
-                        .foregroundColor(.linearTextSecondary)
-                }
-                .padding(.bottom, 8)
-            }
-        )
+        .accessibilityElement(children: .contain)
     }
 
     private func authenticate() {
-        authenticationTimer?.invalidate()
+        guard !isAuthenticating else { return }
         isAuthenticating = true
 
         Task {
@@ -241,28 +133,35 @@ struct BiometricLockView: View {
             )
 
             await MainActor.run {
-                authenticationTimer?.invalidate()
                 isAuthenticating = false
 
                 switch result {
                 case .success, .unavailable:
-                    withAnimation(.easeOut(duration: 0.3)) {
-                        isUnlocked = true
-                    }
+                    unlock()
                 case .failure:
                     hasAttemptedOnce = true
                 }
             }
         }
     }
-}
 
-// MARK: - Preview
+    private func unlock() {
+        if reduceMotion {
+            isUnlocked = true
+        } else {
+            withAnimation(.easeOut(duration: JovieTokens.subtleDuration)) {
+                isUnlocked = true
+            }
+        }
+    }
+}
 
 #Preview("Face ID") {
     BiometricLockView(isUnlocked: .constant(false))
+        .preferredColorScheme(.dark)
 }
 
 #Preview("Unlocked") {
     BiometricLockView(isUnlocked: .constant(true))
+        .preferredColorScheme(.dark)
 }

--- a/apps/ios/LogYourBody/Views/BodySpecIntegrationView.swift
+++ b/apps/ios/LogYourBody/Views/BodySpecIntegrationView.swift
@@ -2,49 +2,35 @@ import SwiftUI
 
 struct BodySpecIntegrationView: View {
     @EnvironmentObject var authManager: AuthManager
+    @Environment(\.theme) private var theme
 
     @State private var isConfigured = false
     @State private var isConnected = false
     @State private var connectedEmail: String?
-
     @State private var isConnecting = false
     @State private var isSyncing = false
     @State private var lastSyncSummary: String?
     @State private var errorMessage: String?
-
+    @State private var recoveryAction: RecoveryAction?
     @State private var isLoadingScans = false
     @State private var recentScans: [DexaResult] = []
     @State private var recentScansError: String?
 
+    private enum RecoveryAction {
+        case connect
+    }
+
     var body: some View {
-        ZStack {
-            Color.appBackground
-                .ignoresSafeArea()
+        SettingsDetailScreen(title: "BodySpec") {
+            introductionSection
+            connectionSection
+            syncSection
+            recentScansSection
 
-            ScrollView {
-                VStack(spacing: 24) {
-                    headerSection
-                    connectionSection
-                    syncSection
-                    recentScansSection
-
-                    if let errorMessage {
-                        Text(errorMessage)
-                            .font(.footnote)
-                            .foregroundColor(.red)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, 16)
-                    }
-
-                    Spacer(minLength: 0)
-                }
-                .padding(.horizontal, 20)
-                .padding(.top, 24)
-                .padding(.bottom, 40)
+            if let errorMessage {
+                errorRecoverySection(message: errorMessage)
             }
         }
-        .navigationTitle("BodySpec")
-        .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             Task { @MainActor in
                 await handleOnAppear()
@@ -52,180 +38,230 @@ struct BodySpecIntegrationView: View {
         }
     }
 
-    private var headerSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("BodySpec DEXA")
-                .font(.title3.weight(.semibold))
-                .foregroundColor(.appText)
-
-            Text(
-                "Connect your BodySpec account to import DEXA scans into LogYourBody. " +
-                    "This feature is currently in early internal testing."
+    private var introductionSection: some View {
+        SettingsSection(header: "About") {
+            DataInfoRow(
+                icon: "waveform.path.ecg",
+                title: "DEXA scan import",
+                description: "Connect BodySpec to bring your DEXA scan history into LogYourBody.",
+                iconColor: theme.colors.info
             )
-            .font(.subheadline)
-            .foregroundColor(.appTextSecondary)
         }
     }
 
     private var connectionSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Connection")
-                .font(.headline)
-                .foregroundColor(.appText)
+        SettingsSection(
+            header: "Connection",
+            footer: isConfigured
+                ? "You can disconnect at any time."
+                : "BodySpec is not available in this version of the app."
+        ) {
+            VStack(spacing: 0) {
+                SettingsRow(
+                    icon: connectionIcon,
+                    title: connectionTitle,
+                    subtitle: connectionDescription,
+                    tintColor: connectionTint
+                )
 
-            VStack(alignment: .leading, spacing: 8) {
-                if !isConfigured {
-                    Text("BodySpec is not configured for this build.")
-                        .font(.subheadline)
-                        .foregroundColor(.appTextSecondary)
-                } else if isConnected {
-                    HStack(spacing: 8) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
+                if isConfigured {
+                    Divider()
 
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Connected")
-                                .font(.subheadline.weight(.semibold))
-                                .foregroundColor(.appText)
-
-                            if let connectedEmail {
-                                Text(connectedEmail)
-                                    .font(.footnote)
-                                    .foregroundColor(.appTextSecondary)
-                            }
-                        }
-                    }
-                } else {
-                    HStack(spacing: 8) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundColor(.orange)
-
-                        Text("Not connected")
-                            .font(.subheadline)
-                            .foregroundColor(.appTextSecondary)
-                    }
-                }
-
-                HStack(spacing: 12) {
-                    Button(action: connectTapped) {
-                        HStack {
-                            if isConnecting {
-                                ProgressView()
-                                    .progressViewStyle(.circular)
-                            }
-
-                            Text(isConnected ? "Reconnect" : "Connect BodySpec")
-                                .font(.subheadline.weight(.semibold))
-                        }
-                        .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(.appPrimary)
-                    .disabled(!isConfigured || isConnecting)
+                    BaseButton(
+                        isConnected ? "Reconnect BodySpec" : "Connect BodySpec",
+                        configuration: ButtonConfiguration(
+                            style: .custom(background: .jovieAction, foreground: .jovieActionText),
+                            isLoading: isConnecting,
+                            isEnabled: !isConnecting,
+                            fullWidth: true,
+                            icon: "link"
+                        ),
+                        action: connectTapped
+                    )
+                    .padding(theme.spacing.md)
+                    .accessibilityHint("Connects your BodySpec account.")
 
                     if isConnected {
-                        Button(role: .destructive, action: disconnectTapped) {
-                            Text("Disconnect")
-                                .font(.subheadline)
-                        }
-                        .buttonStyle(.bordered)
-                        .disabled(isConnecting)
+                        Divider()
+
+                        BaseButton(
+                            "Disconnect BodySpec",
+                            configuration: ButtonConfiguration(
+                                style: .destructive,
+                                isEnabled: !isConnecting,
+                                fullWidth: true,
+                                icon: "link.badge.minus"
+                            ),
+                            action: disconnectTapped
+                        )
+                        .padding(theme.spacing.md)
+                        .accessibilityHint("Disconnects your BodySpec account from LogYourBody.")
                     }
                 }
             }
-            .padding(16)
-            .background(Color.appCard)
-            .cornerRadius(16)
-        }
-    }
-
-    private var recentScansSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Recent Scans")
-                .font(.headline)
-                .foregroundColor(.appText)
-
-            VStack(alignment: .leading, spacing: 8) {
-                if isLoadingScans {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-
-                        Text("Loading scans...")
-                            .font(.subheadline)
-                            .foregroundColor(.appTextSecondary)
-                    }
-                } else if let recentScansError {
-                    Text(recentScansError)
-                        .font(.footnote)
-                        .foregroundColor(.appTextSecondary)
-                } else if recentScans.isEmpty {
-                    Text("No DEXA scans found yet.")
-                        .font(.subheadline)
-                        .foregroundColor(.appTextSecondary)
-                } else {
-                    ForEach(recentScans.prefix(5)) { scan in
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(formattedDate(scan.acquireTime))
-                                .font(.subheadline)
-                                .foregroundColor(.appText)
-
-                            if let location = scan.locationName, !location.isEmpty {
-                                Text(location)
-                                    .font(.footnote)
-                                    .foregroundColor(.appTextSecondary)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.vertical, 4)
-                    }
-                }
-            }
-            .padding(16)
-            .background(Color.appCard)
-            .cornerRadius(16)
         }
     }
 
     private var syncSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("DEXA Sync")
-                .font(.headline)
-                .foregroundColor(.appText)
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text(
-                    "Manually import your DEXA scans from BodySpec. " +
-                        "New scans will be added as body metrics and linked to your account."
-                )
-                .font(.subheadline)
-                .foregroundColor(.appTextSecondary)
-
-                Button(action: syncTapped) {
-                    HStack {
-                        if isSyncing {
-                            ProgressView()
-                                .progressViewStyle(.circular)
-                        }
-
-                        Text("Sync DEXA Scans")
-                            .font(.subheadline.weight(.semibold))
-                    }
-                    .frame(maxWidth: .infinity)
+        SettingsSection(
+            header: "DEXA sync",
+            footer: "New scans are added to your body metrics."
+        ) {
+            VStack(spacing: 0) {
+                if isConfigured, isConnected {
+                    BaseButton(
+                        "Sync DEXA scans",
+                        configuration: ButtonConfiguration(
+                            style: .custom(background: .jovieAction, foreground: .jovieActionText),
+                            isLoading: isSyncing,
+                            isEnabled: !isSyncing,
+                            fullWidth: true,
+                            icon: "arrow.triangle.2.circlepath"
+                        ),
+                        action: syncTapped
+                    )
+                    .padding(theme.spacing.md)
+                    .accessibilityHint("Checks BodySpec for new DEXA scans now.")
+                } else {
+                    SettingsRow(
+                        icon: "arrow.triangle.2.circlepath",
+                        title: "Sync unavailable",
+                        subtitle: syncUnavailableDescription,
+                        tintColor: theme.colors.textSecondary
+                    )
                 }
-                .buttonStyle(.bordered)
-                .disabled(!isConfigured || !isConnected || isSyncing)
 
                 if let lastSyncSummary {
-                    Text(lastSyncSummary)
-                        .font(.footnote)
-                        .foregroundColor(.appTextSecondary)
+                    Divider()
+
+                    DataInfoRow(
+                        icon: "checkmark.circle",
+                        title: "Sync complete",
+                        description: lastSyncSummary,
+                        iconColor: theme.colors.success
+                    )
                 }
             }
-            .padding(16)
-            .background(Color.appCard)
-            .cornerRadius(16)
         }
+    }
+
+    private var recentScansSection: some View {
+        SettingsSection(
+            header: "Recent scans",
+            footer: "Your five most recent BodySpec DEXA scans appear here."
+        ) {
+            VStack(spacing: 0) {
+                if isLoadingScans {
+                    DataInfoRow(
+                        icon: "arrow.triangle.2.circlepath",
+                        title: "Loading scans",
+                        description: "Checking your BodySpec history…",
+                        iconColor: theme.colors.textSecondary
+                    )
+                } else if let recentScansError {
+                    DataInfoRow(
+                        icon: "exclamationmark.triangle",
+                        title: "Couldn’t load scans",
+                        description: recentScansError,
+                        iconColor: theme.colors.warning
+                    )
+
+                    Divider()
+
+                    BaseButton(
+                        "Try again",
+                        configuration: ButtonConfiguration(
+                            style: .secondary,
+                            fullWidth: true,
+                            icon: "arrow.clockwise"
+                        ),
+                        action: reloadRecentScans
+                    )
+                    .padding(theme.spacing.md)
+                } else if recentScans.isEmpty {
+                    DataInfoRow(
+                        icon: "doc.text.magnifyingglass",
+                        title: "No DEXA scans yet",
+                        description: isConnected
+                            ? "New scans from BodySpec will appear here after syncing."
+                            : "Connect BodySpec to see your DEXA scan history.",
+                        iconColor: theme.colors.textSecondary
+                    )
+                } else {
+                    ForEach(Array(recentScans.prefix(5).enumerated()), id: \.element.id) { index, scan in
+                        SettingsRow(
+                            icon: "calendar",
+                            title: formattedDate(scan.acquireTime),
+                            subtitle: scan.locationName?.isEmpty == false ? scan.locationName : "BodySpec DEXA scan",
+                            tintColor: theme.colors.text
+                        )
+
+                        if index < min(recentScans.count, 5) - 1 {
+                            Divider()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func errorRecoverySection(message: String) -> some View {
+        SettingsSection(header: "Needs attention") {
+            VStack(spacing: 0) {
+                DataInfoRow(
+                    icon: "exclamationmark.triangle",
+                    title: "BodySpec couldn’t finish",
+                    description: message,
+                    iconColor: theme.colors.error
+                )
+
+                if recoveryAction != nil {
+                    Divider()
+
+                    BaseButton(
+                        "Try again",
+                        configuration: ButtonConfiguration(
+                            style: .secondary,
+                            fullWidth: true,
+                            icon: "arrow.clockwise"
+                        ),
+                        action: retryLastAction
+                    )
+                    .padding(theme.spacing.md)
+                }
+            }
+        }
+    }
+
+    private var connectionIcon: String {
+        if !isConfigured { return "exclamationmark.triangle" }
+        return isConnected ? "checkmark.circle.fill" : "link"
+    }
+
+    private var connectionTint: Color {
+        if !isConfigured { return theme.colors.warning }
+        return isConnected ? theme.colors.success : theme.colors.textSecondary
+    }
+
+    private var connectionTitle: String {
+        if !isConfigured { return "BodySpec isn’t available" }
+        return isConnected ? "Connected" : "Not connected"
+    }
+
+    private var connectionDescription: String {
+        if !isConfigured {
+            return "This build can’t connect to BodySpec."
+        }
+        return connectedEmail ?? (isConnected
+            ? "Your BodySpec account is ready to sync."
+            : "Connect your account to import DEXA scans.")
+    }
+
+    private var syncUnavailableDescription: String {
+        if !isConfigured {
+            return "BodySpec isn’t available in this build."
+        }
+        return "Connect BodySpec before syncing your scans."
     }
 
     @MainActor
@@ -265,16 +301,22 @@ struct BodySpecIntegrationView: View {
             CoreDataManager.shared.saveDexaResults(scans, userId: userId)
         } catch {
             if recentScans.isEmpty {
-                recentScans = []
-                recentScansError = "Unable to load recent scans."
+                recentScansError = "Check your connection and try again."
             }
         }
 
         isLoadingScans = false
     }
 
+    private func reloadRecentScans() {
+        Task { @MainActor in
+            await loadRecentScansIfNeeded()
+        }
+    }
+
     private func connectTapped() {
         errorMessage = nil
+        recoveryAction = nil
         isConnecting = true
 
         Task { @MainActor in
@@ -283,7 +325,8 @@ struct BodySpecIntegrationView: View {
                 refreshConnectionState()
                 await loadRecentScansIfNeeded()
             } catch {
-                errorMessage = error.localizedDescription
+                errorMessage = "We couldn’t connect BodySpec. Check your connection and try again."
+                recoveryAction = .connect
             }
 
             isConnecting = false
@@ -292,6 +335,7 @@ struct BodySpecIntegrationView: View {
 
     private func disconnectTapped() {
         errorMessage = nil
+        recoveryAction = nil
 
         Task { @MainActor in
             BodySpecAuthManager.shared.disconnect()
@@ -302,32 +346,47 @@ struct BodySpecIntegrationView: View {
 
     private func syncTapped() {
         guard isConfigured else {
-            errorMessage = "BodySpec is not configured for this build."
+            errorMessage = "BodySpec isn’t available in this build."
+            recoveryAction = nil
             return
         }
 
         guard isConnected else {
-            errorMessage = "Connect your BodySpec account before syncing."
+            errorMessage = "Connect BodySpec before syncing your scans."
+            recoveryAction = .connect
             return
         }
 
         errorMessage = nil
+        recoveryAction = nil
         lastSyncSummary = nil
         isSyncing = true
 
         Task { @MainActor in
             let result = await BodySpecDexaImporter.shared.importDexaResults()
-
             isSyncing = false
-
-            if result.importedCount == 0 && result.skippedCount == 0 {
-                lastSyncSummary = "No new DEXA scans found."
-            } else {
-                lastSyncSummary = "Imported \(result.importedCount) new scan(s), skipped \(result.skippedCount)."
-            }
-
+            lastSyncSummary = syncSummary(for: result)
             await loadRecentScansIfNeeded()
         }
+    }
+
+    private func retryLastAction() {
+        switch recoveryAction {
+        case .connect:
+            connectTapped()
+        case nil:
+            break
+        }
+    }
+
+    private func syncSummary(for result: BodySpecDexaImporter.ImportResult) -> String {
+        if result.importedCount == 0, result.skippedCount == 0 {
+            return "No new DEXA scans found."
+        }
+
+        let importedUnit = result.importedCount == 1 ? "scan" : "scans"
+        let skippedUnit = result.skippedCount == 1 ? "scan" : "scans"
+        return "Imported \(result.importedCount) new \(importedUnit) and skipped \(result.skippedCount) \(skippedUnit)."
     }
 
     private func formattedDate(_ date: Date?) -> String {

--- a/apps/ios/LogYourBody/Views/BulkPhotoImportView.swift
+++ b/apps/ios/LogYourBody/Views/BulkPhotoImportView.swift
@@ -3,9 +3,13 @@
 // LogYourBody
 //
 import SwiftUI
+import UIKit
 
 struct BulkPhotoImportView: View {
     @EnvironmentObject var authManager: AuthManager
+    @Environment(\.theme) private var theme
+    @Environment(\.openURL) private var openURL
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @StateObject private var scanner = PhotoLibraryScanner.shared
     @StateObject private var importManager = BulkImportManager.shared
     @Environment(\.dismiss)
@@ -16,6 +20,23 @@ struct BulkPhotoImportView: View {
     @State private var isImporting = false
     @State private var showWelcomeScreen = true
     @State private var hasStartedScan = false
+    @State private var importCompletion: ImportCompletion?
+
+    private struct ImportCompletion: Equatable {
+        let importedCount: Int
+        let failedCount: Int
+
+        var title: String {
+            failedCount == 0 ? "Photos imported" : "Import complete"
+        }
+
+        var message: String {
+            if failedCount == 0 {
+                return "\(importedCount) photo\(importedCount == 1 ? "" : "s") added to your timeline."
+            }
+            return "\(importedCount) added. \(failedCount) could not be imported; you can try those again later."
+        }
+    }
 
     private var selectedCount: Int {
         selectedPhotos.count
@@ -27,7 +48,7 @@ struct BulkPhotoImportView: View {
 
     var body: some View {
         ZStack {
-            Color.appBackground
+            Color.jovieCanvas
                 .ignoresSafeArea()
 
             content
@@ -44,14 +65,13 @@ struct BulkPhotoImportView: View {
                             selectedPhotos = Set(scanner.scannedPhotos.map { $0.id })
                         }
                     }
+                    .jovieTouchTarget()
                 }
             }
         }
         .alert("Photo Library Access", isPresented: $showPermissionAlert) {
             Button("Open Settings") {
-                if let url = URL(string: UIApplication.openSettingsURLString) {
-                    UIApplication.shared.open(url)
-                }
+                openSettings()
             }
             Button("Cancel", role: .cancel) {
                 dismiss()
@@ -79,7 +99,9 @@ struct BulkPhotoImportView: View {
     @ViewBuilder
 
     private var content: some View {
-        if showWelcomeScreen && !hasStartedScan {
+        if let importCompletion {
+            importCompletionView(importCompletion)
+        } else if showWelcomeScreen && !hasStartedScan {
             welcomeView
         } else if scanner.authorizationStatus == .notDetermined {
             permissionRequestView
@@ -99,99 +121,88 @@ struct BulkPhotoImportView: View {
     // MARK: - Welcome View
 
     private var welcomeView: some View {
-        VStack(spacing: 40) {
+        VStack(spacing: JovieTokens.sectionGap) {
             Spacer()
 
-            // Icon
             ZStack {
                 Circle()
-                    .fill(Color.appPrimary.opacity(0.1))
-                    .frame(width: 120, height: 120)
+                    .fill(theme.colors.info.opacity(0.12))
+                    .frame(width: 88, height: 88)
 
                 Image(systemName: "photo.on.rectangle.angled")
-                    .font(.system(size: 60))
-                    .foregroundColor(.appPrimary)
+                    .font(.system(.largeTitle, design: .rounded).weight(.semibold))
+                    .foregroundColor(theme.colors.info)
             }
 
-            VStack(spacing: 16) {
+            VStack(spacing: 12) {
                 Text("Bulk Photo Import")
-                    .font(.title2)
-                    .fontWeight(.bold)
+                    .font(theme.typography.displaySmall)
 
-                Text("Scan your photo library for progress photos and import them with their original dates")
-                    .font(.body)
-                    .foregroundColor(.appTextSecondary)
+                Text("Find likely progress photos and choose exactly which ones to add, keeping their original dates.")
+                    .font(theme.typography.bodyLarge)
+                    .foregroundColor(theme.colors.textSecondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
+                    .padding(.horizontal, JovieTokens.screenInset)
 
-                VStack(alignment: .leading, spacing: 12) {
-                    Label("Analyzes photos to find potential progress photos", systemImage: "magnifyingglass")
+                VStack(alignment: .leading, spacing: 10) {
+                    Label("Scans on this iPhone before anything is imported", systemImage: "lock.shield")
                     Label("Preserves original photo dates", systemImage: "calendar")
-                    Label("Import multiple photos at once", systemImage: "square.stack.3d.up")
+                    Label("Uploads only the photos you select", systemImage: "checkmark.circle")
                 }
-                .font(.footnote)
-                .foregroundColor(.appTextSecondary)
-                .padding(.horizontal, 40)
+                .font(theme.typography.bodySmall)
+                .foregroundColor(theme.colors.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(theme.spacing.md)
+                .background(theme.colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: theme.radius.input, style: .continuous))
+                .padding(.horizontal, JovieTokens.screenInset)
             }
 
             Spacer()
 
-            VStack(spacing: 12) {
-                BaseButton(
-                    "Start Scanning",
-                    configuration: ButtonConfiguration(
-                        style: .custom(background: .appPrimary, foreground: .white),
-                        fullWidth: true
-                    ),
-                    action: {
-                        showWelcomeScreen = false
-                        hasStartedScan = true
-                        checkPermissionAndScan()
-                    }
-                )
-
-                BaseButton(
-                    "Cancel",
-                    configuration: ButtonConfiguration(
-                        style: .tertiary
-                    ),
-                    action: {
-                        dismiss()
-                    }
-                )
-            }
-            .padding(.horizontal)
-            .padding(.bottom, 40)
+            BaseButton(
+                "Start Scanning",
+                configuration: ButtonConfiguration(
+                    style: .custom(background: .jovieAction, foreground: .jovieActionText),
+                    fullWidth: true
+                ),
+                action: {
+                    showWelcomeScreen = false
+                    hasStartedScan = true
+                    checkPermissionAndScan()
+                }
+            )
+            .accessibilityIdentifier("bulk_photo_import_start_scanning")
+            .padding(.horizontal, JovieTokens.screenInset)
+            .padding(.bottom, JovieTokens.sectionGap)
         }
     }
 
     // MARK: - Permission Request View
 
     private var permissionRequestView: some View {
-        VStack(spacing: 40) {
+        VStack(spacing: JovieTokens.sectionGap) {
             Spacer()
 
-            // Icon
             ZStack {
                 Circle()
-                    .fill(Color.appPrimary.opacity(0.1))
-                    .frame(width: 120, height: 120)
+                    .fill(theme.colors.info.opacity(0.12))
+                    .frame(width: 88, height: 88)
 
                 Image(systemName: "photo.stack")
-                    .font(.system(size: 60))
-                    .foregroundColor(.appPrimary)
+                    .font(.system(.largeTitle, design: .rounded).weight(.semibold))
+                    .foregroundColor(theme.colors.info)
             }
 
-            VStack(spacing: 16) {
+            VStack(spacing: 12) {
                 Text("Access Your Photos")
-                    .font(.title2)
-                    .fontWeight(.bold)
+                    .font(theme.typography.displaySmall)
 
-                Text("Allow LogYourBody to scan your photo library for potential progress photos")
-                    .font(.body)
-                    .foregroundColor(.appTextSecondary)
+                Text("Allow access to find likely progress photos on this iPhone. No photo is added until you choose it.")
+                    .font(theme.typography.bodyLarge)
+                    .foregroundColor(theme.colors.textSecondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
+                    .padding(.horizontal, JovieTokens.screenInset)
             }
 
             Spacer()
@@ -199,7 +210,7 @@ struct BulkPhotoImportView: View {
             BaseButton(
                 "Allow Access",
                 configuration: ButtonConfiguration(
-                    style: .custom(background: .appPrimary, foreground: .white),
+                    style: .custom(background: .jovieAction, foreground: .jovieActionText),
                     fullWidth: true
                 ),
                 action: {
@@ -213,31 +224,30 @@ struct BulkPhotoImportView: View {
                     }
                 }
             )
-            .padding(.horizontal)
-            .padding(.bottom, 40)
+            .padding(.horizontal, JovieTokens.screenInset)
+            .padding(.bottom, JovieTokens.sectionGap)
         }
     }
 
     // MARK: - Access Denied View
 
     private var accessDeniedView: some View {
-        VStack(spacing: 40) {
+        VStack(spacing: JovieTokens.sectionGap) {
             Spacer()
 
             Image(systemName: "photo.slash")
-                .font(.system(size: 80))
-                .foregroundColor(.appTextTertiary)
+                .font(.system(.largeTitle, design: .rounded).weight(.semibold))
+                .foregroundColor(theme.colors.error)
 
-            VStack(spacing: 16) {
+            VStack(spacing: 12) {
                 Text("Photo Access Required")
-                    .font(.title2)
-                    .fontWeight(.bold)
+                    .font(theme.typography.displaySmall)
 
                 Text("Please enable photo library access in Settings to import progress photos")
-                    .font(.body)
-                    .foregroundColor(.appTextSecondary)
+                    .font(theme.typography.bodyLarge)
+                    .foregroundColor(theme.colors.textSecondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
+                    .padding(.horizontal, JovieTokens.screenInset)
             }
 
             Spacer()
@@ -245,59 +255,57 @@ struct BulkPhotoImportView: View {
             BaseButton(
                 "Open Settings",
                 configuration: ButtonConfiguration(
-                    style: .custom(background: .appPrimary, foreground: .white),
+                    style: .custom(background: .jovieAction, foreground: .jovieActionText),
                     fullWidth: true
                 ),
                 action: {
-                    if let url = URL(string: UIApplication.openSettingsURLString) {
-                        UIApplication.shared.open(url)
-                    }
+                    openSettings()
                 }
             )
-            .padding(.horizontal)
-            .padding(.bottom, 40)
+            .padding(.horizontal, JovieTokens.screenInset)
+            .padding(.bottom, JovieTokens.sectionGap)
         }
     }
 
     // MARK: - Scanning View
 
     private var scanningView: some View {
-        VStack(spacing: 40) {
+        VStack(spacing: JovieTokens.sectionGap) {
             Spacer()
 
-            // Animated scanner
             ZStack {
                 Circle()
-                    .stroke(Color.appBorder, lineWidth: 3)
-                    .frame(width: 120, height: 120)
+                    .stroke(theme.colors.border, lineWidth: 3)
+                    .frame(width: 88, height: 88)
 
                 Circle()
                     .trim(from: 0, to: scanner.scanProgress)
-                    .stroke(Color.appPrimary, lineWidth: 3)
-                    .frame(width: 120, height: 120)
+                    .stroke(theme.colors.info, lineWidth: 3)
+                    .frame(width: 88, height: 88)
                     .rotationEffect(.degrees(-90))
-                    .animation(.linear(duration: 0.3), value: scanner.scanProgress)
+                    .animation(reduceMotion ? nil : theme.animation.subtle, value: scanner.scanProgress)
 
                 Image(systemName: "photo.stack")
-                    .font(.system(size: 50))
-                    .foregroundColor(.appPrimary)
+                    .font(.system(.title, design: .rounded).weight(.semibold))
+                    .foregroundColor(theme.colors.info)
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Scanning photos, \(Int(scanner.scanProgress * 100)) percent complete")
 
             VStack(spacing: 12) {
-                Text("Scanning Photos...")
-                    .font(.title3)
-                    .fontWeight(.semibold)
+                Text("Scanning photos")
+                    .font(theme.typography.displaySmall)
 
-                Text("Analyzing your photo library for potential progress photos")
-                    .font(.body)
-                    .foregroundColor(.appTextSecondary)
+                Text("Looking for likely progress photos on this iPhone.")
+                    .font(theme.typography.bodyLarge)
+                    .foregroundColor(theme.colors.textSecondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
+                    .padding(.horizontal, JovieTokens.screenInset)
 
                 if scanner.scanProgress > 0 {
                     Text("\(Int(scanner.scanProgress * 100))%")
-                        .font(.caption)
-                        .foregroundColor(.appTextTertiary)
+                        .font(theme.typography.labelMedium)
+                        .foregroundColor(theme.colors.textSecondary)
                 }
             }
 
@@ -313,30 +321,29 @@ struct BulkPhotoImportView: View {
                     dismiss()
                 }
             )
-            .padding(.bottom, 40)
+            .padding(.bottom, JovieTokens.sectionGap)
         }
     }
 
     // MARK: - No Photos Found View
 
     private var noPhotosFoundView: some View {
-        VStack(spacing: 40) {
+        VStack(spacing: JovieTokens.sectionGap) {
             Spacer()
 
             Image(systemName: "photo.badge.exclamationmark")
-                .font(.system(size: 80))
-                .foregroundColor(.appTextTertiary)
+                .font(.system(.largeTitle, design: .rounded).weight(.semibold))
+                .foregroundColor(theme.colors.textSecondary)
 
-            VStack(spacing: 16) {
+            VStack(spacing: 12) {
                 Text("No Progress Photos Found")
-                    .font(.title2)
-                    .fontWeight(.bold)
+                    .font(theme.typography.displaySmall)
 
                 Text("We couldn't find any photos that look like progress photos in your library")
-                    .font(.body)
-                    .foregroundColor(.appTextSecondary)
+                    .font(theme.typography.bodyLarge)
+                    .foregroundColor(theme.colors.textSecondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
+                    .padding(.horizontal, JovieTokens.screenInset)
             }
 
             Spacer()
@@ -344,15 +351,15 @@ struct BulkPhotoImportView: View {
             BaseButton(
                 "Done",
                 configuration: ButtonConfiguration(
-                    style: .custom(background: .appPrimary, foreground: .white),
+                    style: .custom(background: .jovieAction, foreground: .jovieActionText),
                     fullWidth: true
                 ),
                 action: {
                     dismiss()
                 }
             )
-            .padding(.horizontal)
-            .padding(.bottom, 40)
+            .padding(.horizontal, JovieTokens.screenInset)
+            .padding(.bottom, JovieTokens.sectionGap)
         }
     }
 
@@ -360,25 +367,24 @@ struct BulkPhotoImportView: View {
 
     private var photoSelectionView: some View {
         VStack(spacing: 0) {
-            // Header
-            VStack(spacing: 8) {
+            VStack(spacing: 4) {
                 Text("Found \(scanner.scannedPhotos.count) potential photos")
-                    .font(.headline)
+                    .font(theme.typography.headlineSmall)
 
                 Text("Select the photos you want to import")
-                    .font(.subheadline)
-                    .foregroundColor(.appTextSecondary)
+                    .font(theme.typography.bodySmall)
+                    .foregroundColor(theme.colors.textSecondary)
             }
-            .padding()
-            .background(Color.appCard)
+            .padding(theme.spacing.md)
+            .background(theme.colors.surface)
 
             // Photo Grid
             ScrollView {
                 LazyVGrid(columns: [
-                    GridItem(.flexible(), spacing: 8),
-                    GridItem(.flexible(), spacing: 8),
-                    GridItem(.flexible(), spacing: 8)
-                ], spacing: 8) {
+                    GridItem(.flexible(), spacing: JovieTokens.itemGap),
+                    GridItem(.flexible(), spacing: JovieTokens.itemGap),
+                    GridItem(.flexible(), spacing: JovieTokens.itemGap)
+                ], spacing: JovieTokens.itemGap) {
                     ForEach(scanner.scannedPhotos) { photo in
                         PhotoGridItem(
                             photo: photo,
@@ -388,7 +394,7 @@ struct BulkPhotoImportView: View {
                         }
                     }
                 }
-                .padding()
+                .padding(JovieTokens.compactInset)
             }
 
             // Import Button
@@ -399,7 +405,7 @@ struct BulkPhotoImportView: View {
                     BaseButton(
                         "Import \(selectedCount) Photo\(selectedCount == 1 ? "" : "s")",
                         configuration: ButtonConfiguration(
-                            style: .custom(background: .appPrimary, foreground: .white),
+                            style: .custom(background: .jovieAction, foreground: .jovieActionText),
                             fullWidth: true,
                             icon: "square.and.arrow.down"
                         ),
@@ -407,8 +413,8 @@ struct BulkPhotoImportView: View {
                             showImportConfirmation = true
                         }
                     )
-                    .padding()
-                    .background(Color.appCard)
+                    .padding(JovieTokens.compactInset)
+                    .background(theme.colors.surface)
                 }
             }
         }
@@ -417,40 +423,40 @@ struct BulkPhotoImportView: View {
     // MARK: - Importing View
 
     private var importingView: some View {
-        VStack(spacing: 40) {
+        VStack(spacing: JovieTokens.sectionGap) {
             Spacer()
 
-            // Progress
             ZStack {
                 Circle()
-                    .stroke(Color.appBorder, lineWidth: 3)
-                    .frame(width: 120, height: 120)
+                    .stroke(theme.colors.border, lineWidth: 3)
+                    .frame(width: 88, height: 88)
 
                 Circle()
                     .trim(from: 0, to: importManager.overallProgress)
-                    .stroke(Color.appPrimary, lineWidth: 3)
-                    .frame(width: 120, height: 120)
+                    .stroke(theme.colors.info, lineWidth: 3)
+                    .frame(width: 88, height: 88)
                     .rotationEffect(.degrees(-90))
-                    .animation(.linear(duration: 0.3), value: importManager.overallProgress)
+                    .animation(reduceMotion ? nil : theme.animation.subtle, value: importManager.overallProgress)
 
                 VStack(spacing: 4) {
                     Text("\(importManager.completedCount)")
-                        .font(.system(size: 32, weight: .bold))
+                        .font(theme.typography.displaySmall)
                     Text("of \(importManager.totalCount)")
-                        .font(.caption)
-                        .foregroundColor(.appTextSecondary)
+                        .font(theme.typography.captionLarge)
+                        .foregroundColor(theme.colors.textSecondary)
                 }
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Importing photos, \(importManager.completedCount) of \(importManager.totalCount) complete")
 
             VStack(spacing: 12) {
-                Text("Importing Photos...")
-                    .font(.title3)
-                    .fontWeight(.semibold)
+                Text("Importing photos")
+                    .font(theme.typography.displaySmall)
 
                 if let currentPhoto = importManager.currentPhotoName {
                     Text(currentPhoto)
-                        .font(.caption)
-                        .foregroundColor(.appTextSecondary)
+                        .font(theme.typography.captionLarge)
+                        .foregroundColor(theme.colors.textSecondary)
                         .lineLimit(1)
                 }
             }
@@ -466,7 +472,7 @@ struct BulkPhotoImportView: View {
                     dismiss()
                 }
             )
-            .padding(.bottom, 40)
+            .padding(.bottom, JovieTokens.sectionGap)
         }
     }
 
@@ -494,21 +500,66 @@ struct BulkPhotoImportView: View {
     }
 
     private func startImport() {
-        // Prevent multiple imports
         guard !importManager.isImporting else { return }
 
         let photosToImport = scanner.scannedPhotos.filter { selectedPhotos.contains($0.id) }
         isImporting = true
+        importCompletion = nil
 
         Task {
             await importManager.importPhotos(photosToImport)
-
-            // Show success and dismiss
             await MainActor.run {
-                // Show success notification in the import manager instead
-                dismiss()
+                isImporting = false
+                importCompletion = ImportCompletion(
+                    importedCount: max(importManager.completedCount - importManager.failedCount, 0),
+                    failedCount: importManager.failedCount
+                )
+                UIAccessibility.post(
+                    notification: .announcement,
+                    argument: importCompletion?.message
+                )
             }
         }
+    }
+
+    private func openSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        openURL(url)
+    }
+
+    private func importCompletionView(_ completion: ImportCompletion) -> some View {
+        VStack(spacing: JovieTokens.sectionGap) {
+            Spacer()
+
+            Image(systemName: completion.failedCount == 0 ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .font(.system(.largeTitle, design: .rounded).weight(.semibold))
+                .foregroundColor(completion.failedCount == 0 ? theme.colors.success : theme.colors.warning)
+
+            VStack(spacing: 12) {
+                Text(completion.title)
+                    .font(theme.typography.displaySmall)
+
+                Text(completion.message)
+                    .font(theme.typography.bodyLarge)
+                    .foregroundColor(theme.colors.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, JovieTokens.screenInset)
+            }
+
+            Spacer()
+
+            BaseButton(
+                "Done",
+                configuration: ButtonConfiguration(
+                    style: .custom(background: .jovieAction, foreground: .jovieActionText),
+                    fullWidth: true
+                ),
+                action: { dismiss() }
+            )
+            .padding(.horizontal, JovieTokens.screenInset)
+            .padding(.bottom, JovieTokens.sectionGap)
+        }
+        .accessibilityIdentifier("bulk_photo_import_completion")
     }
 }
 
@@ -531,10 +582,10 @@ struct PhotoGridItem: View {
                         .aspectRatio(contentMode: .fill)
                         .frame(height: 120)
                         .clipped()
-                        .cornerRadius(8)
+                        .clipShape(RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous))
                 } else {
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.appCard)
+                    RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                        .fill(Color.jovieSurface)
                         .frame(height: 120)
                         .overlay(
                             ProgressView()
@@ -544,18 +595,18 @@ struct PhotoGridItem: View {
 
                 // Selection overlay
                 if isSelected {
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.appPrimary.opacity(0.3))
+                    RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                        .fill(Color.jovieMetricAccent.opacity(0.24))
                         .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color.appPrimary, lineWidth: 3)
+                            RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                                .stroke(Color.jovieMetricAccent, lineWidth: 3)
                         )
                 }
 
                 // Selection checkmark
                 ZStack {
                     Circle()
-                        .fill(isSelected ? Color.appPrimary : Color.black.opacity(0.5))
+                        .fill(isSelected ? Color.jovieMetricAccent : Color.black.opacity(0.5))
                         .frame(width: 24, height: 24)
 
                     if isSelected {
@@ -577,7 +628,7 @@ struct PhotoGridItem: View {
                             .padding(.horizontal, 8)
                             .padding(.vertical, 4)
                             .background(Color.black.opacity(0.6))
-                            .cornerRadius(4)
+                            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
                         Spacer()
                     }
                     .padding(8)
@@ -598,6 +649,12 @@ struct PhotoGridItem: View {
                 }
             }
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel(
+            "Photo from \(photo.date.formatted(.dateTime.month(.wide).day().year()))\(photo.confidence > 0.85 ? ", high-confidence suggestion" : ", suggested progress photo")"
+        )
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityHint("Double tap to \(isSelected ? "remove from" : "add to") import")
         .onAppear {
             Task {
                 thumbnail = await PhotoLibraryScanner.shared.loadThumbnail(for: photo.asset)

--- a/apps/ios/LogYourBody/Views/DailyWeighInReminderPromptView.swift
+++ b/apps/ios/LogYourBody/Views/DailyWeighInReminderPromptView.swift
@@ -1,9 +1,13 @@
 import SwiftUI
+import UIKit
+import UserNotifications
 
 struct DailyWeighInReminderPromptView: View {
     @ObservedObject private var notificationManager: NotificationManager
+    @Environment(\.openURL) private var openURL
     @State private var reminderTime: Date
     @State private var isRequesting = false
+    @State private var showPermissionRecovery = false
 
     let onComplete: () -> Void
 
@@ -21,46 +25,28 @@ struct DailyWeighInReminderPromptView: View {
         self.init(notificationManager: NotificationManager.shared, onComplete: onComplete)
     }
 
+    private var notificationsDenied: Bool {
+        notificationManager.authorizationStatus == .denied
+    }
+
     var body: some View {
         OnboardingPageTemplate(
-            title: "Want a daily nudge at 7am?",
-            subtitle: "Log your weight once a day so your trend stays useful.",
+            title: "Set a daily weigh-in reminder",
+            subtitle: "Choose a time that works for you. You can change or turn it off anytime in Settings.",
             showsBackButton: false,
             content: {
-                VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: JovieTokens.itemGap) {
                     reminderIcon
+                    reminderTimePicker
 
-                    DatePicker(
-                        "Reminder time",
-                        selection: $reminderTime,
-                        displayedComponents: .hourAndMinute
-                    )
-                    .datePickerStyle(.wheel)
-                    .labelsHidden()
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 20, style: .continuous)
-                            .fill(Color.appCard.opacity(0.55))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 20, style: .continuous)
-                            .stroke(Color.appBorder.opacity(0.45))
-                    )
-                    .accessibilityIdentifier("daily_reminder_time_picker")
+                    Text("One reminder per day helps keep your weight trend useful.")
+                        .font(.subheadline)
+                        .foregroundColor(.jovieTextSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
 
-                    OnboardingBulletList(
-                        items: [
-                            OnboardingBulletItem(
-                                iconName: "clock.fill",
-                                text: "One reminder per day at your chosen time."
-                            ),
-                            OnboardingBulletItem(
-                                iconName: "slider.horizontal.3",
-                                text: "Change or turn it off anytime in Settings."
-                            )
-                        ]
-                    )
+                    if notificationsDenied || showPermissionRecovery {
+                        permissionRecoveryNotice
+                    }
                 }
             },
             footer: {
@@ -70,7 +56,7 @@ struct DailyWeighInReminderPromptView: View {
                     } label: {
                         if isRequesting {
                             ProgressView()
-                                .tint(.black)
+                                .tint(.jovieActionText)
                         } else {
                             Text("Enable reminder")
                         }
@@ -78,6 +64,7 @@ struct DailyWeighInReminderPromptView: View {
                     .buttonStyle(OnboardingPrimaryButtonStyle())
                     .disabled(isRequesting)
                     .accessibilityIdentifier("daily_reminder_enable_button")
+                    .accessibilityHint("Requests permission and schedules a daily reminder at the selected time.")
 
                     Button("Not now") {
                         notificationManager.skipDailyWeighInPrompt()
@@ -86,39 +73,122 @@ struct DailyWeighInReminderPromptView: View {
                     .buttonStyle(OnboardingSecondaryButtonStyle())
                     .disabled(isRequesting)
                     .accessibilityIdentifier("daily_reminder_skip_button")
+                    .accessibilityHint("Continues without a daily reminder.")
                 }
             }
         )
         .task {
             await notificationManager.refreshAuthorizationStatus()
         }
+        .alert("Notifications are unavailable", isPresented: $showPermissionRecovery) {
+            if notificationsDenied {
+                Button("Open Settings") {
+                    openAppSettings()
+                }
+            }
+            Button("Not now", role: .cancel) {
+                onComplete()
+            }
+        } message: {
+            Text(
+                notificationsDenied
+                    ? "Notifications are turned off for LogYourBody. You can enable them in Settings."
+                    : "LogYourBody could not schedule your reminder. You can try again or continue without one."
+            )
+        }
+    }
+
+    private var reminderTimePicker: some View {
+        DatePicker(
+            "Reminder time",
+            selection: $reminderTime,
+            displayedComponents: .hourAndMinute
+        )
+        .datePickerStyle(.compact)
+        .font(.body.weight(.medium))
+        .foregroundColor(.jovieText)
+        .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
+        .padding(.horizontal, 16)
+        .background(
+            RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                .fill(Color.jovieSurface)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                .stroke(Color.jovieHairline, lineWidth: 1)
+        )
+        .accessibilityIdentifier("daily_reminder_time_picker")
+    }
+
+    private var permissionRecoveryNotice: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "bell.slash.fill")
+                .foregroundColor(.warning)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Notifications are off")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(.jovieText)
+
+                Text("Enable notifications in Settings to receive this reminder.")
+                    .font(.footnote)
+                    .foregroundColor(.jovieTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button("Open Settings") {
+                    openAppSettings()
+                }
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(.jovieText)
+                .frame(minHeight: JovieTokens.minimumHitTarget)
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                .fill(Color.jovieSurfaceElevated)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                .stroke(Color.warning.opacity(0.45), lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
     }
 
     private var reminderIcon: some View {
-        ZStack {
-            Circle()
-                .fill(Color.appPrimary.opacity(0.16))
-                .frame(width: 76, height: 76)
-
-            Image(systemName: "bell.badge.fill")
-                .font(.system(size: 32, weight: .semibold))
-                .foregroundStyle(Color.appPrimary)
-        }
-        .frame(maxWidth: .infinity)
-        .accessibilityHidden(true)
+        Image(systemName: "bell.badge.fill")
+            .font(.system(.title, design: .default).weight(.semibold))
+            .foregroundStyle(Color.jovieText)
+            .frame(width: 64, height: 64)
+            .background(Circle().fill(Color.jovieSurfaceElevated))
+            .frame(maxWidth: .infinity)
+            .accessibilityHidden(true)
     }
 
     private func requestReminder() {
         guard !isRequesting else { return }
         isRequesting = true
 
-        Task {
-            _ = await notificationManager.requestDailyWeighInReminder(at: reminderTime)
-            await MainActor.run {
-                isRequesting = false
+        Task { @MainActor in
+            let enabled = await notificationManager.requestDailyWeighInReminder(at: reminderTime)
+            isRequesting = false
+
+            if enabled {
                 onComplete()
+            } else {
+                showPermissionRecovery = true
+                UIAccessibility.post(
+                    notification: .announcement,
+                    argument: "Notifications could not be enabled. Review the available recovery options."
+                )
             }
         }
+    }
+
+    private func openAppSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        openURL(url)
     }
 }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -39,6 +39,8 @@ struct DashboardEmptyStateLiquid: View {
 
 struct DashboardHomeTimelineHero: View {
     @Environment(\.theme) private var theme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @ScaledMetric(relativeTo: .largeTitle) private var bodyScoreFontSize: CGFloat = 50
 
     let metric: BodyMetrics
     let bodyMetrics: [BodyMetrics]
@@ -154,8 +156,11 @@ struct DashboardHomeTimelineHero: View {
                         .frame(width: 32, height: 32)
                         .background(Circle().fill(theme.colors.background.opacity(0.42)))
                 }
+                .frame(width: 44, height: 44)
+                .contentShape(Circle())
                 .buttonStyle(.plain)
                 .accessibilityLabel("Share Body Score")
+                .accessibilityHint("Opens sharing options for this Body Score")
                 .accessibilityIdentifier("body_score_hero_share_button")
             }
 
@@ -170,51 +175,100 @@ struct DashboardHomeTimelineHero: View {
         }
     }
 
+    @ViewBuilder
     private var timelineMetricsHUD: some View {
         VStack(alignment: .leading, spacing: 14) {
             bodyScoreSummary
 
-            GeometryReader { geometry in
-                let dividerTrackWidth = 42.0
-                let columnWidth = max(0, (geometry.size.width - dividerTrackWidth) / 3.0)
-
-                HStack(alignment: .top, spacing: 0) {
-                    DashboardHomeTimelineMetricButton(
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(alignment: .leading, spacing: 10) {
+                    timelineMetricButton(
                         title: "Weight",
                         value: weightValue,
                         caption: weightCaption,
                         color: theme.colors.accentViolet,
                         action: onTapWeight
                     )
-                    .frame(width: columnWidth, alignment: .leading)
 
-                    metricDivider
+                    horizontalMetricDivider
 
-                    DashboardHomeTimelineMetricButton(
+                    timelineMetricButton(
                         title: "Body Fat",
                         value: bodyFatValue,
                         caption: bodyFatCaption,
                         color: theme.colors.accentPink,
                         action: onTapBodyFat
                     )
-                    .frame(width: columnWidth, alignment: .leading)
 
-                    metricDivider
+                    horizontalMetricDivider
 
-                    DashboardHomeTimelineMetricButton(
+                    timelineMetricButton(
                         title: "FFMI",
                         value: ffmiValue,
                         caption: ffmiCaption,
                         color: theme.colors.accentTeal,
                         action: onTapFFMI
                     )
-                    .frame(width: columnWidth, alignment: .leading)
                 }
-                .frame(width: geometry.size.width, alignment: .leading)
+            } else {
+                GeometryReader { geometry in
+                    let dividerTrackWidth = 42.0
+                    let columnWidth = max(0, (geometry.size.width - dividerTrackWidth) / 3.0)
+
+                    HStack(alignment: .top, spacing: 0) {
+                        timelineMetricButton(
+                            title: "Weight",
+                            value: weightValue,
+                            caption: weightCaption,
+                            color: theme.colors.accentViolet,
+                            action: onTapWeight
+                        )
+                        .frame(width: columnWidth, alignment: .leading)
+
+                        metricDivider
+
+                        timelineMetricButton(
+                            title: "Body Fat",
+                            value: bodyFatValue,
+                            caption: bodyFatCaption,
+                            color: theme.colors.accentPink,
+                            action: onTapBodyFat
+                        )
+                        .frame(width: columnWidth, alignment: .leading)
+
+                        metricDivider
+
+                        timelineMetricButton(
+                            title: "FFMI",
+                            value: ffmiValue,
+                            caption: ffmiCaption,
+                            color: theme.colors.accentTeal,
+                            action: onTapFFMI
+                        )
+                        .frame(width: columnWidth, alignment: .leading)
+                    }
+                    .frame(width: geometry.size.width, alignment: .leading)
+                }
+                .frame(height: 68)
             }
-            .frame(height: 68)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func timelineMetricButton(
+        title: String,
+        value: String,
+        caption: String,
+        color: Color,
+        action: @escaping () -> Void
+    ) -> DashboardHomeTimelineMetricButton {
+        DashboardHomeTimelineMetricButton(
+            title: title,
+            value: value,
+            caption: caption,
+            color: color,
+            action: action
+        )
     }
 
     @ViewBuilder
@@ -232,7 +286,7 @@ struct DashboardHomeTimelineHero: View {
     private var bodyScoreContent: some View {
         HStack(alignment: .lastTextBaseline, spacing: 12) {
             Text(bodyScoreText)
-                .font(.system(size: 50, weight: .bold, design: .rounded))
+                .font(.system(size: bodyScoreFontSize, weight: .bold, design: .rounded))
                 .monospacedDigit()
                 .foregroundColor(theme.colors.text)
                 .lineLimit(1)
@@ -247,8 +301,8 @@ struct DashboardHomeTimelineHero: View {
                 Text(bodyScoreTagline)
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundColor(theme.colors.text)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.72)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+                    .minimumScaleFactor(dynamicTypeSize.isAccessibilitySize ? 1 : 0.72)
 
                 if let bodyScoreDeltaText {
                     Text(bodyScoreDeltaText)
@@ -273,10 +327,17 @@ struct DashboardHomeTimelineHero: View {
             .frame(width: 1, height: 44)
             .padding(.horizontal, 10)
     }
+
+    private var horizontalMetricDivider: some View {
+        Rectangle()
+            .fill(theme.colors.border)
+            .frame(height: 1)
+    }
 }
 
 private struct DashboardHomeTimelineMetricButton: View {
     @Environment(\.theme) private var theme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     let title: String
     let value: String
@@ -293,30 +354,31 @@ private struct DashboardHomeTimelineMetricButton: View {
                     .cornerRadius(1)
 
                 Text(title)
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.caption2.weight(.bold))
                     .foregroundColor(theme.colors.textSecondary)
                     .lineLimit(1)
 
                 Text(value)
-                    .font(.system(size: 22, weight: .bold, design: .rounded))
+                    .font(.title3.weight(.bold))
                     .monospacedDigit()
                     .foregroundColor(theme.colors.text)
                     .lineLimit(1)
                     .minimumScaleFactor(0.68)
 
                 Text(caption)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.caption2.weight(.medium))
                     .foregroundColor(theme.colors.textTertiary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.72)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+                    .minimumScaleFactor(dynamicTypeSize.isAccessibilitySize ? 1 : 0.72)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(title), \(value), \(caption)")
+        .accessibilityHint("Opens \(title) details")
     }
 }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+CoreAccessors.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+CoreAccessors.swift
@@ -41,7 +41,7 @@ extension DashboardViewLiquid {
 
     /// Returns the weight goal (optional, nil if not set)
     var weightGoal: Double? {
-        customWeightGoal
+        WeightGoal(kilograms: customWeightGoalKilograms ?? -1)?.kilograms
     }
 
     var currentMeasurementSystem: MeasurementSystem {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HomeTimelineControls.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HomeTimelineControls.swift
@@ -50,11 +50,10 @@ extension DashboardViewLiquid {
             HapticManager.shared.selection()
         } label: {
             Label(mode.title, systemImage: mode.iconName)
-                .font(.system(size: 13, weight: .semibold))
+                .font(.subheadline.weight(.semibold))
                 .lineLimit(1)
-                .minimumScaleFactor(0.8)
                 .frame(maxWidth: .infinity)
-                .frame(height: 34)
+                .frame(minHeight: 44)
                 .foregroundColor(isSelected ? theme.colors.background : theme.colors.textSecondary)
                 .background(
                     Capsule(style: .continuous)
@@ -62,6 +61,10 @@ extension DashboardViewLiquid {
                 )
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(mode.title)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityHint("Shows the \(mode.title.lowercased()) home timeline")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
         .accessibilityIdentifier("home_mode_\(mode.rawValue)_button")
     }
 
@@ -107,12 +110,21 @@ extension DashboardViewLiquid {
 
     func makeBodyScoreShareAction(metric: BodyMetrics? = nil, score: Int? = nil) -> (() -> Void)? {
         if let score, score <= 0 { return nil }
+        guard let initialPayload = makeBodyScoreSharePayload(metric: metric) else { return nil }
 
         return {
+            let presentationID = UUID()
+            bodyScoreSharePresentationID = presentationID
+            bodyScoreSharePayload = initialPayload
+
             Task { @MainActor in
-                if let payload = await makeBodyScoreSharePayloadResolvingPhoto(metric: metric) {
-                    bodyScoreSharePayload = payload
+                guard let resolvedPayload = await makeBodyScoreSharePayloadResolvingPhoto(metric: metric),
+                      resolvedPayload.photoImage != nil,
+                      bodyScoreSharePresentationID == presentationID else {
+                    return
                 }
+
+                bodyScoreSharePayload = resolvedPayload
             }
         }
     }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
@@ -115,7 +115,7 @@ extension DashboardViewLiquid {
                 },
                 metricEntries: cachedMetricEntries(for: .weight),
                 relatedMetrics: metricDetailRelatedMetrics(excluding: .weight),
-                goalValue: weightGoal,
+                goalValue: weightGoal.flatMap { convertWeight($0, to: currentMeasurementSystem) },
                 selectedTimeRange: $selectedRange,
                 selectedTimelineDate: metricDetailSelectedDateBinding
             )

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
@@ -82,8 +82,7 @@ extension DashboardViewLiquid {
             metrics: bodyMetrics,
             heightInches: heightInches
         ) {
-            // Apple Health-style: no decimals for FFMI headline value
-            return String(format: "%.0f", ffmiResult.value)
+            return String(format: "%.1f", ffmiResult.value)
         }
         return "–"
     }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift
@@ -15,57 +15,57 @@ extension DashboardViewLiquid {
             theme.colors.background.ignoresSafeArea()
 
             ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: JovieTokens.sectionGap) {
                     photoTimelineStatsHeader
-                        .padding(.horizontal, 20)
+                        .padding(.horizontal, JovieTokens.screenInset)
 
                     photoTimelinePresenceSummary
-                        .padding(.horizontal, 20)
+                        .padding(.horizontal, JovieTokens.screenInset)
 
                     metricsView
                 }
-                .padding(.top, 14)
-                .padding(.bottom, 32)
+                .padding(.top, JovieTokens.itemGap)
+                .padding(.bottom, JovieTokens.sectionGap)
             }
             .scrollBounceBehavior(.basedOnSize)
         }
     }
 
     var photoTimelineStatsHeader: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 8) {
             Text("Body trends")
-                .font(.system(size: 28, weight: .bold))
+                .font(.title.weight(.bold))
                 .foregroundColor(theme.colors.text)
+                .accessibilityAddTraits(.isHeader)
 
             Text("Open a metric for chart and history.")
-                .font(.system(size: 14, weight: .medium))
+                .font(.body)
                 .foregroundColor(theme.colors.textSecondary)
         }
     }
 
     var photoTimelinePresenceSummary: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("Timeline data")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(theme.colors.text)
+            ViewThatFits(in: .horizontal) {
+                HStack {
+                    timelineDataTitle
+                    Spacer(minLength: JovieTokens.itemGap)
+                    timelineValueCount
+                }
 
-                Spacer()
-
-                Text("\(timelinePresenceValueCount) values")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(theme.colors.textTertiary)
+                VStack(alignment: .leading, spacing: 4) {
+                    timelineDataTitle
+                    timelineValueCount
+                }
             }
 
             Text(photoTimelinePresenceLegendText)
-                .font(.system(size: 12, weight: .semibold))
+                .font(.footnote.weight(.medium))
                 .foregroundColor(theme.colors.textSecondary)
-                .lineLimit(2)
-                .minimumScaleFactor(0.85)
                 .fixedSize(horizontal: false, vertical: true)
                 .accessibilityIdentifier("photo_timeline_stats_presence_legend")
         }
-        .padding(14)
+        .padding(JovieTokens.compactInset)
         .systemBGlassSurface(
             cornerRadius: theme.radius.card,
             tint: theme.colors.text,
@@ -76,6 +76,18 @@ extension DashboardViewLiquid {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Timeline data. \(photoTimelinePresenceLegendText). \(timelinePresenceValueCount) values.")
         .accessibilityIdentifier("photo_timeline_stats_presence_summary")
+    }
+
+    private var timelineDataTitle: some View {
+        Text("Timeline data")
+            .font(.body.weight(.semibold))
+            .foregroundColor(theme.colors.text)
+    }
+
+    private var timelineValueCount: some View {
+        Text("\(timelinePresenceValueCount) values")
+            .font(.footnote.weight(.semibold))
+            .foregroundColor(theme.colors.textTertiary)
     }
 
     var photoTimelinePresenceLegendText: String {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -98,10 +98,10 @@ extension DashboardViewLiquid {
     }
 
     private func photoTimelineRootNavigationButton(page: PhotoTimelineRootPage) -> some View {
-        Button {
-            withAnimation(.easeOut(duration: 0.2)) {
-                selectedPhotoTimelineRootPage = page
-            }
+        let isSelected = selectedPhotoTimelineRootPage == page
+
+        return Button {
+            selectedPhotoTimelineRootPage = page
         } label: {
             VStack(spacing: 6) {
                 Text(page.navigationTitle)
@@ -114,19 +114,21 @@ extension DashboardViewLiquid {
 
                 Capsule()
                     .fill(
-                        selectedPhotoTimelineRootPage == page
+                        isSelected
                             ? theme.colors.text
                             : Color.clear
                     )
                     .frame(width: 24, height: 2)
             }
-            .frame(minHeight: 32, alignment: .bottom)
+            .frame(minHeight: 44, alignment: .bottom)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(page.navigationTitle)
-        .accessibilityAddTraits(selectedPhotoTimelineRootPage == page ? [.isSelected] : [])
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityHint("Shows the \(page.navigationTitle.lowercased()) page")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
         .accessibilityIdentifier(page.accessibilityIdentifier)
     }
 
@@ -279,18 +281,7 @@ extension DashboardViewLiquid {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
-                Button {
-                    presentProgressPhotoAttach(for: nil)
-                } label: {
-                    Label("Add photo", systemImage: "camera.fill")
-                        .font(.system(size: 15, weight: .semibold))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 14)
-                        .background(Capsule().fill(theme.colors.text))
-                        .foregroundColor(theme.colors.background)
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("photo_timeline_hud_empty_add_photo_button")
+                photoTimelineHUDEmptyActions
             }
             .padding(24)
             .frame(maxWidth: .infinity, minHeight: 420, alignment: .bottomLeading)
@@ -306,6 +297,55 @@ extension DashboardViewLiquid {
             Spacer(minLength: 80)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    @ViewBuilder
+    private var photoTimelineHUDEmptyActions: some View {
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(spacing: 12) {
+                photoTimelineHUDEmptyAddWeightButton
+                photoTimelineHUDEmptyAddPhotoButton
+            }
+        } else {
+            HStack(spacing: 12) {
+                photoTimelineHUDEmptyAddWeightButton
+                photoTimelineHUDEmptyAddPhotoButton
+            }
+        }
+    }
+
+    private var photoTimelineHUDEmptyAddWeightButton: some View {
+        Button {
+            presentAddEntrySheet(initialTab: 0)
+        } label: {
+            Label("Add weight", systemImage: "scalemass.fill")
+                .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: .infinity, minHeight: 48)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(theme.colors.background)
+        .background(Capsule().fill(theme.colors.text))
+        .contentShape(Capsule())
+        .accessibilityLabel("Add weight")
+        .accessibilityHint("Opens the weight entry form")
+        .accessibilityIdentifier("photo_timeline_hud_empty_add_weight_button")
+    }
+
+    private var photoTimelineHUDEmptyAddPhotoButton: some View {
+        Button {
+            presentProgressPhotoAttach(for: nil)
+        } label: {
+            Label("Add photo", systemImage: "camera.fill")
+                .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: .infinity, minHeight: 48)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(theme.colors.background)
+        .background(Capsule().fill(theme.colors.text))
+        .contentShape(Capsule())
+        .accessibilityLabel("Add photo")
+        .accessibilityHint("Opens progress photo options")
+        .accessibilityIdentifier("photo_timeline_hud_empty_add_photo_button")
     }
 }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -22,6 +22,7 @@ struct DashboardViewLiquid: View {
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var realtimeSyncManager: RealtimeSyncManager
     @Environment(\.theme) var theme
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @StateObject var viewModel = DashboardViewModel()
     @StateObject var globalTimelineStore = GlobalTimelineStore()
 
@@ -65,7 +66,8 @@ struct DashboardViewLiquid: View {
     @AppStorage("stepGoal") var stepGoal: Int = 10_000
     @AppStorage(Constants.goalFFMIKey) var customFFMIGoal: Double?
     @AppStorage(Constants.goalBodyFatPercentageKey) var customBodyFatGoal: Double?
-    @AppStorage(Constants.goalWeightKey) var customWeightGoal: Double?
+    @AppStorage(Constants.goalWeightKilogramsKey) var customWeightGoalKilograms: Double?
+    @AppStorage(Constants.goalWeightKey) var legacyCustomWeightGoal: Double?
 
     // Preferences
     @AppStorage(Constants.preferredMeasurementSystemKey)
@@ -92,12 +94,13 @@ struct DashboardViewLiquid: View {
     @State private var chartMode: ChartMode = .trend
     @State var bodyScoreRefreshToken = UUID()
     @State var bodyScoreSharePayload: BodyScoreSharePayload?
+    @State var bodyScoreSharePresentationID: UUID?
     @State private var hasPerformedInitialRefresh = false
     @State var featureGateRefreshToken = UUID()
     @State var addEntryInitialTab = 0
     @State var addEntryIncludesGlp1Entry = false
 
-    init(layoutMode: LayoutMode = .legacyTabbed) {
+    init(layoutMode: LayoutMode = .photoTimelineHUD) {
         self.layoutMode = layoutMode
 
         #if DEBUG
@@ -256,7 +259,9 @@ struct DashboardViewLiquid: View {
                 guard selectedTab == .home else { return }
                 guard !isMetricDetailActive else { return }
                 guard let payload = makeBodyScoreSharePayload() else { return }
+                let presentationID = UUID()
                 DispatchQueue.main.async {
+                    bodyScoreSharePresentationID = presentationID
                     bodyScoreSharePayload = payload
                 }
             }
@@ -274,6 +279,7 @@ struct DashboardViewLiquid: View {
         if let payload = bodyScoreSharePayload {
             BodyScoreShareSheet(payload: payload) {
                 bodyScoreSharePayload = nil
+                bodyScoreSharePresentationID = nil
             }
             .ignoresSafeArea()
             .zIndex(20)
@@ -312,6 +318,7 @@ struct DashboardViewLiquid: View {
     }
 
     private func handleOnAppear() {
+        migrateLegacyWeightGoalIfNeeded()
         loadMetricsOrder()
 
         selectedRange = TimeRange(rawValue: storedTimeRangeRawValue) ?? .month1
@@ -344,6 +351,19 @@ struct DashboardViewLiquid: View {
         isPhotosTabEnabled = true
 
         loadGlp1WeeklyCheckInDataIfNeeded()
+    }
+
+    private func migrateLegacyWeightGoalIfNeeded() {
+        guard customWeightGoalKilograms == nil,
+              let migrated = WeightGoal.migrateLegacy(
+                legacyCustomWeightGoal,
+                measurementSystem: currentMeasurementSystem
+              ) else {
+            return
+        }
+
+        customWeightGoalKilograms = migrated.kilograms
+        legacyCustomWeightGoal = nil
     }
 
     private func handleCoreDataContextChange(_ notification: Notification) {

--- a/apps/ios/LogYourBody/Views/DeleteAccountView.swift
+++ b/apps/ios/LogYourBody/Views/DeleteAccountView.swift
@@ -3,11 +3,10 @@
 // LogYourBody
 //
 import SwiftUI
+import UIKit
 
 struct DeleteAccountView: View {
     @EnvironmentObject var authManager: AuthManager
-    @Environment(\.dismiss)
-    private var dismiss
     @Environment(\.theme)
     private var theme
     @State private var showConfirmation = false
@@ -19,116 +18,41 @@ struct DeleteAccountView: View {
 
     private let confirmationPhrase = "DELETE"
 
+    private var hasValidConfirmation: Bool {
+        confirmationText == confirmationPhrase
+    }
+
+    private var confirmationValidationMessage: String? {
+        guard !confirmationText.isEmpty, !hasValidConfirmation else { return nil }
+        return "Type DELETE exactly to enable account deletion."
+    }
+
     var body: some View {
         ZStack {
+            Color.jovieCanvas
+                .ignoresSafeArea()
+
             ScrollView {
-                VStack(spacing: theme.spacing.sectionSpacing) {
-                    VStack(spacing: theme.spacing.md) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(theme.typography.displayMedium)
-                            .foregroundColor(theme.colors.error)
-                            .padding(.top, theme.spacing.lg)
-
-                        Text("Delete Account")
-                            .font(theme.typography.headlineMedium)
-                            .foregroundColor(theme.colors.text)
-
-                        Text(
-                            "This action cannot be undone. Your LogYourBody data will be permanently deleted. " +
-                                "Data in Apple Health stays in the Health app."
-                        )
-                        .font(theme.typography.bodyMedium)
-                        .foregroundColor(theme.colors.textSecondary)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, theme.spacing.lg)
-                    }
-                    .padding(.bottom, theme.spacing.lg)
-
-                    SettingsSection(header: "What will be deleted") {
-                        VStack(spacing: 0) {
-                            DataInfoRow(
-                                icon: "scalemass",
-                                title: "All weight entries",
-                                iconColor: theme.colors.error
-                            )
-
-                            Divider()
-
-                            DataInfoRow(
-                                icon: "person.circle",
-                                title: "Your profile information",
-                                iconColor: theme.colors.error
-                            )
-
-                            Divider()
-
-                            DataInfoRow(
-                                icon: "heart.fill",
-                                title: "Health data stored in LogYourBody",
-                                iconColor: theme.colors.error
-                            )
-
-                            Divider()
-
-                            DataInfoRow(
-                                icon: "creditcard.fill",
-                                title: "Active subscription (if any)",
-                                iconColor: theme.colors.error
-                            )
-                        }
-                    }
-
-                    // Confirm deletion section
-                    SettingsSection(
-                        header: "Confirm deletion",
-                        footer: "Type \"\(confirmationPhrase)\" to confirm account deletion"
-                    ) {
-                        VStack(spacing: 12) {
-                            TextField("Type \(confirmationPhrase)", text: $confirmationText)
-                                .textFieldStyle(.plain)
-                                .autocapitalization(.allCharacters)
-                                .disableAutocorrection(true)
-                                .focused($isTextFieldFocused)
-                                .submitLabel(.done)
-                                .onSubmit {
-                                    isTextFieldFocused = false
-                                }
-                                .settingsInputStyle()
-                                .padding(.horizontal, theme.spacing.md)
-                                .padding(.vertical, theme.spacing.xs)
-                        }
-                    }
-
-                    BaseButton(
-                        "Delete My Account",
-                        configuration: ButtonConfiguration(
-                            style: confirmationText == confirmationPhrase
-                                ? .custom(background: theme.colors.error, foreground: theme.colors.text)
-                                : .custom(background: theme.colors.interactiveDisabled, foreground: theme.colors.text),
-                            isLoading: isDeleting,
-                            isEnabled: confirmationText == confirmationPhrase,
-                            fullWidth: true
-                        ),
-                        action: {
-                            isTextFieldFocused = false
-                            deleteAccount()
-                        }
-                    )
-                    .padding(.horizontal, theme.spacing.screenPadding)
-
-                    Color.clear
-                        .frame(height: 100)
+                VStack(alignment: .leading, spacing: JovieTokens.sectionGap) {
+                    deletionHeader
+                    deletionSummary
+                    accountBoundaryNotice
+                    confirmationSection
                 }
-                .padding(.vertical, theme.spacing.md)
+                .padding(.horizontal, JovieTokens.screenInset)
+                .padding(.top, JovieTokens.sectionGap)
+                .padding(.bottom, 24)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
             .scrollBounceBehavior(.basedOnSize)
             .scrollDismissesKeyboard(.interactively)
-            .settingsBackground()
 
-            // Loading overlay
             if isDeleting {
                 LoadingOverlay(message: "Deleting your account...")
             }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            deleteAction
         }
         .navigationTitle("Delete Account")
         .navigationBarTitleDisplayMode(.inline)
@@ -139,19 +63,160 @@ struct DeleteAccountView: View {
             }
             Button("Cancel", role: .cancel) { }
         } message: {
-            Text("Are you sure you want to delete your account? This cannot be undone.")
-        }
-        .ignoresSafeArea(.keyboard, edges: .bottom)
-        .overlay(
-            SuccessOverlay(
-                isShowing: .constant(false),
-                message: ""
+            Text(
+                "This permanently deletes your account and app-stored data. Apple Health data stays in Health. " +
+                    "This does not cancel an App Store subscription."
             )
+        }
+        .onChange(of: showError) { _, isShowing in
+            if isShowing {
+                UIAccessibility.post(notification: .announcement, argument: errorMessage)
+            }
+        }
+    }
+
+    private var deletionHeader: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("Permanent action", systemImage: "exclamationmark.triangle.fill")
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(theme.colors.error)
+
+            Text("Delete your account")
+                .font(.title2.weight(.bold))
+                .foregroundColor(.jovieText)
+
+            Text("This cannot be undone. Your LogYourBody data will be permanently deleted.")
+                .font(.body)
+                .foregroundColor(.jovieTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var deletionSummary: some View {
+        SettingsSection(header: "What will be deleted") {
+            VStack(spacing: 0) {
+                DataInfoRow(
+                    icon: "scalemass",
+                    title: "Body records",
+                    description: "Weight, body composition, and measurements",
+                    iconColor: theme.colors.error
+                )
+
+                Divider()
+
+                DataInfoRow(
+                    icon: "photo.on.rectangle",
+                    title: "Progress data",
+                    description: "Photos, daily logs, and notes stored in LogYourBody",
+                    iconColor: theme.colors.error
+                )
+
+                Divider()
+
+                DataInfoRow(
+                    icon: "person.crop.circle",
+                    title: "Account data",
+                    description: "Profile, goals, preferences, and local app data",
+                    iconColor: theme.colors.error
+                )
+            }
+        }
+    }
+
+    private var accountBoundaryNotice: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Apple Health data stays in the Health app.", systemImage: "heart.text.square")
+            Label(
+                "Deleting your account does not cancel an App Store subscription. Manage subscriptions in the App Store.",
+                systemImage: "creditcard"
+            )
+        }
+        .font(.footnote)
+        .foregroundColor(.jovieTextSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                .fill(Color.jovieSurfaceElevated)
         )
+        .overlay(
+            RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                .stroke(Color.jovieHairline, lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+    }
+
+    private var confirmationSection: some View {
+        SettingsSection(
+            header: "Confirm permanent deletion",
+            footer: "Type \"\(confirmationPhrase)\" exactly to enable account deletion."
+        ) {
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("Type \(confirmationPhrase)", text: $confirmationText)
+                    .textFieldStyle(.plain)
+                    .textInputAutocapitalization(.characters)
+                    .autocorrectionDisabled(true)
+                    .focused($isTextFieldFocused)
+                    .submitLabel(.done)
+                    .onSubmit {
+                        isTextFieldFocused = false
+                    }
+                    .settingsInputStyle()
+                    .frame(minHeight: JovieTokens.minimumHitTarget)
+                    .accessibilityLabel("Deletion confirmation")
+                    .accessibilityHint("Type DELETE exactly to enable account deletion.")
+                    .accessibilityIdentifier("delete_account_confirmation_field")
+
+                if let confirmationValidationMessage {
+                    Label(confirmationValidationMessage, systemImage: "exclamationmark.circle.fill")
+                        .font(.footnote)
+                        .foregroundColor(theme.colors.error)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("delete_account_confirmation_error")
+                }
+            }
+            .padding(.horizontal, theme.spacing.md)
+            .padding(.vertical, theme.spacing.sm)
+        }
+    }
+
+    private var deleteAction: some View {
+        VStack(spacing: 0) {
+            Rectangle()
+                .fill(Color.jovieHairline)
+                .frame(height: 1)
+
+            BaseButton(
+                "Delete account",
+                configuration: ButtonConfiguration(
+                    style: hasValidConfirmation
+                        ? .custom(background: theme.colors.error, foreground: .jovieText)
+                        : .custom(background: theme.colors.interactiveDisabled, foreground: .jovieTextSecondary),
+                    isLoading: isDeleting,
+                    isEnabled: hasValidConfirmation,
+                    fullWidth: true,
+                    cornerRadius: JovieTokens.controlRadius
+                ),
+                action: {
+                    isTextFieldFocused = false
+                    deleteAccount()
+                }
+            )
+            .accessibilityIdentifier("delete_account_confirm_button")
+            .accessibilityHint(
+                hasValidConfirmation
+                    ? "Shows one final confirmation before permanently deleting your account."
+                    : "Type DELETE exactly to enable this action."
+            )
+            .padding(.horizontal, JovieTokens.screenInset)
+            .padding(.vertical, 12)
+        }
+        .background(Color.jovieCanvas.opacity(0.96).ignoresSafeArea(edges: .bottom))
     }
 
     private func deleteAccount() {
-        guard confirmationText == confirmationPhrase else { return }
+        guard hasValidConfirmation else { return }
         showConfirmation = true
     }
 
@@ -194,6 +259,7 @@ struct AccountDeletionCleanupService {
         Constants.preferredWeightUnitKey,
         Constants.preferredMeasurementSystemKey,
         Constants.goalWeightKey,
+        Constants.goalWeightKilogramsKey,
         Constants.goalBodyFatPercentageKey,
         Constants.goalFFMIKey,
         Constants.timelineModeKey,

--- a/apps/ios/LogYourBody/Views/EditEntrySheet.swift
+++ b/apps/ios/LogYourBody/Views/EditEntrySheet.swift
@@ -1,8 +1,20 @@
 import SwiftUI
 import Foundation
+import UIKit
 
+/// A focused editor for an existing weight or body-fat log.
+///
+/// The sheet deliberately keeps the task to two decisions: when the entry belongs
+/// and what its value is. The save action stays above the keyboard so a user does
+/// not need to hunt through a long form to finish editing.
 struct EditEntrySheet: View {
+    private enum Field: Hashable {
+        case value
+    }
+
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     let entry: MetricEntry
     let metricType: DashboardViewLiquid.DashboardMetricKind
@@ -13,6 +25,8 @@ struct EditEntrySheet: View {
     @State private var primaryValue: String
     @State private var isSaving = false
     @State private var errorMessage: String?
+    @FocusState private var focusedField: Field?
+    @AccessibilityFocusState private var feedbackFocused: Bool
 
     private var measurementSystem: MeasurementSystem {
         useMetricUnits ? .metric : .imperial
@@ -34,96 +48,206 @@ struct EditEntrySheet: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                if showsHealthBanner {
-                    healthIntegrationBanner
-                        .padding(.horizontal)
-                        .padding(.top, 20)
-                }
-
-                Form {
-                    Section(header: Text("Date")) {
-                        DatePicker(
-                            "Entry Date",
-                            selection: $selectedDate,
-                            displayedComponents: .date
-                        )
-                        .datePickerStyle(.graphical)
-                        .onChange(of: selectedDate) { _, _ in
-                            errorMessage = nil
-                        }
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: JovieTokens.sectionGap) {
+                    if showsHealthBanner {
+                        healthIntegrationBanner
                     }
 
-                    Section(header: Text(primaryFieldLabel)) {
-                        TextField("0.0", text: $primaryValue)
-                            .keyboardType(.decimalPad)
-                            .disabled(isSaving)
-                            .onChange(of: primaryValue) { _, _ in
-                                errorMessage = nil
-                            }
-
-                        if metricType == .weight {
-                            HStack {
-                                Spacer()
-                                Text(measurementSystem.weightUnit.uppercased())
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
-                        } else if metricType == .bodyFat {
-                            HStack {
-                                Spacer()
-                                Text("%").font(.caption).foregroundColor(.secondary)
-                            }
-                        }
-
-                        if let message = validationMessage {
-                            Text(message)
-                                .font(.footnote)
-                                .foregroundColor(.red)
-                        } else {
-                            Text(validationHint)
-                                .font(.footnote)
-                                .foregroundColor(.secondary)
-                        }
-                    }
+                    dateField
+                    valueField
 
                     if let message = errorMessage {
-                        Section {
-                            Text(message)
-                                .foregroundColor(.red)
-                                .font(.footnote)
-                        }
+                        feedbackCallout(message, isError: true)
+                            .accessibilityFocused($feedbackFocused)
                     }
                 }
-                .disabled(isSaving)
+                .frame(maxWidth: 560, alignment: .leading)
+                .padding(.horizontal, JovieTokens.screenInset)
+                .padding(.top, JovieTokens.itemGap)
+                .padding(.bottom, JovieTokens.sectionGap)
             }
-            .navigationTitle("Edit Entry")
+            .scrollDismissesKeyboard(.interactively)
+            .disabled(isSaving)
+            .background(Color.jovieCanvas)
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                saveAction
+                    .padding(.horizontal, JovieTokens.screenInset)
+                    .padding(.top, JovieTokens.itemGap)
+                    .padding(
+                        .bottom,
+                        dynamicTypeSize.isAccessibilitySize ? JovieTokens.sectionGap : JovieTokens.itemGap
+                    )
+                    .background(Color.jovieCanvas.opacity(0.98))
+            }
+            .navigationTitle("Edit \(metricName)")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(Color.jovieCanvas, for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
-                        .disabled(isSaving)
+                    Button(action: dismiss.callAsFunction) {
+                        Image(systemName: "xmark")
+                            .font(.body.weight(.semibold))
+                            .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.jovieText)
+                    .disabled(isSaving)
+                    .accessibilityLabel("Cancel editing")
+                    .accessibilityHint("Discards changes to this entry")
                 }
 
-                ToolbarItem(placement: .confirmationAction) {
-                    Button {
-                        Task { await saveChanges() }
-                    } label: {
-                        if isSaving {
-                            ProgressView()
-                        } else {
-                            Text("Save")
-                        }
+                ToolbarItem(placement: .keyboard) {
+                    Button("Done") {
+                        focusedField = nil
                     }
-                    .disabled(!EditEntrySavePolicy.canAttemptSave(
-                        isSaving: isSaving,
-                        validationMessage: validationMessage,
-                        value: primaryValue
-                    ))
+                    .font(.body.weight(.semibold))
+                    .disabled(isSaving)
+                    .accessibilityIdentifier("edit_entry_keyboard_done_button")
                 }
             }
         }
         .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .interactiveDismissDisabled(isSaving)
+        .accessibilityIdentifier("edit_entry_sheet")
+    }
+
+    private var dateField: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Date")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.jovieTextSecondary)
+
+            DatePicker(
+                "Entry date",
+                selection: $selectedDate,
+                displayedComponents: .date
+            )
+            .datePickerStyle(.compact)
+            .labelsHidden()
+            .tint(Color.jovieMetricAccent)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(minHeight: JovieTokens.minimumHitTarget)
+            .accessibilityLabel("Entry date")
+            .accessibilityHint("Choose the date for this \(metricName.lowercased()) entry")
+            .onChange(of: selectedDate) { _, _ in
+                errorMessage = nil
+                feedbackFocused = false
+            }
+        }
+        .padding(JovieTokens.compactInset)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.controlRadius,
+            tint: .white,
+            tintOpacity: 0.025,
+            borderColor: .jovieHairline
+        )
+    }
+
+    private var valueField: some View {
+        VStack(alignment: .leading, spacing: JovieTokens.itemGap) {
+            Text(primaryFieldLabel)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.jovieTextSecondary)
+
+            HStack(alignment: .center, spacing: JovieTokens.itemGap) {
+                TextField("0.0", text: $primaryValue)
+                    .keyboardType(.decimalPad)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .submitLabel(.done)
+                    .font(.system(.title, design: .rounded).weight(.semibold))
+                    .foregroundStyle(Color.jovieText)
+                    .focused($focusedField, equals: .value)
+                    .accessibilityLabel("\(primaryFieldLabel) value")
+                    .accessibilityHint(validationHint)
+                    .accessibilityIdentifier("edit_entry_value_field")
+                    .onChange(of: primaryValue) { _, _ in
+                        handleValueChange()
+                    }
+
+                Text(unitLabel)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(Color.jovieTextSecondary)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, JovieTokens.compactInset)
+            .frame(maxWidth: .infinity, minHeight: 64)
+            .background(Color.jovieSurfaceElevated)
+            .clipShape(RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                    .stroke(fieldBorderColor, lineWidth: focusedField == .value ? 2 : 1)
+            }
+            .animation(
+                reduceMotion ? nil : .easeInOut(duration: JovieTokens.subtleDuration),
+                value: focusedField
+            )
+
+            feedbackCallout(validationMessage ?? validationHint, isError: validationMessage != nil)
+        }
+        .padding(JovieTokens.compactInset)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.controlRadius,
+            tint: .white,
+            tintOpacity: 0.025,
+            borderColor: .jovieHairline
+        )
+    }
+
+    private var saveAction: some View {
+        BaseButton(
+            "Save changes",
+            configuration: ButtonConfiguration(
+                style: .custom(background: .jovieAction, foreground: .jovieActionText),
+                isLoading: isSaving,
+                isEnabled: canSave,
+                fullWidth: true,
+                icon: "checkmark"
+            )
+        ) {
+            focusedField = nil
+            Task { await saveChanges() }
+        }
+        .disabled(!canSave)
+        .accessibilityIdentifier("edit_entry_save_button")
+        .accessibilityHint(canSave ? "Saves the changes to this entry" : saveDisabledHint)
+    }
+
+    private func feedbackCallout(_ message: String, isError: Bool) -> some View {
+        Label(message, systemImage: isError ? "exclamationmark.circle.fill" : "info.circle.fill")
+            .font(.footnote)
+            .foregroundStyle(isError ? Color.red : Color.jovieTextSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(message)
+            .accessibilityIdentifier(isError ? "edit_entry_validation_message" : "edit_entry_validation_hint")
+    }
+
+    private var fieldBorderColor: Color {
+        if validationMessage != nil {
+            return .red.opacity(0.85)
+        }
+        return focusedField == .value ? .jovieMetricAccent : .jovieHairline
+    }
+
+    private var metricName: String {
+        switch metricType {
+        case .weight:
+            return "Weight"
+        case .bodyFat:
+            return "Body Fat"
+        case .steps:
+            return "Steps"
+        case .ffmi:
+            return "FFMI"
+        case .waist:
+            return "Waist"
+        }
     }
 
     private var primaryFieldLabel: String {
@@ -131,9 +255,20 @@ struct EditEntrySheet: View {
         case .weight:
             return "Weight"
         case .bodyFat:
-            return "Body Fat Percentage"
+            return "Body fat percentage"
         default:
             return "Value"
+        }
+    }
+
+    private var unitLabel: String {
+        switch metricType {
+        case .weight:
+            return measurementSystem.weightUnit
+        case .bodyFat:
+            return "%"
+        default:
+            return entry.primaryUnit
         }
     }
 
@@ -142,10 +277,17 @@ struct EditEntrySheet: View {
         case .weight:
             return measurementSystem == .metric ? "Enter weight in kilograms" : "Enter weight in pounds"
         case .bodyFat:
-            return "Enter percentage between 3 and 60"
+            return "Enter a percentage between 3 and 60"
         default:
-            return ""
+            return "Enter a value"
         }
+    }
+
+    private var saveDisabledHint: String {
+        if isSaving {
+            return "Saving changes"
+        }
+        return validationMessage ?? "Enter a value before saving"
     }
 
     private var validationMessage: String? {
@@ -161,9 +303,8 @@ struct EditEntrySheet: View {
                 _ = try ValidationService.shared.validateBodyFat(primaryValue)
             }
         default:
-            break
+            return nil
         }
-        return nil
     }
 
     private var canSave: Bool {
@@ -179,28 +320,43 @@ struct EditEntrySheet: View {
     }
 
     private var healthIntegrationBanner: some View {
-        HStack(alignment: .top, spacing: 12) {
+        HStack(alignment: .top, spacing: JovieTokens.itemGap) {
             Image(systemName: "heart.fill")
-                .foregroundColor(.red)
-                .font(.title2)
+                .font(.body.weight(.semibold))
+                .foregroundStyle(Color.red)
+                .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
+                .background(Color.red.opacity(0.12), in: Circle())
+                .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Synced from Health")
-                    .font(.headline)
-                Text("This entry was imported from HealthKit. Updating it here will override the synced value.")
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Synced from Apple Health")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(Color.jovieText)
+
+                Text("Saving here replaces the synced value for this date.")
                     .font(.footnote)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(Color.jovieTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .padding()
-        .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(Color.red.opacity(0.12))
+        .padding(JovieTokens.compactInset)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.controlRadius,
+            tint: Color.red,
+            tintOpacity: 0.07,
+            borderColor: Color.red.opacity(0.45)
         )
+        .accessibilityElement(children: .combine)
     }
 
     private static func initialValue(for entry: MetricEntry) -> String {
         String(format: "%.1f", entry.primaryValue)
+    }
+
+    private func handleValueChange() {
+        errorMessage = nil
+        feedbackFocused = false
     }
 
     private func saveChanges() async {
@@ -226,7 +382,7 @@ struct EditEntrySheet: View {
                 weightKg = convertToKilograms(validatedWeight)
                 bodyFat = nil
             } catch {
-                errorMessage = error.localizedDescription
+                presentError(error.localizedDescription)
                 return
             }
         case .bodyFat:
@@ -234,7 +390,7 @@ struct EditEntrySheet: View {
                 weightKg = nil
                 bodyFat = try ValidationService.shared.validateBodyFat(primaryValue)
             } catch {
-                errorMessage = error.localizedDescription
+                presentError(error.localizedDescription)
                 return
             }
         default:
@@ -255,9 +411,15 @@ struct EditEntrySheet: View {
                     await MainActor.run { dismiss() }
                 }
             } else {
-                errorMessage = "Failed to save changes. Please try again."
+                presentError("Couldn’t save changes. Try again.")
             }
         }
+    }
+
+    private func presentError(_ message: String) {
+        errorMessage = message
+        feedbackFocused = true
+        UIAccessibility.post(notification: .announcement, argument: message)
     }
 
     private func convertToKilograms(_ value: Double) -> Double {

--- a/apps/ios/LogYourBody/Views/ExportDataView.swift
+++ b/apps/ios/LogYourBody/Views/ExportDataView.swift
@@ -4,6 +4,7 @@
 //
 import SwiftUI
 import UniformTypeIdentifiers
+import UIKit
 
 struct ExportDataView: View {
     @Environment(\.dismiss)
@@ -28,9 +29,9 @@ struct ExportDataView: View {
         var description: String {
             switch self {
             case .email:
-                return "Receive a secure download link via email"
+                return "Receive a secure JSON download link at your registered email address."
             case .download:
-                return "Download directly to this device"
+                return "Save one JSON file directly to this device."
             }
         }
     }
@@ -57,305 +58,31 @@ struct ExportDataView: View {
 
     var body: some View {
         ZStack {
-            Color.appBackground
+            Color.jovieCanvas
                 .ignoresSafeArea()
 
             ScrollView {
-                VStack(spacing: 24) {
-                    // Header
-                    VStack(spacing: 16) {
-                        Image(systemName: "square.and.arrow.up.on.square")
-                            .font(.system(size: 50))
-                            .foregroundColor(.appPrimary)
-                            .symbolRenderingMode(.hierarchical)
-
-                        Text("Export Your Data")
-                            .font(.title2)
-                            .fontWeight(.bold)
-                            .foregroundColor(.appText)
-
-                        Text("Download all your LogYourBody data for your records or to transfer to another service")
-                            .font(.body)
-                            .foregroundColor(.appTextSecondary)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal)
-                    }
-                    .padding(.top, 20)
-
-                    // Export Options
-                    VStack(spacing: 16) {
-                        // Export Method Selection
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text("Export Method")
-                                .font(.headline)
-                                .foregroundColor(.appText)
-                                .padding(.horizontal)
-
-                            VStack(spacing: 0) {
-                                ForEach(ExportMethod.allCases, id: \.self) { method in
-                                    Button(
-                                        action: {
-                                            exportMethod = method
-                                        },
-                                        label: {
-                                            HStack {
-                                                Image(systemName: exportMethod == method ? "checkmark.circle.fill" : "circle")
-                                                    .font(.system(size: 20))
-                                                    .foregroundColor(exportMethod == method ? .appPrimary : .appBorder)
-
-                                                VStack(alignment: .leading, spacing: 4) {
-                                                    Text(method.rawValue)
-                                                        .font(.body)
-                                                        .foregroundColor(.appText)
-
-                                                    Text(method.description)
-                                                        .font(.caption)
-                                                        .foregroundColor(.appTextSecondary)
-                                                }
-
-                                                Spacer()
-                                            }
-                                            .padding()
-                                            .background(Color.appCard)
-                                        }
-                                    )
-                                    .buttonStyle(PlainButtonStyle())
-
-                                    if method != ExportMethod.allCases.last {
-                                        Divider()
-                                            .background(Color.appBorder)
-                                    }
-                                }
-                            }
-                            .background(Color.appCard)
-                            .cornerRadius(12)
-                            .padding(.horizontal)
-                        }
-
-                        // Format Selection (only for direct download)
-                        if exportMethod == .download {
-                            VStack(alignment: .leading, spacing: 12) {
-                                Text("Export Format")
-                                    .font(.headline)
-                                    .foregroundColor(.appText)
-                                    .padding(.horizontal)
-
-                                VStack(spacing: 0) {
-                                    ForEach(ExportFormat.allCases, id: \.self) { format in
-                                        Button(
-                                            action: {
-                                                guard format == .json else { return }
-
-                                                if selectedFormats.contains(format) {
-                                                    selectedFormats.remove(format)
-                                                } else {
-                                                    selectedFormats = [format]
-                                                }
-                                            },
-                                            label: {
-                                                HStack {
-                                                    Image(
-                                                        systemName: selectedFormats.contains(format)
-                                                            ? "checkmark.square.fill"
-                                                            : "square"
-                                                    )
-                                                    .font(.system(size: 20))
-                                                    .foregroundColor(
-                                                        selectedFormats.contains(format)
-                                                            ? .appPrimary
-                                                            : .appBorder
-                                                    )
-
-                                                    VStack(alignment: .leading, spacing: 4) {
-                                                        Text(format.rawValue)
-                                                            .font(.body)
-                                                            .foregroundColor(format == .json ? .appText : .appTextSecondary)
-
-                                                        Text(
-                                                            format == .json
-                                                                ? "Complete data with all fields"
-                                                                : "Use the email request option for CSV export"
-                                                        )
-                                                        .font(.caption)
-                                                        .foregroundColor(.appTextSecondary)
-                                                    }
-
-                                                    Spacer()
-                                                }
-                                                .padding()
-                                                .background(Color.appCard)
-                                            }
-                                        )
-                                        .buttonStyle(PlainButtonStyle())
-                                        .disabled(format != .json)
-                                        .opacity(format == .json ? 1 : 0.6)
-
-                                        if format != ExportFormat.allCases.last {
-                                            Divider()
-                                                .background(Color.appBorder)
-                                        }
-                                    }
-                                }
-                                .background(Color.appCard)
-                                .cornerRadius(12)
-                                .padding(.horizontal)
-                            }
-                        }
-
-                        // Include Photos Option (only for direct download)
-                        if exportMethod == .download {
-                            Button(
-                                action: {
-                                    includePhotos = false
-                                },
-                                label: {
-                                    HStack {
-                                        Image(systemName: includePhotos ? "checkmark.square.fill" : "square")
-                                            .font(.system(size: 20))
-                                            .foregroundColor(includePhotos ? .appPrimary : .appBorder)
-
-                                        VStack(alignment: .leading, spacing: 4) {
-                                            Text("Include Progress Photos")
-                                                .font(.body)
-                                                .foregroundColor(.appTextSecondary)
-
-                                            Text("Use the email request option for progress photos")
-                                                .font(.caption)
-                                                .foregroundColor(.appTextSecondary)
-                                        }
-
-                                        Spacer()
-                                    }
-                                    .padding()
-                                    .background(Color.appCard)
-                                    .cornerRadius(12)
-                                }
-                            )
-                            .buttonStyle(PlainButtonStyle())
-                            .disabled(true)
-                            .opacity(0.6)
-                            .padding(.horizontal)
-                        }
-                    }
-
-                    // Data Included Section
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("Data Included")
-                            .font(.headline)
-                            .foregroundColor(.appText)
-                            .padding(.horizontal)
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            DataTypeRow(
-                                icon: "person.fill",
-                                title: "Profile Information",
-                                description: "Name, email, date of birth, height"
-                            )
-                            DataTypeRow(
-                                icon: "scalemass",
-                                title: "Body Metrics",
-                                description: "Weight, body fat %, measurements"
-                            )
-                            DataTypeRow(
-                                icon: "chart.line.uptrend.xyaxis",
-                                title: "Progress History",
-                                description: "All historical data points"
-                            )
-                            DataTypeRow(
-                                icon: "calendar",
-                                title: "Daily Logs",
-                                description: "Activity, notes, and check-ins"
-                            )
-                            if exportMethod == .download && includePhotos {
-                                DataTypeRow(
-                                    icon: "photo",
-                                    title: "Progress Photos",
-                                    description: "All uploaded photos"
-                                )
-                            }
-                        }
-                        .padding()
-                        .background(Color.appCard)
-                        .cornerRadius(12)
-                        .padding(.horizontal)
-                    }
-
-                    // Export Button
-                    Button(action: exportData) {
-                        HStack {
-                            if isExporting {
-                                ProgressView()
-                                    .progressViewStyle(CircularProgressViewStyle(tint: .black))
-                                    .scaleEffect(0.8)
-                            } else {
-                                Image(systemName: "square.and.arrow.up")
-                                Text("Export Data")
-                                    .fontWeight(.semibold)
-                            }
-                        }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 50)
-                        .background(isExportDisabled ? Color.appBorder : Color.white)
-                        .foregroundColor(isExportDisabled ? .appTextTertiary : .black)
-                        .cornerRadius(25)
-                    }
-                    .disabled(isExportDisabled)
-                    .padding(.horizontal)
-                    .padding(.top, 8)
-
-                    if exportMethod == .download {
-                        Text(
-                            "Direct download currently exports one JSON file. "
-                            + "Use the email request link for CSV or progress photos."
-                        )
-                            .font(.caption)
-                            .foregroundColor(.appTextSecondary)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, 40)
-                    }
-
-                    // Privacy Note
-                    VStack(spacing: 8) {
-                        Text(
-                            exportMethod == .email
-                                ? "A secure download link will be sent to your registered email address. "
-                                + "The link will expire after 24 hours."
-                                : "Your data export will be prepared and saved to your device. You can then "
-                                + "share it or save it to your preferred location."
-                        )
-                        .font(.caption)
-                        .foregroundColor(.appTextSecondary)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 40)
-
-                        Button(action: requestExportViaEmail) {
-                            Text("Or email support to request a data export")
-                                .font(.caption)
-                                .foregroundColor(.appPrimary)
-                                .underline()
-                        }
-                    }
-                    .padding(.bottom, 20)
+                VStack(alignment: .leading, spacing: JovieTokens.sectionGap) {
+                    exportHeader
+                    deliveryMethodPicker
+                    deliveryDetails
+                    includedData
+                    privacyAndSupport
                 }
+                .padding(.horizontal, JovieTokens.screenInset)
+                .padding(.top, JovieTokens.sectionGap)
+                .padding(.bottom, 20)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .scrollIndicators(.hidden)
+            .scrollBounceBehavior(.basedOnSize)
 
             if isExporting {
-                Color.black.opacity(0.5)
-                    .ignoresSafeArea()
-
-                VStack(spacing: 20) {
-                    ProgressView()
-                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                        .scaleEffect(1.5)
-
-                    Text("Preparing your data...")
-                        .font(.headline)
-                        .foregroundColor(.white)
-                }
-                .padding(40)
-                .background(Color.appCard)
-                .cornerRadius(20)
+                exportProgressOverlay
             }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            exportAction
         }
         .navigationTitle("Export Data")
         .navigationBarTitleDisplayMode(.inline)
@@ -364,15 +91,19 @@ struct ExportDataView: View {
                 Button("Cancel") {
                     dismiss()
                 }
+                .accessibilityLabel("Cancel export")
             }
         }
-        .alert("Export Error", isPresented: $showError) {
-            Button("OK", role: .cancel) {}
+        .alert("Export failed", isPresented: $showError) {
+            Button("Try Again") {
+                exportData()
+            }
+            Button("Cancel", role: .cancel) {}
         } message: {
             Text(errorMessage)
         }
-        .alert("Export Successful", isPresented: $showSuccess) {
-            Button("OK", role: .cancel) {
+        .alert("Export ready", isPresented: $showSuccess) {
+            Button("Done", role: .cancel) {
                 dismiss()
             }
         } message: {
@@ -383,6 +114,195 @@ struct ExportDataView: View {
                 ShareSheet(items: [url])
                     .ignoresSafeArea()
             }
+        }
+        .onChange(of: exportMethod) { _, method in
+            if method == .download {
+                selectedFormats = [.json]
+                includePhotos = false
+            }
+        }
+        .onChange(of: showError) { _, isShowing in
+            if isShowing {
+                UIAccessibility.post(notification: .announcement, argument: errorMessage)
+            }
+        }
+    }
+
+    private var exportHeader: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("Your data, on your terms", systemImage: "lock.document.fill")
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(.jovieTextSecondary)
+
+            Text("Export your data")
+                .font(.title2.weight(.bold))
+                .foregroundColor(.jovieText)
+
+            Text("Create a portable copy of your LogYourBody records.")
+                .font(.body)
+                .foregroundColor(.jovieTextSecondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var deliveryMethodPicker: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Delivery")
+                .font(.headline)
+                .foregroundColor(.jovieText)
+
+            Picker("Delivery method", selection: $exportMethod) {
+                ForEach(ExportMethod.allCases, id: \.self) { method in
+                    Text(method.rawValue).tag(method)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(minHeight: JovieTokens.minimumHitTarget)
+            .padding(4)
+            .background(
+                RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                    .fill(Color.jovieSurface)
+            )
+            .accessibilityIdentifier("export_delivery_method_picker")
+        }
+    }
+
+    private var deliveryDetails: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(exportMethod == .email ? "Secure email link" : "Direct device download")
+                .font(.headline)
+                .foregroundColor(.jovieText)
+
+            Text(exportMethod.description)
+                .font(.subheadline)
+                .foregroundColor(.jovieTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if exportMethod == .download {
+                Label("Direct download contains one JSON file and does not include progress photos.", systemImage: "info.circle")
+                    .font(.footnote)
+                    .foregroundColor(.jovieTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(16)
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.cardRadius,
+            tint: .jovieText,
+            tintOpacity: 0.045,
+            borderColor: .jovieHairline,
+            borderOpacity: 0.9
+        )
+        .accessibilityElement(children: .combine)
+    }
+
+    private var includedData: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Included")
+                .font(.headline)
+                .foregroundColor(.jovieText)
+
+            VStack(alignment: .leading, spacing: 4) {
+                DataTypeRow(
+                    icon: "person.fill",
+                    title: "Profile information",
+                    description: "Name, email, date of birth, and height"
+                )
+                DataTypeRow(
+                    icon: "scalemass",
+                    title: "Body metrics",
+                    description: "Weight, body fat, and measurements"
+                )
+                DataTypeRow(
+                    icon: "chart.line.uptrend.xyaxis",
+                    title: "Progress history",
+                    description: "Historical data points and daily logs"
+                )
+            }
+            .padding(12)
+            .systemBGlassSurface(
+                cornerRadius: JovieTokens.cardRadius,
+                tint: .jovieText,
+                tintOpacity: 0.045,
+                borderColor: .jovieHairline,
+                borderOpacity: 0.9
+            )
+        }
+    }
+
+    private var privacyAndSupport: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(
+                exportMethod == .email
+                    ? "A secure download link will be sent to your registered email address and expires after 24 hours."
+                    : "The JSON file is saved to your device. Share it only with people and services you trust."
+            )
+            .font(.footnote)
+            .foregroundColor(.jovieTextSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Button("Email support about an export") {
+                requestExportViaEmail()
+            }
+            .font(.subheadline.weight(.semibold))
+            .foregroundColor(.jovieText)
+            .frame(minHeight: JovieTokens.minimumHitTarget)
+            .accessibilityHint("Opens an email to LogYourBody support.")
+        }
+    }
+
+    private var exportAction: some View {
+        VStack(spacing: 0) {
+            Rectangle()
+                .fill(Color.jovieHairline)
+                .frame(height: 1)
+
+            BaseButton(
+                exportMethod == .email ? "Email secure link" : "Download JSON",
+                configuration: ButtonConfiguration(
+                    style: .custom(background: .jovieAction, foreground: .jovieActionText),
+                    isLoading: isExporting,
+                    isEnabled: !isExportDisabled,
+                    fullWidth: true,
+                    icon: "square.and.arrow.up",
+                    cornerRadius: JovieTokens.controlRadius
+                ),
+                action: exportData
+            )
+            .accessibilityIdentifier("export_data_action")
+            .accessibilityHint(
+                exportMethod == .email
+                    ? "Sends a secure export link to your registered email address."
+                    : "Prepares a JSON export on this device."
+            )
+            .padding(.horizontal, JovieTokens.screenInset)
+            .padding(.vertical, 12)
+        }
+        .background(Color.jovieCanvas.opacity(0.96).ignoresSafeArea(edges: .bottom))
+    }
+
+    private var exportProgressOverlay: some View {
+        ZStack {
+            Color.black.opacity(0.55)
+                .ignoresSafeArea()
+
+            VStack(spacing: 14) {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: .jovieText))
+                    .scaleEffect(1.2)
+
+                Text("Preparing your data")
+                    .font(.headline)
+                    .foregroundColor(.jovieText)
+            }
+            .padding(28)
+            .background(
+                RoundedRectangle(cornerRadius: JovieTokens.cardRadius, style: .continuous)
+                    .fill(Color.jovieSurfaceElevated)
+            )
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Preparing your data")
+            .accessibilityAddTraits(.updatesFrequently)
         }
     }
 
@@ -683,14 +603,14 @@ enum ExportError: LocalizedError {
         case .exportFailed(let reason):
             return "Export failed: \(reason)"
         case .unsupportedDirectDownload:
-            return "Direct download currently supports one JSON file. Use the email request link for CSV or progress photos."
+            return "Direct download supports one JSON file without progress photos. Contact support for other export requests."
         }
     }
 }
 
 // MARK: - Helper Views
 
-struct DataTypeRow: View {
+private struct DataTypeRow: View {
     let icon: String
     let title: String
     let description: String
@@ -698,23 +618,26 @@ struct DataTypeRow: View {
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: icon)
-                .font(.system(size: 20))
-                .foregroundColor(.appPrimary)
-                .frame(width: 30)
+                .font(.body.weight(.medium))
+                .foregroundColor(.jovieTextSecondary)
+                .frame(width: JovieTokens.minimumHitTarget)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .foregroundColor(.appText)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(.jovieText)
 
                 Text(description)
-                    .font(.caption)
-                    .foregroundColor(.appTextSecondary)
+                    .font(.footnote)
+                    .foregroundColor(.jovieTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Spacer()
         }
+        .frame(minHeight: JovieTokens.minimumHitTarget)
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/apps/ios/LogYourBody/Views/FaceIDEnableView.swift
+++ b/apps/ios/LogYourBody/Views/FaceIDEnableView.swift
@@ -2,36 +2,43 @@
 //  FaceIDEnableView.swift
 //  LogYourBody
 //
-//  Guided flow for enabling Face ID lock from Settings.
+//  Guided flow for enabling the device biometric lock from Settings.
 //
-
 import SwiftUI
 
 struct FaceIDEnableView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     let onEnabled: () -> Void
 
     @State private var isAuthenticating = false
     @State private var showError = false
+    @AccessibilityFocusState private var errorFocused: Bool
+
     private let biometricAuthenticator: BiometricAuthenticating = LocalBiometricAuthenticationAdapter.shared
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: 28) {
-                header
-                description
-                Spacer(minLength: 0)
-                if showError {
-                    errorCallout
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    ScrollView {
+                        content
+                            .padding(.vertical, JovieTokens.sectionGap)
+                    }
+                } else {
+                    content
                 }
-                actionButtons
             }
-            .padding(.horizontal, 24)
-            .padding(.top, 32)
-            .padding(.bottom, 24)
-            .background(Color.appBackground.ignoresSafeArea())
-            .navigationTitle("")
+            .padding(.horizontal, JovieTokens.screenInset)
+            .background(Color.jovieCanvas.ignoresSafeArea())
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                actionButtons
+                    .padding(.horizontal, JovieTokens.screenInset)
+                    .padding(.top, JovieTokens.itemGap)
+                    .padding(.bottom, JovieTokens.itemGap)
+                    .background(Color.jovieCanvas)
+            }
             .toolbar(.hidden, for: .navigationBar)
         }
         .presentationDetents([.medium, .large])
@@ -42,82 +49,114 @@ struct FaceIDEnableView: View {
         }
     }
 
+    private var content: some View {
+        VStack(alignment: .leading, spacing: JovieTokens.sectionGap) {
+            header
+            privacyDetails
+
+            if showError {
+                errorCallout
+            }
+        }
+        .frame(maxWidth: 520, alignment: .leading)
+    }
+
     private var header: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Enable Face ID for LogYourBody")
-                .font(.system(size: 24, weight: .semibold))
-                .foregroundColor(.appText)
-            Text("Use Face ID to lock the app and keep your data private.")
-                .font(.system(size: 16))
-                .foregroundColor(.appTextSecondary)
+        VStack(alignment: .leading, spacing: 10) {
+            Image(systemName: "faceid")
+                .font(.system(.largeTitle, design: .default).weight(.medium))
+                .foregroundStyle(Color.jovieText)
+                .frame(width: 64, height: 64)
+                .background(Color.jovieSurfaceElevated, in: Circle())
+                .overlay(Circle().stroke(Color.jovieHairline, lineWidth: 1))
+                .accessibilityHidden(true)
+
+            Text("Enable Face ID")
+                .font(.title.weight(.bold))
+                .foregroundStyle(Color.jovieText)
+
+            Text("Use Face ID to add a privacy lock when you open LogYourBody.")
+                .font(.body)
+                .foregroundStyle(Color.jovieTextSecondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
 
-    private var description: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Label("Required to open LogYourBody", systemImage: "lock.fill")
-            Label("You can turn this off in Settings", systemImage: "gear")
+    private var privacyDetails: some View {
+        VStack(alignment: .leading, spacing: JovieTokens.itemGap) {
+            FaceIDDetailRow(
+                title: "Required when opening the app",
+                icon: "lock.fill"
+            )
+            FaceIDDetailRow(
+                title: "You can turn this off in Settings",
+                icon: "gearshape.fill"
+            )
         }
-        .font(.system(size: 15))
-        .foregroundColor(.appTextSecondary)
-        .labelStyle(FaceIDBulletedLabelStyle())
-    }
-
-    private var errorCallout: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top, spacing: 12) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundColor(.orange)
-                    .font(.system(size: 18))
-                Text("Couldn't enable Face ID. Try again or use your passcode.")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.appText)
-            }
-
-            BaseButton(
-                "Try Again",
-                configuration: ButtonConfiguration(style: .secondary, fullWidth: true)
-            ) {
-                triggerFaceID(isRetry: true)
-            }
-            .accessibilityLabel("Try Face ID again to enable the lock")
-        }
-        .padding(16)
+        .padding(JovieTokens.cardRadius - 4)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 14)
-                .fill(Color.appCard)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14)
-                        .stroke(Color.orange.opacity(0.4), lineWidth: 1)
-                )
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.controlRadius,
+            tint: .white,
+            tintOpacity: 0.02,
+            borderColor: .jovieHairline
         )
     }
 
+    private var errorCallout: some View {
+        VStack(alignment: .leading, spacing: JovieTokens.itemGap) {
+            Label("Couldn’t enable Face ID", systemImage: "exclamationmark.triangle.fill")
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(Color.jovieText)
+
+            Text("Try again, or come back to this from Settings later.")
+                .font(.body)
+                .foregroundStyle(Color.jovieTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button("Try again") {
+                triggerFaceID(isRetry: true)
+            }
+            .font(.body.weight(.semibold))
+            .foregroundStyle(Color.jovieText)
+            .frame(minHeight: JovieTokens.minimumHitTarget)
+            .jovieTouchTarget()
+            .accessibilityHint("Starts Face ID setup again")
+        }
+        .padding(JovieTokens.compactInset)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.controlRadius,
+            tint: Color.orange,
+            tintOpacity: 0.08,
+            borderColor: Color.orange.opacity(0.55)
+        )
+        .accessibilityFocused($errorFocused)
+    }
+
     private var actionButtons: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: JovieTokens.itemGap) {
             BaseButton(
-                "Turn On Face ID",
-                configuration: ButtonConfiguration(fullWidth: true, isLoading: isAuthenticating)
+                "Turn on Face ID",
+                configuration: ButtonConfiguration(
+                    style: .custom(background: .jovieAction, foreground: .jovieActionText),
+                    isLoading: isAuthenticating,
+                    fullWidth: true,
+                    icon: "faceid"
+                )
             ) {
-                guard !isAuthenticating else { return }
                 triggerFaceID()
             }
-            .accessibilityLabel("Turn on Face ID for LogYourBody")
             .disabled(isAuthenticating)
+            .accessibilityHint("Requires Face ID before enabling the app lock")
 
-            Button {
-                dismiss()
-            } label: {
-                Text("Not Now")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.appTextSecondary)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 12)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Dismiss without enabling Face ID")
+            Button("Not now", action: dismiss.callAsFunction)
+                .font(.body.weight(.semibold))
+                .foregroundStyle(Color.jovieTextSecondary)
+                .frame(maxWidth: .infinity, minHeight: JovieTokens.minimumHitTarget)
+                .buttonStyle(.plain)
+                .jovieTouchTarget()
+                .accessibilityHint("Dismisses without enabling the lock")
         }
     }
 
@@ -125,12 +164,13 @@ struct FaceIDEnableView: View {
         if !isRetry {
             showError = false
         }
+        guard !isAuthenticating else { return }
         isAuthenticating = true
 
         Task {
             let result = await biometricAuthenticator.authenticate(
                 reason: "Enable Face ID for LogYourBody",
-                cancelTitle: "Not Now",
+                cancelTitle: "Not now",
                 fallbackTitle: "",
                 timeout: nil
             )
@@ -148,20 +188,22 @@ struct FaceIDEnableView: View {
             dismiss()
         } else {
             showError = true
+            errorFocused = true
             HapticManager.shared.notification(type: .error)
         }
     }
 }
 
-private struct FaceIDBulletedLabelStyle: LabelStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        HStack(alignment: .top, spacing: 10) {
-            configuration.icon
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.appPrimary)
-                .padding(.top, 2)
-            configuration.title
-        }
+private struct FaceIDDetailRow: View {
+    let title: String
+    let icon: String
+
+    var body: some View {
+        Label(title, systemImage: icon)
+            .font(.body)
+            .foregroundStyle(Color.jovieTextSecondary)
+            .labelStyle(.titleAndIcon)
+            .accessibilityElement(children: .combine)
     }
 }
 

--- a/apps/ios/LogYourBody/Views/HealthDisclaimerView.swift
+++ b/apps/ios/LogYourBody/Views/HealthDisclaimerView.swift
@@ -3,38 +3,20 @@
 // LogYourBody
 //
 import SwiftUI
+
 struct HealthDisclaimerView: View {
-    @Environment(\.dismiss)
-    private var dismiss
+    @Environment(\.dismiss) private var dismiss
+
     var body: some View {
         ZStack {
-            Color.appBackground
+            Color.jovieCanvas
                 .ignoresSafeArea()
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 24) {
-                    // Header Section
-                    VStack(alignment: .center, spacing: 16) {
-                        Image(systemName: "heart.text.square.fill")
-                            .font(.system(size: 60))
-                            .foregroundColor(.red)
-                            .padding(.top, 20)
+                VStack(alignment: .leading, spacing: JovieTokens.sectionGap) {
+                    header
 
-                        Text("Health & Medical Disclaimer")
-                            .font(.system(size: 24, weight: .bold))
-                            .foregroundColor(.primary)
-                            .multilineTextAlignment(.center)
-
-                        Text("Please read this important information")
-                            .font(.system(size: 16))
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.horizontal)
-
-                    // Disclaimer Content
-                    VStack(alignment: .leading, spacing: 20) {
+                    VStack(alignment: .leading, spacing: 24) {
                         DisclaimerSection(
                             title: "General Information",
                             content: """
@@ -80,7 +62,8 @@ struct HealthDisclaimerView: View {
                             content: """
                             In case of a medical emergency, call your local emergency services immediately.
                             Do not rely on this app for emergency medical situations.
-                            """
+                            """,
+                            emphasis: .emergency
                         )
 
                         DisclaimerSection(
@@ -109,30 +92,24 @@ struct HealthDisclaimerView: View {
                             """
                         )
 
-                        // Acknowledgment
-                        VStack(spacing: 16) {
-                            Text(
-                                """
-                                By using LogYourBody, you acknowledge that you have read and understood this disclaimer
-                                and agree to use the app at your own risk.
-                                """
-                            )
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(.primary)
-                            .padding()
-                            .background(Color(.systemGray6))
-                            .cornerRadius(12)
-
-                            Text("Last updated: \(Date(), style: .date)")
-                                .font(.system(size: 12))
-                                .foregroundColor(.secondary)
-                        }
-                        .padding(.top, 20)
+                        acknowledgment
                     }
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 40)
+                    .padding(JovieTokens.screenInset)
+                    .systemBGlassSurface(
+                        cornerRadius: JovieTokens.cardRadius,
+                        tint: .jovieText,
+                        tintOpacity: 0.045,
+                        borderColor: .jovieHairline,
+                        borderOpacity: 0.9
+                    )
                 }
+                .padding(.horizontal, JovieTokens.screenInset)
+                .padding(.top, JovieTokens.sectionGap)
+                .padding(.bottom, 32)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .scrollIndicators(.hidden)
+            .scrollBounceBehavior(.basedOnSize)
         }
         .navigationTitle("Health Disclaimer")
         .navigationBarTitleDisplayMode(.inline)
@@ -141,35 +118,83 @@ struct HealthDisclaimerView: View {
                 Button("Done") {
                     dismiss()
                 }
-                .fontWeight(.medium)
+                .accessibilityLabel("Done")
             }
         }
     }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("Important health information", systemImage: "cross.case.fill")
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(.warning)
+
+            Text("Health & Medical Disclaimer")
+                .font(.title2.weight(.bold))
+                .foregroundColor(.jovieText)
+
+            Text("Please read this information before relying on LogYourBody data.")
+                .font(.body)
+                .foregroundColor(.jovieTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var acknowledgment: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(
+                """
+                By using LogYourBody, you acknowledge that you have read and understood this disclaimer
+                and agree to use the app at your own risk.
+                """
+            )
+            .font(.subheadline.weight(.medium))
+            .foregroundColor(.jovieText)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Text("Last updated: \(Date(), style: .date)")
+                .font(.footnote)
+                .foregroundColor(.jovieTextSecondary)
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                .fill(Color.jovieSurfaceElevated)
+        )
+        .accessibilityElement(children: .combine)
+    }
 }
 
-struct DisclaimerSection: View {
+private struct DisclaimerSection: View {
+    enum Emphasis: Equatable {
+        case standard
+        case emergency
+    }
+
     let title: String
     let content: String
+    var emphasis: Emphasis = .standard
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 8) {
-                Image(systemName: "exclamationmark.circle.fill")
-                    .font(.system(size: 20))
-                    .foregroundColor(.orange)
-
+            if emphasis == .emergency {
+                Label(title, systemImage: "exclamationmark.triangle.fill")
+                    .font(.headline)
+                    .foregroundColor(.jovieText)
+            } else {
                 Text(title)
-                    .font(.system(size: 18, weight: .semibold))
-                    .foregroundColor(.primary)
+                    .font(.headline)
+                    .foregroundColor(.jovieText)
             }
 
             Text(content)
-                .font(.system(size: 15))
-                .foregroundColor(.secondary)
-                .lineSpacing(4)
+                .font(.body)
+                .foregroundColor(.jovieTextSecondary)
+                .lineSpacing(3)
                 .fixedSize(horizontal: false, vertical: true)
         }
-        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/apps/ios/LogYourBody/Views/IntegrationsView.swift
+++ b/apps/ios/LogYourBody/Views/IntegrationsView.swift
@@ -12,6 +12,9 @@ struct IntegrationsView: View {
     @StateObject private var healthKitManager = HealthKitManager.shared
     @AppStorage("healthKitSyncEnabled") private var healthKitSyncEnabled = true
     @State private var showHealthKitConnect = false
+    @State private var isConnectingHealthKit = false
+    @State private var isSyncingHealthKit = false
+    @State private var healthSyncStatusMessage: String?
     @State private var bodySpecLastSyncedText: String?
     @State private var isLoadingBodySpecLastSynced = false
     @State private var progressPhotoCount = 0
@@ -20,25 +23,21 @@ struct IntegrationsView: View {
 
     var dismiss
     var body: some View {
-        ZStack {
-            theme.colors.background
-                .ignoresSafeArea()
-
-            ScrollView {
-                VStack(spacing: theme.spacing.sectionSpacing) {
-                    healthAndFitnessSection
-                    photoImportSection
-                    dataExportSection
-                }
-                .padding(.horizontal, theme.spacing.screenPadding)
-                .padding(.top, theme.spacing.md)
-                .padding(.bottom, 40)
+        ScrollView {
+            VStack(spacing: theme.spacing.sectionSpacing) {
+                healthAndFitnessSection
+                photoImportSection
+                dataExportSection
             }
-            .scrollBounceBehavior(.basedOnSize)
+            .padding(.horizontal, theme.spacing.screenPadding)
+            .padding(.top, theme.spacing.md)
+            .padding(.bottom, 40)
         }
+        .scrollBounceBehavior(.basedOnSize)
+        .settingsBackground()
         .navigationTitle("Integrations")
         .navigationBarTitleDisplayMode(.inline)
-        .alert("Apple Health Permission Needed", isPresented: $showHealthKitConnect) {
+        .alert("Apple Health access is needed", isPresented: $showHealthKitConnect) {
             Button("Open Settings") {
                 if let url = URL(string: UIApplication.openSettingsURLString) {
                     UIApplication.shared.open(url)
@@ -46,7 +45,7 @@ struct IntegrationsView: View {
             }
             Button("Not Now", role: .cancel) {}
         } message: {
-            Text("Enable Apple Health access in Settings to sync weight and body-composition data.")
+            Text("Allow Health access in Settings to sync weight and body-composition data.")
         }
         .onAppear {
             // Check HealthKit authorization status
@@ -66,46 +65,17 @@ struct IntegrationsView: View {
     private var healthAndFitnessSection: some View {
         SettingsSection(
             header: "Health & Fitness",
-            footer: "Connect your favorite health apps to sync data automatically"
+            footer: "Control data connections and sync."
         ) {
             VStack(spacing: 0) {
                 // Apple Health
                 if healthKitManager.isHealthKitAvailable {
-                    HStack {
-                        Image(systemName: "heart.fill")
-                            .foregroundColor(theme.colors.error)
-                            .font(theme.typography.headlineSmall)
-                            .frame(width: 24)
-
-                        Text("Apple Health")
-                            .font(theme.typography.labelLarge)
-                            .foregroundColor(theme.colors.text)
-
-                        Spacer()
-
-                        if healthKitManager.isAuthorized {
-                            Label("Connected", systemImage: "checkmark.circle.fill")
-                                .font(theme.typography.captionLarge)
-                                .foregroundColor(theme.colors.success)
-                                .labelStyle(.titleAndIcon)
-                        } else {
-                            Button("Connect") {
-                                Task {
-                                    let authorized = await healthKitManager.requestAuthorization()
-                                    if authorized {
-                                        await HealthSyncCoordinator.shared
-                                            .configureSyncPipelineAfterAuthorizationAndRunInitialWeightAndStepSync()
-                                    } else {
-                                        showHealthKitConnect = true
-                                    }
-                                }
-                            }
-                            .font(theme.typography.captionLarge)
-                            .foregroundColor(theme.colors.primary)
-                        }
+                    ViewThatFits(in: .horizontal) {
+                        appleHealthConnectionRow
+                        appleHealthConnectionStack
                     }
                     .padding(.horizontal, theme.spacing.md)
-                    .padding(.vertical, theme.spacing.sm)
+                    .frame(minHeight: JovieTokens.minimumHitTarget)
 
                     if healthKitManager.isAuthorized {
                         Divider()
@@ -114,7 +84,8 @@ struct IntegrationsView: View {
                         SettingsToggleRow(
                             icon: "arrow.triangle.2.circlepath",
                             title: "Enable Sync",
-                            isOn: $healthKitSyncEnabled
+                            isOn: $healthKitSyncEnabled,
+                            subtitle: "Keep weight and steps up to date"
                         )
                         .onChange(of: healthKitSyncEnabled) { _, newValue in
                             if newValue {
@@ -135,23 +106,26 @@ struct IntegrationsView: View {
 
                         Divider()
 
-                        // Manual Sync Button
-                        SettingsButtonRow(
-                            icon: "arrow.triangle.2.circlepath",
-                            title: "Sync All Historical Data",
-                            action: {
-                                Task {
-                                    await HealthSyncCoordinator.shared.forceFullHealthKitSync()
-                                }
+                        Button {
+                            Task { @MainActor in
+                                await syncAllHealthData()
                             }
-                        )
+                        } label: {
+                            SettingsRow(
+                                icon: "arrow.triangle.2.circlepath",
+                                title: isSyncingHealthKit ? "Syncing historical data" : "Sync all historical data",
+                                subtitle: healthSyncStatusMessage,
+                                showChevron: false
+                            )
+                        }
+                        .disabled(isSyncingHealthKit)
+                        .accessibilityHint("Syncs your historical Apple Health data now.")
                     }
                 } else {
-                    // HealthKit Not Available
                     DataInfoRow(
                         icon: "exclamationmark.triangle",
-                        title: "Apple Health Not Available",
-                        description: "Apple Health is not available on this device",
+                        title: "Apple Health isn’t available",
+                        description: "This device doesn’t support Apple Health.",
                         iconColor: theme.colors.warning
                     )
                 }
@@ -163,37 +137,88 @@ struct IntegrationsView: View {
                         destination: BodySpecIntegrationView()
                             .environmentObject(authManager)
                     ) {
-                        HStack {
-                            Image(systemName: "waveform.path.ecg")
-                                .foregroundColor(theme.colors.info)
-                                .font(theme.typography.headlineSmall)
-                                .frame(width: 24)
-
-                            Text("BodySpec")
-                                .font(theme.typography.labelLarge)
-                                .foregroundColor(theme.colors.text)
-
-                            Spacer()
-
-                            if isLoadingBodySpecLastSynced {
-                                Text("Checking…")
-                                    .font(theme.typography.captionLarge)
-                                    .foregroundColor(theme.colors.textSecondary)
-                            } else if let bodySpecLastSyncedText {
-                                Text(bodySpecLastSyncedText)
-                                    .font(theme.typography.captionLarge)
-                                    .foregroundColor(theme.colors.textSecondary)
-                            } else {
-                                Text("Not synced yet")
-                                    .font(theme.typography.captionLarge)
-                                    .foregroundColor(theme.colors.textSecondary)
-                            }
-                        }
+                        SettingsRow(
+                            icon: "waveform.path.ecg",
+                            title: "BodySpec",
+                            subtitle: "DEXA scans",
+                            value: bodySpecSyncStatusText,
+                            showChevron: true,
+                            tintColor: theme.colors.text
+                        )
                     }
-                    .padding(.horizontal, theme.spacing.md)
-                    .padding(.vertical, theme.spacing.sm)
+                    .accessibilityIdentifier("integrations_bodyspec_link")
                 }
             }
+        }
+    }
+
+    private var appleHealthConnectionRow: some View {
+        HStack(spacing: theme.spacing.sm) {
+            Image(systemName: "heart.fill")
+                .foregroundColor(theme.colors.error)
+                .font(theme.typography.headlineSmall)
+                .frame(width: 24)
+
+            Text("Apple Health")
+                .font(theme.typography.labelLarge)
+                .foregroundColor(theme.colors.text)
+
+            Spacer()
+
+            healthConnectionStatus
+        }
+    }
+
+    private var appleHealthConnectionStack: some View {
+        VStack(alignment: .leading, spacing: theme.spacing.sm) {
+            HStack(spacing: theme.spacing.sm) {
+                Image(systemName: "heart.fill")
+                    .foregroundColor(theme.colors.error)
+                    .font(theme.typography.headlineSmall)
+                    .frame(width: 24)
+
+                Text("Apple Health")
+                    .font(theme.typography.labelLarge)
+                    .foregroundColor(theme.colors.text)
+            }
+
+            healthConnectionStatus
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+
+    @ViewBuilder
+    private var healthConnectionStatus: some View {
+        if healthKitManager.isAuthorized {
+            Label("Connected", systemImage: "checkmark.circle.fill")
+                .font(theme.typography.captionLarge)
+                .foregroundColor(theme.colors.success)
+                .labelStyle(.titleAndIcon)
+                .accessibilityLabel("Apple Health connected")
+        } else {
+            Button {
+                Task { @MainActor in
+                    await connectAppleHealth()
+                }
+            } label: {
+                HStack(spacing: theme.spacing.xs) {
+                    if isConnectingHealthKit {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .tint(.jovieActionText)
+                    }
+
+                    Text(isConnectingHealthKit ? "Connecting" : "Connect")
+                        .font(theme.typography.labelMedium.weight(.semibold))
+                }
+                .foregroundColor(.jovieActionText)
+                .padding(.horizontal, theme.spacing.md)
+                .frame(minHeight: JovieTokens.minimumHitTarget)
+                .background(Color.jovieAction, in: Capsule())
+            }
+            .disabled(isConnectingHealthKit)
+            .accessibilityLabel("Connect Apple Health")
+            .accessibilityHint("Requests Apple Health access to sync your data.")
         }
     }
 
@@ -210,6 +235,7 @@ struct IntegrationsView: View {
                     SettingsRow(
                         icon: "photo.stack",
                         title: "Import Progress Photos",
+                        subtitle: "Choose photos from your library",
                         value: "Scan library",
                         showChevron: true
                     )
@@ -219,11 +245,12 @@ struct IntegrationsView: View {
                 SettingsRow(
                     icon: "photo.stack",
                     title: "Import Progress Photos",
+                    subtitle: "Add progress photos to unlock",
                     value: "Locked",
                     tintColor: theme.colors.textSecondary
                 )
-                .opacity(0.6)
                 .accessibilityIdentifier("integrations_bulk_photo_import_locked")
+                .accessibilityHint("Add progress photos or request migration access to unlock bulk import.")
             }
         }
     }
@@ -231,7 +258,7 @@ struct IntegrationsView: View {
     private var dataExportSection: some View {
         SettingsSection(
             header: "Data Export",
-            footer: "Export your data in available formats"
+            footer: "Download a copy of your LogYourBody data as a CSV file."
         ) {
             NavigationLink(destination: ExportDataView()) {
                 SettingsRow(
@@ -255,6 +282,44 @@ struct IntegrationsView: View {
 // MARK: - BodySpec Helpers
 
 extension IntegrationsView {
+    private var bodySpecSyncStatusText: String {
+        if isLoadingBodySpecLastSynced {
+            return "Checking"
+        }
+
+        return bodySpecLastSyncedText ?? "Not synced yet"
+    }
+
+    @MainActor
+    private func connectAppleHealth() async {
+        guard !isConnectingHealthKit else { return }
+
+        isConnectingHealthKit = true
+        healthSyncStatusMessage = nil
+
+        let authorized = await healthKitManager.requestAuthorization()
+        if authorized {
+            await HealthSyncCoordinator.shared
+                .configureSyncPipelineAfterAuthorizationAndRunInitialWeightAndStepSync()
+            healthSyncStatusMessage = "Apple Health sync is set up"
+        } else {
+            showHealthKitConnect = true
+        }
+
+        isConnectingHealthKit = false
+    }
+
+    @MainActor
+    private func syncAllHealthData() async {
+        guard !isSyncingHealthKit else { return }
+
+        isSyncingHealthKit = true
+        healthSyncStatusMessage = nil
+        await HealthSyncCoordinator.shared.forceFullHealthKitSync()
+        healthSyncStatusMessage = "Historical Apple Health data synced"
+        isSyncingHealthKit = false
+    }
+
     private var isBulkProgressPhotoImportEnabled: Bool {
         _ = featureGateRefreshToken
 

--- a/apps/ios/LogYourBody/Views/LegalConsentView.swift
+++ b/apps/ios/LogYourBody/Views/LegalConsentView.swift
@@ -5,6 +5,8 @@
 import SwiftUI
 
 struct LegalConsentView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @Binding var isPresented: Bool
     let userId: String
     let onAccept: () async -> Void
@@ -21,93 +23,56 @@ struct LegalConsentView: View {
 
     var body: some View {
         ZStack {
-            // Background
-            Color.black.opacity(0.8)
+            Color.jovieCanvas
                 .ignoresSafeArea()
-                .onTapGesture { } // Prevent dismissal by tapping background
 
-            VStack(spacing: 0) {
-                // Content
-                VStack(spacing: 24) {
-                    // Title
+            ScrollView {
+                VStack(alignment: .leading, spacing: JovieTokens.sectionGap) {
+                    header
+
                     VStack(spacing: 8) {
-                        Text("Welcome to LogYourBody")
-                            .font(.system(size: 24, weight: .bold))
-                            .foregroundColor(.white)
-
-                        Text("Please review and accept our terms")
-                            .font(.system(size: 16))
-                            .foregroundColor(.white.opacity(0.7))
-                    }
-                    .padding(.top, 32)
-
-                    // Checkboxes
-                    VStack(spacing: 16) {
-                        ConsentCheckbox(
+                        LegalConsentCheckbox(
                             isChecked: $acceptedTerms,
-                            text: "I accept the ",
-                            linkText: "Terms of Service",
-                            url: nil,
-                            onLinkTap: {
-                                showTermsSheet = true
-                            }
+                            agreement: "I accept the Terms of Service",
+                            linkTitle: "Read Terms of Service",
+                            linkHint: "Opens the Terms of Service.",
+                            onLinkTap: { showTermsSheet = true }
                         )
 
-                        ConsentCheckbox(
+                        LegalConsentCheckbox(
                             isChecked: $acceptedPrivacy,
-                            text: "I accept the ",
-                            linkText: "Privacy Policy",
-                            url: nil,
-                            onLinkTap: {
-                                showPrivacySheet = true
-                            }
+                            agreement: "I accept the Privacy Policy",
+                            linkTitle: "Read Privacy Policy",
+                            linkHint: "Opens the Privacy Policy.",
+                            onLinkTap: { showPrivacySheet = true }
                         )
                     }
-                    .padding(.horizontal, 24)
-
-                    // Continue Button
-                    Button(
-                        action: {
-                            Task {
-                                isLoading = true
-                                await onAccept()
-                                isLoading = false
-                                isPresented = false
-                            }
-                        },
-                        label: {
-                            HStack {
-                                if isLoading {
-                                    ProgressView()
-                                        .progressViewStyle(CircularProgressViewStyle(tint: .black))
-                                        .scaleEffect(0.8)
-                                } else {
-                                    Text("Continue")
-                                        .font(.system(size: 17, weight: .semibold))
-                                        .foregroundColor(canContinue ? .black : .white.opacity(0.5))
-                                }
-                            }
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 50)
-                            .background(canContinue ? Color.white : Color.white.opacity(0.2))
-                            .cornerRadius(12)
-                            .animation(.easeInOut(duration: 0.2), value: canContinue)
-                        }
+                    .padding(12)
+                    .systemBGlassSurface(
+                        cornerRadius: JovieTokens.cardRadius,
+                        tint: .jovieText,
+                        tintOpacity: 0.045,
+                        borderColor: .jovieHairline,
+                        borderOpacity: 0.9
                     )
-                    .disabled(!canContinue)
-                    .padding(.horizontal, 24)
-                    .padding(.bottom, 32)
+
+                    Text("You can review these documents again in Settings.")
+                        .font(.footnote)
+                        .foregroundColor(.jovieTextSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .background(Color.black)
-                .cornerRadius(20)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 20)
-                        .stroke(Color.white.opacity(0.1), lineWidth: 1)
-                )
-                .padding(.horizontal, 24)
+                .padding(.horizontal, JovieTokens.screenInset)
+                .padding(.top, 48)
+                .padding(.bottom, 24)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .scrollIndicators(.hidden)
+            .scrollBounceBehavior(.basedOnSize)
         }
-        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            continueAction
+        }
+        .transition(reduceMotion ? .opacity : .opacity.combined(with: .scale(scale: 0.98)))
         .sheet(isPresented: $showTermsSheet) {
             NavigationStack {
                 LegalDocumentView(documentType: .terms)
@@ -119,69 +84,103 @@ struct LegalConsentView: View {
             }
         }
     }
-}
 
-struct ConsentCheckbox: View {
-    @Binding var isChecked: Bool
-    let text: String
-    let linkText: String
-    let url: URL?
-    let onLinkTap: (() -> Void)?
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Before you continue")
+                .font(.title2.weight(.bold))
+                .foregroundColor(.jovieText)
 
-    @Environment(\.openURL) private var openURL
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            // Custom checkbox
-            Button(
-                action: {
-                    isChecked.toggle()
-                },
-                label: {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 6)
-                            .stroke(Color.white.opacity(0.3), lineWidth: 2)
-                            .frame(width: 24, height: 24)
-                            .background(
-                                RoundedRectangle(cornerRadius: 6)
-                                    .fill(isChecked ? Color.white : Color.clear)
-                            )
-
-                        if isChecked {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 14, weight: .bold))
-                                .foregroundColor(.black)
-                        }
-                    }
-                }
-            )
-            .buttonStyle(PlainButtonStyle())
-
-            // Text with link
-            HStack(spacing: 0) {
-                Text(text)
-                    .font(.system(size: 15))
-                    .foregroundColor(.white.opacity(0.9))
-
-                Button(action: handleLinkTap) {
-                    Text(linkText)
-                        .font(.system(size: 15))
-                        .foregroundColor(.white)
-                        .underline()
-                }
-                .buttonStyle(PlainButtonStyle())
-            }
-
-            Spacer()
+            Text("Please review and accept the Terms of Service and Privacy Policy.")
+                .font(.body)
+                .foregroundColor(.jovieTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
+        .accessibilityElement(children: .combine)
     }
 
-    private func handleLinkTap() {
-        if let onLinkTap {
-            onLinkTap()
-        } else if let url {
-            openURL(url)
+    private var continueAction: some View {
+        VStack(spacing: 0) {
+            Rectangle()
+                .fill(Color.jovieHairline)
+                .frame(height: 1)
+
+            BaseButton(
+                "Continue",
+                configuration: ButtonConfiguration(
+                    style: .custom(background: .jovieAction, foreground: .jovieActionText),
+                    isLoading: isLoading,
+                    isEnabled: canContinue,
+                    fullWidth: true,
+                    cornerRadius: JovieTokens.controlRadius
+                ),
+                action: accept
+            )
+            .accessibilityIdentifier("legal_consent_continue_button")
+            .accessibilityHint(
+                canContinue
+                    ? "Accepts the selected agreements and continues."
+                    : "Accept both agreements to continue."
+            )
+            .padding(.horizontal, JovieTokens.screenInset)
+            .padding(.vertical, 12)
         }
+        .background(Color.jovieCanvas.opacity(0.96).ignoresSafeArea(edges: .bottom))
+    }
+
+    private func accept() {
+        guard canContinue else { return }
+
+        isLoading = true
+        Task { @MainActor in
+            await onAccept()
+            isLoading = false
+            isPresented = false
+        }
+    }
+}
+
+private struct LegalConsentCheckbox: View {
+    @Binding var isChecked: Bool
+    let agreement: String
+    let linkTitle: String
+    let linkHint: String
+    let onLinkTap: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 8) {
+            Button(action: { isChecked.toggle() }, label: {
+                Image(systemName: isChecked ? "checkmark" : "square")
+                    .font(.system(.body, design: .default).weight(.semibold))
+                    .foregroundColor(isChecked ? .jovieActionText : .jovieTextSecondary)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        RoundedRectangle(cornerRadius: 9, style: .continuous)
+                            .fill(isChecked ? Color.jovieAction : Color.jovieSurfaceElevated)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 9, style: .continuous)
+                            .stroke(isChecked ? Color.clear : Color.jovieHairline, lineWidth: 1)
+                    )
+                    .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
+            })
+            .buttonStyle(.plain)
+            .accessibilityLabel(agreement)
+            .accessibilityValue(isChecked ? "Selected" : "Not selected")
+            .accessibilityHint("Required to continue.")
+
+            Button(action: onLinkTap) {
+                Text(linkTitle)
+                    .font(.body.weight(.medium))
+                    .foregroundColor(.jovieText)
+                    .underline()
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, minHeight: JovieTokens.minimumHitTarget, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+            .accessibilityHint(linkHint)
+        }
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 

--- a/apps/ios/LogYourBody/Views/PaywallView.swift
+++ b/apps/ios/LogYourBody/Views/PaywallView.swift
@@ -2,14 +2,18 @@
 // PaywallView.swift
 // LogYourBody
 //
-// Premium subscription paywall with glassmorphic design
+// One compact, trust-first subscription surface. Pricing is shown only when the
+// currently loaded offering is available; stale partial offers are never reused
+// as a purchase proposition.
 //
 import SwiftUI
 
 struct PaywallView: View {
     @Environment(\.openURL) private var openURL
-    @EnvironmentObject var authManager: AuthManager
-    @EnvironmentObject var subscriptionManager: SubscriptionManager
+    @Environment(\.theme) private var theme
+    @EnvironmentObject private var authManager: AuthManager
+    @EnvironmentObject private var subscriptionManager: SubscriptionManager
+
     @State private var isLoading = true
     @State private var showRestoreSuccess = false
     @State private var showRestoreError = false
@@ -21,66 +25,54 @@ struct PaywallView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(
-                colors: [Color.appBackground, Color.black],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-            .ignoresSafeArea()
+            theme.colors.background.ignoresSafeArea()
 
-            ScrollView {
-                VStack(spacing: 24) {
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: JovieTokens.sectionGap) {
                     header
-                    featuresSection
+                    valueProposition
 
                     if !availablePrimaryPackages.isEmpty {
-                        pricingOptionsSection(packages: availablePrimaryPackages)
+                        pricingOptions
                     } else if isLoading {
-                        ProgressView()
-                            .tint(.appPrimary)
+                        ProgressView("Loading plans…")
+                            .tint(theme.colors.text)
+                            .foregroundStyle(theme.colors.textSecondary)
+                            .frame(maxWidth: .infinity, minHeight: 96)
                     } else {
-                        plansUnavailableState(
-                            cachedPackage: subscriptionManager.cachedPaywallOfferingDisplay?.preferredPackage
-                        )
+                        plansUnavailableState
                     }
 
                     if let package = selectedPackage {
                         purchaseButton(package: package)
                     }
 
-                    restorePurchasesButton
-                    logoutButton
+                    recoveryActions
                     legalLinks
-
-                    Spacer(minLength: 50)
                 }
-                .padding(.horizontal, 24)
-                .padding(.top, 60)
-                .padding(.bottom, 40)
+                .padding(.horizontal, JovieTokens.screenInset)
+                .padding(.top, JovieTokens.sectionGap)
+                .padding(.bottom, JovieTokens.sectionGap)
             }
+            .scrollBounceBehavior(.basedOnSize)
             .accessibilityIdentifier("paywall_screen")
 
-            // Loading overlay
             if subscriptionManager.isPurchasing {
-                LoadingOverlay(message: "Processing purchase...")
+                LoadingOverlay(message: "Processing purchase…")
             }
         }
         .alert("Purchase Error", isPresented: $showPurchaseError) {
-            Button("OK", role: .cancel) {
-                subscriptionManager.errorMessage = nil
-            }
+            Button("OK", role: .cancel) { subscriptionManager.errorMessage = nil }
         } message: {
             Text(subscriptionManager.errorMessage ?? "An error occurred")
         }
         .alert("Restore Successful", isPresented: $showRestoreSuccess) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("Your subscription has been restored!")
+            Text("Your subscription has been restored.")
         }
         .alert("No Subscription Found", isPresented: $showRestoreError) {
-            Button("OK", role: .cancel) {
-                subscriptionManager.errorMessage = nil
-            }
+            Button("OK", role: .cancel) { subscriptionManager.errorMessage = nil }
         } message: {
             Text(subscriptionManager.errorMessage ?? "No active subscription found")
         }
@@ -99,412 +91,328 @@ struct PaywallView: View {
         } message: {
             Text("Use this to switch accounts on this device.")
         }
-        .onAppear {
-            // Use cached offerings if available, otherwise fetch
-            if !subscriptionManager.paywallPackages.isEmpty {
-                isLoading = false
-                // print("💰 Using cached offerings")
+        .task {
+            if subscriptionManager.paywallPackages.isEmpty {
+                await loadOfferings()
             } else {
-                Task {
-                    await loadOfferings()
-                }
+                isLoading = false
             }
-
             AppServicePorts.analyticsTracker.track(event: "paywall_view")
         }
         .sheet(isPresented: $showTermsSheet) {
-            NavigationStack {
-                LegalDocumentView(documentType: .terms)
-            }
+            NavigationStack { LegalDocumentView(documentType: .terms) }
         }
         .sheet(isPresented: $showPrivacySheet) {
-            NavigationStack {
-                LegalDocumentView(documentType: .privacy)
-            }
+            NavigationStack { LegalDocumentView(documentType: .privacy) }
         }
     }
-
-    // MARK: - Computed Properties
 
     private var availablePrimaryPackages: [PaywallPackageDisplay] {
         subscriptionManager.paywallPackages
     }
 
     private var selectedPackage: PaywallPackageDisplay? {
-        let packages = availablePrimaryPackages
-
-        if let selected = packages.first(where: { $0.packageIdentifier == selectedPackageIdentifier }) {
-            return selected
-        }
-
-        if let annual = packages.first(where: { $0.packageIdentifier == "$rc_annual" }) {
-            return annual
-        }
-
-        return packages.first
+        availablePrimaryPackages.first { $0.packageIdentifier == selectedPackageIdentifier }
+            ?? availablePrimaryPackages.first { $0.packageIdentifier == "$rc_annual" }
+            ?? availablePrimaryPackages.first
     }
-
-    // MARK: - Components
 
     private var header: some View {
-        VStack(spacing: 14) {
-            Image(systemName: "chart.line.uptrend.xyaxis.circle.fill")
-                .font(.system(size: 56))
-                .foregroundStyle(Color.appPrimary)
+        VStack(spacing: 10) {
+            Image(systemName: "chart.line.uptrend.xyaxis")
+                .font(.system(.title, design: .rounded).weight(.semibold))
+                .foregroundStyle(theme.colors.text)
+                .frame(width: 52, height: 52)
+                .background(Circle().fill(theme.colors.text.opacity(0.08)))
 
             Text("LogYourBody Pro")
-                .font(.system(size: 32, weight: .bold, design: .rounded))
-                .foregroundColor(.appText)
+                .font(theme.typography.headlineLarge)
+                .foregroundStyle(theme.colors.text)
                 .accessibilityIdentifier("paywall_title")
 
-            Text("Log your body in under 10 seconds and see if you are moving in the right direction.")
-                .font(.system(size: 16, weight: .medium))
-                .foregroundColor(.appTextSecondary)
+            Text("A clear, private view of your progress.")
+                .font(theme.typography.bodySmall)
+                .foregroundStyle(theme.colors.textSecondary)
                 .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
         }
+        .frame(maxWidth: .infinity)
     }
 
-    private var featuresSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            PaywallFeatureRow(
-                icon: "scalemass.fill",
-                title: "Daily logging",
-                description: "Save weight and body fat fast."
-            )
-
-            PaywallFeatureRow(
-                icon: "chart.xyaxis.line",
-                title: "Clear trends",
-                description: "See weight, body fat, FFMI, and body score."
-            )
-
-            PaywallFeatureRow(
-                icon: "icloud.fill",
-                title: "Private sync",
-                description: "Keep local data backed up to your account."
-            )
-        }
-        .padding(.horizontal, 8)
+    private var valueProposition: some View {
+        Text("Log quickly. See weight, body fat, FFMI, and your trend in one place.")
+            .font(theme.typography.bodyMedium)
+            .foregroundStyle(theme.colors.textSecondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
     }
 
-    private func pricingOptionsSection(packages: [PaywallPackageDisplay]) -> some View {
-        VStack(spacing: 12) {
-            if packages.count > 1 {
-                HStack(spacing: 10) {
-                    ForEach(packages) { package in
-                        pricingOptionCard(
-                            package: package,
-                            isSelected: package.packageIdentifier == selectedPackage?.packageIdentifier
-                        )
-                    }
+    private var pricingOptions: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: JovieTokens.itemGap) {
+                ForEach(availablePrimaryPackages) { package in
+                    pricingOption(package)
+                        .frame(minWidth: 156)
                 }
-            } else if let package = packages.first {
-                pricingOptionCard(
-                    package: package,
-                    isSelected: package.packageIdentifier == selectedPackage?.packageIdentifier
-                )
+            }
+
+            VStack(spacing: JovieTokens.itemGap) {
+                ForEach(availablePrimaryPackages) { package in
+                    pricingOption(package)
+                }
             }
         }
+        .accessibilityElement(children: .contain)
     }
 
-    private func pricingOptionCard(package: PaywallPackageDisplay, isSelected: Bool) -> some View {
-        Button {
+    private func pricingOption(_ package: PaywallPackageDisplay) -> some View {
+        let isSelected = package.packageIdentifier == selectedPackage?.packageIdentifier
+
+        return Button {
             selectedPackageIdentifier = package.packageIdentifier
             HapticManager.shared.impact(style: .light)
         } label: {
-            VStack(alignment: .leading, spacing: 12) {
-                HStack(alignment: .top, spacing: 8) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(package.planTitle)
-                            .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(.appText)
-
-                        if let trialText = package.trialText {
-                            Text(trialText.uppercased())
-                                .font(.system(size: 10, weight: .bold))
-                                .foregroundColor(.appPrimary)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.85)
-                        }
-                    }
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(package.planTitle)
+                        .font(theme.typography.labelLarge)
+                        .foregroundStyle(theme.colors.text)
 
                     Spacer(minLength: 4)
 
-                    selectionIndicator(isSelected: isSelected)
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .font(.system(.headline, design: .default).weight(.semibold))
+                        .foregroundStyle(isSelected ? theme.colors.text : theme.colors.textTertiary)
                 }
 
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(alignment: .firstTextBaseline, spacing: 3) {
-                        Text(package.localizedPrice)
-                            .font(.system(size: 30, weight: .bold, design: .rounded))
-                            .foregroundColor(.appText)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.75)
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(package.localizedPrice)
+                        .font(theme.typography.displaySmall)
+                        .foregroundStyle(theme.colors.text)
+                        .monospacedDigit()
 
-                        Text(package.billingPeriodSuffix)
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(.appTextSecondary)
-                    }
-
-                    Text(package.summaryText)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.appTextSecondary)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
+                    Text(package.billingPeriodSuffix)
+                        .font(theme.typography.bodySmall)
+                        .foregroundStyle(theme.colors.textSecondary)
                 }
+
+                Text(package.summaryText)
+                    .font(theme.typography.captionLarge)
+                    .foregroundStyle(theme.colors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 if let savingsText = package.savingsBadgeText {
                     Text(savingsText)
-                        .font(.system(size: 11, weight: .bold))
-                        .foregroundColor(.black)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.8)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(Color.appPrimary)
-                        .clipShape(Capsule())
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    Text("Flexible")
-                        .font(.system(size: 11, weight: .bold))
-                        .foregroundColor(.appTextSecondary)
-                        .lineLimit(1)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(Color.appCard.opacity(0.8))
-                        .clipShape(Capsule())
+                        .font(theme.typography.labelSmall)
+                        .foregroundStyle(theme.colors.background)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(theme.colors.text))
+                } else if let trialText = package.trialText {
+                    Text(trialText)
+                        .font(theme.typography.labelSmall)
+                        .foregroundStyle(theme.colors.textSecondary)
                 }
             }
-            .frame(maxWidth: .infinity, minHeight: 166, alignment: .topLeading)
-            .padding(14)
-            .background(
-                ZStack {
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .fill(isSelected ? Color.appCard : Color.appCard.opacity(0.68))
-
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .stroke(
-                            isSelected ? Color.appPrimary : Color.appBorder.opacity(0.75),
-                            lineWidth: isSelected ? 2 : 1
-                        )
-                }
+            .frame(maxWidth: .infinity, minHeight: 132, alignment: .topLeading)
+            .padding(16)
+            .systemBGlassSurface(
+                cornerRadius: JovieTokens.cardRadius,
+                tint: theme.colors.text,
+                tintOpacity: isSelected ? 0.08 : 0.03,
+                borderColor: isSelected ? theme.colors.text : theme.colors.border,
+                borderOpacity: isSelected ? 0.62 : 0.6,
+                borderWidth: isSelected ? 1.5 : 1,
+                shadowOpacity: isSelected ? 0.12 : 0.04,
+                shadowRadius: isSelected ? 14 : 8,
+                shadowY: 5
             )
-            .shadow(color: isSelected ? Color.appPrimary.opacity(0.18) : .clear, radius: 14, x: 0, y: 8)
         }
         .buttonStyle(.plain)
         .accessibilityLabel("\(package.planTitle) plan")
-        .accessibilityHint(isSelected ? "Selected" : "Double tap to select this plan")
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityHint("Double tap to select this plan")
         .accessibilityIdentifier("paywall_plan_\(package.accessibilityIdentifierSuffix)")
     }
 
-    private func selectionIndicator(isSelected: Bool) -> some View {
-        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-            .font(.system(size: 20, weight: .semibold))
-            .foregroundColor(isSelected ? .appPrimary : .appTextSecondary.opacity(0.65))
-    }
-
     private func purchaseButton(package: PaywallPackageDisplay) -> some View {
-        Button {
-            Task {
-                AppServicePorts.analyticsTracker.track(
-                    event: "purchase_start",
-                    properties: [
-                        "package_id": package.packageIdentifier
-                    ]
-                )
-
-                let success = await subscriptionManager.purchase(packageIdentifier: package.packageIdentifier)
-                if !success && subscriptionManager.errorMessage != nil {
-                    showPurchaseError = true
-                }
-
-                AppServicePorts.analyticsTracker.track(
-                    event: success ? "purchase_success" : "purchase_failed",
-                    properties: [
-                        "package_id": package.packageIdentifier
-                    ]
-                )
+        BaseButton(
+            subscriptionManager.isPurchasing ? "Processing…" : package.purchaseButtonTitle,
+            configuration: ButtonConfiguration(
+                style: .custom(background: .jovieAction, foreground: .jovieActionText),
+                size: .large,
+                isLoading: subscriptionManager.isPurchasing,
+                isEnabled: !subscriptionManager.isPurchasing,
+                fullWidth: true,
+                icon: subscriptionManager.isPurchasing ? nil : "checkmark",
+                iconPosition: .leading,
+                cornerRadius: 9_999
+            ),
+            action: {
+                Task { await purchase(package) }
             }
-        } label: {
-            HStack(spacing: 12) {
-                if !subscriptionManager.isPurchasing {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 20, weight: .semibold))
-                }
-
-                Text(subscriptionManager.isPurchasing ? "Processing..." : package.purchaseButtonTitle)
-                    .font(.system(size: 18, weight: .semibold))
-            }
-            .foregroundColor(.black)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 18)
-            .background(Color.appPrimary)
-            .cornerRadius(16)
-        }
-        .disabled(subscriptionManager.isPurchasing)
+        )
         .accessibilityIdentifier("paywall_purchase_button")
     }
 
-    private var restorePurchasesButton: some View {
-        Button {
-            Task {
-                let success = await subscriptionManager.restorePurchases()
-                if success {
-                    showRestoreSuccess = true
-                } else if subscriptionManager.errorMessage != nil {
-                    showRestoreError = true
-                }
+    private var plansUnavailableState: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Plans are temporarily unavailable", systemImage: "wifi.exclamationmark")
+                .font(theme.typography.labelLarge)
+                .foregroundStyle(theme.colors.text)
+                .accessibilityIdentifier("paywall_plans_unavailable_state")
 
-                AppServicePorts.analyticsTracker.track(
-                    event: success ? "restore_success" : "restore_failed"
-                )
-            }
-        } label: {
-            Text("Restore Purchases")
-                .font(.system(size: 16, weight: .medium))
-                .foregroundColor(.white.opacity(0.7))
+            Text("Check your connection and try again. You can still restore a previous purchase or switch accounts.")
+                .font(theme.typography.bodySmall)
+                .foregroundStyle(theme.colors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            unavailablePlanActions
         }
-        .disabled(subscriptionManager.isPurchasing)
-        .accessibilityIdentifier("paywall_restore_purchases_button")
+        .padding(16)
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.cardRadius,
+            tint: theme.colors.text,
+            tintOpacity: 0.035,
+            borderColor: theme.colors.border,
+            borderOpacity: 0.65,
+            shadowOpacity: 0.06,
+            shadowRadius: 10,
+            shadowY: 4
+        )
     }
 
-    private var logoutButton: some View {
-        Button(role: .destructive) {
-            HapticManager.shared.notification(type: .warning)
-            showLogoutConfirmation = true
-        } label: {
-            Label("Log out", systemImage: "rectangle.portrait.and.arrow.right")
-                .font(.system(size: 16, weight: .medium))
-                .foregroundColor(.red.opacity(0.85))
+    private var unavailablePlanActions: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 12) {
+                retryOfferingsButton
+                contactSupportButton
+            }
+
+            VStack(spacing: 8) {
+                retryOfferingsButton
+                contactSupportButton
+            }
         }
-        .disabled(subscriptionManager.isPurchasing)
-        .accessibilityLabel("Log out")
-        .accessibilityHint("Signs you out so you can use another account.")
-        .accessibilityIdentifier("paywall_logout_button")
+    }
+
+    private var retryOfferingsButton: some View {
+        Button {
+            Task { await loadOfferings() }
+        } label: {
+            Label("Retry", systemImage: "arrow.clockwise")
+                .font(theme.typography.labelLarge)
+                .foregroundStyle(theme.colors.text)
+                .frame(maxWidth: .infinity, minHeight: JovieTokens.minimumHitTarget)
+                .background(
+                    RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                        .fill(theme.colors.text.opacity(0.06))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                        .stroke(theme.colors.border, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(isLoading)
+        .accessibilityLabel("Retry loading subscription plans")
+        .accessibilityHint("Attempts to load the available subscription plans again.")
+        .accessibilityIdentifier("paywall_retry_offerings_button")
+    }
+
+    private var contactSupportButton: some View {
+        Button(action: contactSupportAboutUnavailablePlans) {
+            Label("Contact support", systemImage: "envelope")
+                .font(theme.typography.labelLarge)
+                .foregroundStyle(theme.colors.text)
+                .frame(maxWidth: .infinity, minHeight: JovieTokens.minimumHitTarget)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Contact support")
+        .accessibilityHint("Opens email support for unavailable subscription plans.")
+        .accessibilityIdentifier("paywall_contact_support_button")
+    }
+
+    private var recoveryActions: some View {
+        VStack(spacing: 4) {
+            Button {
+                Task { await restorePurchases() }
+            } label: {
+                Label("Restore Purchases", systemImage: "arrow.clockwise")
+                    .font(theme.typography.labelLarge)
+                    .foregroundStyle(theme.colors.text)
+                    .frame(maxWidth: .infinity, minHeight: JovieTokens.minimumHitTarget)
+            }
+            .buttonStyle(.plain)
+            .disabled(subscriptionManager.isPurchasing)
+            .accessibilityIdentifier("paywall_restore_purchases_button")
+
+            Button(role: .destructive) {
+                showLogoutConfirmation = true
+            } label: {
+                Label("Log out", systemImage: "rectangle.portrait.and.arrow.right")
+                    .font(theme.typography.labelMedium)
+                    .foregroundStyle(theme.colors.error)
+                    .frame(maxWidth: .infinity, minHeight: JovieTokens.minimumHitTarget)
+            }
+            .buttonStyle(.plain)
+            .disabled(subscriptionManager.isPurchasing)
+            .accessibilityIdentifier("paywall_logout_button")
+        }
     }
 
     private var legalLinks: some View {
-        HStack(spacing: 16) {
-            Button {
-                showTermsSheet = true
-            } label: {
-                Text("Terms of Service")
-                    .font(.system(size: 13))
-                    .foregroundColor(.white.opacity(0.5))
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 16) {
+                termsButton
+                Text("•").foregroundStyle(theme.colors.textTertiary)
+                privacyButton
             }
 
-            Text("•")
-                .foregroundColor(.white.opacity(0.3))
-
-            Button {
-                showPrivacySheet = true
-            } label: {
-                Text("Privacy Policy")
-                    .font(.system(size: 13))
-                    .foregroundColor(.white.opacity(0.5))
+            VStack(spacing: 2) {
+                termsButton
+                privacyButton
             }
         }
+        .font(theme.typography.captionLarge)
     }
 
-    private func plansUnavailableState(
-        cachedPackage: CachedPaywallOfferingDisplay.PackageDisplay?
-    ) -> some View {
-        VStack(spacing: 12) {
-            Text("Subscription plans are unavailable")
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundColor(.appText)
+    private var termsButton: some View {
+        Button("Terms of Service") { showTermsSheet = true }
+            .foregroundStyle(theme.colors.textSecondary)
+            .frame(minHeight: JovieTokens.minimumHitTarget)
+    }
 
-            if let cachedPackage {
-                cachedPricingSummary(package: cachedPackage)
-            }
+    private var privacyButton: some View {
+        Button("Privacy Policy") { showPrivacySheet = true }
+            .foregroundStyle(theme.colors.textSecondary)
+            .frame(minHeight: JovieTokens.minimumHitTarget)
+    }
 
-            Text("Check your connection and retry. You can still restore a purchase or log out below.")
-                .font(.system(size: 14))
-                .foregroundColor(.appTextSecondary)
-                .multilineTextAlignment(.center)
-
-            HStack(spacing: 10) {
-                Button {
-                    Task {
-                        await loadOfferings()
-                    }
-                } label: {
-                    Label("Retry", systemImage: "arrow.clockwise")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(.appText)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 10)
-                        .background(Color.appCard)
-                        .cornerRadius(12)
-                }
-                .disabled(isLoading)
-                .accessibilityIdentifier("paywall_retry_offerings_button")
-
-                Button {
-                    contactSupportAboutUnavailablePlans()
-                } label: {
-                    Label("Contact Support", systemImage: "envelope")
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(.appTextSecondary)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 10)
-                        .background(Color.appCard.opacity(0.45))
-                        .cornerRadius(12)
-                }
-                .accessibilityLabel("Contact Support")
-                .accessibilityHint("Opens an email to LogYourBody support.")
-                .accessibilityIdentifier("paywall_contact_support_button")
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .padding(20)
-        .background(Color.appCard.opacity(0.65))
-        .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(Color.appBorder.opacity(0.8), lineWidth: 1)
+    private func purchase(_ package: PaywallPackageDisplay) async {
+        AppServicePorts.analyticsTracker.track(
+            event: "purchase_start",
+            properties: ["package_id": package.packageIdentifier]
         )
-        .cornerRadius(16)
-        .accessibilityIdentifier("paywall_plans_unavailable_state")
+
+        let success = await subscriptionManager.purchase(packageIdentifier: package.packageIdentifier)
+        if !success, subscriptionManager.errorMessage != nil {
+            showPurchaseError = true
+        }
+
+        AppServicePorts.analyticsTracker.track(
+            event: success ? "purchase_success" : "purchase_failed",
+            properties: ["package_id": package.packageIdentifier]
+        )
     }
 
-    private func cachedPricingSummary(package: CachedPaywallOfferingDisplay.PackageDisplay) -> some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Last loaded price")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(.appTextSecondary)
-                    .textCase(.uppercase)
-
-                HStack(alignment: .firstTextBaseline, spacing: 3) {
-                    Text(package.localizedPrice)
-                        .font(.system(size: 28, weight: .bold, design: .rounded))
-                        .foregroundColor(.appText)
-
-                    Text(package.billingPeriod.isEmpty ? "" : "/\(package.billingPeriod)")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(.appTextSecondary)
-                }
-            }
-
-            Spacer(minLength: 8)
-
-            if let trialText = package.trialText {
-                Text(trialText.uppercased())
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundColor(.black)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(Color.appPrimary.opacity(0.8))
-                    .clipShape(Capsule())
-            }
+    private func restorePurchases() async {
+        let success = await subscriptionManager.restorePurchases()
+        if success {
+            showRestoreSuccess = true
+        } else if subscriptionManager.errorMessage != nil {
+            showRestoreError = true
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 12)
-        .background(Color.appCard.opacity(0.65))
-        .cornerRadius(14)
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("paywall_cached_pricing_card")
+        AppServicePorts.analyticsTracker.track(event: success ? "restore_success" : "restore_failed")
     }
 
     private func contactSupportAboutUnavailablePlans() {
@@ -512,55 +420,18 @@ struct PaywallView: View {
             .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "Subscription%20plans%20unavailable"
         let body = "I cannot load subscription plans in the iOS app."
             .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        if let url = URL(string: "mailto:support@logyourbody.com?subject=\(subject)&body=\(body)") {
-            openURL(url)
+        guard let url = URL(string: "mailto:support@logyourbody.com?subject=\(subject)&body=\(body)") else {
+            return
         }
+        openURL(url)
     }
-
-    // MARK: - Functions
 
     private func loadOfferings() async {
         isLoading = true
         await subscriptionManager.fetchOfferings()
         isLoading = false
-
-        if subscriptionManager.paywallPackages.isEmpty {
-            // print("⚠️ No offerings available")
-        }
     }
 }
-
-// MARK: - Feature Row Component
-
-private struct PaywallFeatureRow: View {
-    let icon: String
-    let title: String
-    let description: String
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 16) {
-            Image(systemName: icon)
-                .font(.system(size: 21, weight: .semibold))
-                .foregroundColor(.appPrimary)
-                .frame(width: 30, height: 28, alignment: .top)
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(.appText)
-
-                Text(description)
-                    .font(.system(size: 15))
-                    .foregroundColor(.appTextSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            Spacer()
-        }
-    }
-}
-
-// MARK: - Preview
 
 #Preview {
     PaywallView()

--- a/apps/ios/LogYourBody/Views/PreferenceGoalEditing.swift
+++ b/apps/ios/LogYourBody/Views/PreferenceGoalEditing.swift
@@ -96,12 +96,22 @@ enum PreferenceGoalValidator {
 }
 
 struct PreferenceGoalEditorSheet: View {
+    private enum Field: Hashable {
+        case value
+    }
+
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let goal: PreferenceGoalKind
     let initialText: String
     let unitLabel: String?
     let save: (Double) -> Void
+
     @State private var draftText: String
+    @FocusState private var focusedField: Field?
+    @AccessibilityFocusState private var errorFocused: Bool
 
     init(
         goal: PreferenceGoalKind,
@@ -122,69 +132,179 @@ struct PreferenceGoalEditorSheet: View {
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: 16) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(goal.title)
-                        .font(.system(size: 24, weight: .semibold))
-                        .foregroundColor(.appText)
+            ZStack {
+                Color.jovieCanvas
+                    .ignoresSafeArea()
 
-                    Text(goal.helperText)
-                        .font(.subheadline)
-                        .foregroundColor(.appTextSecondary)
-                }
-
-                HStack(spacing: 10) {
-                    TextField(goal.placeholder, text: $draftText)
-                        .keyboardType(.decimalPad)
-                        .textInputAutocapitalization(.never)
-                        .disableAutocorrection(true)
-                        .font(.system(size: 20, weight: .semibold))
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 12)
-                        .background(Color.appCard)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(Color.appBorder, lineWidth: 1)
-                        )
-                        .accessibilityIdentifier("settings_goal_editor_text_field")
-
-                    if let unitLabel {
-                        Text(unitLabel)
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundColor(.appTextSecondary)
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: JovieTokens.sectionGap) {
+                        valueCard
                     }
+                    .frame(maxWidth: 560, alignment: .leading)
+                    .padding(.horizontal, JovieTokens.screenInset)
+                    .padding(.top, JovieTokens.itemGap)
+                    .padding(.bottom, JovieTokens.sectionGap)
                 }
-
-                if let message = validation.errorMessage {
-                    Text(message)
-                        .font(.caption)
-                        .foregroundColor(.red)
-                        .accessibilityIdentifier("settings_goal_editor_error")
-                }
-
-                Spacer()
             }
-            .padding(20)
-            .background(Color.appBackground.ignoresSafeArea())
+            .scrollDismissesKeyboard(.interactively)
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                saveAction
+                    .padding(.horizontal, JovieTokens.screenInset)
+                    .padding(.top, JovieTokens.itemGap)
+                    .padding(
+                        .bottom,
+                        dynamicTypeSize.isAccessibilitySize ? JovieTokens.sectionGap : JovieTokens.itemGap
+                    )
+                    .background(Color.jovieCanvas.opacity(0.98))
+            }
             .navigationTitle(goal.title)
             .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(Color.jovieCanvas, for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        dismiss()
+                    Button(action: dismiss.callAsFunction) {
+                        Image(systemName: "xmark")
+                            .font(.body.weight(.semibold))
+                            .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
                     }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.jovieText)
+                    .accessibilityLabel("Cancel editing")
+                    .accessibilityHint("Discards changes to this goal")
                 }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
-                        if let value = validation.value {
-                            save(value)
-                            dismiss()
-                        }
+
+                ToolbarItem(placement: .keyboard) {
+                    Button("Done") {
+                        focusedField = nil
                     }
-                    .disabled(!validation.isValid)
+                    .font(.body.weight(.semibold))
+                    .accessibilityIdentifier("settings_goal_editor_keyboard_done_button")
                 }
             }
         }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .onAppear {
+            errorFocused = validation.errorMessage != nil
+        }
+        .onChange(of: focusedField) { _, field in
+            if field == nil, validation.errorMessage != nil {
+                errorFocused = true
+            }
+        }
+        .onChange(of: draftText) { _, _ in
+            if validation.isValid {
+                errorFocused = false
+            }
+        }
+        .accessibilityIdentifier("settings_goal_editor_sheet")
+    }
+
+    private var valueCard: some View {
+        VStack(alignment: .leading, spacing: JovieTokens.itemGap) {
+            Text("Goal")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.jovieTextSecondary)
+
+            HStack(alignment: .center, spacing: JovieTokens.itemGap) {
+                TextField(goal.placeholder, text: $draftText)
+                    .keyboardType(.decimalPad)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .submitLabel(.done)
+                    .font(.system(.title, design: .rounded).weight(.semibold))
+                    .foregroundStyle(Color.jovieText)
+                    .focused($focusedField, equals: .value)
+                    .accessibilityLabel(goal.title)
+                    .accessibilityValue(accessibilityValue)
+                    .accessibilityHint(validation.errorMessage ?? goal.helperText)
+                    .accessibilityIdentifier("settings_goal_editor_text_field")
+
+                if let unitLabel {
+                    Text(unitLabel)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(Color.jovieTextSecondary)
+                        .accessibilityHidden(true)
+                }
+            }
+            .padding(.horizontal, JovieTokens.compactInset)
+            .frame(maxWidth: .infinity, minHeight: 64)
+            .background(Color.jovieSurfaceElevated)
+            .clipShape(RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                    .stroke(fieldBorderColor, lineWidth: focusedField == .value ? 2 : 1)
+            }
+            .animation(
+                reduceMotion ? nil : .easeInOut(duration: JovieTokens.subtleDuration),
+                value: focusedField
+            )
+
+            if let message = validation.errorMessage {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .accessibilityHidden(true)
+
+                    Text(message)
+                        .accessibilityIdentifier("settings_goal_editor_error")
+                        .accessibilityFocused($errorFocused)
+                }
+                .font(.footnote)
+                .foregroundStyle(Color.red)
+                .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Label(goal.helperText, systemImage: "info.circle.fill")
+                    .font(.footnote)
+                    .foregroundStyle(Color.jovieTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(goal.helperText)
+            }
+        }
+        .padding(JovieTokens.compactInset)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.controlRadius,
+            tint: .white,
+            tintOpacity: 0.025,
+            borderColor: .jovieHairline
+        )
+    }
+
+    private var saveAction: some View {
+        BaseButton(
+            "Save",
+            configuration: ButtonConfiguration(
+                style: .custom(background: .jovieAction, foreground: .jovieActionText),
+                isEnabled: validation.isValid,
+                fullWidth: true,
+                icon: "checkmark"
+            )
+        ) {
+            guard let value = validation.value else { return }
+            save(value)
+            dismiss()
+        }
+        .disabled(!validation.isValid)
+        .accessibilityLabel("Save")
+        .accessibilityHint(validation.isValid ? "Saves this goal" : validation.errorMessage ?? "Enter a valid goal")
+    }
+
+    private var accessibilityValue: String {
+        let value = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return "No value" }
+
+        if let unitLabel, !unitLabel.isEmpty {
+            return "\(value) \(unitLabel)"
+        }
+        return value
+    }
+
+    private var fieldBorderColor: Color {
+        if validation.errorMessage != nil {
+            return .red.opacity(0.85)
+        }
+        return focusedField == .value ? .jovieMetricAccent : .jovieHairline
     }
 }

--- a/apps/ios/LogYourBody/Views/PreferenceGoalRows.swift
+++ b/apps/ios/LogYourBody/Views/PreferenceGoalRows.swift
@@ -7,11 +7,39 @@ import SwiftUI
 struct PreferenceMeasurementSystemRow: View {
     @Environment(\.theme)
     private var theme
+    @Environment(\.dynamicTypeSize)
+    private var dynamicTypeSize
 
     @Binding var measurementSystem: String
     let currentSystem: MeasurementSystem
 
     var body: some View {
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(alignment: .leading, spacing: theme.spacing.sm) {
+                    measurementLabel
+                    measurementPicker
+                        .frame(maxWidth: .infinity)
+                }
+            } else {
+                HStack(spacing: theme.spacing.sm) {
+                    measurementLabel
+
+                    Spacer(minLength: theme.spacing.sm)
+
+                    measurementPicker
+                        .frame(maxWidth: 210)
+                }
+            }
+        }
+        .padding(.horizontal, theme.spacing.md)
+        .padding(.vertical, theme.spacing.sm)
+        .frame(minHeight: JovieTokens.minimumHitTarget)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("settings_units_row")
+    }
+
+    private var measurementLabel: some View {
         HStack(spacing: theme.spacing.sm) {
             Image(systemName: "globe")
                 .font(theme.typography.headlineSmall)
@@ -27,20 +55,17 @@ struct PreferenceMeasurementSystemRow: View {
                     .font(theme.typography.captionLarge)
                     .foregroundColor(theme.colors.textSecondary)
             }
-
-            Spacer(minLength: theme.spacing.sm)
-
-            Picker("Units", selection: $measurementSystem) {
-                Text("Metric").tag(MeasurementSystem.metric.rawValue)
-                Text("Imperial").tag(MeasurementSystem.imperial.rawValue)
-            }
-            .pickerStyle(.segmented)
-            .frame(maxWidth: 210)
         }
-        .padding(.horizontal, theme.spacing.md)
-        .padding(.vertical, theme.spacing.sm)
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("settings_units_row")
+        .layoutPriority(1)
+    }
+
+    private var measurementPicker: some View {
+        Picker("Units", selection: $measurementSystem) {
+            Text("Metric").tag(MeasurementSystem.metric.rawValue)
+            Text("Imperial").tag(MeasurementSystem.imperial.rawValue)
+        }
+        .pickerStyle(.segmented)
+        .frame(minHeight: JovieTokens.minimumHitTarget)
     }
 }
 
@@ -72,6 +97,7 @@ struct PreferenceStepGoalRow: View {
         }
         .padding(.horizontal, theme.spacing.md)
         .padding(.vertical, theme.spacing.sm)
+        .frame(minHeight: JovieTokens.minimumHitTarget)
         .accessibilityIdentifier("settings_step_goal_row")
     }
 }
@@ -122,7 +148,10 @@ struct PreferenceGoalRow: View {
                     Image(systemName: "arrow.counterclockwise.circle.fill")
                         .font(theme.typography.headlineSmall)
                         .foregroundColor(theme.colors.textSecondary)
-                        .frame(width: 36, height: 36)
+                        .frame(
+                            width: JovieTokens.minimumHitTarget,
+                            height: JovieTokens.minimumHitTarget
+                        )
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Reset \(goal.title)")
@@ -131,5 +160,6 @@ struct PreferenceGoalRow: View {
         }
         .padding(.horizontal, theme.spacing.md)
         .padding(.vertical, theme.spacing.sm)
+        .frame(minHeight: JovieTokens.minimumHitTarget)
     }
 }

--- a/apps/ios/LogYourBody/Views/PreferencesView+AccountSection.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView+AccountSection.swift
@@ -99,33 +99,12 @@ extension PreferencesView {
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            HStack(spacing: theme.spacing.sm) {
-                Image(systemName: icon)
-                    .font(theme.typography.headlineSmall)
-                    .foregroundColor(theme.colors.textSecondary)
-                    .frame(width: 30)
-
-                VStack(alignment: .leading, spacing: theme.spacing.xxs) {
-                    Text(title)
-                        .font(theme.typography.labelLarge)
-                        .foregroundColor(theme.colors.text)
-
-                    Text(value)
-                        .font(theme.typography.captionLarge)
-                        .foregroundColor(theme.colors.textSecondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-
-                Spacer()
-
-                Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundColor(theme.colors.textTertiary)
-            }
-            .padding(.horizontal, theme.spacing.md)
-            .padding(.vertical, theme.spacing.sm)
-            .background(Color.clear)
+            SettingsRow(
+                icon: icon,
+                title: title,
+                value: value,
+                showChevron: true
+            )
         }
         .buttonStyle(.plain)
     }

--- a/apps/ios/LogYourBody/Views/PreferencesView+Header.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView+Header.swift
@@ -5,6 +5,93 @@
 import SwiftUI
 
 extension PreferencesView {
+    var settingsLauncher: some View {
+        VStack(spacing: theme.spacing.sectionSpacing) {
+            heroHeader
+
+            SettingsSection(header: "Personal") {
+                VStack(spacing: 0) {
+                    SettingsNavigationLink(
+                        icon: "person.crop.circle",
+                        title: "Profile",
+                        subtitle: "Personal details and profile photo"
+                    ) {
+                        SettingsDetailScreen(title: "Profile") {
+                            VStack(spacing: theme.spacing.sectionSpacing) {
+                                accountSection
+                                profileSection
+                            }
+                        }
+                    }
+                    .accessibilityIdentifier("settings_profile_link")
+
+                    DSDivider().insetted(16)
+
+                    SettingsNavigationLink(
+                        icon: "target",
+                        title: "Tracking",
+                        subtitle: "Goals, units, and reminders"
+                    ) {
+                        SettingsDetailScreen(title: "Tracking") {
+                            VStack(spacing: theme.spacing.sectionSpacing) {
+                                trackingGoalsSection
+                                remindersSection
+                            }
+                        }
+                    }
+                    .accessibilityIdentifier("settings_tracking_link")
+
+                    DSDivider().insetted(16)
+
+                    integrationsLauncherRow
+                        .accessibilityIdentifier("settings_integrations_link")
+                }
+            }
+
+            SettingsSection(header: "Account & data") {
+                VStack(spacing: 0) {
+                    SettingsNavigationLink(
+                        icon: "person.badge.key",
+                        title: "Account & subscription",
+                        subtitle: accountSubscriptionSummary
+                    ) {
+                        SettingsDetailScreen(title: "Account & subscription") {
+                            VStack(spacing: theme.spacing.sectionSpacing) {
+                                subscriptionSection
+                                advancedSection
+                                securitySection
+                            }
+                        }
+                    }
+                    .accessibilityIdentifier("settings_account_subscription_link")
+
+                    DSDivider().insetted(16)
+
+                    SettingsNavigationLink(
+                        icon: "hand.raised",
+                        title: "Privacy & data",
+                        subtitle: "Photo handling and account deletion"
+                    ) {
+                        SettingsDetailScreen(title: "Privacy & data") {
+                            VStack(spacing: theme.spacing.sectionSpacing) {
+                                photosSection
+                                dangerSection
+                            }
+                        }
+                    }
+                    .accessibilityIdentifier("settings_privacy_data_link")
+                }
+            }
+        }
+    }
+
+    var accountSubscriptionSummary: String {
+        if let plan = subscriptionPlanDisplay {
+            return "\(subscriptionStatusText) · \(plan)"
+        }
+        return subscriptionStatusText
+    }
+
     var heroHeader: some View {
         VStack(spacing: theme.spacing.md) {
             HStack(alignment: .center, spacing: theme.spacing.md) {
@@ -132,6 +219,7 @@ extension PreferencesView {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
     }
 
     var avatarPlaceholder: some View {

--- a/apps/ios/LogYourBody/Views/PreferencesView+PhotosAdvancedSection.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView+PhotosAdvancedSection.swift
@@ -20,42 +20,17 @@ extension PreferencesView {
     }
 
     var advancedSection: some View {
-        SettingsSection(header: "Advanced") {
-            VStack(spacing: 12) {
-                Button {
-                    HapticManager.shared.selection()
-                    Task {
-                        let success = await subscriptionManager.restorePurchases()
-                        await MainActor.run {
-                            restoreAlertMessage = success
-                                ? "Your subscription has been restored"
-                                : (subscriptionManager.errorMessage ?? "No active subscription found")
-                            showingRestoreAlert = true
-                        }
-                    }
-                } label: {
-                    HStack {
-                        Image(systemName: "arrow.triangle.2.circlepath")
-                        Text("Restore purchases")
-                            .fontWeight(.semibold)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, theme.spacing.sm)
-                    .systemBGlassSurface(
-                        cornerRadius: theme.radius.input,
-                        tint: theme.colors.text,
-                        tintOpacity: 0.045,
-                        borderColor: theme.colors.border,
-                        borderOpacity: 0.75
-                    )
-                }
-                .accessibilityLabel("Restore purchases")
-                .accessibilityHint("Attempts to restore your active subscription.")
-                .accessibilityIdentifier("settings_restore_purchases_button")
+        SettingsSection(header: "Restore purchases") {
+            SettingsButtonRow(
+                icon: "arrow.triangle.2.circlepath",
+                title: isRestoringPurchases ? "Restoring purchases…" : "Restore purchases"
+            ) {
+                restorePurchases()
             }
-            .padding(.top, theme.spacing.xxs)
-            .padding(.bottom, theme.spacing.xs)
-            .padding(.horizontal, theme.spacing.md)
+            .disabled(isRestoringPurchases)
+            .accessibilityValue(isRestoringPurchases ? "In progress" : "")
+            .accessibilityHint("Attempts to restore your active subscription.")
+            .accessibilityIdentifier("settings_restore_purchases_button")
         }
     }
 
@@ -67,15 +42,13 @@ extension PreferencesView {
             NavigationLink {
                 DeleteAccountView()
             } label: {
-                Text("Delete account")
-                    .font(theme.typography.labelLarge)
-                    .foregroundColor(theme.colors.error)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, theme.spacing.md)
-                    .background(
-                        RoundedRectangle(cornerRadius: theme.radius.card)
-                            .fill(theme.colors.error.opacity(0.14))
-                    )
+                SettingsRow(
+                    icon: "trash",
+                    title: "Delete account",
+                    subtitle: "Permanently remove your account and data.",
+                    showChevron: true,
+                    tintColor: theme.colors.error
+                )
             }
             .accessibilityLabel("Delete account")
             .accessibilityHint("Permanently deletes your account and all data.")
@@ -85,7 +58,24 @@ extension PreferencesView {
                 }
             )
             .buttonStyle(.plain)
-            .padding(.horizontal, theme.spacing.md)
+        }
+    }
+
+    func restorePurchases() {
+        guard !isRestoringPurchases else { return }
+
+        isRestoringPurchases = true
+        HapticManager.shared.selection()
+
+        Task {
+            let success = await subscriptionManager.restorePurchases()
+            await MainActor.run {
+                isRestoringPurchases = false
+                restoreAlertMessage = success
+                    ? "Your subscription has been restored"
+                    : (subscriptionManager.errorMessage ?? "No active subscription found")
+                showingRestoreAlert = true
+            }
         }
     }
 }

--- a/apps/ios/LogYourBody/Views/PreferencesView+RemindersSection.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView+RemindersSection.swift
@@ -38,15 +38,13 @@ extension PreferencesView {
         }
     }
 
-    var integrationsSection: some View {
-        SettingsSection(header: "Integrations") {
-            SettingsNavigationLink(
-                icon: "square.stack.3d.up.fill",
-                title: "Integrations",
-                subtitle: "Connect Apple Health and other services."
-            ) {
-                IntegrationsView()
-            }
+    var integrationsLauncherRow: some View {
+        SettingsNavigationLink(
+            icon: "square.stack.3d.up.fill",
+            title: "Integrations",
+            subtitle: "Apple Health, imports, and export"
+        ) {
+            IntegrationsView()
         }
     }
 

--- a/apps/ios/LogYourBody/Views/PreferencesView+TrackingGoalsSection.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView+TrackingGoalsSection.swift
@@ -116,7 +116,8 @@ extension PreferencesView {
     }
 
     func resetToDefaults() {
-        customWeightGoal = nil
+        customWeightGoalKilograms = nil
+        legacyCustomWeightGoal = nil
         customBodyFatGoal = nil
         customFFMIGoal = nil
     }
@@ -124,9 +125,7 @@ extension PreferencesView {
     func goalValueText(for goal: PreferenceGoalKind) -> String {
         switch goal {
         case .weight:
-            return customWeightGoal.map {
-                "\(String(format: "%.1f", $0)) \(currentSystem.weightUnit)"
-            } ?? "Not set"
+            return currentWeightGoal?.displayText(in: currentSystem) ?? "Not set"
         case .bodyFat:
             guard let currentBodyFatGoal else { return "Not set" }
             let suffix = customBodyFatGoal == nil ? " (default)" : ""
@@ -141,7 +140,7 @@ extension PreferencesView {
     func isGoalCustom(_ goal: PreferenceGoalKind) -> Bool {
         switch goal {
         case .weight:
-            return customWeightGoal != nil
+            return currentWeightGoal != nil
         case .bodyFat:
             return customBodyFatGoal != nil
         case .ffmi:
@@ -152,7 +151,8 @@ extension PreferencesView {
     func resetGoal(_ goal: PreferenceGoalKind) {
         switch goal {
         case .weight:
-            customWeightGoal = nil
+            customWeightGoalKilograms = nil
+            legacyCustomWeightGoal = nil
         case .bodyFat:
             customBodyFatGoal = nil
         case .ffmi:
@@ -163,7 +163,9 @@ extension PreferencesView {
     func initialGoalEditorText(for goal: PreferenceGoalKind) -> String {
         switch goal {
         case .weight:
-            return customWeightGoal.map { String(format: "%.1f", $0) } ?? ""
+            return currentWeightGoal.map {
+                String(format: "%.1f", $0.displayValue(in: currentSystem))
+            } ?? ""
         case .bodyFat:
             if let customBodyFatGoal {
                 return String(format: "%.1f", customBodyFatGoal)
@@ -191,11 +193,32 @@ extension PreferencesView {
     func saveGoal(_ value: Double, for goal: PreferenceGoalKind) {
         switch goal {
         case .weight:
-            customWeightGoal = value
+            customWeightGoalKilograms = WeightGoal(
+                displayValue: value,
+                measurementSystem: currentSystem
+            )?.kilograms
+            legacyCustomWeightGoal = nil
         case .bodyFat:
             customBodyFatGoal = value
         case .ffmi:
             customFFMIGoal = value
         }
+    }
+
+    var currentWeightGoal: WeightGoal? {
+        WeightGoal(kilograms: customWeightGoalKilograms ?? -1)
+    }
+
+    func migrateLegacyWeightGoalIfNeeded() {
+        guard customWeightGoalKilograms == nil,
+              let migrated = WeightGoal.migrateLegacy(
+                legacyCustomWeightGoal,
+                measurementSystem: currentSystem
+              ) else {
+            return
+        }
+
+        customWeightGoalKilograms = migrated.kilograms
+        legacyCustomWeightGoal = nil
     }
 }

--- a/apps/ios/LogYourBody/Views/PreferencesView.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView.swift
@@ -16,7 +16,8 @@ struct PreferencesView: View {
     @AppStorage("healthKitSyncEnabled") var healthKitSyncEnabled = true
     @AppStorage(Constants.deletePhotosAfterImportKey) var deletePhotosAfterImport = false
     @AppStorage("stepGoal") var stepGoal = 10_000
-    @AppStorage(Constants.goalWeightKey) var customWeightGoal: Double?
+    @AppStorage(Constants.goalWeightKilogramsKey) var customWeightGoalKilograms: Double?
+    @AppStorage(Constants.goalWeightKey) var legacyCustomWeightGoal: Double?
     @AppStorage(Constants.goalBodyFatPercentageKey) var customBodyFatGoal: Double?
     @AppStorage(Constants.goalFFMIKey) var customFFMIGoal: Double?
 
@@ -24,6 +25,7 @@ struct PreferencesView: View {
     @ObservedObject var healthKitManager = HealthKitManager.shared
     @State var showingRestoreAlert = false
     @State var restoreAlertMessage = ""
+    @State var isRestoringPurchases = false
     @State var activeGoalEditor: PreferenceGoalKind?
     @State var isShowingProfileSettings = false
     @State var isUploadingPhoto = false
@@ -51,19 +53,7 @@ struct PreferencesView: View {
     var body: some View {
         ZStack(alignment: .top) {
             ScrollView {
-                VStack(spacing: theme.spacing.sectionSpacing) {
-                    heroHeader
-                    accountSection
-                    profileSection
-                    trackingGoalsSection
-                    remindersSection
-                    integrationsSection
-                    securitySection
-                    subscriptionSection
-                    photosSection
-                    advancedSection
-                    dangerSection
-                }
+                settingsLauncher
                 .padding(.horizontal, theme.spacing.screenPadding)
                 .padding(.vertical, theme.spacing.md)
                 .background(
@@ -110,6 +100,7 @@ struct PreferencesView: View {
             goalEditorSheet(for: goal)
         }
         .onAppear {
+            migrateLegacyWeightGoalIfNeeded()
             checkBiometricAvailability()
             updateCachedValues()
             dailyReminderDate = notificationManager.dailyWeighInReminderDate

--- a/apps/ios/LogYourBody/Views/ProfileSettingsViewV2.swift
+++ b/apps/ios/LogYourBody/Views/ProfileSettingsViewV2.swift
@@ -4,6 +4,7 @@
 //
 import SwiftUI
 import OSLog
+import UIKit
 
 struct ProfileSettingsViewV2: View {
     @EnvironmentObject var authManager: AuthManager
@@ -28,19 +29,18 @@ struct ProfileSettingsViewV2: View {
     @State private var hasChanges = false
     @State private var isSaving = false
     @State private var showingSaveSuccess = false
+    @State private var saveErrorMessage: String?
 
     var body: some View {
         ZStack {
             ScrollView {
                 VStack(spacing: theme.spacing.sectionSpacing) {
-                    profileHeader
-                        .padding(.top)
-
                     basicInformationCard
 
                     physicalInformationCard
                 }
                 .padding(.horizontal, theme.spacing.screenPadding)
+                .padding(.top, theme.spacing.md)
                 .padding(.bottom, 40)
             }
             .scrollBounceBehavior(.basedOnSize)
@@ -54,12 +54,15 @@ struct ProfileSettingsViewV2: View {
                     ProgressView()
                         .scaleEffect(0.8)
                         .tint(theme.colors.primary)
+                        .frame(minWidth: JovieTokens.minimumHitTarget, minHeight: JovieTokens.minimumHitTarget)
                 } else if hasChanges {
                     Button("Save") {
                         saveProfile()
                     }
                     .fontWeight(.medium)
                     .foregroundColor(theme.colors.primary)
+                    .jovieTouchTarget()
+                    .accessibilityHint("Saves your profile changes.")
                 }
             }
         }
@@ -85,6 +88,23 @@ struct ProfileSettingsViewV2: View {
                 message: "Profile updated"
             )
         )
+        .alert(
+            "Couldn’t save profile",
+            isPresented: Binding(
+                get: { saveErrorMessage != nil },
+                set: { if !$0 { saveErrorMessage = nil } }
+            )
+        ) {
+            Button("Try Again") {
+                saveErrorMessage = nil
+                saveProfile()
+            }
+            Button("Cancel", role: .cancel) {
+                saveErrorMessage = nil
+            }
+        } message: {
+            Text(saveErrorMessage ?? "Check your connection and try again.")
+        }
     }
 
     // MARK: - View Components
@@ -92,48 +112,20 @@ struct ProfileSettingsViewV2: View {
     private var basicInformationCard: some View {
         SettingsSection(header: "Basic Information") {
             VStack(spacing: 0) {
-                // First Name Field
-                settingsRow(
+                editableTextRow(
                     label: "First name",
-                    value: editableFirstName.isEmpty ? "Not set" : editableFirstName,
-                    showDisclosure: false
-                ) {
-                    AnyView(
-                        TextField("First name", text: $editableFirstName)
-                            .multilineTextAlignment(.trailing)
-                            .onChange(of: editableFirstName) { _, _ in
-                                hasChanges = true
-                                let first = editableFirstName.trimmingCharacters(in: .whitespaces)
-                                let last = editableLastName.trimmingCharacters(in: .whitespaces)
-                                editableName = [first, last]
-                                    .filter { !$0.isEmpty }
-                                    .joined(separator: " ")
-                            }
-                    )
-                }
+                    text: $editableFirstName,
+                    contentType: .givenName
+                )
 
                 Divider()
                     .padding(.leading, 16)
 
-                // Last Name Field
-                settingsRow(
+                editableTextRow(
                     label: "Last name",
-                    value: editableLastName.isEmpty ? "Not set" : editableLastName,
-                    showDisclosure: false
-                ) {
-                    AnyView(
-                        TextField("Last name", text: $editableLastName)
-                            .multilineTextAlignment(.trailing)
-                            .onChange(of: editableLastName) { _, _ in
-                                hasChanges = true
-                                let first = editableFirstName.trimmingCharacters(in: .whitespaces)
-                                let last = editableLastName.trimmingCharacters(in: .whitespaces)
-                                editableName = [first, last]
-                                    .filter { !$0.isEmpty }
-                                    .joined(separator: " ")
-                            }
-                    )
-                }
+                    text: $editableLastName,
+                    contentType: .familyName
+                )
 
                 Divider()
                     .padding(.leading, 16)
@@ -149,40 +141,43 @@ struct ProfileSettingsViewV2: View {
                 Divider()
                     .padding(.leading, 16)
 
-                // Gender Selector with modern segmented control
                 genderSelector
             }
         }
     }
 
     private var genderSelector: some View {
-        HStack {
-            Text("Biological sex")
-                .foregroundColor(theme.colors.text)
-                .font(theme.typography.labelLarge)
-
-            Spacer()
-
-            Picker("Biological Sex", selection: $editableGender) {
-                ForEach(BiologicalSex.allCases, id: \.self) { gender in
-                    Text(gender.description)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.9)
-                        .tag(gender)
-                }
+        Picker(selection: $editableGender) {
+            ForEach(BiologicalSex.allCases, id: \.self) { gender in
+                Text(gender.description).tag(gender)
             }
-            .pickerStyle(SegmentedPickerStyle())
-            .frame(width: 160)
-            .scaleEffect(0.95) // Slightly smaller for better fit
-            .onChange(of: editableGender) { _, _ in
-                hasChanges = true
+        } label: {
+            HStack(spacing: theme.spacing.xs) {
+                Text("Biological sex")
+                    .foregroundColor(theme.colors.text)
+                    .font(theme.typography.labelLarge)
+
+                Spacer(minLength: theme.spacing.sm)
+
+                Text(editableGender.description)
+                    .font(theme.typography.labelMedium)
+                    .foregroundColor(theme.colors.textSecondary)
+                    .lineLimit(1)
+
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(theme.typography.captionMedium.weight(.semibold))
+                    .foregroundColor(theme.colors.textTertiary)
             }
         }
+        .pickerStyle(.menu)
+        .tint(theme.colors.text)
         .padding(.horizontal, theme.spacing.md)
-        .padding(.vertical, theme.spacing.sm)
-        .accessibilityElement(children: .combine)
+        .frame(minHeight: JovieTokens.minimumHitTarget)
         .accessibilityLabel("Biological sex")
         .accessibilityValue(editableGender.description)
+        .onChange(of: editableGender) { _, _ in
+            hasChanges = true
+        }
     }
 
     private var physicalInformationCard: some View {
@@ -206,11 +201,11 @@ struct ProfileSettingsViewV2: View {
                                 .foregroundColor(theme.colors.textSecondary)
                         }
                         Image(systemName: "chevron.right")
-                            .font(.caption2.weight(.semibold))
+                            .font(theme.typography.captionMedium.weight(.semibold))
                             .foregroundColor(theme.colors.textTertiary)
                     }
                     .padding(.horizontal, theme.spacing.md)
-                    .padding(.vertical, theme.spacing.sm)
+                    .frame(minHeight: JovieTokens.minimumHitTarget)
                 }
                 .accessibilityLabel("Height")
                 .accessibilityValue(formattedHeight)
@@ -237,62 +232,15 @@ struct ProfileSettingsViewV2: View {
                                 .foregroundColor(theme.colors.textSecondary)
                         }
                         Image(systemName: "chevron.right")
-                            .font(.caption2.weight(.semibold))
+                            .font(theme.typography.captionMedium.weight(.semibold))
                             .foregroundColor(theme.colors.textTertiary)
                     }
                     .padding(.horizontal, theme.spacing.md)
-                    .padding(.vertical, theme.spacing.sm)
+                    .frame(minHeight: JovieTokens.minimumHitTarget)
                 }
                 .accessibilityLabel("Age")
                 .accessibilityValue(formattedAge)
                 .accessibilityHint("Double-tap to edit your date of birth.")
-            }
-        }
-    }
-
-    private var profileHeader: some View {
-        VStack(spacing: theme.spacing.md) {
-            ZStack {
-                if let avatarUrl = authManager.currentUser?.avatarUrl,
-                   !avatarUrl.isEmpty,
-                   let url = URL(string: avatarUrl) {
-                    AsyncImage(url: url) { image in
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .frame(width: 80, height: 80)
-                            .clipShape(Circle())
-                    } placeholder: {
-                        Circle()
-                            .fill(theme.colors.surfaceTertiary)
-                            .frame(width: 80, height: 80)
-                            .overlay(
-                                ProgressView()
-                                    .scaleEffect(0.8)
-                            )
-                    }
-                } else {
-                    Circle()
-                        .fill(theme.colors.surfaceTertiary)
-                        .frame(width: 80, height: 80)
-                        .overlay(
-                            Text(profileInitials)
-                                .font(theme.typography.displaySmall)
-                                .foregroundColor(theme.colors.textSecondary)
-                        )
-                }
-            }
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Profile photo")
-
-            VStack(spacing: theme.spacing.xxs) {
-                Text(authManager.currentUser?.displayName ?? authManager.currentUser?.name ?? "User")
-                    .font(theme.typography.headlineSmall)
-                    .foregroundColor(theme.colors.text)
-
-                Text(authManager.currentUser?.email ?? "")
-                    .font(theme.typography.captionLarge)
-                    .foregroundColor(theme.colors.textSecondary)
             }
         }
     }
@@ -302,8 +250,7 @@ struct ProfileSettingsViewV2: View {
         label: String,
         value: String,
         showDisclosure: Bool = true,
-        isDisabled: Bool = false,
-        customContent: (() -> AnyView)? = nil
+        isDisabled: Bool = false
     ) -> some View {
         HStack {
             Text(label)
@@ -312,43 +259,60 @@ struct ProfileSettingsViewV2: View {
 
             Spacer()
 
-            if let customContent = customContent {
-                customContent()
-            } else {
-                Text(value)
-                    .font(theme.typography.labelMedium)
-                    .foregroundColor(isDisabled ? theme.colors.textTertiary : theme.colors.textSecondary)
-            }
+            Text(value)
+                .font(theme.typography.labelMedium)
+                .foregroundColor(isDisabled ? theme.colors.textTertiary : theme.colors.textSecondary)
 
             if showDisclosure && !isDisabled {
                 Image(systemName: "chevron.right")
-                    .font(.caption2.weight(.semibold))
+                    .font(theme.typography.captionMedium.weight(.semibold))
                     .foregroundColor(theme.colors.textTertiary)
             }
         }
         .padding(.horizontal, theme.spacing.md)
-        .padding(.vertical, theme.spacing.sm)
+        .frame(minHeight: JovieTokens.minimumHitTarget)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(label)
         .accessibilityValue(value)
     }
 
-    // MARK: - Computed Properties
+    private func editableTextRow(
+        label: String,
+        text: Binding<String>,
+        contentType: UITextContentType
+    ) -> some View {
+        HStack(spacing: theme.spacing.md) {
+            Text(label)
+                .font(theme.typography.labelLarge)
+                .foregroundColor(theme.colors.text)
+                .accessibilityHidden(true)
 
-    private var profileInitials: String {
-        let name: String
-        if !editableName.isEmpty {
-            name = editableName
-        } else {
-            name = authManager.currentUser?.name ?? authManager.currentUser?.email ?? ""
+            TextField(label, text: text)
+                .textContentType(contentType)
+                .textInputAutocapitalization(.words)
+                .submitLabel(.done)
+                .font(theme.typography.labelMedium)
+                .foregroundColor(theme.colors.text)
+                .multilineTextAlignment(.trailing)
+                .accessibilityLabel(label)
+                .onChange(of: text.wrappedValue) { _, _ in
+                    hasChanges = true
+                    updateEditableName()
+                }
         }
-        let components = name.components(separatedBy: " ")
-        if components.count >= 2 {
-            return String(components[0].prefix(1) + components[1].prefix(1)).uppercased()
-        } else {
-            return String(name.prefix(2)).uppercased()
-        }
+        .padding(.horizontal, theme.spacing.md)
+        .frame(minHeight: JovieTokens.minimumHitTarget)
     }
+
+    private func updateEditableName() {
+        let first = editableFirstName.trimmingCharacters(in: .whitespaces)
+        let last = editableLastName.trimmingCharacters(in: .whitespaces)
+        editableName = [first, last]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    // MARK: - Computed Properties
 
     private var formattedHeight: String {
         if useMetricHeight {
@@ -460,7 +424,7 @@ struct ProfileSettingsViewV2: View {
                 await MainActor.run {
                     isSaving = false
                     hasChanges = true
-                    // print("Failed to update profile: \(error)")
+                    saveErrorMessage = "Your changes are still here. Check your connection and try again."
                 }
 
                 let elapsed = Date().timeIntervalSince(start)
@@ -487,6 +451,8 @@ struct ProfileHeightPickerSheet: View {
                 heightDisplay
                 heightPicker
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .settingsBackground()
             .navigationTitle("Set Height")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -494,6 +460,7 @@ struct ProfileHeightPickerSheet: View {
                     Button("Cancel") {
                         dismiss()
                     }
+                    .jovieTouchTarget()
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Done") {
@@ -501,6 +468,7 @@ struct ProfileHeightPickerSheet: View {
                         dismiss()
                     }
                     .fontWeight(.medium)
+                    .jovieTouchTarget()
                 }
             }
         }
@@ -511,8 +479,11 @@ struct ProfileHeightPickerSheet: View {
             Text("Imperial (ft/in)").tag(false)
             Text("Metric (cm)").tag(true)
         }
-        .pickerStyle(SegmentedPickerStyle())
-        .padding()
+        .pickerStyle(.menu)
+        .tint(theme.colors.text)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, theme.spacing.md)
+        .frame(minHeight: JovieTokens.minimumHitTarget)
     }
 
     private var heightDisplay: some View {
@@ -572,7 +543,7 @@ struct ProfileHeightPickerSheet: View {
                 }
             }
             .pickerStyle(WheelPickerStyle())
-            .frame(width: 100)
+            .frame(maxWidth: .infinity)
 
             Picker("Inches", selection: inchesBinding) {
                 ForEach(0...11, id: \.self) { inches in
@@ -580,7 +551,7 @@ struct ProfileHeightPickerSheet: View {
                 }
             }
             .pickerStyle(WheelPickerStyle())
-            .frame(width: 100)
+            .frame(maxWidth: .infinity)
         }
     }
 
@@ -614,12 +585,15 @@ struct DatePickerSheet: View {
     @Binding var hasChanges: Bool
     @Environment(\.dismiss)
     var dismiss
+    @Environment(\.theme)
+    private var theme
     var body: some View {
         NavigationStack {
-            VStack {
+            VStack(spacing: theme.spacing.md) {
                 DatePicker(
                     "",
                     selection: $date,
+                    in: ...Date(),
                     displayedComponents: .date
                 )
                 .datePickerStyle(WheelDatePickerStyle())
@@ -627,6 +601,8 @@ struct DatePickerSheet: View {
 
                 Spacer()
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .settingsBackground()
             .navigationTitle("Date of Birth")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -634,6 +610,7 @@ struct DatePickerSheet: View {
                     Button("Cancel") {
                         dismiss()
                     }
+                    .jovieTouchTarget()
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Done") {
@@ -641,6 +618,7 @@ struct DatePickerSheet: View {
                         dismiss()
                     }
                     .fontWeight(.medium)
+                    .jovieTouchTarget()
                 }
             }
         }

--- a/apps/ios/LogYourBody/Views/ProgressPhotoAttachSheet.swift
+++ b/apps/ios/LogYourBody/Views/ProgressPhotoAttachSheet.swift
@@ -75,6 +75,8 @@ struct ProgressPhotoAttachPolicy {
 struct ProgressPhotoAttachSheet: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var authManager: AuthManager
+    @Environment(\.theme) private var theme
+    @Environment(\.openURL) private var openURL
     @ObservedObject private var uploadManager = PhotoUploadManager.shared
     private let photoLibrary: PhotoLibraryManaging = LivePhotoLibraryAdapter.shared
     private let cameraAuthorizer: CameraAuthorizing = LiveCameraAuthorizationAdapter.shared
@@ -88,6 +90,7 @@ struct ProgressPhotoAttachSheet: View {
     @State private var attachStatus: ProgressPhotoAttachStatus = .empty
     @State private var isCameraPresented = false
     @State private var photoSelectionLoadID = UUID()
+    @AccessibilityFocusState private var isStatusFocused: Bool
 
     private var targetDate: Date {
         targetMetric?.date ?? selectedImageDate ?? fallbackDate
@@ -116,19 +119,27 @@ struct ProgressPhotoAttachSheet: View {
 
     var body: some View {
         NavigationStack {
-            ZStack {
-                Color.metricCanvas.ignoresSafeArea()
+            GeometryReader { geometry in
+                ZStack {
+                    Color.jovieCanvas.ignoresSafeArea()
 
-                ScrollView(showsIndicators: false) {
-                    VStack(alignment: .leading, spacing: 18) {
-                        header
-                        previewPane
-                        statusPane
-                        actionPane
-                        attachButton
+                    ScrollView(showsIndicators: false) {
+                        VStack(alignment: .leading, spacing: JovieTokens.itemGap) {
+                            header
+                            previewPane(height: previewHeight(for: geometry.size.height))
+                            statusPane
+                            actionPane
+                        }
+                        .padding(.horizontal, JovieTokens.screenInset)
+                        .padding(.top, JovieTokens.itemGap)
+                        .padding(.bottom, JovieTokens.itemGap)
                     }
-                    .padding(20)
-                    .padding(.bottom, 18)
+                }
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    attachButton
+                        .padding(.horizontal, JovieTokens.screenInset)
+                        .padding(.vertical, JovieTokens.itemGap)
+                        .background(Color.jovieCanvas.opacity(0.96))
                 }
             }
             .navigationTitle("Progress Photo")
@@ -140,14 +151,6 @@ struct ProgressPhotoAttachSheet: View {
                     }
                     .disabled(isBusy)
                 }
-
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    if isSuccess {
-                        Button("Done") {
-                            dismiss()
-                        }
-                    }
-                }
             }
             .sheet(isPresented: $isCameraPresented) {
                 CameraView { image in
@@ -157,15 +160,18 @@ struct ProgressPhotoAttachSheet: View {
             .onAppear {
                 updateInitialPermissionState()
             }
+            .onChange(of: attachStatus) { status in
+                announceStatusChange(status)
+            }
         }
         .accessibilityIdentifier("progress_photo_attach_sheet")
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 4) {
             Text(ProgressPhotoAttachPolicy.title(targetHasPhoto: PhotoTimelineHUDPolicy.hasUsablePhoto(targetMetric)))
-                .font(.system(size: 26, weight: .bold))
-                .foregroundColor(.white)
+                .font(theme.typography.displaySmall)
+                .foregroundColor(theme.colors.text)
 
             Text(
                 ProgressPhotoAttachPolicy.targetCopy(
@@ -173,38 +179,38 @@ struct ProgressPhotoAttachSheet: View {
                     targetDate: targetDate
                 )
             )
-            .font(.system(size: 14, weight: .medium))
-            .foregroundColor(Color.metricTextSecondary)
+            .font(theme.typography.bodySmall)
+            .foregroundColor(theme.colors.textSecondary)
         }
     }
 
-    private var previewPane: some View {
+    private func previewPane(height: CGFloat) -> some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 24)
-                .fill(Color.white.opacity(0.065))
-                .frame(height: 360)
+            RoundedRectangle(cornerRadius: JovieTokens.cardRadius, style: .continuous)
+                .fill(theme.colors.surface)
+                .frame(height: height)
 
             if let selectedImage {
                 Image(uiImage: selectedImage)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(maxWidth: .infinity)
-                    .frame(height: 360)
-                    .clipShape(RoundedRectangle(cornerRadius: 24))
+                    .frame(height: height)
+                    .clipShape(RoundedRectangle(cornerRadius: JovieTokens.cardRadius, style: .continuous))
                     .overlay(
-                        RoundedRectangle(cornerRadius: 24)
-                            .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                        RoundedRectangle(cornerRadius: JovieTokens.cardRadius, style: .continuous)
+                            .stroke(theme.colors.border, lineWidth: 1)
                     )
                     .accessibilityLabel("Selected progress photo preview")
             } else {
-                VStack(spacing: 14) {
+                VStack(spacing: 8) {
                     Image(systemName: "photo.on.rectangle.angled")
-                        .font(.system(size: 42, weight: .semibold))
-                        .foregroundColor(Color.white.opacity(0.48))
+                        .font(.system(.title, design: .rounded).weight(.semibold))
+                        .foregroundColor(theme.colors.textSecondary)
 
                     Text("No photo selected")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(Color.metricTextSecondary)
+                        .font(theme.typography.labelLarge)
+                        .foregroundColor(theme.colors.textSecondary)
                 }
                 .accessibilityLabel("No photo selected")
             }
@@ -217,18 +223,18 @@ struct ProgressPhotoAttachSheet: View {
     }
 
     private var processingOverlay: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 8) {
             ProgressView(value: uploadManager.uploadProgress > 0 ? uploadManager.uploadProgress : nil)
-                .tint(.white)
+                .tint(theme.colors.text)
                 .frame(width: 120)
 
             Text(uploadProgressText)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(.white)
+                .font(theme.typography.labelSmall)
+                .foregroundColor(theme.colors.text)
         }
-        .padding(18)
+        .padding(theme.spacing.md)
         .background(
-            RoundedRectangle(cornerRadius: 18)
+            RoundedRectangle(cornerRadius: theme.radius.input, style: .continuous)
                 .fill(Color.black.opacity(0.58))
         )
         .accessibilityIdentifier("progress_photo_attach_processing")
@@ -244,33 +250,46 @@ struct ProgressPhotoAttachSheet: View {
     private var statusPane: some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: statusIcon)
-                .font(.system(size: 16, weight: .semibold))
+                .font(.system(.headline, design: .rounded).weight(.semibold))
                 .foregroundColor(statusColor)
-                .frame(width: 30, height: 30)
+                .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
                 .background(Circle().fill(statusColor.opacity(0.12)))
 
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(ProgressPhotoAttachPolicy.statusTitle(for: attachStatus))
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white)
+                    .font(theme.typography.labelLarge)
+                    .foregroundColor(theme.colors.text)
 
                 Text(ProgressPhotoAttachPolicy.statusMessage(for: attachStatus))
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(Color.metricTextSecondary)
+                    .font(theme.typography.bodySmall)
+                    .foregroundColor(theme.colors.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                if case .permissionDenied = attachStatus {
+                    Button("Open Settings") {
+                        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                        openURL(url)
+                    }
+                    .font(theme.typography.labelMedium)
+                    .foregroundColor(theme.colors.text)
+                    .jovieTouchTarget()
+                    .accessibilityHint("Opens iPhone Settings to allow camera or photo access")
+                }
             }
 
             Spacer(minLength: 0)
         }
-        .padding(14)
+        .padding(theme.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: 18)
-                .fill(Color.white.opacity(0.06))
+            RoundedRectangle(cornerRadius: theme.radius.input, style: .continuous)
+                .fill(theme.colors.surface)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 18)
-                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            RoundedRectangle(cornerRadius: theme.radius.input, style: .continuous)
+                .stroke(theme.colors.border, lineWidth: 1)
         )
+        .accessibilityElement(children: .contain)
+        .accessibilityFocused($isStatusFocused)
         .accessibilityIdentifier("progress_photo_attach_status")
     }
 
@@ -294,15 +313,15 @@ struct ProgressPhotoAttachSheet: View {
     private var statusColor: Color {
         switch attachStatus {
         case .empty:
-            return Color.metricTextTertiary
+            return theme.colors.textSecondary
         case .ready:
-            return Color.metricAccent
+            return theme.colors.info
         case .permissionDenied, .failed:
-            return Color.metricAccentBodyFat
+            return theme.colors.error
         case .processing:
-            return Color.metricAccentFFMI
+            return theme.colors.info
         case .success:
-            return Color.metricAccentSteps
+            return theme.colors.success
         }
     }
 
@@ -338,8 +357,8 @@ struct ProgressPhotoAttachSheet: View {
 
             if !cameraAuthorizer.isCameraAvailable {
                 Text("Camera capture is unavailable in Simulator. Choose from Library for simulator validation.")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(Color.metricTextTertiary)
+                    .font(theme.typography.captionLarge)
+                    .foregroundColor(theme.colors.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -371,32 +390,38 @@ struct ProgressPhotoAttachSheet: View {
     private func actionRow(title: String, subtitle: String, icon: String) -> some View {
         HStack(spacing: 12) {
             Image(systemName: icon)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(Color.metricAccent)
-                .frame(width: 32, height: 32)
-                .background(Circle().fill(Color.white.opacity(0.08)))
+                .font(.system(.body, design: .rounded).weight(.semibold))
+                .foregroundColor(theme.colors.info)
+                .frame(width: JovieTokens.minimumHitTarget, height: JovieTokens.minimumHitTarget)
+                .background(Circle().fill(theme.colors.info.opacity(0.12)))
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white)
+                    .font(theme.typography.labelLarge)
+                    .foregroundColor(theme.colors.text)
 
                 Text(subtitle)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(Color.metricTextSecondary)
+                    .font(theme.typography.bodySmall)
+                    .foregroundColor(theme.colors.textSecondary)
+                    .lineLimit(2)
             }
 
             Spacer()
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(Color.metricTextTertiary)
+                .font(.system(.footnote, design: .default).weight(.semibold))
+                .foregroundColor(theme.colors.textSecondary)
         }
-        .padding(14)
+        .padding(.horizontal, theme.spacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: 18)
-                .fill(Color.white.opacity(0.06))
+            RoundedRectangle(cornerRadius: theme.radius.input, style: .continuous)
+                .fill(theme.colors.surface)
         )
+        .overlay(
+            RoundedRectangle(cornerRadius: theme.radius.input, style: .continuous)
+                .stroke(theme.colors.border, lineWidth: 1)
+        )
+        .jovieTouchTarget()
     }
 
     private var attachButton: some View {
@@ -410,22 +435,34 @@ struct ProgressPhotoAttachSheet: View {
                     ProgressView()
                         .tint(.black)
                 } else if isSuccess {
-                    Label("Done", systemImage: "checkmark")
+                    Label("Close", systemImage: "checkmark")
                 } else {
                     Label("Attach Photo", systemImage: "paperclip")
                 }
 
                 Spacer()
             }
-            .font(.system(size: 15, weight: .semibold))
-            .frame(height: 48)
-            .background(canAttach || isSuccess ? Color.white : Color.white.opacity(0.18))
-            .foregroundColor(canAttach || isSuccess ? .black : Color.white.opacity(0.42))
+            .font(theme.typography.labelLarge)
+            .frame(minHeight: JovieTokens.controlHeight)
+            .background(canAttach || isSuccess ? theme.colors.interactive : theme.colors.interactiveDisabled)
+            .foregroundColor(canAttach || isSuccess ? Color.jovieActionText : theme.colors.textSecondary)
             .clipShape(Capsule())
         }
         .buttonStyle(.plain)
         .disabled((!canAttach && !isSuccess) || isBusy)
+        .accessibilityLabel(isSuccess ? "Close progress photo" : "Attach progress photo")
+        .accessibilityHint(canAttach ? "Attaches the selected photo to this timeline point" : "Choose a photo before attaching")
         .accessibilityIdentifier("progress_photo_attach_submit_button")
+    }
+
+    private func previewHeight(for availableHeight: CGFloat) -> CGFloat {
+        min(260, max(184, availableHeight * 0.30))
+    }
+
+    private func announceStatusChange(_ status: ProgressPhotoAttachStatus) {
+        let message = "\(ProgressPhotoAttachPolicy.statusTitle(for: status)). \(ProgressPhotoAttachPolicy.statusMessage(for: status))"
+        UIAccessibility.post(notification: .announcement, argument: message)
+        isStatusFocused = true
     }
 
     private func updateInitialPermissionState() {

--- a/apps/ios/LogYourBodyTests/BodyCompositionMathGoldenTests.swift
+++ b/apps/ios/LogYourBodyTests/BodyCompositionMathGoldenTests.swift
@@ -82,6 +82,35 @@ final class BodyCompositionMathGoldenTests: XCTestCase {
         }
     }
 
+    func testWeightGoalStoresKilogramsAndPresentsOncePerSelectedUnit() throws {
+        let goal = try XCTUnwrap(WeightGoal(displayValue: 180, measurementSystem: .imperial))
+
+        XCTAssertEqual(goal.kilograms, UnitConversion.lbsToKg(180), accuracy: 0.0001)
+        XCTAssertEqual(goal.displayValue(in: .imperial), 180, accuracy: 0.0001)
+        XCTAssertEqual(goal.displayValue(in: .metric), UnitConversion.lbsToKg(180), accuracy: 0.0001)
+        XCTAssertEqual(goal.displayText(in: .imperial), "180.0 lbs")
+
+        let migrated = try XCTUnwrap(WeightGoal.migrateLegacy(180, measurementSystem: .imperial))
+        XCTAssertEqual(migrated, goal)
+    }
+
+    func testInterpolatedFFMIUsesTheCanonicalNormalizedFormula() throws {
+        let date = date(daysAfterStart: 0)
+        let metrics = [makeMetric(date: date, weight: 80, bodyFatPercentage: 10)]
+        let result = try XCTUnwrap(
+            MetricsInterpolationService.shared.estimateFFMI(
+                for: date,
+                metrics: metrics,
+                heightInches: 70
+            )
+        )
+        let expected = try XCTUnwrap(
+            UnitConversion.calculateFFMI(weightKg: 80, bodyFatPercentage: 10, heightCm: 177.8)
+        )
+
+        XCTAssertEqual(result.value, (expected * 10).rounded() / 10, accuracy: 0.001)
+    }
+
     func testWeightSanityRangeMatchesLaunchValidationBounds() {
         XCTAssertFalse(UnitConversion.isValidWeight(31.9))
         XCTAssertTrue(UnitConversion.isValidWeight(32))
@@ -144,14 +173,14 @@ final class BodyCompositionMathGoldenTests: XCTestCase {
         return try XCTUnwrap(MetricsInterpolationService.shared.makeWeightInterpolationContext(for: metrics))
     }
 
-    private func makeMetric(date: Date, weight: Double) -> BodyMetrics {
+    private func makeMetric(date: Date, weight: Double, bodyFatPercentage: Double? = nil) -> BodyMetrics {
         BodyMetrics(
             id: UUID().uuidString,
             userId: "body-comp-golden-tests",
             date: date,
             weight: weight,
             weightUnit: "kg",
-            bodyFatPercentage: nil,
+            bodyFatPercentage: bodyFatPercentage,
             bodyFatMethod: nil,
             muscleMass: nil,
             boneMass: nil,

--- a/apps/ios/LogYourBodyTests/BodyScoreShareCardTests.swift
+++ b/apps/ios/LogYourBodyTests/BodyScoreShareCardTests.swift
@@ -102,7 +102,8 @@ final class BodyScoreShareCardTests: XCTestCase {
 
         XCTAssertEqual(payload.avatarMatch.assetName, "avatar_male_15")
         XCTAssertEqual(payload.avatarMatch.badgeText, "Male 15% body fat")
-        XCTAssertEqual(payload.visualBadgeText, "Male 15% body fat")
+        XCTAssertEqual(payload.visualBadgeText(includeVisual: true), "Male 15% body fat")
+        XCTAssertEqual(payload.visualBadgeText(includeVisual: false), "Private summary")
         XCTAssertNil(payload.photoImage)
     }
 
@@ -113,8 +114,22 @@ final class BodyScoreShareCardTests: XCTestCase {
             photoImage: makeShareTestImage()
         )
 
-        XCTAssertEqual(payload.visualBadgeText, "Progress photo")
+        XCTAssertEqual(payload.visualBadgeText(includeVisual: true), "Progress photo")
         XCTAssertNotNil(payload.photoImage)
+    }
+
+    func testShareOptionsStartPrivateAndDescribeOnlyChosenDetails() {
+        var options = BodyScoreShareOptions()
+
+        XCTAssertFalse(options.hasMetrics)
+        XCTAssertFalse(options.includeVisual)
+        XCTAssertEqual(options.includedSummary, "Body Score")
+
+        options.includeWeight = true
+        options.includeVisual = true
+
+        XCTAssertTrue(options.hasMetrics)
+        XCTAssertEqual(options.includedSummary, "Body Score, weight, visual")
     }
 
     func testShareCardRendersRequestedExportSize() throws {

--- a/apps/ios/LogYourBodyTests/Glp1CardAndCatalogTests.swift
+++ b/apps/ios/LogYourBodyTests/Glp1CardAndCatalogTests.swift
@@ -110,18 +110,180 @@ final class Glp1CardAndCatalogTests: XCTestCase {
         }
     }
 
+    // MARK: - Glp1DoseDraftResolver
+
+    func testDoseDraftUsesLatestCompatibleDoseForMedicationID() {
+        let medication = makeMedication(
+            id: "zepbound-current",
+            brand: "Zepbound",
+            genericName: "tirzepatide",
+            doseUnit: "mg/week"
+        )
+        let draft = Glp1DoseDraftResolver.resolve(
+            for: medication,
+            doseLogs: [
+                makeDoseLog(
+                    id: "older",
+                    takenAt: base,
+                    doseAmount: 2.5,
+                    medicationID: medication.id,
+                    brand: "Zepbound"
+                ),
+                makeDoseLog(
+                    id: "latest",
+                    takenAt: base.addingTimeInterval(86_400),
+                    doseAmount: 5,
+                    medicationID: medication.id,
+                    brand: "Zepbound"
+                )
+            ]
+        )
+
+        XCTAssertEqual(draft.source, .latestLog)
+        XCTAssertEqual(draft.doseText, "5")
+        XCTAssertEqual(draft.doseUnit, "mg/week")
+        XCTAssertEqual(draft.selectedDoseIndex, 1)
+        XCTAssertFalse(draft.usesCustomDose)
+        XCTAssertEqual(draft.lastLoggedDoseText, "5 mg/week")
+    }
+
+    func testDoseDraftUsesCustomValueForDoseOutsideCatalog() {
+        let medication = makeMedication(
+            id: "zepbound-current",
+            brand: "Zepbound",
+            genericName: "tirzepatide",
+            doseUnit: "mg/week"
+        )
+        let draft = Glp1DoseDraftResolver.resolve(
+            for: medication,
+            doseLogs: [
+                makeDoseLog(
+                    id: "custom",
+                    takenAt: base,
+                    doseAmount: 6.25,
+                    medicationID: medication.id,
+                    brand: "Zepbound"
+                )
+            ]
+        )
+
+        XCTAssertEqual(draft.doseText, "6.25")
+        XCTAssertNil(draft.selectedDoseIndex)
+        XCTAssertTrue(draft.usesCustomDose)
+        XCTAssertEqual(draft.lastLoggedDoseText, "6.25 mg/week")
+    }
+
+    func testDoseDraftPrefersMedicationIDOverNewerBrandFallback() {
+        let medication = makeMedication(
+            id: "zepbound-current",
+            brand: "Zepbound",
+            genericName: "tirzepatide",
+            doseUnit: "mg/week"
+        )
+        let draft = Glp1DoseDraftResolver.resolve(
+            for: medication,
+            doseLogs: [
+                makeDoseLog(
+                    id: "current-medication",
+                    takenAt: base,
+                    doseAmount: 5,
+                    medicationID: medication.id,
+                    brand: "Zepbound"
+                ),
+                makeDoseLog(
+                    id: "legacy-medication",
+                    takenAt: base.addingTimeInterval(86_400),
+                    doseAmount: 7.5,
+                    medicationID: "previous-zepbound-record",
+                    brand: "Zepbound"
+                ),
+                makeDoseLog(
+                    id: "different-medication",
+                    takenAt: base.addingTimeInterval(172_800),
+                    doseAmount: 2.4,
+                    medicationID: "wegovy",
+                    brand: "Wegovy"
+                )
+            ]
+        )
+
+        XCTAssertEqual(draft.doseText, "5")
+        XCTAssertEqual(draft.selectedDoseIndex, 1)
+        XCTAssertEqual(draft.lastLoggedDoseText, "5 mg/week")
+    }
+
+    func testDoseDraftFallsBackToMatchingBrandWhenMedicationIDChanged() {
+        let medication = makeMedication(
+            id: "zepbound-current",
+            brand: "Zepbound",
+            genericName: "tirzepatide",
+            doseUnit: "mg/week"
+        )
+        let draft = Glp1DoseDraftResolver.resolve(
+            for: medication,
+            doseLogs: [
+                makeDoseLog(
+                    id: "legacy-zepbound",
+                    takenAt: base,
+                    doseAmount: 7.5,
+                    medicationID: nil,
+                    brand: "Zepbound"
+                )
+            ]
+        )
+
+        XCTAssertEqual(draft.source, .latestLog)
+        XCTAssertEqual(draft.doseText, "7.5")
+        XCTAssertEqual(draft.selectedDoseIndex, 2)
+        XCTAssertFalse(draft.usesCustomDose)
+    }
+
+    func testDoseDraftUsesFirstCatalogDoseWhenThereIsNoCompatibleHistory() {
+        let medication = makeMedication(
+            id: "zepbound-current",
+            brand: "Zepbound",
+            genericName: "tirzepatide",
+            doseUnit: "mg/week"
+        )
+        let draft = Glp1DoseDraftResolver.resolve(
+            for: medication,
+            doseLogs: [
+                makeDoseLog(
+                    id: "other-medication",
+                    takenAt: base,
+                    doseAmount: 2.4,
+                    medicationID: "wegovy",
+                    brand: "Wegovy"
+                )
+            ]
+        )
+
+        XCTAssertEqual(draft.source, .catalogDefault)
+        XCTAssertEqual(draft.doseText, "2.5")
+        XCTAssertEqual(draft.selectedDoseIndex, 0)
+        XCTAssertFalse(draft.usesCustomDose)
+        XCTAssertNil(draft.lastLoggedDoseText)
+    }
+
     // MARK: - Fixtures
 
-    private func makeDoseLog(id: String, takenAt: Date, doseAmount: Double?, unit: String? = "mg/week") -> Glp1DoseLog {
+    private func makeDoseLog(
+        id: String,
+        takenAt: Date,
+        doseAmount: Double?,
+        unit: String? = "mg/week",
+        medicationID: String? = "med",
+        brand: String? = "Ozempic"
+    ) -> Glp1DoseLog {
         Glp1DoseLog(
             id: id,
             userId: "glp1-card-user",
             takenAt: takenAt,
-            medicationId: "med",
+            medicationId: medicationID,
             doseAmount: doseAmount,
             doseUnit: unit,
             drugClass: "GLP-1 receptor agonist",
-            brand: "Ozempic",
+            brand: brand,
             isCompounded: false,
             supplierType: nil,
             supplierName: nil,
@@ -131,9 +293,14 @@ final class Glp1CardAndCatalogTests: XCTestCase {
         )
     }
 
-    private func makeMedication(brand: String?, genericName: String?, doseUnit: String?) -> Glp1Medication {
+    private func makeMedication(
+        id: String = "med",
+        brand: String?,
+        genericName: String?,
+        doseUnit: String?
+    ) -> Glp1Medication {
         Glp1Medication(
-            id: "med",
+            id: id,
             userId: "glp1-card-user",
             displayName: brand ?? "Custom",
             genericName: genericName,

--- a/apps/ios/LogYourBodyTests/MetricChartDataPointPresenceTests.swift
+++ b/apps/ios/LogYourBodyTests/MetricChartDataPointPresenceTests.swift
@@ -41,4 +41,27 @@ final class MetricChartDataPointPresenceTests: XCTestCase {
         XCTAssertFalse(measuredPoint.isEstimated)
         XCTAssertTrue(MetricPresence.allCases.contains(.missing))
     }
+
+    func testChartLayoutPolicyLimitsXAxisLabelsForCompactAndAccessibilityLayouts() {
+        XCTAssertEqual(
+            MetricChartLayoutPolicy.xAxisTickCount(for: .week1, isAccessibilitySize: false),
+            4
+        )
+        XCTAssertEqual(
+            MetricChartLayoutPolicy.xAxisTickCount(for: .month6, isAccessibilitySize: false),
+            4
+        )
+        XCTAssertEqual(
+            MetricChartLayoutPolicy.xAxisTickCount(for: .year1, isAccessibilitySize: false),
+            3
+        )
+
+        for range in TimeRange.allCases {
+            XCTAssertEqual(
+                MetricChartLayoutPolicy.xAxisTickCount(for: range, isAccessibilitySize: true),
+                3,
+                "\(range.rawValue) should retain room for readable accessibility labels"
+            )
+        }
+    }
 }

--- a/apps/ios/LogYourBodyTests/OnboardingFlowViewModelTests.swift
+++ b/apps/ios/LogYourBodyTests/OnboardingFlowViewModelTests.swift
@@ -500,6 +500,22 @@ final class OnboardingFlowViewModelTests: XCTestCase {
         XCTAssertNil(disabledViewModel.progress(for: .firstPhoto))
     }
 
+    func testProgressUsesStableMilestonesAcrossConditionalMeasurementBranches() throws {
+        let viewModel = OnboardingFlowViewModel(includesFirstPhotoStep: true)
+
+        let health = try XCTUnwrap(viewModel.progress(for: .healthConnect))
+        let manualWeight = try XCTUnwrap(viewModel.progress(for: .manualWeight))
+        let visualBodyFat = try XCTUnwrap(viewModel.progress(for: .bodyFatVisual))
+        let finalPhoto = try XCTUnwrap(viewModel.progress(for: .firstPhoto))
+
+        XCTAssertEqual(health.label, "Measurements")
+        XCTAssertEqual(health.currentIndex, manualWeight.currentIndex)
+        XCTAssertEqual(manualWeight.currentIndex, visualBodyFat.currentIndex)
+        XCTAssertEqual(health.totalCount, finalPhoto.totalCount)
+        XCTAssertEqual(finalPhoto.currentIndex, finalPhoto.totalCount)
+        XCTAssertEqual(finalPhoto.fractionComplete, 1)
+    }
+
     func testBuildOnboardingProfileUpdatesIncludesGenderDobAndHeight() {
         let viewModel = OnboardingFlowViewModel()
         viewModel.updateSex(.female)

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -18,14 +18,13 @@ final class LogYourBodyUITests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testSignedOutPhoneOTPIsTheOnlyAuthAction() throws {
+    func testSignedOutAppleIsTheOnlyAuthAction() throws {
         let app = XCUIApplication()
         app.launchArguments = ["-lybUITestSignedOutFixture"]
         app.launch()
 
         XCTAssertTrue(app.staticTexts["LogYourBody"].waitForExistence(timeout: 8))
-        XCTAssertTrue(app.buttons["continueWithPhoneButton"].exists)
-        XCTAssertFalse(app.buttons["Continue with Apple"].exists)
+        XCTAssertTrue(app.buttons["continueWithAppleButton"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["login_email_field"].exists)
     }
 
@@ -87,11 +86,16 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(
             app.descendants(matching: .any)["paywall_plans_unavailable_state"].waitForExistence(timeout: 8)
         )
-        XCTAssertTrue(app.staticTexts["$79.99"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.staticTexts["$79.99"].exists, "Unavailable offerings must not show a stale price")
 
-        let supportButton = app.buttons["Contact Support"]
+        let supportButton = app.buttons["paywall_contact_support_button"]
         XCTAssertTrue(supportButton.waitForExistence(timeout: 3))
         XCTAssertTrue(supportButton.isHittable)
+        XCTAssertEqual(supportButton.label, "Contact support")
+
+        let retryButton = app.buttons["paywall_retry_offerings_button"]
+        XCTAssertTrue(retryButton.waitForExistence(timeout: 3))
+        XCTAssertTrue(retryButton.isHittable)
 
         let restoreButton = app.buttons["paywall_restore_purchases_button"]
         XCTAssertTrue(restoreButton.waitForExistence(timeout: 3))
@@ -134,9 +138,23 @@ final class LogYourBodyUITests: XCTestCase {
 
         try openSettings(in: app)
 
+        let profileLink = app.descendants(matching: .any)["settings_profile_link"]
+        XCTAssertTrue(profileLink.waitForExistence(timeout: 5))
+        XCTAssertTrue(profileLink.isHittable)
+        profileLink.tap()
+
         let logoutButton = app.descendants(matching: .any)["settings_logout_button"]
         XCTAssertTrue(logoutButton.waitForExistence(timeout: 5))
         XCTAssertTrue(logoutButton.isHittable)
+
+        let settingsBackButton = app.navigationBars.buttons["Settings"]
+        XCTAssertTrue(settingsBackButton.waitForExistence(timeout: 5))
+        settingsBackButton.tap()
+
+        let accountLink = app.descendants(matching: .any)["settings_account_subscription_link"]
+        XCTAssertTrue(accountLink.waitForExistence(timeout: 5))
+        XCTAssertTrue(accountLink.isHittable)
+        accountLink.tap()
 
         let manageSubscriptionButton = app.descendants(matching: .any)["settings_manage_subscription_button"]
         scrollUntilHittable(manageSubscriptionButton, in: app)
@@ -153,6 +171,11 @@ final class LogYourBodyUITests: XCTestCase {
         app.launch()
 
         try openSettings(in: app)
+
+        let trackingLink = app.descendants(matching: .any)["settings_tracking_link"]
+        XCTAssertTrue(trackingLink.waitForExistence(timeout: 5))
+        XCTAssertTrue(trackingLink.isHittable)
+        trackingLink.tap()
 
         let weightGoalButton = app.buttons["settings_weight_goal_edit_button"]
         scrollUntilHittable(weightGoalButton, in: app)
@@ -430,6 +453,12 @@ final class LogYourBodyUITests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["Log GLP-1 dose"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Zepbound"].waitForExistence(timeout: 10))
+        let selectedDose = app.descendants(matching: .any)["glp1_dose_picker"]
+        XCTAssertTrue(selectedDose.waitForExistence(timeout: 10))
+        XCTAssertTrue((selectedDose.value as? String)?.contains("5 mg/week") == true)
+        let lastLoggedDose = app.descendants(matching: .any)["glp1_last_logged_dose_status"]
+        XCTAssertTrue(lastLoggedDose.waitForExistence(timeout: 10))
+        XCTAssertTrue(lastLoggedDose.label.contains("5 mg/week"))
         XCTAssertTrue(app.descendants(matching: .any)["glp1DoseHistorySection"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.switches["Rest day"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.textFields["GLP-1 dose notes"].waitForExistence(timeout: 5))
@@ -704,7 +733,8 @@ final class LogYourBodyUITests: XCTestCase {
 
         let shareCard = app.descendants(matching: .any)["body_score_share_card"]
         XCTAssertTrue(shareCard.waitForExistence(timeout: 8))
-        XCTAssertTrue(app.descendants(matching: .any)["body_score_share_avatar_visual"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["body_score_share_content_controls"].exists)
+        XCTAssertFalse(app.descendants(matching: .any)["body_score_share_avatar_visual"].exists)
         XCTAssertTrue(app.descendants(matching: .any)["body_score_share_save_button"].exists)
         XCTAssertTrue(app.descendants(matching: .any)["body_score_share_system_button"].exists)
 
@@ -744,20 +774,22 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(presenceSummary.label.contains("Measured"))
         XCTAssertTrue(presenceSummary.label.contains("Interpolated"))
         XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_stats_metric_stack"].exists)
-        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_stats_metric_card_weight"].exists)
-        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_stats_metric_card_body_fat"].exists)
-        XCTAssertTrue(app.descendants(matching: .any)["photo_timeline_stats_metric_card_ffmi"].exists)
+        let weightCard = app.descendants(matching: .any)["photo_timeline_stats_metric_card_weight"]
+        XCTAssertTrue(weightCard.waitForExistence(timeout: 10))
+        let bodyFatCard = app.descendants(matching: .any)["photo_timeline_stats_metric_card_body_fat"]
+        XCTAssertTrue(bodyFatCard.waitForExistence(timeout: 5))
         XCTAssertFalse(app.staticTexts["Timeline states"].exists)
         attachScreenshot(named: "launch-quality-analytics", from: app)
+        let ffmiCard = app.descendants(matching: .any)["photo_timeline_stats_metric_card_ffmi"]
+        scrollUntilExists(ffmiCard, in: app)
+        XCTAssertTrue(ffmiCard.waitForExistence(timeout: 5))
         XCTAssertFalse(app.descendants(matching: .any)["legacy_full_dashboard_beta"].exists)
     }
 
     private func openIntegrations(in app: XCUIApplication) throws {
         try openSettings(in: app)
 
-        let integrationsButton = app.buttons.matching(
-            NSPredicate(format: "label CONTAINS %@", "Integrations")
-        ).firstMatch
+        let integrationsButton = app.descendants(matching: .any)["settings_integrations_link"]
         scrollUntilHittable(integrationsButton, in: app)
         XCTAssertTrue(integrationsButton.waitForExistence(timeout: 5))
         XCTAssertTrue(integrationsButton.isHittable)


### PR DESCRIPTION
## Summary
- standardize the production iPhone experience on dark Jovie tokens and accessible shared controls
- simplify onboarding, paywall, dashboard, logging, sharing, and settings while closing validation, recovery, privacy, data-consistency, and interaction gaps from the audit
- make the Body Score share sheet immediate and deterministic: capture the visible cached payload when the CTA is exposed, then safely enrich that same presentation with a resolved progress photo without ever blocking the overlay
- reconcile the UI work with the newly landed shared Jovie Apple identity flow; legacy email and OTP sign-in surfaces remain intentionally removed
- add deterministic regression coverage for onboarding progress, goal editing, GLP-1 selection, share privacy, chart and timeline accessibility, paywall recovery, bulk import, and auth-surface policy
- stabilize the Stats quality audit across simulator viewports by waiting for loaded metric cards and scrolling to the lower FFMI card before assertion

## Validation
- `swiftlint lint --strict --quiet` — 0 violations
- `python3 scripts/ios/launch-ui-regression-audit.py --root . --artifact-dir /tmp/lyb-local-launch-audit` — passed
- `xcodebuild … build-for-testing` — passed
- `xcodebuild … test -only-testing:LogYourBodyTests` — 354 passed
- `xcodebuild … test -only-testing:LogYourBodyUITests` — 26 tests, 27 device executions passed on LYB Golden iPhone 16 (iOS 26.5)
- `xcodebuild … test -only-testing:LogYourBodyUITests/LogYourBodyUITests/testLaunchQualityGateCapturesCriticalSurfaces` — passed three times after the cross-viewport and Body Score share hardening
- representative visual review on the Golden simulator: auth, account setup, onboarding, paywall recovery, photo timeline, Stats, Settings, and Tracking

## Notes
- no web, debug-only, legacy product, or iPad work is included
- temporary local simulator configuration was removed before commit
