### PR TITLE
fix: satisfy generated registry swiftlint

### DIFF
--- a/apps/ios/LogYourBody/GeneratedProductRegistry.swift
+++ b/apps/ios/LogYourBody/GeneratedProductRegistry.swift
@@ -5,7 +5,7 @@ enum ProductRegistry {
     static let appName = "LogYourBody"
     static let legalName = "LogYourBody, Inc."
     static let slogan = "Know if the work is working."
-    static let productDescription = "Weight, body fat, lean mass, HealthKit data, and progress photos in one private timeline that shows the trend."
+    static let productDescription = "Weight, body fat, lean mass, HealthKit, and progress photos in one private timeline."
     static let supportEmail = "support@logyourbody.com"
     static let appStoreURL = "https://apps.apple.com/us/app/logyourbody/id6755209876"
 

--- a/docs/product/product-registry.generated.md
+++ b/docs/product/product-registry.generated.md
@@ -9,7 +9,7 @@ Canonical source: `packages/product-registry/src/products/logyourbody.mjs`. Web 
 ## Brand and messaging
 
 - Slogan: **Know if the work is working.**
-- Description: Weight, body fat, lean mass, HealthKit data, and progress photos in one private timeline that shows the trend.
+- Description: Weight, body fat, lean mass, HealthKit, and progress photos in one private timeline.
 - Voice: clear, concise, evidence-based, non-judgmental, private
 - Support: support@logyourbody.com
 

--- a/packages/product-registry/src/products/logyourbody.mjs
+++ b/packages/product-registry/src/products/logyourbody.mjs
@@ -14,7 +14,7 @@ export const logYourBody = {
     promise: 'Answer “How am I doing?” with one private body-composition timeline.',
     slogan: 'Know if the work is working.',
     description:
-      'Weight, body fat, lean mass, HealthKit data, and progress photos in one private timeline that shows the trend.',
+      'Weight, body fat, lean mass, HealthKit, and progress photos in one private timeline.',
     voice: ['clear', 'concise', 'evidence-based', 'non-judgmental', 'private'],
     colors: { background: '#08090A', foreground: '#F7F8F8', accent: '#5E6AD2' },
     logos: {


### PR DESCRIPTION
## Summary
- shorten the canonical product description so the generated Swift registry satisfies the strict 130-character SwiftLint limit
- regenerate Swift and Markdown outputs from the registry

## Validation
- `pnpm product:check`
- `swiftlint lint --strict` (367 files, 0 violations)
- pre-push lint, typecheck, build, and 345 web tests