### PR TITLE
test(ios): cover version-upgrade migrations and debug reset paths

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		3FA11453ACB47EEEFEAFF581 /* PhotoUploadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A98EF222E91570CB37F44C0 /* PhotoUploadManagerTests.swift */; };
 		42B0784EAF04F40C031D0186 /* DailyReminderPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D9694F1EA5B5091B0AE8B /* DailyReminderPolicyTests.swift */; };
 		43ED1CCFAE5CC7DA20E6DB3E /* BaseTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB074F9FFF63EE8FD17BA /* BaseTextField.swift */; };
+		465512C30A97EB5CF09760D4 /* AppVersionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2827EFD1E859BCE7F2067D /* AppVersionManagerTests.swift */; };
 		46D2D60CC0C168272E5B0A14 /* BulkProgressPhotoImportPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060DD24271B0B2120CB0AA33 /* BulkProgressPhotoImportPolicyTests.swift */; };
 		475B6676DE2161CF4BB8861E /* BiometricLockPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF03916F06E4F2537E89838 /* BiometricLockPolicyTests.swift */; };
 		4C2DA948F919366D436CEF26 /* DSIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458AAF24645E3634CCF88E16 /* DSIcon.swift */; };
@@ -70,6 +71,7 @@
 		98DAEAD9993013F8C7C81764 /* DashboardTimelineAndPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B95EB9919EA722470321074 /* DashboardTimelineAndPolicyTests.swift */; };
 		9B5611E2F8314E22A5BF7889 /* ImageCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75034CADEA1D4697BDCB5555 /* ImageCacheService.swift */; };
 		9BCEB21BE7B69676BCA5C211 /* HealthSyncCoordinatorPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDACB9E8EEAB1EBF446F0F02 /* HealthSyncCoordinatorPipelineTests.swift */; };
+		9E81C3C41951BB662ADA2C6F /* DebugResetManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE8DE6FD2A76A65AF63D2D9 /* DebugResetManagerTests.swift */; };
 		9EBBDD6AF2FF4E4FF8B9E3BC /* BodyCompositionMathGoldenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927B7D58E8E1756BB92364B6 /* BodyCompositionMathGoldenTests.swift */; };
 		A4856A2B9E1FC174F9F1739F /* RevenueCatFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE602CA4F092CAB186EE952 /* RevenueCatFlowTests.swift */; };
 		A7876ACC0BAFED8A57643661 /* AccountDeletionAndShareCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8631504046C70A4EE432C9B8 /* AccountDeletionAndShareCardTests.swift */; };
@@ -319,6 +321,7 @@
 		BC360577C7E72F397010D7B1 /* CachedPaywallOfferingDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AFDB2060EF2522DE93E10D /* CachedPaywallOfferingDisplayTests.swift */; };
 		BDDE3AD864DBBABF8214836A /* FullMetricChartView+Part02.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0DAD82BAAEB27B75923381 /* FullMetricChartView+Part02.swift */; };
 		BE37C87CC62A611B794DC9B9 /* PreferenceGoalValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6047B9B9F0280ED4CEC0DFB /* PreferenceGoalValidatorTests.swift */; };
+		BEF108E2A2F1DFFA716E58E5 /* AppVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DEC696E9D9EFBFAE8202F0 /* AppVersionTests.swift */; };
 		C0D300012F30000100ABCDEF /* GeneratedProductRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300022F30000100ABCDEF /* GeneratedProductRegistry.swift */; };
 		C2465BE618C74154F47B1E1F /* HealthSyncTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4A1C6C2438CB1EDCEC43C67 /* HealthSyncTestDoubles.swift */; };
 		C5C96F424F3D65A1180A3EA7 /* SyncIntegrationRemotePayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 128B0622423D7E7711DCD94D /* SyncIntegrationRemotePayloadTests.swift */; };
@@ -435,6 +438,7 @@
 		629DBB90EB2F0C9F3D9D1105 /* VerificationForm.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VerificationForm.swift; path = DesignSystem/Organisms/VerificationForm.swift; sourceTree = "<group>"; };
 		62F02AB81FF64BBC27043BB9 /* CoreDataManager+Part04.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CoreDataManager+Part04.swift"; path = "CoreDataManager+Part04.swift"; sourceTree = "<group>"; };
 		656A7105DE085AFF17E796C8 /* HealthKitManager+Part03.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HealthKitManager+Part03.swift"; path = "HealthKitManager+Part03.swift"; sourceTree = "<group>"; };
+		6C2827EFD1E859BCE7F2067D /* AppVersionManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppVersionManagerTests.swift; sourceTree = "<group>"; };
 		6C4817DC7BA2D43606C0D8CB /* DashboardContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DashboardContent.swift; path = DesignSystem/Organisms/DashboardContent.swift; sourceTree = "<group>"; };
 		6EBD5BF3F1671BC8D17ABE5D /* BodyMetricSourceContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyMetricSourceContractTests.swift; sourceTree = "<group>"; };
 		7148912B179107B65580E27E /* RevenueCatManager+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "RevenueCatManager+Part02.swift"; path = "RevenueCatManager+Part02.swift"; sourceTree = "<group>"; };
@@ -466,6 +470,7 @@
 		9ED9F05E697F00813F824903 /* LogoutButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LogoutButton.swift; path = DesignSystem/Molecules/LogoutButton.swift; sourceTree = "<group>"; };
 		9F0DAD82BAAEB27B75923381 /* FullMetricChartView+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "FullMetricChartView+Part02.swift"; path = "Components/FullMetricChartView+Part02.swift"; sourceTree = "<group>"; };
 		9F7D800638256D10A5ACB992 /* Glp1DoseCoreDataTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Glp1DoseCoreDataTests.swift; sourceTree = "<group>"; };
+		A1DEC696E9D9EFBFAE8202F0 /* AppVersionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppVersionTests.swift; sourceTree = "<group>"; };
 		A4A1C6C2438CB1EDCEC43C67 /* HealthSyncTestDoubles.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HealthSyncTestDoubles.swift; sourceTree = "<group>"; };
 		A88D7AC2C7FF4E14A3BB8168 /* CoreDataManager+Part03.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CoreDataManager+Part03.swift"; path = "CoreDataManager+Part03.swift"; sourceTree = "<group>"; };
 		AB992727D1333B365F93F30E /* AccountDeletionCleanupServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountDeletionCleanupServiceTests.swift; sourceTree = "<group>"; };
@@ -818,6 +823,7 @@
 		FE11C1C100000000000000FB /* ImageCacheServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheServiceTests.swift; sourceTree = "<group>"; };
 		FE12D2D100000000000000FC /* GoldenPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoldenPathTests.swift; sourceTree = "<group>"; };
 		FECEBC7B2B956D26BF45822F /* DSLogo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSLogo.swift; path = DesignSystem/Atoms/DSLogo.swift; sourceTree = "<group>"; };
+		FEE8DE6FD2A76A65AF63D2D9 /* DebugResetManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DebugResetManagerTests.swift; sourceTree = "<group>"; };
 		FF0B649CA62200DAACE12AA8 /* AddEntrySheet+Part03.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AddEntrySheet+Part03.swift"; path = "AddEntrySheet+Part03.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1072,6 +1078,9 @@
 				7A98EF222E91570CB37F44C0 /* PhotoUploadManagerTests.swift */,
 				0C616D3012947DD91D1BEF39 /* BackgroundPhotoUploadServiceTests.swift */,
 				9A58DAB61B2BBDF2D4EF761B /* ExternalServicePortsTests.swift */,
+				6C2827EFD1E859BCE7F2067D /* AppVersionManagerTests.swift */,
+				FEE8DE6FD2A76A65AF63D2D9 /* DebugResetManagerTests.swift */,
+				A1DEC696E9D9EFBFAE8202F0 /* AppVersionTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1868,6 +1877,9 @@
 				3FA11453ACB47EEEFEAFF581 /* PhotoUploadManagerTests.swift in Sources */,
 				B0BCDE6BE3E9D61B8CF9F3B5 /* BackgroundPhotoUploadServiceTests.swift in Sources */,
 				08009BD8B382A4A3372C1D2D /* ExternalServicePortsTests.swift in Sources */,
+				465512C30A97EB5CF09760D4 /* AppVersionManagerTests.swift in Sources */,
+				9E81C3C41951BB662ADA2C6F /* DebugResetManagerTests.swift in Sources */,
+				BEF108E2A2F1DFFA716E58E5 /* AppVersionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/LogYourBody/Utils/ShakeDetector.swift
+++ b/apps/ios/LogYourBody/Utils/ShakeDetector.swift
@@ -113,7 +113,9 @@ class DebugResetManager {
         }
     }
 
-    private func clearUserDefaults() {
+    // MARK: - Reset steps (internal visibility as an integration-test seam)
+
+    func clearUserDefaults() {
         // print("🗑️ Clearing UserDefaults...")
         if let bundleID = Bundle.main.bundleIdentifier {
             UserDefaults.standard.removePersistentDomain(forName: bundleID)
@@ -140,17 +142,17 @@ class DebugResetManager {
         UserDefaults.standard.synchronize()
     }
 
-    private func clearCoreData() {
+    func clearCoreData() {
         // print("🗑️ Clearing Core Data...")
         CoreDataManager.shared.deleteAllData()
     }
 
-    private func clearKeychain() {
+    func clearKeychain() {
         // print("🗑️ Clearing Keychain...")
         try? KeychainManager.shared.clearAll()
     }
 
-    private func clearImageCache() {
+    func clearImageCache() {
         // print("🗑️ Clearing image cache...")
         // Clear URLCache
         URLCache.shared.removeAllCachedResponses()
@@ -174,7 +176,7 @@ class DebugResetManager {
         await AuthManager.shared.logout()
     }
 
-    private func clearDerivedDataCache() {
+    func clearDerivedDataCache() {
         // print("🗑️ Clearing derived data cache...")
         // Clear any app-specific caches
         if let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {

--- a/apps/ios/LogYourBodyTests/AppVersionManagerTests.swift
+++ b/apps/ios/LogYourBodyTests/AppVersionManagerTests.swift
@@ -1,0 +1,430 @@
+//
+// AppVersionManagerTests.swift
+// LogYourBodyTests
+//
+import XCTest
+@testable import LogYourBody
+
+/// Integration tests for `AppVersionManager.performStartupMaintenance()`.
+///
+/// Seams and limits (per the test-hardening brief):
+/// - `AppVersionManager` hardcodes `UserDefaults.standard`, so this suite
+///   snapshots and restores every managed key instead of using a suite-named
+///   domain.
+/// - Cache clearing targets the real app-container tmp/Caches directories, so
+///   tests seed uniquely-named files and remove leftovers in teardown.
+/// - `clearImageCache()` replaces `URLCache.shared`; the shared instance is
+///   snapshotted in setUp and restored in tearDown.
+/// - Startup maintenance touches `CoreDataManager.shared` synchronously
+///   (migration 1.1.0, `optimizeDatabase`), so tests invoke it on the main
+///   thread to match production and keep the main-queue viewContext legal.
+/// - Fire-and-forget Tasks (`RealtimeSyncManager.updatePendingSyncCount`,
+///   `CoreDataManager.cleanupOldData`, the `pendingSyncCount > 1_000` guard)
+///   are not deterministic and are intentionally not asserted.
+/// - `cleanupKeychain()` is an empty no-op, so no KeychainAvailability gate is
+///   needed here.
+final class AppVersionManagerTests: XCTestCase {
+    // Keys performStartupMaintenance reads, writes, or deletes.
+    private let managedKeys = [
+        "lastLaunchedAppVersion",
+        "lastLaunchedBuildNumber",
+        "firstLaunchDate",
+        "lastMigrationVersion",
+        "lastCoreDataOptimization",
+        Constants.preferredWeightUnitKey,
+        "healthKitSyncEnabled",
+        "old_setting_key",
+        "legacy_preference",
+        "stuck_sync_flag"
+    ]
+
+    private var capturedDefaults: [String: Any] = [:]
+    private var seededFiles: [URL] = []
+    private var snapshotURLCache: URLCache?
+
+    override func setUp() {
+        super.setUp()
+        snapshotURLCache = URLCache.shared
+        captureAndRemoveManagedKeys()
+        // Suppress the weekly CoreData optimize (and its shared-store rewrite)
+        // except in the tests that exercise it explicitly.
+        UserDefaults.standard.set(Date(), forKey: "lastCoreDataOptimization")
+        seededFiles = []
+    }
+
+    override func tearDown() {
+        for file in seededFiles {
+            try? FileManager.default.removeItem(at: file)
+        }
+        seededFiles = []
+        restoreManagedKeys()
+        if let snapshotURLCache {
+            URLCache.shared = snapshotURLCache
+        }
+        snapshotURLCache = nil
+        super.tearDown()
+    }
+
+    // MARK: - Fresh install
+
+    func testFreshInstallSeedsFirstLaunchDateAndDefaultSettings() async throws {
+        try await runStartup()
+
+        let firstLaunch = try XCTUnwrap(UserDefaults.standard.object(forKey: "firstLaunchDate") as? Date)
+        XCTAssertEqual(firstLaunch.timeIntervalSinceNow, 0, accuracy: 5)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: Constants.preferredWeightUnitKey), "lbs")
+        XCTAssertEqual(UserDefaults.standard.object(forKey: "healthKitSyncEnabled") as? Bool, true)
+
+        // Every launch records the current version/build.
+        let manager = AppVersionManager.shared
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "lastLaunchedAppVersion"), manager.currentVersion)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "lastLaunchedBuildNumber"), manager.currentBuild)
+    }
+
+    func testFreshInstallPreservesExistingUserSettings() async throws {
+        UserDefaults.standard.set("kg", forKey: Constants.preferredWeightUnitKey)
+        UserDefaults.standard.set(false, forKey: "healthKitSyncEnabled")
+
+        try await runStartup()
+
+        XCTAssertEqual(UserDefaults.standard.string(forKey: Constants.preferredWeightUnitKey), "kg")
+        XCTAssertEqual(UserDefaults.standard.object(forKey: "healthKitSyncEnabled") as? Bool, false)
+    }
+
+    func testFreshInstallDoesNotRunMigrationsOrUpdateCleanup() async throws {
+        let tempFile = try seedFile(in: tempDirectory(), named: "fresh-temp")
+        let cacheFile = try seedFile(in: cachesDirectory(), named: "fresh-cache")
+        UserDefaults.standard.set("stale", forKey: "old_setting_key")
+        UserDefaults.standard.set("stale", forKey: "legacy_preference")
+        UserDefaults.standard.set(true, forKey: "stuck_sync_flag")
+
+        try await runStartup()
+
+        // Migrations are update-only: no completion marker is recorded.
+        XCTAssertNil(UserDefaults.standard.string(forKey: "lastMigrationVersion"))
+        // Cache wiping and stale-key cleanup are update-only as well.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile.path))
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "old_setting_key"), "stale")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "legacy_preference"), "stale")
+        XCTAssertNotNil(UserDefaults.standard.object(forKey: "stuck_sync_flag"))
+    }
+
+    // MARK: - Update path
+
+    func testUpdateRunsMigrationsAndRecordsCompletion() async throws {
+        forceUpdateFrom(lastVersion: "1.0.0", lastBuild: "1")
+
+        try await runStartup()
+
+        let manager = AppVersionManager.shared
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "lastMigrationVersion"), manager.currentVersion)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "lastLaunchedAppVersion"), manager.currentVersion)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "lastLaunchedBuildNumber"), manager.currentBuild)
+    }
+
+    func testUpdateWipesTempAndCachesButPreservesDocuments() async throws {
+        forceUpdateFrom(lastVersion: "1.0.0", lastBuild: "1")
+        let tempFile = try seedFile(in: tempDirectory(), named: "update-temp")
+        let cacheFile = try seedFile(in: cachesDirectory(), named: "update-cache")
+        let documentFile = try seedFile(in: documentsDirectory(), named: "update-document")
+
+        try await runStartup()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: documentFile.path))
+    }
+
+    func testUpdateRemovesDeprecatedKeysAndStuckFlagsOnly() async throws {
+        forceUpdateFrom(lastVersion: "1.0.0", lastBuild: "1")
+        UserDefaults.standard.set("stale", forKey: "old_setting_key")
+        UserDefaults.standard.set("stale", forKey: "legacy_preference")
+        UserDefaults.standard.set(true, forKey: "stuck_sync_flag")
+        UserDefaults.standard.set("kg", forKey: Constants.preferredWeightUnitKey)
+        UserDefaults.standard.set("keep", forKey: "someUnrelatedKey")
+        addTeardownBlock {
+            UserDefaults.standard.removeObject(forKey: "someUnrelatedKey")
+        }
+
+        try await runStartup()
+
+        XCTAssertNil(UserDefaults.standard.string(forKey: "old_setting_key"))
+        XCTAssertNil(UserDefaults.standard.string(forKey: "legacy_preference"))
+        XCTAssertNil(UserDefaults.standard.object(forKey: "stuck_sync_flag"))
+        XCTAssertEqual(UserDefaults.standard.string(forKey: Constants.preferredWeightUnitKey), "kg")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "someUnrelatedKey"), "keep")
+    }
+
+    func testUpdateFromPartialMigrationRunsOnlyRemainingMigrations() async throws {
+        // Marker says 1.1.0 already ran: only the 1.2.0 temp-file wipe remains.
+        UserDefaults.standard.set("1.1.0", forKey: "lastMigrationVersion")
+        forceUpdateFrom(lastVersion: "1.1.0", lastBuild: "1")
+        let tempFile = try seedFile(in: tempDirectory(), named: "partial-migration")
+
+        try await runStartup()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempFile.path))
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "lastMigrationVersion"),
+            AppVersionManager.shared.currentVersion
+        )
+    }
+
+    func testUpdateWithCompletedMigrationsSkipsThemButStillClearsCaches() async throws {
+        let manager = AppVersionManager.shared
+        try XCTSkipUnless(
+            manager.currentVersion.compare("1.2.0", options: .numeric) != .orderedAscending,
+            "Migration idempotency requires currentVersion >= 1.2.0"
+        )
+        UserDefaults.standard.set(manager.currentVersion, forKey: "lastMigrationVersion")
+        // Force the update path via a build-only bump so the version marker stays current.
+        forceUpdateFrom(lastVersion: manager.currentVersion, lastBuild: "0")
+        let tempFile = try seedFile(in: tempDirectory(), named: "idempotent-temp")
+        let cacheFile = try seedFile(in: cachesDirectory(), named: "idempotent-cache")
+
+        try await runStartup()
+
+        // Both migrations are already recorded, so the 1.2.0 temp wipe must not re-run.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempFile.path))
+        // clearCaches() is unconditional on the update path, independent of migration state.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheFile.path))
+    }
+
+    func testSecondStartupDoesNotRerunMigrations() async throws {
+        let manager = AppVersionManager.shared
+        try XCTSkipUnless(
+            manager.currentVersion.compare("1.2.0", options: .numeric) != .orderedAscending,
+            "Migration idempotency requires currentVersion >= 1.2.0"
+        )
+        forceUpdateFrom(lastVersion: "1.0.0", lastBuild: "1")
+        try await runStartup()
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "lastMigrationVersion"), manager.currentVersion)
+
+        let tempFile = try seedFile(in: tempDirectory(), named: "second-launch")
+        try await runStartup()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempFile.path))
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "lastMigrationVersion"), manager.currentVersion)
+    }
+
+    // MARK: - Same-version launch
+
+    func testSameVersionLaunchKeepsDataAndSkipsCleanup() async throws {
+        let manager = AppVersionManager.shared
+        forceSameVersion()
+        let originalFirstLaunch = Date(timeIntervalSince1970: 1_700_000_000)
+        UserDefaults.standard.set(originalFirstLaunch, forKey: "firstLaunchDate")
+        let tempFile = try seedFile(in: tempDirectory(), named: "same-version-temp")
+        let cacheFile = try seedFile(in: cachesDirectory(), named: "same-version-cache")
+        UserDefaults.standard.set("stale", forKey: "old_setting_key")
+
+        try await runStartup()
+
+        let firstLaunch = try XCTUnwrap(UserDefaults.standard.object(forKey: "firstLaunchDate") as? Date)
+        XCTAssertEqual(firstLaunch.timeIntervalSince1970, originalFirstLaunch.timeIntervalSince1970, accuracy: 0.001)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile.path))
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "old_setting_key"), "stale")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "lastLaunchedAppVersion"), manager.currentVersion)
+    }
+
+    // MARK: - Routine maintenance (every launch)
+
+    func testRoutineMaintenanceDeletesOnlyTempFilesOlderThan7Days() async throws {
+        forceSameVersion()
+        let recentFile = try seedFile(in: tempDirectory(), named: "recent-temp")
+        let oldFile = try seedFile(in: tempDirectory(), named: "old-temp", createdDaysAgo: 8)
+
+        try await runStartup()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recentFile.path))
+    }
+
+    func testOptimizeCoreDataRecordsRunWhenNeverRecorded() async throws {
+        forceSameVersion()
+        UserDefaults.standard.removeObject(forKey: "lastCoreDataOptimization")
+
+        try await runStartup()
+
+        let recorded = try XCTUnwrap(UserDefaults.standard.object(forKey: "lastCoreDataOptimization") as? Date)
+        XCTAssertEqual(recorded.timeIntervalSinceNow, 0, accuracy: 5)
+    }
+
+    func testOptimizeCoreDataRerunsAfterMoreThanAWeek() async throws {
+        forceSameVersion()
+        UserDefaults.standard.set(
+            Date().addingTimeInterval(-8 * 24 * 60 * 60),
+            forKey: "lastCoreDataOptimization"
+        )
+
+        try await runStartup()
+
+        let recorded = try XCTUnwrap(UserDefaults.standard.object(forKey: "lastCoreDataOptimization") as? Date)
+        XCTAssertEqual(recorded.timeIntervalSinceNow, 0, accuracy: 5)
+    }
+
+    func testOptimizeCoreDataSkippedWithinAWeek() async throws {
+        forceSameVersion()
+        let recent = Date().addingTimeInterval(-24 * 60 * 60)
+        UserDefaults.standard.set(recent, forKey: "lastCoreDataOptimization")
+
+        try await runStartup()
+
+        let recorded = try XCTUnwrap(UserDefaults.standard.object(forKey: "lastCoreDataOptimization") as? Date)
+        XCTAssertEqual(recorded.timeIntervalSince1970, recent.timeIntervalSince1970, accuracy: 0.001)
+    }
+
+    // MARK: - Migration 1.1.0 (Core Data effect)
+
+    func testMigration110MarksOnlyHealthKitEntriesAsSynced() async throws {
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+        addTeardownBlock {
+            try? await CoreDataManager.shared.deleteAllDataAndWait()
+        }
+        let userId = "avm-migration-\(UUID().uuidString)"
+        let healthKitId = try await seedBodyMetric(
+            userId: userId,
+            notes: "Imported from HealthKit",
+            dataSource: .healthKit
+        )
+        let manualId = try await seedBodyMetric(
+            userId: userId,
+            notes: "Manual weigh-in",
+            dataSource: .manual
+        )
+        UserDefaults.standard.set("1.0.0", forKey: "lastMigrationVersion")
+        forceUpdateFrom(lastVersion: "1.0.0", lastBuild: "1")
+
+        try await runStartup()
+
+        let metrics = await CoreDataManager.shared.fetchBodyMetrics(for: userId)
+        let healthKitEntry = try XCTUnwrap(metrics.first { $0.id == healthKitId })
+        let manualEntry = try XCTUnwrap(metrics.first { $0.id == manualId })
+        XCTAssertTrue(healthKitEntry.isSynced)
+        XCTAssertEqual(healthKitEntry.syncStatus, "synced")
+        XCTAssertFalse(manualEntry.isSynced)
+        XCTAssertEqual(manualEntry.syncStatus, "pending")
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "lastMigrationVersion"),
+            AppVersionManager.shared.currentVersion
+        )
+    }
+
+    func testMigration110SkippedWhenAlreadyRecorded() async throws {
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+        addTeardownBlock {
+            try? await CoreDataManager.shared.deleteAllDataAndWait()
+        }
+        let userId = "avm-migration-\(UUID().uuidString)"
+        let healthKitId = try await seedBodyMetric(
+            userId: userId,
+            notes: "Imported from HealthKit",
+            dataSource: .healthKit
+        )
+        UserDefaults.standard.set("1.1.0", forKey: "lastMigrationVersion")
+        forceUpdateFrom(lastVersion: "1.1.0", lastBuild: "1")
+
+        try await runStartup()
+
+        let metrics = await CoreDataManager.shared.fetchBodyMetrics(for: userId)
+        let healthKitEntry = try XCTUnwrap(metrics.first { $0.id == healthKitId })
+        XCTAssertFalse(healthKitEntry.isSynced)
+        XCTAssertEqual(healthKitEntry.syncStatus, "pending")
+    }
+
+    // MARK: - Helpers
+
+    /// Runs startup maintenance on the main thread, matching production launch.
+    private func runStartup() async throws {
+        await MainActor.run {
+            AppVersionManager.shared.performStartupMaintenance()
+        }
+    }
+
+    private func forceUpdateFrom(lastVersion: String, lastBuild: String) {
+        UserDefaults.standard.set(lastVersion, forKey: "lastLaunchedAppVersion")
+        UserDefaults.standard.set(lastBuild, forKey: "lastLaunchedBuildNumber")
+    }
+
+    private func forceSameVersion() {
+        let manager = AppVersionManager.shared
+        forceUpdateFrom(lastVersion: manager.currentVersion, lastBuild: manager.currentBuild)
+    }
+
+    private func seedBodyMetric(
+        userId: String,
+        notes: String,
+        dataSource: BodyMetricSource
+    ) async throws -> String {
+        let id = UUID().uuidString
+        let now = Date(timeIntervalSince1970: 1_735_000_000)
+        let metric = BodyMetrics(
+            id: id,
+            userId: userId,
+            date: now,
+            weight: 80.0,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: notes,
+            photoUrl: nil,
+            dataSource: dataSource.rawValue,
+            sourceMetadata: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(metric, userId: userId, markAsSynced: false)
+        return id
+    }
+
+    private func seedFile(
+        in directory: URL,
+        named name: String,
+        createdDaysAgo days: Int? = nil
+    ) throws -> URL {
+        let fileURL = directory.appendingPathComponent("lyb-avm-tests-\(name)-\(UUID().uuidString)")
+        try Data("seed".utf8).write(to: fileURL)
+        if let days {
+            let creationDate = Date().addingTimeInterval(-Double(days) * 24 * 60 * 60)
+            try FileManager.default.setAttributes([.creationDate: creationDate], ofItemAtPath: fileURL.path)
+        }
+        seededFiles.append(fileURL)
+        return fileURL
+    }
+
+    private func tempDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+    }
+
+    private func cachesDirectory() -> URL {
+        // Force-unwrap mirrors the app's own force-unwrap in clearAppCaches().
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+    }
+
+    private func documentsDirectory() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+    }
+
+    private func captureAndRemoveManagedKeys() {
+        for key in managedKeys {
+            if let value = UserDefaults.standard.object(forKey: key) {
+                capturedDefaults[key] = value
+            }
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    private func restoreManagedKeys() {
+        for key in managedKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+            if let value = capturedDefaults[key] {
+                UserDefaults.standard.set(value, forKey: key)
+            }
+        }
+        capturedDefaults.removeAll()
+    }
+}

--- a/apps/ios/LogYourBodyTests/AppVersionTests.swift
+++ b/apps/ios/LogYourBodyTests/AppVersionTests.swift
@@ -1,0 +1,36 @@
+//
+// AppVersionTests.swift
+// LogYourBodyTests
+//
+import XCTest
+@testable import LogYourBody
+
+/// Unit tests for `AppVersion`.
+///
+/// Scope note: `AppVersion` is a thin bundle-metadata reader — it has no
+/// semver parsing, comparison, or prerelease logic (the only version
+/// comparison in the app is `String.compare(_:options: .numeric)` inside
+/// `AppVersionManager`, exercised by `AppVersionManagerTests`). These tests
+/// pin the actual contract: bundle wiring, fallbacks, and the display
+/// format consumed by `VersionRow` and `AnalyticsService`.
+final class AppVersionTests: XCTestCase {
+    func testValuesReflectBundleInfoDictionary() {
+        let info = Bundle.main.infoDictionary
+        let expectedVersion = info?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+        let expectedBuild = info?["CFBundleVersion"] as? String ?? "1"
+
+        XCTAssertEqual(AppVersion.current, expectedVersion)
+        XCTAssertEqual(AppVersion.build, expectedBuild)
+    }
+
+    func testShortVersionIsCurrentVersionWithoutPrefix() {
+        XCTAssertEqual(AppVersion.shortVersion, AppVersion.current)
+        XCTAssertFalse(AppVersion.shortVersion.hasPrefix("Version"))
+    }
+
+    func testFullVersionEmbedsVersionAndBuildInDisplayFormat() {
+        XCTAssertEqual(AppVersion.fullVersion, "Version \(AppVersion.current) (\(AppVersion.build))")
+        XCTAssertTrue(AppVersion.fullVersion.hasPrefix("Version "))
+        XCTAssertTrue(AppVersion.fullVersion.hasSuffix("(\(AppVersion.build))"))
+    }
+}

--- a/apps/ios/LogYourBodyTests/DebugResetManagerTests.swift
+++ b/apps/ios/LogYourBodyTests/DebugResetManagerTests.swift
@@ -1,0 +1,263 @@
+//
+// DebugResetManagerTests.swift
+// LogYourBodyTests
+//
+import Security
+import XCTest
+@testable import LogYourBody
+
+/// Integration tests for `DebugResetManager`'s reset steps (a data-loss-risk
+/// debug surface).
+///
+/// Coverage boundary: `performCompleteReset()` itself is not exercisable
+/// in-process — it presents a `UIAlertController` confirmation, awaits a tap,
+/// and finishes with an intentional `fatalError` under `#if DEBUG`. The
+/// shake → alert wiring is XCUITest/manual territory per the tier
+/// definitions. What is covered here is the destructive payload: each
+/// clear* step the confirmation would unleash.
+///
+/// Notes:
+/// - `clearUserDefaults()` wipes the entire app persistent domain, so this
+///   suite captures/restores the documented keys and asserts the full-wipe
+///   contract on seeded keys only.
+/// - `clearKeychain()` touches the real keychain and is gated on
+///   `KeychainAvailability`.
+/// - `clearCoreData()` operates on `CoreDataManager.shared`; the suite
+///   cleans the shared store before/after via `deleteAllDataAndWait()`
+///   (same pattern as `Glp1DoseCoreDataTests`). The verification fetch is
+///   enqueued on the same serial context queue as the delete, so it
+///   observes the completed wipe without sleeps.
+final class DebugResetManagerTests: XCTestCase {
+    private let documentedKeys = [
+        Constants.hasCompletedOnboardingKey,
+        Constants.onboardingCompletedVersionKey,
+        Constants.onboardingCompletedUserIdKey,
+        Constants.preferredMeasurementSystemKey,
+        "healthKitSyncEnabled",
+        "biometricLockEnabled",
+        "appleSignInName",
+        "HasSyncedHistoricalSteps",
+        "lastSyncDate",
+        "hasSeenWhatsNew"
+    ]
+
+    private var capturedDefaults: [String: Any] = [:]
+    private var seededFiles: [URL] = []
+
+    override func setUp() {
+        super.setUp()
+        for key in documentedKeys {
+            if let value = UserDefaults.standard.object(forKey: key) {
+                capturedDefaults[key] = value
+            }
+        }
+        seededFiles = []
+    }
+
+    override func tearDown() {
+        for file in seededFiles {
+            try? FileManager.default.removeItem(at: file)
+        }
+        seededFiles = []
+        for key in documentedKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+            if let value = capturedDefaults[key] {
+                UserDefaults.standard.set(value, forKey: key)
+            }
+        }
+        capturedDefaults.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - UserDefaults
+
+    func testClearUserDefaultsWipesEntireAppDomain() {
+        for key in documentedKeys {
+            UserDefaults.standard.set("seed", forKey: key)
+        }
+        UserDefaults.standard.set("seed", forKey: "lyb-debug-reset-arbitrary")
+
+        DebugResetManager.shared.clearUserDefaults()
+
+        for key in documentedKeys {
+            XCTAssertNil(
+                UserDefaults.standard.object(forKey: key),
+                "Expected \(key) to be removed"
+            )
+        }
+        // The real contract is a full app-domain wipe, not just the documented list.
+        XCTAssertNil(UserDefaults.standard.object(forKey: "lyb-debug-reset-arbitrary"))
+    }
+
+    func testClearUserDefaultsPreservesOtherDefaultsSuites() throws {
+        let suiteName = "DebugResetManagerTests.\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        suite.set("keep", forKey: "suiteKey")
+        addTeardownBlock {
+            suite.removePersistentDomain(forName: suiteName)
+        }
+
+        DebugResetManager.shared.clearUserDefaults()
+
+        XCTAssertEqual(suite.string(forKey: "suiteKey"), "keep")
+    }
+
+    // MARK: - Core Data
+
+    func testClearCoreDataDeletesSeededRecords() async throws {
+        let coreData = CoreDataManager.shared
+        try await coreData.deleteAllDataAndWait()
+        addTeardownBlock {
+            try? await CoreDataManager.shared.deleteAllDataAndWait()
+        }
+        let userId = "debug-reset-\(UUID().uuidString)"
+        try await coreData.saveBodyMetricsAndWait(makeBodyMetric(userId: userId), userId: userId)
+        try await coreData.saveGlp1DoseLogsAndWait([makeDoseLog(userId: userId)], userId: userId, markAsSynced: true)
+        let seededMetrics = await coreData.fetchBodyMetrics(for: userId)
+        let seededLogs = await coreData.fetchGlp1DoseLogs(for: userId)
+        XCTAssertFalse(seededMetrics.isEmpty)
+        XCTAssertFalse(seededLogs.isEmpty)
+
+        DebugResetManager.shared.clearCoreData()
+
+        // Both the delete and the fetch are enqueued on the same serial
+        // viewContext queue, so the fetch observes the completed wipe.
+        let remainingMetrics = await coreData.fetchBodyMetrics(for: userId)
+        let remainingLogs = await coreData.fetchGlp1DoseLogs(for: userId)
+        XCTAssertTrue(remainingMetrics.isEmpty)
+        XCTAssertTrue(remainingLogs.isEmpty)
+    }
+
+    // MARK: - Keychain
+
+    func testClearKeychainRemovesManagedItemsButKeepsUnrelatedEntries() throws {
+        try XCTSkipUnless(
+            KeychainAvailability.isAvailable(),
+            "Keychain unavailable on unsigned CI test host (errSecMissingEntitlement); "
+                + "runs fully on signed hosts and local dev. "
+                + "TODO(@itstimwhite): enable when CI signs the test host."
+        )
+        let keychain = KeychainManager.shared
+        try keychain.saveAuthToken("debug-reset-auth-token")
+        try keychain.saveRefreshToken("debug-reset-refresh-token")
+        try keychain.save("debug-reset-session", forKey: "debugResetSession")
+
+        let unrelatedService = "com.logyourbody.tests.unrelated.\(UUID().uuidString)"
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: unrelatedService,
+            kSecAttrAccount as String: "probe",
+            kSecValueData as String: Data("keep".utf8)
+        ]
+        XCTAssertEqual(SecItemAdd(addQuery as CFDictionary, nil), errSecSuccess)
+        addTeardownBlock {
+            try? KeychainManager.shared.clearAll()
+            let deleteQuery: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: unrelatedService
+            ]
+            SecItemDelete(deleteQuery as CFDictionary)
+        }
+
+        DebugResetManager.shared.clearKeychain()
+
+        XCTAssertNil(try keychain.getAuthToken())
+        XCTAssertNil(try keychain.getRefreshToken())
+        XCTAssertNil(try keychain.get(forKey: "debugResetSession", as: String.self))
+
+        // clearAll() scopes deletion to the app's own keychain services only.
+        var copied: AnyObject?
+        let copyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: unrelatedService,
+            kSecAttrAccount as String: "probe",
+            kSecReturnData as String: true
+        ]
+        XCTAssertEqual(SecItemCopyMatching(copyQuery as CFDictionary, &copied), errSecSuccess)
+        XCTAssertEqual(copied as? Data, Data("keep".utf8))
+    }
+
+    // MARK: - File caches
+
+    func testClearImageCacheWipesOnlyTempDirectory() throws {
+        let tempFile = try seedFile(in: FileManager.default.temporaryDirectory, named: "image-cache-temp")
+        let cacheFile = try seedFile(in: cachesDirectory(), named: "image-cache-cache")
+        let documentFile = try seedFile(in: documentsDirectory(), named: "image-cache-document")
+
+        DebugResetManager.shared.clearImageCache()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: documentFile.path))
+    }
+
+    func testClearDerivedDataCacheWipesOnlyCachesDirectory() throws {
+        let cacheFile = try seedFile(in: cachesDirectory(), named: "derived-cache")
+        let tempFile = try seedFile(in: FileManager.default.temporaryDirectory, named: "derived-temp")
+        let documentFile = try seedFile(in: documentsDirectory(), named: "derived-document")
+
+        DebugResetManager.shared.clearDerivedDataCache()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: documentFile.path))
+    }
+
+    // MARK: - Helpers
+
+    private func makeBodyMetric(userId: String) -> BodyMetrics {
+        let now = Date(timeIntervalSince1970: 1_735_000_000)
+        return BodyMetrics(
+            id: UUID().uuidString,
+            userId: userId,
+            date: now,
+            weight: 80.0,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: "Debug reset seed",
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            sourceMetadata: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    private func makeDoseLog(userId: String) -> Glp1DoseLog {
+        let now = Date(timeIntervalSince1970: 1_735_000_000)
+        return Glp1DoseLog(
+            id: UUID().uuidString,
+            userId: userId,
+            takenAt: now,
+            medicationId: "medication",
+            doseAmount: 5.0,
+            doseUnit: "mg/week",
+            drugClass: "dual GIP/GLP-1 receptor agonist",
+            brand: "Zepbound",
+            isCompounded: false,
+            supplierType: nil,
+            supplierName: nil,
+            notes: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    private func seedFile(in directory: URL, named name: String) throws -> URL {
+        let fileURL = directory.appendingPathComponent("lyb-debug-reset-tests-\(name)-\(UUID().uuidString)")
+        try Data("seed".utf8).write(to: fileURL)
+        seededFiles.append(fileURL)
+        return fileURL
+    }
+
+    private func cachesDirectory() -> URL {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+    }
+
+    private func documentsDirectory() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+    }
+}

--- a/apps/ios/TestPlans/Integration.xctestplan
+++ b/apps/ios/TestPlans/Integration.xctestplan
@@ -14,10 +14,12 @@
   "testTargets" : [
     {
       "selectedTests" : [
+        "AppVersionManagerTests",
         "BodyMetricPhotoUpdateTests",
         "BodyScoreHealthKitTriggerTests",
         "CoreDataModelMigrationTests",
         "DashboardViewModelHealthSyncWiringTests",
+        "DebugResetManagerTests",
         "Glp1DoseCoreDataTests",
         "HealthSyncCoordinatorPipelineTests",
         "LoadingManagerHealthSyncTests",

--- a/apps/ios/TestPlans/Unit.xctestplan
+++ b/apps/ios/TestPlans/Unit.xctestplan
@@ -14,10 +14,12 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "AppVersionManagerTests",
         "BodyMetricPhotoUpdateTests",
         "BodyScoreHealthKitTriggerTests",
         "CoreDataModelMigrationTests",
         "DashboardViewModelHealthSyncWiringTests",
+        "DebugResetManagerTests",
         "Glp1DoseCoreDataTests",
         "HealthSyncCoordinatorPipelineTests",
         "LoadingManagerHealthSyncTests",


### PR DESCRIPTION
## Summary

Batch 6 of the iOS test-hardening effort (inventory B.1 — the data-loss-risk surfaces). 25 new tests, all on observable state; both tier plans verified.

- **`AppVersionManagerTests` (16, integration):** version-upgrade lifecycle on real tmp/Caches/Documents dirs and snapshotted UserDefaults — fresh-install vs update vs same-version path differentiation (what gets seeded vs preserved), migration gating + order + idempotency (never re-runs), the 1.1.0 Core Data migration's real effect (HealthKit entries marked synced, manual untouched), cache-clearing contract (tmp+Caches wiped on update, Documents preserved), routine maintenance (only >7-day temp files removed), stale-key cleanup, weekly optimize marker.
- **`DebugResetManagerTests` (6, integration):** the debug reset's real blast radius — full app-domain UserDefaults wipe (other suites' domains survive), Core Data metric/dose clearing (deterministic via the serial viewContext queue), keychain clearing (gated on `KeychainAvailability`; unrelated items survive), tmp-vs-Caches scope. One justified seam: dropped `private` on the five `clear*` methods (visibility only, zero logic change).
- **`AppVersionTests` (3, unit):** the file's real contract (bundle wiring + fallbacks + display format) — the hypothesized semver logic doesn't exist; version comparison lives in `AppVersionManager` and is covered by the Task-1 migration tests.

**Latent risk documented, not fixed (needs its own PR):** `AppVersionManager.optimizeCoreData` calls `replacePersistentStore` on the live shared store, which can silently fail or diverge the on-disk file from the open handle; tests assert only the marker. `performCompleteReset`'s alert+`fatalError` path is XCUITest/manual territory.

## Validation evidence

- `swiftlint lint --strict`: 0 violations
- New classes: `** TEST SUCCEEDED **` — 25/25 (two independent runs)
- Full Integration plan: 101 tests, 0 failures; full Unit plan: 363 tests, 0 failures (tier placements correct)
- Pre-push turbo lint/typecheck/test: green
