### PR TITLE
test(ios): cover photo upload pipeline and vendor ports

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		04BF4BAC82CF6B37F817592F /* CoreDataModelMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA050E7DCEBA5BAF62341363 /* CoreDataModelMigrationTests.swift */; };
 		04EB1D7AD1947D32BDE7AD70 /* BodyMetricSourceContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EBD5BF3F1671BC8D17ABE5D /* BodyMetricSourceContractTests.swift */; };
 		050A49949BCAA09D23C66035 /* DashboardViewModelHealthSyncWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1C56EE58FC0F4BEFDA1345 /* DashboardViewModelHealthSyncWiringTests.swift */; };
+		08009BD8B382A4A3372C1D2D /* ExternalServicePortsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A58DAB61B2BBDF2D4EF761B /* ExternalServicePortsTests.swift */; };
 		0922CA98E79021C4CB2595A5 /* SupabaseProfilePayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA82A71E77423D56A70AA46 /* SupabaseProfilePayloadTests.swift */; };
 		099DD9F0055C4CFBF7190F4B /* PhotoMetadataAndImportPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E0D5025A2839599F4E281D /* PhotoMetadataAndImportPolicyTests.swift */; };
 		0C4EFBDDCBCA1C2DBAC4DA0A /* BaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5A5D6BAAD9FB2F7B8AFACB /* BaseButton.swift */; };
@@ -478,6 +479,7 @@
 		91C10C0E4F8B40568047DA88 /* AddEntrySheet+Part01.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AddEntrySheet+Part01.swift"; path = "AddEntrySheet+Part01.swift"; sourceTree = "<group>"; };
 		927B7D58E8E1756BB92364B6 /* BodyCompositionMathGoldenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyCompositionMathGoldenTests.swift; sourceTree = "<group>"; };
 		95E35CCA2D3778DD47C8E104 /* ErrorStateViewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorStateViewTests.swift; sourceTree = "<group>"; };
+		9A58DAB61B2BBDF2D4EF761B /* ExternalServicePortsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExternalServicePortsTests.swift; sourceTree = "<group>"; };
 		9C89CCE0BFAE9B2ACB9A017B /* UserHeaderSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserHeaderSection.swift; path = DesignSystem/Organisms/UserHeaderSection.swift; sourceTree = "<group>"; };
 		9ED9F05E697F00813F824903 /* LogoutButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LogoutButton.swift; path = DesignSystem/Molecules/LogoutButton.swift; sourceTree = "<group>"; };
 		9F0DAD82BAAEB27B75923381 /* FullMetricChartView+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "FullMetricChartView+Part02.swift"; path = "Components/FullMetricChartView+Part02.swift"; sourceTree = "<group>"; };
@@ -1116,6 +1118,7 @@
 				89E358ECC97E3F08357502AC /* LegalDocumentLoaderTests.swift */,
 				7A98EF222E91570CB37F44C0 /* PhotoUploadManagerTests.swift */,
 				0C616D3012947DD91D1BEF39 /* BackgroundPhotoUploadServiceTests.swift */,
+				9A58DAB61B2BBDF2D4EF761B /* ExternalServicePortsTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1940,6 +1943,7 @@
 				CEA13DB06DA2A2D160A48D1D /* LegalDocumentLoaderTests.swift in Sources */,
 				3FA11453ACB47EEEFEAFF581 /* PhotoUploadManagerTests.swift in Sources */,
 				B0BCDE6BE3E9D61B8CF9F3B5 /* BackgroundPhotoUploadServiceTests.swift in Sources */,
+				08009BD8B382A4A3372C1D2D /* ExternalServicePortsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -327,6 +327,7 @@
 		ADF1F6BE2ED58E3F00745F33 /* HealthSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF1F6BD2ED58E3F00745F33 /* HealthSyncCoordinator.swift */; };
 		ADFC6A2D2E188FD5004FCE40 /* HKRawSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFC6A2C2E188FD5004FCE40 /* HKRawSample.swift */; };
 		ADFF001E313D59B6006E3A22 /* BodyScoreOnboardingFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFF001D313D59B6006E3A22 /* BodyScoreOnboardingFlowView.swift */; };
+		B0BCDE6BE3E9D61B8CF9F3B5 /* BackgroundPhotoUploadServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C616D3012947DD91D1BEF39 /* BackgroundPhotoUploadServiceTests.swift */; };
 		B11404E6ED2FB64ADE0E0EAE /* EditEntrySavePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51C80EB60F2EA0D7AFA62AB /* EditEntrySavePolicyTests.swift */; };
 		B12671012F16000100ABCDEF /* BodyScoreEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12671002F16000100ABCDEF /* BodyScoreEngineTests.swift */; };
 		B12671032F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12671022F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift */; };
@@ -406,6 +407,7 @@
 		095D9694F1EA5B5091B0AE8B /* DailyReminderPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DailyReminderPolicyTests.swift; sourceTree = "<group>"; };
 		0AB2ACF16AEA86A36EDAD936 /* BiometricAuthView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BiometricAuthView.swift; path = DesignSystem/Organisms/BiometricAuthView.swift; sourceTree = "<group>"; };
 		0B3ECAB100575E759C5A3D7A /* LogWeightFormValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogWeightFormValidatorTests.swift; sourceTree = "<group>"; };
+		0C616D3012947DD91D1BEF39 /* BackgroundPhotoUploadServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundPhotoUploadServiceTests.swift; sourceTree = "<group>"; };
 		0D90F6DA60C58AF02CF23737 /* DSLoadingIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSLoadingIndicator.swift; path = DesignSystem/Atoms/DSLoadingIndicator.swift; sourceTree = "<group>"; };
 		0DBA8FB9B9980A35A865BCAA /* Glp1DoseHistoryFormatterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Glp1DoseHistoryFormatterTests.swift; sourceTree = "<group>"; };
 		118D0C354059446D0FDC1EDA /* AuthConfigurationValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthConfigurationValidationTests.swift; sourceTree = "<group>"; };
@@ -1113,6 +1115,7 @@
 				3CD03E6E0BF889812FE27D44 /* LegalConsentPolicyTests.swift */,
 				89E358ECC97E3F08357502AC /* LegalDocumentLoaderTests.swift */,
 				7A98EF222E91570CB37F44C0 /* PhotoUploadManagerTests.swift */,
+				0C616D3012947DD91D1BEF39 /* BackgroundPhotoUploadServiceTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1936,6 +1939,7 @@
 				1E182FE84F374514F7F31F17 /* LegalConsentPolicyTests.swift in Sources */,
 				CEA13DB06DA2A2D160A48D1D /* LegalDocumentLoaderTests.swift in Sources */,
 				3FA11453ACB47EEEFEAFF581 /* PhotoUploadManagerTests.swift in Sources */,
+				B0BCDE6BE3E9D61B8CF9F3B5 /* BackgroundPhotoUploadServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		2EEA145D3CD52D5D72ECB544 /* Collection+Safe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E7F3F0A162AA751785D876A /* Collection+Safe.swift */; };
 		327C8C9174FEC7C23E350270 /* OnboardingFlowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6868B1C7F6167E2A9AE0A1 /* OnboardingFlowViewModelTests.swift */; };
 		3892032426C339D69DEF73EE /* LaunchSurfacePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47A7741CF9BBCD0F5DC0D5C /* LaunchSurfacePolicyTests.swift */; };
+		3FA11453ACB47EEEFEAFF581 /* PhotoUploadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A98EF222E91570CB37F44C0 /* PhotoUploadManagerTests.swift */; };
 		42B0784EAF04F40C031D0186 /* DailyReminderPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D9694F1EA5B5091B0AE8B /* DailyReminderPolicyTests.swift */; };
 		43ED1CCFAE5CC7DA20E6DB3E /* BaseTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB074F9FFF63EE8FD17BA /* BaseTextField.swift */; };
 		46D2D60CC0C168272E5B0A14 /* BulkProgressPhotoImportPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060DD24271B0B2120CB0AA33 /* BulkProgressPhotoImportPolicyTests.swift */; };
@@ -458,6 +459,7 @@
 		77CA7B3D87EC0BFA00AC6A9F /* Font+Custom.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Font+Custom.swift"; path = "Font+Custom.swift"; sourceTree = "<group>"; };
 		7899ADA31AC216735A9FE299 /* RevenueCatProductConfigurationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RevenueCatProductConfigurationTests.swift; sourceTree = "<group>"; };
 		7A1DE682AE51BF7A3EFF75FF /* HealthKitManager+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HealthKitManager+Part02.swift"; path = "HealthKitManager+Part02.swift"; sourceTree = "<group>"; };
+		7A98EF222E91570CB37F44C0 /* PhotoUploadManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhotoUploadManagerTests.swift; sourceTree = "<group>"; };
 		7B5A5D6BAAD9FB2F7B8AFACB /* BaseButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BaseButton.swift; path = DesignSystem/Atoms/BaseButton.swift; sourceTree = "<group>"; };
 		7CEFB36F814C3D7E8AE709B4 /* DSCircularProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSCircularProgress.swift; path = DesignSystem/Atoms/DSCircularProgress.swift; sourceTree = "<group>"; };
 		7EF9F0EEBB2D999F7FEEF7D0 /* DSAuthLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSAuthLink.swift; path = DesignSystem/Atoms/DSAuthLink.swift; sourceTree = "<group>"; };
@@ -1110,6 +1112,7 @@
 				4C3BCDDCDB314367722653A8 /* ValidationServiceTests.swift */,
 				3CD03E6E0BF889812FE27D44 /* LegalConsentPolicyTests.swift */,
 				89E358ECC97E3F08357502AC /* LegalDocumentLoaderTests.swift */,
+				7A98EF222E91570CB37F44C0 /* PhotoUploadManagerTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1932,6 +1935,7 @@
 				E740BE7171B6D98EEC5796B5 /* ErrorStateViewTests.swift in Sources */,
 				1E182FE84F374514F7F31F17 /* LegalConsentPolicyTests.swift in Sources */,
 				CEA13DB06DA2A2D160A48D1D /* LegalDocumentLoaderTests.swift in Sources */,
+				3FA11453ACB47EEEFEAFF581 /* PhotoUploadManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/LogYourBody/Services/PhotoUploadManager.swift
+++ b/apps/ios/LogYourBody/Services/PhotoUploadManager.swift
@@ -18,6 +18,10 @@ class PhotoUploadManager: ObservableObject {
     private let authManager = AuthManager.shared
     private let supabaseManager = SupabaseManager.shared
     private let coreDataManager = CoreDataManager.shared
+    private let supabaseTokenProvider: () async -> String?
+    private let supabaseBaseURL: String
+    private let storageSessionProvider: () -> URLSession
+    private let functionSessionProvider: () -> URLSession
     private var uploadCancellables = Set<AnyCancellable>()
 
     struct UploadTask {
@@ -59,7 +63,36 @@ class PhotoUploadManager: ObservableObject {
         }
     }
 
-    private init() {}
+    private init() {
+        supabaseTokenProvider = { await AuthManager.shared.getSupabaseToken() }
+        supabaseBaseURL = Constants.supabaseURL
+        storageSessionProvider = {
+            let configuration = URLSessionConfiguration.default
+            configuration.timeoutIntervalForRequest = 60.0 // 60 seconds
+            configuration.timeoutIntervalForResource = 120.0 // 2 minutes
+            return URLSession(configuration: configuration)
+        }
+        functionSessionProvider = { .shared }
+    }
+
+    /// Test seam: injects the Supabase token provider, base URL, and URL
+    /// sessions so the upload pipeline can be exercised without a live auth
+    /// session or Info.plist Supabase configuration. URLSession only honors
+    /// custom URLProtocols via configuration.protocolClasses, so stubbing
+    /// the network boundary requires session injection. Production code uses
+    /// `.shared`, which wires `AuthManager`, `Constants.supabaseURL`, and the
+    /// production sessions.
+    init(
+        supabaseTokenProvider: @escaping () async -> String?,
+        supabaseBaseURL: String,
+        storageSession: URLSession,
+        functionSession: URLSession
+    ) {
+        self.supabaseTokenProvider = supabaseTokenProvider
+        self.supabaseBaseURL = supabaseBaseURL
+        storageSessionProvider = { storageSession }
+        functionSessionProvider = { functionSession }
+    }
 
     private func mapUploadEndpointError(_ error: Error, action: String) -> PhotoError {
         if error is SupabaseError {
@@ -103,7 +136,7 @@ class PhotoUploadManager: ObservableObject {
     }
 
     private func authenticatedJWT() async throws -> String {
-        guard let token = await authManager.getSupabaseToken() else {
+        guard let token = await supabaseTokenProvider() else {
             throw PhotoError.notAuthenticated
         }
 
@@ -419,7 +452,7 @@ class PhotoUploadManager: ObservableObject {
 
         let url: URL
         do {
-            url = try SupabaseURLBuilder.storageURL(bucket: "photos", path: fileName)
+            url = try SupabaseURLBuilder.storageURL(bucket: "photos", path: fileName, baseURL: supabaseBaseURL)
         } catch {
             throw mapUploadEndpointError(error, action: "Photo upload")
         }
@@ -432,10 +465,7 @@ class PhotoUploadManager: ObservableObject {
         request.httpBody = imageData
 
         // Configure URLSession with longer timeout for photo uploads
-        let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = 60.0 // 60 seconds
-        configuration.timeoutIntervalForResource = 120.0 // 2 minutes
-        let uploadSession = URLSession(configuration: configuration)
+        let uploadSession = storageSessionProvider()
 
         let data: Data
         let response: URLResponse
@@ -467,7 +497,7 @@ class PhotoUploadManager: ObservableObject {
 
         let url: URL
         do {
-            url = try SupabaseURLBuilder.functionURL("process-progress-photo")
+            url = try SupabaseURLBuilder.functionURL("process-progress-photo", baseURL: supabaseBaseURL)
         } catch {
             if error is SupabaseError {
                 throw PhotoError.processingFailed("Photo processing is temporarily unavailable. Please try again.")
@@ -493,7 +523,7 @@ class PhotoUploadManager: ObservableObject {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            (data, response) = try await functionSessionProvider().data(for: request)
         } catch {
             if let networkError = mapNetworkError(error) {
                 throw networkError

--- a/apps/ios/LogYourBodyTests/BackgroundPhotoUploadServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/BackgroundPhotoUploadServiceTests.swift
@@ -1,0 +1,67 @@
+//
+// BackgroundPhotoUploadServiceTests.swift
+// LogYourBodyTests
+//
+import XCTest
+@testable import LogYourBody
+
+@MainActor
+final class BackgroundPhotoUploadServiceTests: XCTestCase {
+    private let service = BackgroundPhotoUploadService.shared
+
+    override func setUp() async throws {
+        try await super.setUp()
+        service.cancelAllUploads()
+        service.reset()
+    }
+
+    override func tearDown() async throws {
+        service.cancelAllUploads()
+        service.reset()
+        try await super.tearDown()
+    }
+
+    func testInitialStateIsEmptyAndReadyToUpload() {
+        XCTAssertEqual(service.pendingCount, 0)
+        XCTAssertEqual(service.completedCount, 0)
+        XCTAssertEqual(service.failedCount, 0)
+        XCTAssertEqual(service.totalCount, 0)
+        XCTAssertFalse(service.isUploading)
+        XCTAssertNil(service.currentUploadingPhoto)
+        XCTAssertEqual(service.totalProgress, 0.0)
+        XCTAssertEqual(service.uploadSummary, "Ready to upload photos")
+    }
+
+    func testStartProcessingQueueWithEmptyQueueDoesNotStartUploading() {
+        service.startProcessingQueue()
+
+        XCTAssertFalse(service.isUploading)
+        XCTAssertNil(service.currentUploadingPhoto)
+        XCTAssertEqual(service.uploadSummary, "Ready to upload photos")
+    }
+
+    func testCancelAllUploadsClearsInFlightState() {
+        service.isUploading = true
+        service.totalProgress = 0.5
+
+        service.cancelAllUploads()
+
+        XCTAssertFalse(service.isUploading)
+        XCTAssertNil(service.currentUploadingPhoto)
+        XCTAssertEqual(service.totalProgress, 0.0)
+        XCTAssertTrue(service.uploadQueue.isEmpty)
+        XCTAssertEqual(service.uploadSummary, "Ready to upload photos")
+    }
+
+    func testResetClearsPublishedQueueState() {
+        service.isUploading = true
+        service.totalProgress = 0.75
+
+        service.reset()
+
+        XCTAssertFalse(service.isUploading)
+        XCTAssertNil(service.currentUploadingPhoto)
+        XCTAssertEqual(service.totalProgress, 0.0)
+        XCTAssertEqual(service.uploadSummary, "Ready to upload photos")
+    }
+}

--- a/apps/ios/LogYourBodyTests/ExternalServicePortsTests.swift
+++ b/apps/ios/LogYourBodyTests/ExternalServicePortsTests.swift
@@ -1,0 +1,222 @@
+//
+// ExternalServicePortsTests.swift
+// LogYourBodyTests
+//
+import AVFoundation
+import LocalAuthentication
+import Photos
+import UIKit
+import XCTest
+@testable import LogYourBody
+
+final class ExternalServicePortsTests: XCTestCase {
+    // MARK: - Protocol convenience extensions
+
+    func testAnalyticsConvenienceMethodsForwardNilProperties() throws {
+        let tracker = FakeAnalyticsTracker()
+
+        tracker.identify(userId: "user-1")
+        tracker.track(event: "photo_uploaded")
+
+        let identified = try XCTUnwrap(tracker.identified.first)
+        XCTAssertEqual(identified.userId, "user-1")
+        XCTAssertNil(identified.properties)
+
+        let tracked = try XCTUnwrap(tracker.tracked.first)
+        XCTAssertEqual(tracked.event, "photo_uploaded")
+        XCTAssertNil(tracked.properties)
+    }
+
+    func testGlp1DoseLogsConvenienceUsesDefaultLimitOfOneHundred() async throws {
+        let provider = FakeGlp1RemoteDataProvider()
+
+        let logs = try await provider.fetchGlp1DoseLogs(userId: "user-7")
+
+        XCTAssertTrue(logs.isEmpty)
+        XCTAssertEqual(provider.recordedLimits, [100])
+        XCTAssertEqual(provider.recordedUserIds, ["user-7"])
+    }
+
+    // MARK: - Port type mappings
+
+    func testBiometryTypeMapsToAuthViewType() {
+        XCTAssertEqual(AppBiometryType.touchID.authViewType, .touchID)
+        XCTAssertEqual(AppBiometryType.faceID.authViewType, .faceID)
+        XCTAssertEqual(AppBiometryType.none.authViewType, .faceID)
+    }
+
+    // MARK: - Adapter delegation to vendor objects
+
+    func testBiometricAdapterMirrorsVendorAvailability() {
+        let context = LAContext()
+        var error: NSError?
+        let expected: AppBiometryType
+        if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) {
+            switch context.biometryType {
+            case .faceID:
+                expected = .faceID
+            case .touchID:
+                expected = .touchID
+            default:
+                expected = .none
+            }
+        } else {
+            expected = .none
+        }
+
+        XCTAssertEqual(LocalBiometricAuthenticationAdapter().availableBiometryType(), expected)
+    }
+
+    func testCancelAuthenticationWithoutActiveSessionIsSafeNoOp() {
+        // BiometricLockView calls cancelCurrentAuthentication() from .onDisappear,
+        // including when no authentication was ever started.
+        let adapter = LocalBiometricAuthenticationAdapter()
+        adapter.cancelCurrentAuthentication()
+        adapter.cancelCurrentAuthentication()
+
+        XCTAssertEqual(adapter.availableBiometryType(), LocalBiometricAuthenticationAdapter().availableBiometryType())
+    }
+
+    func testPhotoLibraryAdapterMirrorsVendorAuthorizationStatus() {
+        let vendorStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+
+        XCTAssertEqual(
+            LivePhotoLibraryAdapter().authorizationStatus(),
+            expectedAuthorizationState(for: vendorStatus)
+        )
+    }
+
+    func testDeleteAssetsWithNoIdentifiersCompletesWithoutTouchingLibrary() async throws {
+        // Empty input must short-circuit before any PHPhotoLibrary.performChanges call.
+        try await LivePhotoLibraryAdapter().deleteAssets(localIdentifiers: [])
+    }
+
+    func testCameraAdapterMirrorsVendorAuthorizationStatusAndAvailability() {
+        let vendorStatus = AVCaptureDevice.authorizationStatus(for: .video)
+
+        XCTAssertEqual(
+            LiveCameraAuthorizationAdapter().authorizationStatus(),
+            expectedAuthorizationState(for: vendorStatus)
+        )
+        XCTAssertEqual(
+            LiveCameraAuthorizationAdapter().isCameraAvailable,
+            UIImagePickerController.isSourceTypeAvailable(.camera)
+        )
+    }
+
+    // MARK: - Camera capture coordinator
+
+    func testCameraCoordinatorDeliversCapturedImage() {
+        var captured: [UIImage] = []
+        let view = PlatformCameraCaptureView(onImageCaptured: { captured.append($0) })
+        let coordinator = view.makeCoordinator()
+        let image = makeTestImage()
+
+        coordinator.imagePickerController(
+            UIImagePickerController(),
+            didFinishPickingMediaWithInfo: [.originalImage: image]
+        )
+
+        XCTAssertEqual(captured.count, 1)
+        XCTAssertTrue(captured.first === image)
+    }
+
+    func testCameraCoordinatorIgnoresPickerResultWithoutOriginalImage() {
+        var captured: [UIImage] = []
+        let view = PlatformCameraCaptureView(onImageCaptured: { captured.append($0) })
+        let coordinator = view.makeCoordinator()
+
+        coordinator.imagePickerController(
+            UIImagePickerController(),
+            didFinishPickingMediaWithInfo: [:]
+        )
+
+        XCTAssertTrue(captured.isEmpty)
+    }
+
+    func testCameraCoordinatorCancelDoesNotDeliverImage() {
+        var captured: [UIImage] = []
+        let view = PlatformCameraCaptureView(onImageCaptured: { captured.append($0) })
+        let coordinator = view.makeCoordinator()
+
+        coordinator.imagePickerControllerDidCancel(UIImagePickerController())
+
+        XCTAssertTrue(captured.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func expectedAuthorizationState(for status: PHAuthorizationStatus) -> AppAuthorizationState {
+        switch status {
+        case .authorized, .limited:
+            return .authorized
+        case .notDetermined:
+            return .notDetermined
+        case .denied:
+            return .denied
+        case .restricted:
+            return .restricted
+        @unknown default:
+            return .unknown
+        }
+    }
+
+    private func expectedAuthorizationState(for status: AVAuthorizationStatus) -> AppAuthorizationState {
+        switch status {
+        case .authorized:
+            return .authorized
+        case .notDetermined:
+            return .notDetermined
+        case .denied:
+            return .denied
+        case .restricted:
+            return .restricted
+        @unknown default:
+            return .unknown
+        }
+    }
+
+    private func makeTestImage() -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 8, height: 8))
+        return renderer.image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(origin: .zero, size: CGSize(width: 8, height: 8)))
+        }
+    }
+}
+
+private final class FakeAnalyticsTracker: AnalyticsTracking {
+    private(set) var identified: [(userId: String?, properties: [String: String]?)] = []
+    private(set) var tracked: [(event: String, properties: [String: String]?)] = []
+
+    func start() { }
+
+    func identify(userId: String?, properties: [String: String]?) {
+        identified.append((userId: userId, properties: properties))
+    }
+
+    func track(event: String, properties: [String: String]?) {
+        tracked.append((event: event, properties: properties))
+    }
+
+    func reset() { }
+
+    func isFeatureEnabled(flagKey: String) -> Bool {
+        false
+    }
+}
+
+private final class FakeGlp1RemoteDataProvider: Glp1RemoteDataProviding {
+    private(set) var recordedLimits: [Int] = []
+    private(set) var recordedUserIds: [String] = []
+
+    func fetchGlp1Medications(userId: String) async throws -> [Glp1Medication] {
+        []
+    }
+
+    func fetchGlp1DoseLogs(userId: String, limit: Int) async throws -> [Glp1DoseLog] {
+        recordedUserIds.append(userId)
+        recordedLimits.append(limit)
+        return []
+    }
+}

--- a/apps/ios/LogYourBodyTests/PhotoUploadManagerTests.swift
+++ b/apps/ios/LogYourBodyTests/PhotoUploadManagerTests.swift
@@ -1,0 +1,540 @@
+//
+// PhotoUploadManagerTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import CoreData
+import UIKit
+@testable import LogYourBody
+
+@MainActor
+final class PhotoUploadManagerTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+        AuthManager.shared.currentUser = nil
+        PhotoUploadStubURLProtocol.reset()
+    }
+
+    override func tearDown() async throws {
+        PhotoUploadStubURLProtocol.reset()
+        AuthManager.shared.currentUser = nil
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+        try await super.tearDown()
+    }
+
+    // MARK: - Error contract
+
+    func testPhotoErrorDescriptionsMatchDocumentedContract() {
+        XCTAssertEqual(
+            PhotoUploadManager.PhotoError.notAuthenticated.errorDescription,
+            "Please log in to upload photos"
+        )
+        XCTAssertEqual(
+            PhotoUploadManager.PhotoError.imageConversionFailed.errorDescription,
+            "Failed to process the image"
+        )
+        XCTAssertEqual(
+            PhotoUploadManager.PhotoError.uploadFailed("server said no").errorDescription,
+            "server said no"
+        )
+        XCTAssertEqual(
+            PhotoUploadManager.PhotoError.processingFailed("broken pipe").errorDescription,
+            "broken pipe"
+        )
+        XCTAssertEqual(
+            PhotoUploadManager.PhotoError.networkError.errorDescription,
+            "Network connection error. Check your connection and try again."
+        )
+    }
+
+    // MARK: - Authentication guard
+
+    func testImageDataUploadWithoutUserThrowsNotAuthenticatedBeforeAnyWork() async throws {
+        let manager = makeManager(token: "stub-jwt")
+        let metrics = makeMetrics(id: UUID().uuidString, userId: "anonymous")
+        PhotoUploadStubURLProtocol.install { _ in .http(200, body: Data()) }
+
+        await assertThrowsPhotoError(.notAuthenticated) {
+            _ = try await manager.uploadProgressPhoto(for: metrics, imageData: try makePNGData())
+        }
+
+        XCTAssertFalse(manager.isUploading)
+        XCTAssertNil(manager.uploadError)
+        XCTAssertNil(manager.currentUploadTask)
+        XCTAssertTrue(PhotoUploadStubURLProtocol.requests.isEmpty)
+    }
+
+    func testImageUploadWithoutUserThrowsNotAuthenticatedBeforeVisionProcessing() async throws {
+        let manager = makeManager(token: "stub-jwt")
+        let metrics = makeMetrics(id: UUID().uuidString, userId: "anonymous")
+
+        await assertThrowsPhotoError(.notAuthenticated) {
+            _ = try await manager.uploadProgressPhoto(for: metrics, image: makeSolidImage())
+        }
+
+        XCTAssertFalse(manager.isUploading)
+        XCTAssertTrue(PhotoUploadStubURLProtocol.requests.isEmpty)
+    }
+
+    // MARK: - Vision processing stage (real Vision, synthetic image)
+
+    func testImageUploadFailsBeforeNetworkWhenVisionRejectsSyntheticImage() async throws {
+        // Real Vision on a synthetic person-less image never reaches the network:
+        // the stage throws (no human detected, or Vision unavailable on this
+        // platform) and the raw processing error is surfaced verbatim.
+        let userId = "photo_vision_user_\(UUID().uuidString)"
+        authenticate(userId: userId)
+        let manager = makeManager(token: "stub-jwt")
+        let metrics = makeMetrics(id: UUID().uuidString, userId: userId)
+        PhotoUploadStubURLProtocol.install { _ in .http(200, body: Data()) }
+
+        var thrownError: Error?
+        do {
+            _ = try await manager.uploadProgressPhoto(for: metrics, image: makeSolidImage())
+            XCTFail("Expected the Vision stage to reject a person-less image")
+        } catch {
+            thrownError = error
+        }
+
+        let error = try XCTUnwrap(thrownError)
+        XCTAssertFalse(error is PhotoUploadManager.PhotoError, "Processing errors surface raw, not as PhotoError")
+        XCTAssertEqual(manager.uploadError, error.localizedDescription)
+        XCTAssertFalse(manager.isUploading)
+        XCTAssertNil(manager.currentUploadTask)
+        XCTAssertTrue(PhotoUploadStubURLProtocol.requests.isEmpty)
+    }
+
+    // MARK: - Successful upload
+
+    func testSuccessfulUploadStoresPhotoAndTriggersProcessing() async throws {
+        let userId = "photo_upload_user_\(UUID().uuidString)"
+        let metricId = UUID().uuidString
+        let metrics = try await seedPhotoPlaceholder(id: metricId, userId: userId)
+        authenticate(userId: userId)
+
+        let processedURL = "https://cdn.example.com/processed.png"
+        PhotoUploadStubURLProtocol.install { request in
+            if request.url?.path.contains("/storage/v1/") == true {
+                return .http(200, body: Data("{}".utf8))
+            }
+            return .http(200, body: Data(#"{"processedUrl": "\#(processedURL)"}"#.utf8))
+        }
+
+        let manager = makeManager(token: "stub-jwt")
+        let pngData = try makePNGData()
+        let returnedURL = try await manager.uploadProgressPhoto(for: metrics, imageData: pngData)
+
+        XCTAssertEqual(returnedURL, processedURL)
+        XCTAssertFalse(manager.isUploading)
+        XCTAssertNil(manager.uploadError)
+        XCTAssertNil(manager.currentUploadTask)
+        XCTAssertEqual(manager.uploadProgress, 1.0)
+
+        // Storage upload request construction (bucket/path/auth headers/body)
+        let requests = PhotoUploadStubURLProtocol.requests
+        XCTAssertEqual(requests.count, 2)
+        let storageRequest = try XCTUnwrap(requests.first)
+        XCTAssertEqual(storageRequest.httpMethod, "POST")
+        XCTAssertEqual(storageRequest.url?.host, PhotoUploadStubURLProtocol.stubHost)
+        let storagePath = try XCTUnwrap(
+            storageRequest.url?.path.replacingOccurrences(of: "/storage/v1/object/photos/", with: "")
+        )
+        XCTAssertTrue(storagePath.hasPrefix("\(userId)/\(metricId)_"))
+        XCTAssertTrue(storagePath.hasSuffix(".jpg"))
+        XCTAssertEqual(storageRequest.value(forHTTPHeaderField: "apikey"), Constants.supabaseAnonKey)
+        XCTAssertEqual(storageRequest.value(forHTTPHeaderField: "Authorization"), "Bearer stub-jwt")
+        XCTAssertEqual(storageRequest.value(forHTTPHeaderField: "Content-Type"), "image/png")
+        XCTAssertEqual(PhotoUploadStubURLProtocol.bodyData(of: storageRequest), pngData)
+
+        // Processing trigger fires after the upload with the stored path
+        let functionRequest = try XCTUnwrap(requests.last)
+        XCTAssertEqual(functionRequest.httpMethod, "POST")
+        XCTAssertEqual(functionRequest.url?.path, "/functions/v1/process-progress-photo")
+        XCTAssertEqual(functionRequest.value(forHTTPHeaderField: "apikey"), Constants.supabaseAnonKey)
+        XCTAssertEqual(functionRequest.value(forHTTPHeaderField: "Authorization"), "Bearer stub-jwt")
+        XCTAssertEqual(functionRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        let functionBody = try XCTUnwrap(PhotoUploadStubURLProtocol.bodyData(of: functionRequest))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: functionBody) as? [String: Any])
+        XCTAssertEqual(json["storagePath"] as? String, storagePath)
+        XCTAssertEqual(json["metricsId"] as? String, metricId)
+
+        // Local Core Data record updated with both URLs and marked for sync
+        let cached = try await cachedPhotoState(metricId: metricId)
+        XCTAssertEqual(cached.photoUrl, processedURL)
+        XCTAssertEqual(cached.originalPhotoUrl, storagePath)
+        XCTAssertEqual(cached.syncStatus, "pending")
+        XCTAssertFalse(cached.isSynced)
+    }
+
+    func testHEICInputIsConvertedToJPEGBeforeUpload() async throws {
+        let userId = "photo_heic_user_\(UUID().uuidString)"
+        let metricId = UUID().uuidString
+        let metrics = try await seedPhotoPlaceholder(id: metricId, userId: userId)
+        authenticate(userId: userId)
+
+        let processedURL = "https://cdn.example.com/heic-processed.png"
+        PhotoUploadStubURLProtocol.install { request in
+            if request.url?.path.contains("/storage/v1/") == true {
+                return .http(200, body: Data("{}".utf8))
+            }
+            return .http(200, body: Data(#"{"processedUrl": "\#(processedURL)"}"#.utf8))
+        }
+
+        let manager = makeManager(token: "stub-jwt")
+        let heicData = try makeHEICData()
+        let returnedURL = try await manager.uploadProgressPhoto(for: metrics, imageData: heicData)
+
+        XCTAssertEqual(returnedURL, processedURL)
+        let storageRequest = try XCTUnwrap(PhotoUploadStubURLProtocol.requests.first)
+        XCTAssertTrue(storageRequest.url?.path.hasSuffix(".jpg") ?? false)
+        let body = try XCTUnwrap(PhotoUploadStubURLProtocol.bodyData(of: storageRequest))
+        XCTAssertTrue(body.starts(with: [0xFF, 0xD8, 0xFF]), "Expected JPEG payload after HEIC conversion")
+    }
+
+    // MARK: - Failure paths
+
+    func testStorageHTTPErrorSurfacesServerMessageAndSkipsProcessing() async throws {
+        let userId = "photo_http_user_\(UUID().uuidString)"
+        let metricId = UUID().uuidString
+        let metrics = try await seedPhotoPlaceholder(id: metricId, userId: userId)
+        authenticate(userId: userId)
+
+        PhotoUploadStubURLProtocol.install { _ in
+            .http(400, body: Data("row level security violated".utf8))
+        }
+
+        let manager = makeManager(token: "stub-jwt")
+        await assertThrowsPhotoError(.uploadFailed("row level security violated")) {
+            _ = try await manager.uploadProgressPhoto(for: metrics, imageData: try makePNGData())
+        }
+
+        XCTAssertEqual(manager.uploadError, "row level security violated")
+        XCTAssertFalse(manager.isUploading)
+        XCTAssertNil(manager.currentUploadTask)
+
+        // Only the storage request was attempted; processing was never triggered
+        XCTAssertEqual(PhotoUploadStubURLProtocol.requests.count, 1)
+        XCTAssertTrue(PhotoUploadStubURLProtocol.requests.first?.url?.path.contains("/storage/v1/") ?? false)
+
+        // The local record was not marked storage-committed
+        let cached = try await cachedPhotoState(metricId: metricId)
+        XCTAssertNil(cached.originalPhotoUrl)
+        XCTAssertNil(cached.photoUrl)
+    }
+
+    func testStorageNetworkErrorMapsToDocumentedNetworkMessage() async throws {
+        let userId = "photo_network_user_\(UUID().uuidString)"
+        let metricId = UUID().uuidString
+        let metrics = try await seedPhotoPlaceholder(id: metricId, userId: userId)
+        authenticate(userId: userId)
+
+        PhotoUploadStubURLProtocol.install { _ in .failure(URLError(.notConnectedToInternet)) }
+
+        let manager = makeManager(token: "stub-jwt")
+        await assertThrowsPhotoError(.networkError) {
+            _ = try await manager.uploadProgressPhoto(for: metrics, imageData: try makePNGData())
+        }
+
+        XCTAssertEqual(
+            manager.uploadError,
+            "Network connection error. Check your connection and try again."
+        )
+        XCTAssertFalse(manager.isUploading)
+    }
+
+    func testProcessingHTTPErrorSurfacesServerMessageAfterStorageCommit() async throws {
+        let userId = "photo_processing_user_\(UUID().uuidString)"
+        let metricId = UUID().uuidString
+        let metrics = try await seedPhotoPlaceholder(id: metricId, userId: userId)
+        authenticate(userId: userId)
+
+        PhotoUploadStubURLProtocol.install { request in
+            if request.url?.path.contains("/storage/v1/") == true {
+                return .http(200, body: Data("{}".utf8))
+            }
+            return .http(500, body: Data("edge function exploded".utf8))
+        }
+
+        let manager = makeManager(token: "stub-jwt")
+        await assertThrowsPhotoError(.processingFailed("edge function exploded")) {
+            _ = try await manager.uploadProgressPhoto(for: metrics, imageData: try makePNGData())
+        }
+
+        XCTAssertEqual(manager.uploadError, "edge function exploded")
+        XCTAssertFalse(manager.isUploading)
+        XCTAssertNil(manager.currentUploadTask)
+
+        // The storage commit survives the processing failure (retry-safe state)
+        let storagePath = try XCTUnwrap(
+            PhotoUploadStubURLProtocol.requests.first?.url?.path
+                .replacingOccurrences(of: "/storage/v1/object/photos/", with: "")
+        )
+        let cached = try await cachedPhotoState(metricId: metricId)
+        XCTAssertEqual(cached.originalPhotoUrl, storagePath)
+        XCTAssertEqual(cached.syncStatus, CoreDataManager.photoUploadStorageCommittedSyncStatus)
+        XCTAssertNil(cached.photoUrl)
+    }
+
+    func testProcessingResponseWithoutURLSurfacesFormatError() async throws {
+        let userId = "photo_format_user_\(UUID().uuidString)"
+        let metricId = UUID().uuidString
+        let metrics = try await seedPhotoPlaceholder(id: metricId, userId: userId)
+        authenticate(userId: userId)
+
+        PhotoUploadStubURLProtocol.install { request in
+            if request.url?.path.contains("/storage/v1/") == true {
+                return .http(200, body: Data("{}".utf8))
+            }
+            return .http(200, body: Data(#"{"unexpected": true}"#.utf8))
+        }
+
+        let manager = makeManager(token: "stub-jwt")
+        await assertThrowsPhotoError(.processingFailed("Invalid response format")) {
+            _ = try await manager.uploadProgressPhoto(for: metrics, imageData: try makePNGData())
+        }
+
+        XCTAssertEqual(manager.uploadError, "Invalid response format")
+    }
+
+    // MARK: - Helpers
+
+    private enum PhotoErrorCase {
+        case notAuthenticated
+        case uploadFailed(String)
+        case processingFailed(String)
+        case networkError
+    }
+
+    private func assertThrowsPhotoError(
+        _ expected: PhotoErrorCase,
+        operation: () async throws -> Void
+    ) async {
+        do {
+            try await operation()
+            XCTFail("Expected PhotoError.\(expected) to be thrown")
+        } catch let error as PhotoUploadManager.PhotoError {
+            switch (expected, error) {
+            case (.notAuthenticated, .notAuthenticated),
+                 (.networkError, .networkError):
+                break
+            case (.uploadFailed(let expectedMessage), .uploadFailed(let actualMessage)),
+                 (.processingFailed(let expectedMessage), .processingFailed(let actualMessage)):
+                XCTAssertEqual(actualMessage, expectedMessage)
+            default:
+                XCTFail("Expected PhotoError.\(expected), got \(error)")
+            }
+        } catch {
+            XCTFail("Expected PhotoError.\(expected), got \(error)")
+        }
+    }
+
+    private func makeManager(token: String?) -> PhotoUploadManager {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [PhotoUploadStubURLProtocol.self]
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        let session = URLSession(configuration: configuration)
+        return PhotoUploadManager(
+            supabaseTokenProvider: { token },
+            supabaseBaseURL: "https://\(PhotoUploadStubURLProtocol.stubHost)",
+            storageSession: session,
+            functionSession: session
+        )
+    }
+
+    private func authenticate(userId: String) {
+        AuthManager.shared.currentUser = LocalUser(
+            id: userId,
+            email: "photo-upload-tests@example.com",
+            name: nil,
+            avatarUrl: nil,
+            profile: nil
+        )
+    }
+
+    private func makeMetrics(id: String, userId: String) -> BodyMetrics {
+        let date = Date(timeIntervalSince1970: 1_766_000_000)
+        return BodyMetrics(
+            id: id,
+            userId: userId,
+            date: date,
+            weight: nil,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.photo.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+
+    private func seedPhotoPlaceholder(id: String, userId: String) async throws -> BodyMetrics {
+        let metrics = makeMetrics(id: id, userId: userId)
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(metrics, userId: userId, markAsSynced: false)
+        return metrics
+    }
+
+    private func cachedPhotoState(metricId: String) async throws -> (
+        photoUrl: String?,
+        originalPhotoUrl: String?,
+        isSynced: Bool,
+        syncStatus: String?
+    ) {
+        let context = CoreDataManager.shared.viewContext
+
+        return try await context.perform {
+            let request: NSFetchRequest<CachedBodyMetrics> = CachedBodyMetrics.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", metricId)
+            request.fetchLimit = 1
+
+            guard let metric = try context.fetch(request).first else {
+                throw PhotoUploadTestError.missingMetric
+            }
+
+            return (metric.photoUrl, metric.originalPhotoUrl, metric.isSynced, metric.syncStatus)
+        }
+    }
+
+    private func makeSolidImage(size: CGSize = CGSize(width: 64, height: 64)) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1.0
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        return renderer.image { context in
+            UIColor.gray.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+
+    private func makePNGData() throws -> Data {
+        try XCTUnwrap(makeSolidImage().pngData())
+    }
+
+    private func makeHEICData() throws -> Data {
+        let cgImage = try XCTUnwrap(makeSolidImage().cgImage)
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(data, "public.heic" as CFString, 1, nil) else {
+            throw PhotoUploadTestError.heicEncodingUnavailable
+        }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw PhotoUploadTestError.heicEncodingUnavailable
+        }
+        return data as Data
+    }
+
+    private enum PhotoUploadTestError: Error {
+        case missingMetric
+        case heicEncodingUnavailable
+    }
+}
+
+private struct StubbedPhotoResponse {
+    let statusCode: Int
+    let body: Data
+    let error: URLError?
+
+    static func http(_ statusCode: Int, body: Data) -> StubbedPhotoResponse {
+        StubbedPhotoResponse(statusCode: statusCode, body: body, error: nil)
+    }
+
+    static func failure(_ error: URLError) -> StubbedPhotoResponse {
+        StubbedPhotoResponse(statusCode: 0, body: Data(), error: error)
+    }
+}
+
+private final class PhotoUploadStubURLProtocol: URLProtocol {
+    static let stubHost = "photo-upload-tests.example.com"
+
+    private static let lock = NSLock()
+    private static var requestHandler: ((URLRequest) -> StubbedPhotoResponse)?
+    private static var recordedRequests: [URLRequest] = []
+
+    static func install(handler: @escaping (URLRequest) -> StubbedPhotoResponse) {
+        lock.lock()
+        recordedRequests = []
+        requestHandler = handler
+        lock.unlock()
+    }
+
+    static func reset() {
+        lock.lock()
+        recordedRequests = []
+        requestHandler = nil
+        lock.unlock()
+    }
+
+    static var requests: [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedRequests
+    }
+
+    static func bodyData(of request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1_024)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let count = stream.read(buffer, maxLength: 1_024)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data.isEmpty ? nil : data
+    }
+
+    override static func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == stubHost
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.lock.lock()
+        let handler = Self.requestHandler
+        Self.recordedRequests.append(request)
+        Self.lock.unlock()
+
+        guard let handler, let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        let stub = handler(request)
+        if let error = stub.error {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: stub.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: [
+                "Content-Type": "application/json",
+                "Cache-Control": "no-store"
+            ]
+        ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() { }
+}

--- a/apps/ios/TestPlans/Integration.xctestplan
+++ b/apps/ios/TestPlans/Integration.xctestplan
@@ -22,6 +22,7 @@
         "HealthSyncCoordinatorPipelineTests",
         "LoadingManagerHealthSyncTests",
         "PhotoMetadataServiceTests",
+        "PhotoUploadManagerTests",
         "ProgressPhotoImagePipelineTests",
         "RevenueCatProductConfigurationTests",
         "SyncIntegrationBodyMetricSyncTests",

--- a/apps/ios/TestPlans/Unit.xctestplan
+++ b/apps/ios/TestPlans/Unit.xctestplan
@@ -22,6 +22,7 @@
         "HealthSyncCoordinatorPipelineTests",
         "LoadingManagerHealthSyncTests",
         "PhotoMetadataServiceTests",
+        "PhotoUploadManagerTests",
         "ProgressPhotoImagePipelineTests",
         "RevenueCatProductConfigurationTests",
         "SyncIntegrationBodyMetricSyncTests",


### PR DESCRIPTION
## Summary

Batch 5 of the iOS test-hardening effort (inventory section B.1 — photo upload pipeline, previously zero coverage). 25 new tests across 3 classes; integration tier placement updated in both test plans.

- **`PhotoUploadManagerTests` (10, integration tier):** full upload pipeline with only HTTP stubbed (test-local `URLProtocol`) — auth guard (zero requests when signed out), storage POST construction (URL/headers/body), processing-trigger call ordered after storage, Core Data state transitions (`pending` → storage-committed, survives processing failure for retry safety), HEIC→JPEG conversion, error mapping per status/body. Real Vision stage with a synthetic image (documents that simulator Vision fails *before* any network call).
- **`BackgroundPhotoUploadServiceTests` (4, unit tier):** the live queue-state contract consumed by `BackgroundTaskMonitor` — initial state, no-op on empty queue, cancel clears in-flight, reset restores ready.
- **`ExternalServicePortsTests` (11, unit tier):** fake vendor objects against the port protocols — adapter delegation and result/error mapping for photos/camera/biometrics boundaries, GLP-1 default limit, safe no-op contracts.

One justified testability seam (~48 lines): `PhotoUploadManager` internal init injecting token provider/base URL/sessions — required because production token provider is fail-closed `nil`, the checked-in Info.plist has no Supabase keys, and iOS 26 ignores globally-registered URLProtocols (only `configuration.protocolClasses` works). `.shared` unchanged.

**Deliberately not tested (dead code, recommend deletion PR instead):** `queuePhotosForUpload`/`processAndUploadPhotos` have zero call sites anywhere in the app and require `PhotosPickerItem` (no public init) — per the inventory's delete-rather-than-pad rule. Also noted (pinned, unfixed): dead `.failed` task assignment in `PhotoUploadManager` (defer nils it immediately); `uploadToSupabase` always sends `Content-Type: image/png`.

## Validation evidence

- `swiftlint lint --strict`: 0 violations (366 files)
- New classes: `** TEST SUCCEEDED **` — 25/25 (verified on two independent runs)
- Full suite regression (incl. UI tests): `** TEST SUCCEEDED **`
- Tier plans: JSON valid, arrays sorted; `PhotoUploadManagerTests` moved to Integration tier
- Pre-push turbo lint/typecheck/test: green
