### PR TITLE
test(ios): cover legal consent gate and document loading

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		18EBE5224556DDF573EE3E12 /* RevenueCatManager+Part02.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7148912B179107B65580E27E /* RevenueCatManager+Part02.swift */; };
 		18ED1A86B416E8821C250840 /* GlobalTimelineServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620823F9E8905856BB1B666D /* GlobalTimelineServiceTests.swift */; };
 		1CCAD9C764D3D35B5BF0522B /* HealthKitAuthorizationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84A7C68943959BD45325D9B /* HealthKitAuthorizationPolicyTests.swift */; };
+		1E182FE84F374514F7F31F17 /* LegalConsentPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD03E6E0BF889812FE27D44 /* LegalConsentPolicyTests.swift */; };
 		2117B18E82C133B5150AB357 /* CoreDataManager+Part03.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88D7AC2C7FF4E14A3BB8168 /* CoreDataManager+Part03.swift */; };
 		272AFFF5324345C4B93608F8 /* MainTabViewPolicies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3A26E632164AACAA5D77FD /* MainTabViewPolicies.swift */; };
 		2B3C4D5E6F7890ABCDEF1234 /* LoadingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF12 /* LoadingScreen.swift */; };
@@ -341,6 +342,7 @@
 		CC4917DEC8E46FACECDF3424 /* DashboardDataVizPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0211D1493A398942561196F /* DashboardDataVizPolicyTests.swift */; };
 		CCCD701F26CEB5C9F56AA8FB /* PaywallSavingsPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C87F359CE5509C2457AB583 /* PaywallSavingsPolicyTests.swift */; };
 		CCE3FEEC83AAC1B3F1F82BF6 /* DSProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18AA7A0EC7327CC6EB9725D /* DSProgressBar.swift */; };
+		CEA13DB06DA2A2D160A48D1D /* LegalDocumentLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E358ECC97E3F08357502AC /* LegalDocumentLoaderTests.swift */; };
 		D2184ADBFB25DEB92514F85D /* DSCircularProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C575F720A1D8D1DFDC4F1CEF /* DSCircularProgressTests.swift */; };
 		D47F9BD18CBEE2413DF244FC /* RevenueCatProductConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7899ADA31AC216735A9FE299 /* RevenueCatProductConfigurationTests.swift */; };
 		D5F71D2685408ED4D599FC28 /* BodyMetricPhotoUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2E34BC49376B87D43D81AD /* BodyMetricPhotoUpdateTests.swift */; };
@@ -429,6 +431,7 @@
 		36A9ED1D5319B495A194EE88 /* LoadingManagerHealthSyncTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoadingManagerHealthSyncTests.swift; sourceTree = "<group>"; };
 		3B8B5B2EBD6BD4427633C2F5 /* HealthKitManager+Part01.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HealthKitManager+Part01.swift"; path = "HealthKitManager+Part01.swift"; sourceTree = "<group>"; };
 		3CBF4E377107434EA53A2F1B /* PaidWeightLoggerMVPPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaidWeightLoggerMVPPolicyTests.swift; sourceTree = "<group>"; };
+		3CD03E6E0BF889812FE27D44 /* LegalConsentPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LegalConsentPolicyTests.swift; sourceTree = "<group>"; };
 		3F2E34BC49376B87D43D81AD /* BodyMetricPhotoUpdateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyMetricPhotoUpdateTests.swift; sourceTree = "<group>"; };
 		458AAF24645E3634CCF88E16 /* DSIcon.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSIcon.swift; path = DesignSystem/Atoms/DSIcon.swift; sourceTree = "<group>"; };
 		4590E4EDF067461157CAE028 /* ErrorStateView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorStateView.swift; path = DesignSystem/Molecules/ErrorStateView.swift; sourceTree = "<group>"; };
@@ -462,6 +465,7 @@
 		83531C42434F71BA31C75D89 /* RealtimeSyncManager+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "RealtimeSyncManager+Part02.swift"; path = "RealtimeSyncManager+Part02.swift"; sourceTree = "<group>"; };
 		8631504046C70A4EE432C9B8 /* AccountDeletionAndShareCardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountDeletionAndShareCardTests.swift; sourceTree = "<group>"; };
 		898E428E2D5EE162E00B0BD7 /* DashboardHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DashboardHeader.swift; path = DesignSystem/Organisms/DashboardHeader.swift; sourceTree = "<group>"; };
+		89E358ECC97E3F08357502AC /* LegalDocumentLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LegalDocumentLoaderTests.swift; sourceTree = "<group>"; };
 		8A593DE7333C6FAE0E20815A /* AuthLegacyStorageMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthLegacyStorageMigrationTests.swift; sourceTree = "<group>"; };
 		8B717977805C943E5BA1410B /* AddEntrySheet+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AddEntrySheet+Part02.swift"; path = "AddEntrySheet+Part02.swift"; sourceTree = "<group>"; };
 		8E3A26E632164AACAA5D77FD /* MainTabViewPolicies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTabViewPolicies.swift; sourceTree = "<group>"; };
@@ -1104,6 +1108,8 @@
 				245B5601A048FDB45C7F4042 /* SyncIntegrationSupplementalSyncTests.swift */,
 				45999DF3001C2F424CBB44DB /* SyncIntegrationTestDoubles.swift */,
 				4C3BCDDCDB314367722653A8 /* ValidationServiceTests.swift */,
+				3CD03E6E0BF889812FE27D44 /* LegalConsentPolicyTests.swift */,
+				89E358ECC97E3F08357502AC /* LegalDocumentLoaderTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1924,6 +1930,8 @@
 				75A151025036A3D85388BD19 /* ValidationServiceTests.swift in Sources */,
 				D2184ADBFB25DEB92514F85D /* DSCircularProgressTests.swift in Sources */,
 				E740BE7171B6D98EEC5796B5 /* ErrorStateViewTests.swift in Sources */,
+				1E182FE84F374514F7F31F17 /* LegalConsentPolicyTests.swift in Sources */,
+				CEA13DB06DA2A2D160A48D1D /* LegalDocumentLoaderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/LogYourBody/Views/LegalConsentView.swift
+++ b/apps/ios/LogYourBody/Views/LegalConsentView.swift
@@ -4,6 +4,16 @@
 //
 import SwiftUI
 
+enum LegalConsentPolicy {
+    static func canContinue(
+        acceptedTerms: Bool,
+        acceptedPrivacy: Bool,
+        isLoading: Bool
+    ) -> Bool {
+        acceptedTerms && acceptedPrivacy && !isLoading
+    }
+}
+
 struct LegalConsentView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -18,7 +28,11 @@ struct LegalConsentView: View {
     @State private var showPrivacySheet = false
 
     private var canContinue: Bool {
-        acceptedTerms && acceptedPrivacy && !isLoading
+        LegalConsentPolicy.canContinue(
+            acceptedTerms: acceptedTerms,
+            acceptedPrivacy: acceptedPrivacy,
+            isLoading: isLoading
+        )
     }
 
     var body: some View {

--- a/apps/ios/LogYourBody/Views/LegalDocumentView.swift
+++ b/apps/ios/LogYourBody/Views/LegalDocumentView.swift
@@ -4,6 +4,107 @@
 //
 import SwiftUI
 
+// MARK: - Legal Document Loading
+
+enum LegalDocumentLoader {
+    static func loadMarkdown(
+        for documentType: LegalDocumentView.LegalDocumentType,
+        in bundle: Bundle = .main
+    ) -> String {
+        // Try to load from Resources/Legal directory in bundle
+        if let bundlePath = bundle.path(forResource: "Legal/\(documentType.filename)", ofType: "md"),
+           let content = try? String(contentsOfFile: bundlePath, encoding: .utf8) {
+            return content
+        }
+
+        // Try alternate path without subfolder
+        if let bundlePath = bundle.path(forResource: documentType.filename, ofType: "md", inDirectory: "Legal"),
+           let content = try? String(contentsOfFile: bundlePath, encoding: .utf8) {
+            return content
+        }
+
+        // Try without any directory
+        if let bundlePath = bundle.path(forResource: documentType.filename, ofType: "md"),
+           let content = try? String(contentsOfFile: bundlePath, encoding: .utf8) {
+            return content
+        }
+
+        // Fallback: embedded placeholder content
+        return fallbackMarkdown(for: documentType)
+    }
+
+    static func fallbackMarkdown(for documentType: LegalDocumentView.LegalDocumentType) -> String {
+        switch documentType {
+        case .terms:
+            return """
+            # Terms of Service
+
+            **Last Updated: July 11, 2025**
+
+            We couldn't load the full Terms of Service on this device.
+
+            By using LogYourBody, you agree to our terms and conditions.
+            If you need a full copy of the latest Terms, contact \(ProductRegistry.supportEmail).
+            """
+        case .privacy:
+            return """
+            # Privacy Policy
+
+            **Last Updated: July 11, 2025**
+
+            We couldn't load the full Privacy Policy on this device.
+
+            We are committed to protecting your privacy and personal data.
+            If you need a full copy of the latest Privacy Policy, contact \(ProductRegistry.supportEmail).
+            """
+        case .healthDisclosure:
+            return """
+            # Health Disclosure
+
+            **Last Updated: July 11, 2025**
+
+            We couldn't load the full Health Disclosure on this device.
+
+            LogYourBody is not a medical service and does not provide medical advice.
+            If you need a full copy of the latest Health Disclosure, contact \(ProductRegistry.supportEmail).
+            """
+        case .gdprCompliance:
+            return """
+            # GDPR Compliance
+
+            **Last Updated: July 14, 2025**
+
+            We couldn't load the full GDPR Compliance information on this device.
+
+            We comply with the General Data Protection Regulation for EU users.
+            If you need a full copy of the latest GDPR compliance document, contact \(ProductRegistry.supportEmail).
+            """
+        case .ccpaCompliance:
+            return """
+            # CCPA Compliance
+
+            **Last Updated: July 14, 2025**
+
+            We couldn't load the full CCPA Compliance information on this device.
+
+            We respect the privacy rights of California residents.
+            If you need a full copy of the latest CCPA compliance document, contact \(ProductRegistry.supportEmail).
+            """
+        case .openSourceLicenses:
+            return """
+            # Open Source Licenses
+
+            **Last Updated: July 14, 2025**
+
+            We couldn't load the full list of open source licenses on this device.
+
+            LogYourBody is built with amazing open source software.
+            If you need a full copy of the latest license list, contact \(ProductRegistry.supportEmail).
+            """
+        }
+    }
+}
+
 // MARK: - Refactored Legal Document View using Atomic Design
 
 struct LegalDocumentView: View {
@@ -13,7 +114,7 @@ struct LegalDocumentView: View {
     @State private var loadError = false
     @Environment(\.dismiss) var dismiss
 
-    enum LegalDocumentType {
+    enum LegalDocumentType: CaseIterable {
         case terms
         case privacy
         case healthDisclosure
@@ -99,104 +200,7 @@ struct LegalDocumentView: View {
     private func loadDocument() {
         isLoading = true
         loadError = false
-
-        // Try to load from Resources/Legal directory in bundle
-        if let bundlePath = Bundle.main.path(forResource: "Legal/\(documentType.filename)", ofType: "md"),
-           let content = try? String(contentsOfFile: bundlePath, encoding: .utf8) {
-            documentContent = content
-            isLoading = false
-            return
-        }
-
-        // Try alternate path without subfolder
-        if let bundlePath = Bundle.main.path(forResource: documentType.filename, ofType: "md", inDirectory: "Legal"),
-           let content = try? String(contentsOfFile: bundlePath, encoding: .utf8) {
-            documentContent = content
-            isLoading = false
-            return
-        }
-
-        // Try without any directory
-        if let bundlePath = Bundle.main.path(forResource: documentType.filename, ofType: "md"),
-           let content = try? String(contentsOfFile: bundlePath, encoding: .utf8) {
-            documentContent = content
-            isLoading = false
-            return
-        }
-
-        // Fallback: Load embedded placeholder content
-        loadFallbackContent()
-    }
-
-    private func loadFallbackContent() {
-        switch documentType {
-        case .terms:
-            documentContent = """
-            # Terms of Service
-
-            **Last Updated: July 11, 2025**
-
-            We couldn't load the full Terms of Service on this device.
-
-            By using LogYourBody, you agree to our terms and conditions.
-            If you need a full copy of the latest Terms, contact \(ProductRegistry.supportEmail).
-            """
-        case .privacy:
-            documentContent = """
-            # Privacy Policy
-
-            **Last Updated: July 11, 2025**
-
-            We couldn't load the full Privacy Policy on this device.
-
-            We are committed to protecting your privacy and personal data.
-            If you need a full copy of the latest Privacy Policy, contact \(ProductRegistry.supportEmail).
-            """
-        case .healthDisclosure:
-            documentContent = """
-            # Health Disclosure
-
-            **Last Updated: July 11, 2025**
-
-            We couldn't load the full Health Disclosure on this device.
-
-            LogYourBody is not a medical service and does not provide medical advice.
-            If you need a full copy of the latest Health Disclosure, contact \(ProductRegistry.supportEmail).
-            """
-        case .gdprCompliance:
-            documentContent = """
-            # GDPR Compliance
-
-            **Last Updated: July 14, 2025**
-
-            We couldn't load the full GDPR Compliance information on this device.
-
-            We comply with the General Data Protection Regulation for EU users.
-            If you need a full copy of the latest GDPR compliance document, contact \(ProductRegistry.supportEmail).
-            """
-        case .ccpaCompliance:
-            documentContent = """
-            # CCPA Compliance
-
-            **Last Updated: July 14, 2025**
-
-            We couldn't load the full CCPA Compliance information on this device.
-
-            We respect the privacy rights of California residents.
-            If you need a full copy of the latest CCPA compliance document, contact \(ProductRegistry.supportEmail).
-            """
-        case .openSourceLicenses:
-            documentContent = """
-            # Open Source Licenses
-
-            **Last Updated: July 14, 2025**
-
-            We couldn't load the full list of open source licenses on this device.
-
-            LogYourBody is built with amazing open source software.
-            If you need a full copy of the latest license list, contact \(ProductRegistry.supportEmail).
-            """
-        }
+        documentContent = LegalDocumentLoader.loadMarkdown(for: documentType)
         isLoading = false
     }
 }

--- a/apps/ios/LogYourBodyTests/LegalConsentPolicyTests.swift
+++ b/apps/ios/LogYourBodyTests/LegalConsentPolicyTests.swift
@@ -1,0 +1,272 @@
+import XCTest
+@testable import LogYourBody
+
+@MainActor
+final class LegalConsentPolicyTests: XCTestCase {
+    private let defaultsSuiteName = "LegalConsentPolicyTests"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults().removePersistentDomain(forName: defaultsSuiteName)
+        LegalConsentStubURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        LegalConsentStubURLProtocol.reset()
+        UserDefaults().removePersistentDomain(forName: defaultsSuiteName)
+        super.tearDown()
+    }
+
+    // MARK: - Continue-gate policy
+
+    func testContinueStartsDisabled() {
+        XCTAssertFalse(
+            LegalConsentPolicy.canContinue(acceptedTerms: false, acceptedPrivacy: false, isLoading: false)
+        )
+    }
+
+    func testContinueRequiresBothDocuments() {
+        XCTAssertFalse(
+            LegalConsentPolicy.canContinue(acceptedTerms: true, acceptedPrivacy: false, isLoading: false)
+        )
+        XCTAssertFalse(
+            LegalConsentPolicy.canContinue(acceptedTerms: false, acceptedPrivacy: true, isLoading: false)
+        )
+    }
+
+    func testContinueEnabledWhenBothDocumentsAccepted() {
+        XCTAssertTrue(
+            LegalConsentPolicy.canContinue(acceptedTerms: true, acceptedPrivacy: true, isLoading: false)
+        )
+    }
+
+    func testContinueDisabledWhileAcceptInFlight() {
+        XCTAssertFalse(
+            LegalConsentPolicy.canContinue(acceptedTerms: true, acceptedPrivacy: true, isLoading: true)
+        )
+    }
+
+    // MARK: - Persistence through the stubbed profile endpoint
+
+    func testAcceptSuccessPersistsConsentAndClearsGate() async throws {
+        let store = StubbedConsentStore()
+        let manager = try makeManager(store: store)
+
+        let consentBeforeAccept = await manager.checkLegalConsent(userId: "consent-user")
+        XCTAssertFalse(consentBeforeAccept)
+        XCTAssertTrue(manager.needsLegalConsent)
+
+        await manager.acceptLegalConsent(userId: "consent-user")
+
+        XCTAssertFalse(manager.needsLegalConsent)
+        let patch = try XCTUnwrap(LegalConsentStubURLProtocol.requests.first { $0.httpMethod == "PATCH" })
+        XCTAssertEqual(patch.url?.path, "/api/auth/mobile/profile")
+        XCTAssertEqual(patch.value(forHTTPHeaderField: "Authorization"), "Bearer stub-access-token")
+        let body = try XCTUnwrap(LegalConsentStubURLProtocol.bodyData(of: patch))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["legalAccepted"] as? Bool, true)
+
+        let consentAfterAccept = await manager.checkLegalConsent(userId: "consent-user")
+        XCTAssertTrue(consentAfterAccept)
+    }
+
+    func testAcceptFailureKeepsGateEngagedAndPersistsNothing() async throws {
+        let store = StubbedConsentStore(patchBehavior: .reject)
+        let manager = try makeManager(store: store)
+
+        await manager.acceptLegalConsent(userId: "consent-user")
+
+        XCTAssertTrue(manager.needsLegalConsent)
+        let consentAfterFailure = await manager.checkLegalConsent(userId: "consent-user")
+        XCTAssertFalse(consentAfterFailure)
+    }
+
+    func testAcceptForMismatchedUserDoesNotPersist() async throws {
+        let store = StubbedConsentStore()
+        let manager = try makeManager(store: store)
+
+        await manager.acceptLegalConsent(userId: "someone-else")
+
+        XCTAssertTrue(manager.needsLegalConsent)
+        XCTAssertTrue(LegalConsentStubURLProtocol.requests.isEmpty)
+    }
+
+    func testCheckLegalConsentFailsClosedOnServerError() async throws {
+        let store = StubbedConsentStore(readsFail: true)
+        let manager = try makeManager(store: store)
+
+        let consentOnError = await manager.checkLegalConsent(userId: "consent-user")
+        XCTAssertFalse(consentOnError)
+        XCTAssertTrue(manager.needsLegalConsent)
+    }
+
+    // MARK: - Helpers
+
+    private func makeManager(store: StubbedConsentStore) throws -> AuthManager {
+        guard let defaults = UserDefaults(suiteName: defaultsSuiteName) else {
+            throw TestSetupError.userDefaultsUnavailable
+        }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [LegalConsentStubURLProtocol.self]
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        let manager = AuthManager(
+            userDefaults: defaults,
+            urlSession: URLSession(configuration: configuration)
+        )
+        manager.currentUser = LocalUser(
+            id: "consent-user",
+            email: "consent@example.com",
+            name: nil,
+            avatarUrl: nil,
+            profile: nil
+        )
+        manager.authSession = ProductAuthSession(
+            accessToken: "stub-access-token",
+            refreshToken: "stub-refresh-token",
+            expiresAt: Date(timeIntervalSinceNow: 3_600),
+            subject: "consent-user",
+            email: "consent@example.com",
+            name: nil,
+            issuedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        manager.needsLegalConsent = true
+        LegalConsentStubURLProtocol.install { request in
+            store.response(for: request)
+        }
+        return manager
+    }
+}
+
+private enum TestSetupError: Error {
+    case userDefaultsUnavailable
+}
+
+private struct StubbedHTTPResponse {
+    let statusCode: Int
+    let body: Data
+}
+
+private final class StubbedConsentStore {
+    enum PatchBehavior {
+        case accept
+        case reject
+    }
+
+    private let lock = NSLock()
+    private let patchBehavior: PatchBehavior
+    private let readsFail: Bool
+    private var accepted = false
+
+    init(patchBehavior: PatchBehavior = .accept, readsFail: Bool = false) {
+        self.patchBehavior = patchBehavior
+        self.readsFail = readsFail
+    }
+
+    func response(for request: URLRequest) -> StubbedHTTPResponse {
+        lock.lock()
+        defer { lock.unlock() }
+        if request.httpMethod == "PATCH" {
+            switch patchBehavior {
+            case .accept:
+                accepted = true
+                return StubbedHTTPResponse(statusCode: 204, body: Data())
+            case .reject:
+                return StubbedHTTPResponse(statusCode: 500, body: Data())
+            }
+        }
+        if readsFail {
+            return StubbedHTTPResponse(statusCode: 500, body: Data())
+        }
+        let acceptedAt = accepted ? "\"2025-07-11\"" : "null"
+        let payload = """
+        {"profile": {"id": "consent-user", "legal_accepted_at": \(acceptedAt)}}
+        """
+        return StubbedHTTPResponse(statusCode: 200, body: Data(payload.utf8))
+    }
+}
+
+private final class LegalConsentStubURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var requestHandler: ((URLRequest) -> StubbedHTTPResponse)?
+    private static var recordedRequests: [URLRequest] = []
+
+    static func install(handler: @escaping (URLRequest) -> StubbedHTTPResponse) {
+        lock.lock()
+        recordedRequests = []
+        requestHandler = handler
+        lock.unlock()
+    }
+
+    static func reset() {
+        lock.lock()
+        recordedRequests = []
+        requestHandler = nil
+        lock.unlock()
+    }
+
+    static var requests: [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedRequests
+    }
+
+    static func bodyData(of request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1_024)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let count = stream.read(buffer, maxLength: 1_024)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data.isEmpty ? nil : data
+    }
+
+    override static func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.lock.lock()
+        let handler = Self.requestHandler
+        Self.recordedRequests.append(request)
+        Self.lock.unlock()
+
+        guard let handler, let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        let stub = handler(request)
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: stub.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: [
+                "Content-Type": "application/json",
+                "Cache-Control": "no-store"
+            ]
+        ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() { }
+}

--- a/apps/ios/LogYourBodyTests/LegalDocumentLoaderTests.swift
+++ b/apps/ios/LogYourBodyTests/LegalDocumentLoaderTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import LogYourBody
+
+final class LegalDocumentLoaderTests: XCTestCase {
+    private typealias DocumentType = LegalDocumentView.LegalDocumentType
+
+    func testEveryAdvertisedDocumentShipsNonEmptyInAppBundle() {
+        for documentType in DocumentType.allCases {
+            let content = LegalDocumentLoader.loadMarkdown(for: documentType, in: .main)
+            XCTAssertFalse(
+                content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                "\(documentType.filename) must ship non-empty markdown"
+            )
+            XCTAssertFalse(
+                content.contains("couldn't load"),
+                "\(documentType.filename) served the embedded fallback; the real document is missing from the app bundle"
+            )
+        }
+    }
+
+    func testEachDocumentTypeMapsToDistinctContent() {
+        var seen: Set<String> = []
+        for documentType in DocumentType.allCases {
+            let content = LegalDocumentLoader.loadMarkdown(for: documentType, in: .main)
+            XCTAssertTrue(
+                seen.insert(content).inserted,
+                "\(documentType) serves the same content as another document"
+            )
+        }
+        XCTAssertEqual(seen.count, DocumentType.allCases.count)
+    }
+
+    func testFallbackServesEmbeddedCopyWhenBundleLacksDocument() {
+        let bundleWithoutLegalDocs = Bundle(for: BundleToken.self)
+        for documentType in DocumentType.allCases {
+            let content = LegalDocumentLoader.loadMarkdown(for: documentType, in: bundleWithoutLegalDocs)
+            XCTAssertTrue(
+                content.contains("couldn't load"),
+                "\(documentType) fallback should explain the document could not load"
+            )
+            XCTAssertTrue(
+                content.contains(documentType.title),
+                "\(documentType) fallback should keep the document title"
+            )
+            XCTAssertTrue(
+                content.contains(ProductRegistry.supportEmail),
+                "\(documentType) fallback should point at support"
+            )
+        }
+    }
+}
+
+private final class BundleToken { }


### PR DESCRIPTION
## Summary

Batch 4 of the iOS test-hardening effort (inventory section A.10 — the launch-blocking legal gate with zero coverage). 11 new tests, plus two minimal zero-behavior-change policy extractions in the repo's `*Policy` idiom.

- **`LegalConsentPolicyTests` (8):** gate enable/disable transitions (both documents required, in-flight re-disables) and persistence through the real `AuthManager` with only the HTTP boundary stubbed (test-local `URLProtocol`): success PATCH round-trip clears the gate, failure keeps it engaged, mismatched user issues zero requests, `checkLegalConsent` fails closed on 500.
- **`LegalDocumentLoaderTests` (3):** all 6 shipped legal documents are present and non-empty in the app bundle (real bundle via TEST_HOST, not fallbacks), each type maps to distinct content, embedded fallback serves when the bundle lacks the files. `LegalDocumentType` gained `CaseIterable` so future document types auto-fail the test.
- **Extractions (no behavior change):** `LegalConsentPolicy` (enable logic) and `LegalDocumentLoader` (3-tier bundle lookup + embedded fallback) lifted to the top of their view files; views now delegate.

## App bugs found — pinned by tests, NOT fixed here (need product decision, see below)

1. **The legal consent gate is inert.** `AuthManager.needsLegalConsent` is only ever assigned `false` (init, logout, accept success) and `checkLegalConsent(userId:)` has **zero call sites** — nothing ever arms the gate, so no user is ever actually gated. Arming it is a user-visible compliance change that needs a product decision + Statsig gate, not a test-hardening PR.
2. **On accept failure the gate silently closes.** `LegalConsentView.accept()` sets `isPresented = false` unconditionally; since `ContentView`'s `onChange` only fires on value changes, a failed PATCH leaves consent unrecorded while the sheet never re-presents that session. Only manifests once bug 1 is armed; fix = make `onAccept` report success and dismiss conditionally.
3. Minor dead code noted: unused `LegalConsentView.userId`; never-set `LegalDocumentView.loadError`.

## Validation evidence

- `swiftlint lint --strict`: 0 violations (363 files)
- New classes: `** TEST SUCCEEDED **` — 11/11, all ≪200ms (verified on two independent runs)
- Pre-push turbo lint/typecheck/test: green

XCUITest follow-up noted in the inventory: the gate isn't reachable by existing fixtures (nothing sets `needsLegalConsent`); a `-lybUITestLegalConsentFixture` would arm it for the future UI batch.
