### PR TITLE
test(ios): cover BodySpec API contract and OAuth token state

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		8FB91216C622624E0F7815CC /* HealthSyncPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C662CF613D4755CA2B93A43 /* HealthSyncPipelineTests.swift */; };
 		91DA2456348FBCCDC9343F30 /* ProgressPhotoAttachPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EBF62AD8F9F25BB301D998 /* ProgressPhotoAttachPolicyTests.swift */; };
 		929DE2322E275AEB79624023 /* RevenueCatManager+Part01.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29553DC6811B06CAE2621869 /* RevenueCatManager+Part01.swift */; };
+		93335DCBFB7D09586F330149 /* BodySpecAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2D877BFA93E04F9E168FA7 /* BodySpecAPITests.swift */; };
 		93AEA1AF2FA4E6E91E7B482A /* LoadingManagerHealthSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A9ED1D5319B495A194EE88 /* LoadingManagerHealthSyncTests.swift */; };
 		948778D2A40C5957E42E40CF /* PhaseInsightPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E40D3BC9C969629954E803 /* PhaseInsightPolicyTests.swift */; };
 		9528AB022858D682E801AC01 /* AuthProfileBootstrapPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBDA30F8A24DC3754F3CD216 /* AuthProfileBootstrapPolicyTests.swift */; };
@@ -316,6 +317,7 @@
 		B11404E6ED2FB64ADE0E0EAE /* EditEntrySavePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51C80EB60F2EA0D7AFA62AB /* EditEntrySavePolicyTests.swift */; };
 		B12671012F16000100ABCDEF /* BodyScoreEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12671002F16000100ABCDEF /* BodyScoreEngineTests.swift */; };
 		B12671032F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12671022F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift */; };
+		B13F1CC0CFEB9076519101DB /* BodySpecAuthManagerTokenStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9C6D5CF67D9E4FA0995EC1 /* BodySpecAuthManagerTokenStateTests.swift */; };
 		B1F00834695D3233B62404FD /* BodyMetricLoggingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C639B8116483011892C95543 /* BodyMetricLoggingServiceTests.swift */; };
 		BB64CACAE821CFB2A97F53BA /* AuthSurfacePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA456B8668AB1B5DDFA6C5CA /* AuthSurfacePolicyTests.swift */; };
 		BC360577C7E72F397010D7B1 /* CachedPaywallOfferingDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AFDB2060EF2522DE93E10D /* CachedPaywallOfferingDisplayTests.swift */; };
@@ -330,6 +332,7 @@
 		CC4917DEC8E46FACECDF3424 /* DashboardDataVizPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0211D1493A398942561196F /* DashboardDataVizPolicyTests.swift */; };
 		CCCD701F26CEB5C9F56AA8FB /* PaywallSavingsPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C87F359CE5509C2457AB583 /* PaywallSavingsPolicyTests.swift */; };
 		CCE3FEEC83AAC1B3F1F82BF6 /* DSProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18AA7A0EC7327CC6EB9725D /* DSProgressBar.swift */; };
+		CD05B6509260D3FC351104B4 /* BodySpecAuthManagerPKCETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F614C8BD21F414268DB7829 /* BodySpecAuthManagerPKCETests.swift */; };
 		CEA13DB06DA2A2D160A48D1D /* LegalDocumentLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E358ECC97E3F08357502AC /* LegalDocumentLoaderTests.swift */; };
 		D2184ADBFB25DEB92514F85D /* DSCircularProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C575F720A1D8D1DFDC4F1CEF /* DSCircularProgressTests.swift */; };
 		D47F9BD18CBEE2413DF244FC /* RevenueCatProductConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7899ADA31AC216735A9FE299 /* RevenueCatProductConfigurationTests.swift */; };
@@ -428,6 +431,7 @@
 		4C3BCDDCDB314367722653A8 /* ValidationServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ValidationServiceTests.swift; sourceTree = "<group>"; };
 		4C87F359CE5509C2457AB583 /* PaywallSavingsPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallSavingsPolicyTests.swift; sourceTree = "<group>"; };
 		4CD612A21566CB070FFC0086 /* CoreDataManager+Part05.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CoreDataManager+Part05.swift"; path = "CoreDataManager+Part05.swift"; sourceTree = "<group>"; };
+		4F614C8BD21F414268DB7829 /* BodySpecAuthManagerPKCETests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodySpecAuthManagerPKCETests.swift; sourceTree = "<group>"; };
 		4FE602CA4F092CAB186EE952 /* RevenueCatFlowTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RevenueCatFlowTests.swift; sourceTree = "<group>"; };
 		50EBF62AD8F9F25BB301D998 /* ProgressPhotoAttachPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProgressPhotoAttachPolicyTests.swift; sourceTree = "<group>"; };
 		55090E3269B8A8F8E45E46D0 /* SecondaryMetricsRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SecondaryMetricsRow.swift; path = DesignSystem/Organisms/SecondaryMetricsRow.swift; sourceTree = "<group>"; };
@@ -457,6 +461,7 @@
 		8631504046C70A4EE432C9B8 /* AccountDeletionAndShareCardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountDeletionAndShareCardTests.swift; sourceTree = "<group>"; };
 		898E428E2D5EE162E00B0BD7 /* DashboardHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DashboardHeader.swift; path = DesignSystem/Organisms/DashboardHeader.swift; sourceTree = "<group>"; };
 		89E358ECC97E3F08357502AC /* LegalDocumentLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LegalDocumentLoaderTests.swift; sourceTree = "<group>"; };
+		8A2D877BFA93E04F9E168FA7 /* BodySpecAPITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodySpecAPITests.swift; sourceTree = "<group>"; };
 		8A593DE7333C6FAE0E20815A /* AuthLegacyStorageMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthLegacyStorageMigrationTests.swift; sourceTree = "<group>"; };
 		8B717977805C943E5BA1410B /* AddEntrySheet+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AddEntrySheet+Part02.swift"; path = "AddEntrySheet+Part02.swift"; sourceTree = "<group>"; };
 		8E3A26E632164AACAA5D77FD /* MainTabViewPolicies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTabViewPolicies.swift; sourceTree = "<group>"; };
@@ -822,6 +827,7 @@
 		FE10B0B000000000000000FA /* DashboardTimelineProviderPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTimelineProviderPerformanceTests.swift; sourceTree = "<group>"; };
 		FE11C1C100000000000000FB /* ImageCacheServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheServiceTests.swift; sourceTree = "<group>"; };
 		FE12D2D100000000000000FC /* GoldenPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoldenPathTests.swift; sourceTree = "<group>"; };
+		FE9C6D5CF67D9E4FA0995EC1 /* BodySpecAuthManagerTokenStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodySpecAuthManagerTokenStateTests.swift; sourceTree = "<group>"; };
 		FECEBC7B2B956D26BF45822F /* DSLogo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSLogo.swift; path = DesignSystem/Atoms/DSLogo.swift; sourceTree = "<group>"; };
 		FEE8DE6FD2A76A65AF63D2D9 /* DebugResetManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DebugResetManagerTests.swift; sourceTree = "<group>"; };
 		FF0B649CA62200DAACE12AA8 /* AddEntrySheet+Part03.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AddEntrySheet+Part03.swift"; path = "AddEntrySheet+Part03.swift"; sourceTree = "<group>"; };
@@ -1081,6 +1087,9 @@
 				6C2827EFD1E859BCE7F2067D /* AppVersionManagerTests.swift */,
 				FEE8DE6FD2A76A65AF63D2D9 /* DebugResetManagerTests.swift */,
 				A1DEC696E9D9EFBFAE8202F0 /* AppVersionTests.swift */,
+				8A2D877BFA93E04F9E168FA7 /* BodySpecAPITests.swift */,
+				4F614C8BD21F414268DB7829 /* BodySpecAuthManagerPKCETests.swift */,
+				FE9C6D5CF67D9E4FA0995EC1 /* BodySpecAuthManagerTokenStateTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1880,6 +1889,9 @@
 				465512C30A97EB5CF09760D4 /* AppVersionManagerTests.swift in Sources */,
 				9E81C3C41951BB662ADA2C6F /* DebugResetManagerTests.swift in Sources */,
 				BEF108E2A2F1DFFA716E58E5 /* AppVersionTests.swift in Sources */,
+				93335DCBFB7D09586F330149 /* BodySpecAPITests.swift in Sources */,
+				CD05B6509260D3FC351104B4 /* BodySpecAuthManagerPKCETests.swift in Sources */,
+				B13F1CC0CFEB9076519101DB /* BodySpecAuthManagerTokenStateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/LogYourBody/Services/BodySpecAPI.swift
+++ b/apps/ios/LogYourBody/Services/BodySpecAPI.swift
@@ -104,8 +104,16 @@ struct BodySpecDexaCompositionResponse: Decodable {
     }
 }
 
+/// Token source for `BodySpecAPI`. Mirrors the `BodySpecDexaAPIClient` seam so
+/// tests can inject a stub instead of the keychain-backed `BodySpecAuthManager`.
+protocol BodySpecAuthTokenProviding {
+    func ensureValidToken() async throws -> String?
+}
+
+extension BodySpecAuthManager: BodySpecAuthTokenProviding {}
+
 final class BodySpecAPI {
-    @MainActor static let shared = BodySpecAPI(authManager: .shared)
+    @MainActor static let shared = BodySpecAPI(authManager: BodySpecAuthManager.shared)
 
     private static var defaultBaseURL: URL {
         var components = URLComponents()
@@ -116,12 +124,12 @@ final class BodySpecAPI {
 
     private let baseURL: URL
     private let urlSession: URLSession
-    private let authManager: BodySpecAuthManager
+    private let authManager: BodySpecAuthTokenProviding
 
     init(
         baseURL: URL = BodySpecAPI.defaultBaseURL,
         urlSession: URLSession = .shared,
-        authManager: BodySpecAuthManager
+        authManager: BodySpecAuthTokenProviding
     ) {
         self.baseURL = baseURL
         self.urlSession = urlSession

--- a/apps/ios/LogYourBody/Services/BodySpecAuthManager.swift
+++ b/apps/ios/LogYourBody/Services/BodySpecAuthManager.swift
@@ -220,7 +220,8 @@ final class BodySpecAuthManager: NSObject, ASWebAuthenticationPresentationContex
         )
     }
 
-    private func generateCodeVerifier() -> String {
+    // Internal (not private) so deterministic PKCE behavior is unit-testable.
+    func generateCodeVerifier() -> String {
         let length = 64
         let characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~"
         var result = ""
@@ -235,7 +236,8 @@ final class BodySpecAuthManager: NSObject, ASWebAuthenticationPresentationContex
         return result
     }
 
-    private func codeChallenge(for verifier: String) -> String {
+    // Internal (not private) so deterministic PKCE behavior is unit-testable.
+    func codeChallenge(for verifier: String) -> String {
         let data = Data(verifier.utf8)
         let hash = SHA256.hash(data: data)
         return Data(hash)

--- a/apps/ios/LogYourBodyTests/BodySpecAPITests.swift
+++ b/apps/ios/LogYourBodyTests/BodySpecAPITests.swift
@@ -1,0 +1,448 @@
+//
+// BodySpecAPITests.swift
+// LogYourBodyTests
+//
+import XCTest
+@testable import LogYourBody
+
+/// Stubs the BodySpec REST boundary for `BodySpecAPI` contract tests.
+/// Registered on a per-test URLSessionConfiguration, so no global state leaks
+/// into other suites.
+private final class BodySpecStubURLProtocol: URLProtocol {
+    enum Stub {
+        case http(statusCode: Int, body: Data)
+        case nonHTTPResponse
+        case networkError(URLError.Code)
+    }
+
+    static var stub: Stub = .http(statusCode: 200, body: Data())
+    static var recordedRequests: [URLRequest] = []
+
+    // swiftlint:disable:next static_over_final_class
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    // swiftlint:disable:next static_over_final_class
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url, let client else {
+            return
+        }
+
+        Self.recordedRequests.append(request)
+
+        switch Self.stub {
+        case .http(let statusCode, let body):
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            ) ?? HTTPURLResponse()
+            client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client.urlProtocol(self, didLoad: body)
+            client.urlProtocolDidFinishLoading(self)
+        case .nonHTTPResponse:
+            let response = URLResponse(
+                url: url,
+                mimeType: nil,
+                expectedContentLength: 0,
+                textEncodingName: nil
+            )
+            client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client.urlProtocolDidFinishLoading(self)
+        case .networkError(let code):
+            client.urlProtocol(self, didFailWithError: URLError(code))
+        }
+    }
+
+    override func stopLoading() {}
+
+    static func reset() {
+        stub = .http(statusCode: 200, body: Data())
+        recordedRequests = []
+    }
+}
+
+private struct StubBodySpecAuthProvider: BodySpecAuthTokenProviding {
+    let token: String?
+
+    func ensureValidToken() async throws -> String? {
+        token
+    }
+}
+
+private enum BodySpecAPIFixture {
+    static let userJSON = """
+        {"user_id":"user-123","email":"dexa@example.com","first_name":"Alex","last_name":"Rivera"}
+        """
+
+    static let userMinimalJSON = """
+        {"user_id":"user-123","email":"dexa@example.com"}
+        """
+
+    static let resultsJSON = """
+        {
+          "results": [
+            {
+              "result_id": "result-123",
+              "start_time": "2025-01-15T10:30:00Z",
+              "location": { "location_id": "loc-1", "name": "Santa Monica" },
+              "service": {
+                "name": "DEXA Scan",
+                "description": "Full body composition",
+                "service_id": "svc-1",
+                "service_code": "DXA"
+              }
+            }
+          ]
+        }
+        """
+
+    static let resultsNullOptionalsJSON = """
+        {
+          "results": [
+            {
+              "result_id": "result-9",
+              "start_time": "2024-11-02T07:15:44Z",
+              "location": { "location_id": "loc-2", "name": null },
+              "service": { "name": "DEXA Scan", "description": "Composition scan" }
+            }
+          ]
+        }
+        """
+
+    static let scanInfoJSON = """
+        {
+          "result_id": "result-123",
+          "scanner_model": "Hologic Horizon W",
+          "acquire_time": "2025-01-15T10:30:00Z",
+          "analyze_time": "2025-01-15T10:31:12Z"
+        }
+        """
+
+    static let compositionJSON = """
+        {
+          "result_id": "result-123",
+          "total": {
+            "fat_mass_kg": 14.02,
+            "lean_mass_kg": 61.85,
+            "bone_mass_kg": 3.11,
+            "total_mass_kg": 78.98,
+            "tissue_fat_pct": 18.4,
+            "region_fat_pct": 17.7
+          }
+        }
+        """
+
+    static let emptyResultsJSON = """
+        {"results":[]}
+        """
+}
+
+@MainActor
+final class BodySpecAPITests: XCTestCase {
+    private let baseURL = URL(string: "https://bodyspec.test")!
+    private let accessToken = "test-access-token"
+
+    override func setUp() {
+        super.setUp()
+        BodySpecStubURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        BodySpecStubURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Request construction
+
+    func testGetUserBuildsAuthorizedGETRequest() async throws {
+        stubJSON(BodySpecAPIFixture.userJSON)
+
+        _ = try await makeAPI(authToken: accessToken).getUser()
+
+        let request = try recordedRequest()
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.url?.absoluteString, "https://bodyspec.test/api/v1/users/me")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(accessToken)")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+        XCTAssertNil(request.httpBody)
+    }
+
+    func testListResultsBuildsPaginatedPathAndQuery() async throws {
+        stubJSON(BodySpecAPIFixture.emptyResultsJSON)
+
+        _ = try await makeAPI(authToken: accessToken).listResults(page: 3, pageSize: 50)
+
+        let request = try recordedRequest()
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.url?.path, "/api/v1/users/me/results/")
+        let queryItems = try queryItems(of: request)
+        XCTAssertEqual(queryItems.count, 2)
+        XCTAssertEqual(queryItems.first(where: { $0.name == "page" })?.value, "3")
+        XCTAssertEqual(queryItems.first(where: { $0.name == "page_size" })?.value, "50")
+    }
+
+    func testListResultsUsesDefaultPagination() async throws {
+        stubJSON(BodySpecAPIFixture.emptyResultsJSON)
+
+        _ = try await makeAPI(authToken: accessToken).listResults()
+
+        let request = try recordedRequest()
+        let queryItems = try queryItems(of: request)
+        XCTAssertEqual(queryItems.first(where: { $0.name == "page" })?.value, "1")
+        XCTAssertEqual(queryItems.first(where: { $0.name == "page_size" })?.value, "20")
+    }
+
+    func testGetDexaScanInfoBuildsResultScopedRequest() async throws {
+        stubJSON(BodySpecAPIFixture.scanInfoJSON)
+
+        _ = try await makeAPI(authToken: accessToken).getDexaScanInfo(resultId: "result-123")
+
+        let request = try recordedRequest()
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "https://bodyspec.test/api/v1/users/me/results/result-123/dexa/scan-info"
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(accessToken)")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+    }
+
+    func testGetDexaCompositionBuildsResultScopedRequest() async throws {
+        stubJSON(BodySpecAPIFixture.compositionJSON)
+
+        _ = try await makeAPI(authToken: accessToken).getDexaComposition(resultId: "result-123")
+
+        let request = try recordedRequest()
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "https://bodyspec.test/api/v1/users/me/results/result-123/dexa/composition"
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(accessToken)")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+    }
+
+    // MARK: - Response decoding
+
+    func testGetUserDecodesAllFields() async throws {
+        stubJSON(BodySpecAPIFixture.userJSON)
+
+        let user = try await makeAPI(authToken: accessToken).getUser()
+
+        XCTAssertEqual(user.userId, "user-123")
+        XCTAssertEqual(user.email, "dexa@example.com")
+        XCTAssertEqual(user.firstName, "Alex")
+        XCTAssertEqual(user.lastName, "Rivera")
+    }
+
+    func testGetUserDecodesMissingOptionalNamesAsNil() async throws {
+        stubJSON(BodySpecAPIFixture.userMinimalJSON)
+
+        let user = try await makeAPI(authToken: accessToken).getUser()
+
+        XCTAssertEqual(user.userId, "user-123")
+        XCTAssertEqual(user.email, "dexa@example.com")
+        XCTAssertNil(user.firstName)
+        XCTAssertNil(user.lastName)
+    }
+
+    func testListResultsDecodesSummaries() async throws {
+        stubJSON(BodySpecAPIFixture.resultsJSON)
+
+        let response = try await makeAPI(authToken: accessToken).listResults()
+
+        XCTAssertEqual(response.results.count, 1)
+        let summary = try XCTUnwrap(response.results.first)
+        XCTAssertEqual(summary.resultId, "result-123")
+        XCTAssertEqual(summary.startTime, Date(timeIntervalSince1970: 1_736_937_000))
+        XCTAssertEqual(summary.location.locationId, "loc-1")
+        XCTAssertEqual(summary.location.name, "Santa Monica")
+        XCTAssertEqual(summary.service.name, "DEXA Scan")
+        XCTAssertEqual(summary.service.description, "Full body composition")
+        XCTAssertEqual(summary.service.serviceId, "svc-1")
+        XCTAssertEqual(summary.service.serviceCode, "DXA")
+    }
+
+    func testListResultsDecodesNullAndMissingOptionalFields() async throws {
+        stubJSON(BodySpecAPIFixture.resultsNullOptionalsJSON)
+
+        let response = try await makeAPI(authToken: accessToken).listResults()
+
+        let summary = try XCTUnwrap(response.results.first)
+        XCTAssertEqual(summary.resultId, "result-9")
+        XCTAssertEqual(summary.startTime, Date(timeIntervalSince1970: 1_730_531_744))
+        XCTAssertEqual(summary.location.locationId, "loc-2")
+        XCTAssertNil(summary.location.name)
+        XCTAssertEqual(summary.service.name, "DEXA Scan")
+        XCTAssertNil(summary.service.serviceId)
+        XCTAssertNil(summary.service.serviceCode)
+    }
+
+    func testListResultsDecodesEmptyResults() async throws {
+        stubJSON(BodySpecAPIFixture.emptyResultsJSON)
+
+        let response = try await makeAPI(authToken: accessToken).listResults()
+
+        XCTAssertTrue(response.results.isEmpty)
+    }
+
+    func testGetDexaScanInfoDecodesResponse() async throws {
+        stubJSON(BodySpecAPIFixture.scanInfoJSON)
+
+        let scanInfo = try await makeAPI(authToken: accessToken).getDexaScanInfo(resultId: "result-123")
+
+        XCTAssertEqual(scanInfo.resultId, "result-123")
+        XCTAssertEqual(scanInfo.scannerModel, "Hologic Horizon W")
+        XCTAssertEqual(scanInfo.acquireTime, Date(timeIntervalSince1970: 1_736_937_000))
+        XCTAssertEqual(scanInfo.analyzeTime, Date(timeIntervalSince1970: 1_736_937_072))
+    }
+
+    func testGetDexaCompositionDecodesResponse() async throws {
+        stubJSON(BodySpecAPIFixture.compositionJSON)
+
+        let composition = try await makeAPI(authToken: accessToken).getDexaComposition(resultId: "result-123")
+
+        XCTAssertEqual(composition.resultId, "result-123")
+        XCTAssertEqual(composition.total.fatMassKg, 14.02, accuracy: 0.0001)
+        XCTAssertEqual(composition.total.leanMassKg, 61.85, accuracy: 0.0001)
+        XCTAssertEqual(composition.total.boneMassKg, 3.11, accuracy: 0.0001)
+        XCTAssertEqual(composition.total.totalMassKg, 78.98, accuracy: 0.0001)
+        XCTAssertEqual(composition.total.tissueFatPct, 18.4, accuracy: 0.0001)
+        XCTAssertEqual(composition.total.regionFatPct, 17.7, accuracy: 0.0001)
+    }
+
+    // MARK: - Error mapping
+
+    func testMissingTokenThrowsNotConnectedWithoutNetworkCall() async {
+        await expectAPIError(.notConnected) {
+            try await self.makeAPI(authToken: nil).getUser()
+        }
+        XCTAssertTrue(BodySpecStubURLProtocol.recordedRequests.isEmpty)
+    }
+
+    func testNonSuccessStatusCodesThrowHTTPErrorWithStatusCode() async {
+        for statusCode in [401, 403, 404, 500] {
+            stubJSON(BodySpecAPIFixture.emptyResultsJSON, statusCode: statusCode)
+            await expectAPIError(.httpError(statusCode)) {
+                try await self.makeAPI(authToken: self.accessToken).listResults()
+            }
+        }
+    }
+
+    func testNonHTTPResponseThrowsInvalidResponse() async {
+        BodySpecStubURLProtocol.stub = .nonHTTPResponse
+
+        await expectAPIError(.invalidResponse) {
+            try await self.makeAPI(authToken: self.accessToken).getUser()
+        }
+    }
+
+    func testMalformedJSONThrowsDecodingError() async {
+        stubJSON("not-json")
+
+        let error = await captureError {
+            try await self.makeAPI(authToken: self.accessToken).getUser()
+        }
+
+        XCTAssertTrue(
+            error is DecodingError,
+            "Expected DecodingError, got \(String(describing: error))"
+        )
+    }
+
+    func testNetworkFailurePropagatesURLError() async {
+        BodySpecStubURLProtocol.stub = .networkError(.notConnectedToInternet)
+
+        let error = await captureError {
+            try await self.makeAPI(authToken: self.accessToken).getUser()
+        }
+
+        guard let urlError = error as? URLError else {
+            XCTFail("Expected URLError, got \(String(describing: error))")
+            return
+        }
+        XCTAssertEqual(urlError.code, .notConnectedToInternet)
+    }
+
+    // MARK: - Helpers
+
+    private func makeAPI(authToken: String?) -> BodySpecAPI {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BodySpecStubURLProtocol.self]
+        return BodySpecAPI(
+            baseURL: baseURL,
+            urlSession: URLSession(configuration: configuration),
+            authManager: StubBodySpecAuthProvider(token: authToken)
+        )
+    }
+
+    private func stubJSON(_ json: String, statusCode: Int = 200) {
+        BodySpecStubURLProtocol.stub = .http(statusCode: statusCode, body: Data(json.utf8))
+    }
+
+    private func recordedRequest(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> URLRequest {
+        XCTAssertEqual(BodySpecStubURLProtocol.recordedRequests.count, 1, file: file, line: line)
+        return try XCTUnwrap(BodySpecStubURLProtocol.recordedRequests.first, file: file, line: line)
+    }
+
+    private func queryItems(
+        of request: URLRequest,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> [URLQueryItem] {
+        let url = try XCTUnwrap(request.url, file: file, line: line)
+        let components = try XCTUnwrap(
+            URLComponents(url: url, resolvingAgainstBaseURL: false),
+            file: file,
+            line: line
+        )
+        return components.queryItems ?? []
+    }
+
+    private func expectAPIError<T>(
+        _ expected: BodySpecAPIError,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ operation: () async throws -> T
+    ) async {
+        do {
+            _ = try await operation()
+            XCTFail("Expected \(expected) but the request succeeded", file: file, line: line)
+        } catch let error as BodySpecAPIError {
+            switch (error, expected) {
+            case (.notConnected, .notConnected), (.invalidResponse, .invalidResponse):
+                break
+            case (.httpError(let actualCode), .httpError(let expectedCode)):
+                XCTAssertEqual(actualCode, expectedCode, file: file, line: line)
+            default:
+                XCTFail("Expected \(expected), got \(error)", file: file, line: line)
+            }
+        } catch {
+            XCTFail("Expected \(expected), got \(error)", file: file, line: line)
+        }
+    }
+
+    private func captureError<T>(
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ operation: () async throws -> T
+    ) async -> Error? {
+        do {
+            _ = try await operation()
+            XCTFail("Expected the request to throw", file: file, line: line)
+            return nil
+        } catch {
+            return error
+        }
+    }
+}

--- a/apps/ios/LogYourBodyTests/BodySpecAPITests.swift
+++ b/apps/ios/LogYourBodyTests/BodySpecAPITests.swift
@@ -181,7 +181,9 @@ final class BodySpecAPITests: XCTestCase {
 
         let request = try recordedRequest()
         XCTAssertEqual(request.httpMethod, "GET")
-        XCTAssertEqual(request.url?.path, "/api/v1/users/me/results/")
+        // URL.appendingPathComponent normalizes away the source literal's
+        // trailing slash; this pins the actual wire path.
+        XCTAssertEqual(request.url?.path, "/api/v1/users/me/results")
         let queryItems = try queryItems(of: request)
         XCTAssertEqual(queryItems.count, 2)
         XCTAssertEqual(queryItems.first(where: { $0.name == "page" })?.value, "3")

--- a/apps/ios/LogYourBodyTests/BodySpecAuthManagerPKCETests.swift
+++ b/apps/ios/LogYourBodyTests/BodySpecAuthManagerPKCETests.swift
@@ -1,0 +1,73 @@
+//
+// BodySpecAuthManagerPKCETests.swift
+// LogYourBodyTests
+//
+import XCTest
+@testable import LogYourBody
+
+/// Covers the deterministic PKCE surface of `BodySpecAuthManager` (RFC 7636).
+/// The OAuth web session itself (`ASWebAuthenticationSession`) cannot be faked,
+/// so these tests exercise the pure crypto helpers directly.
+@MainActor
+final class BodySpecAuthManagerPKCETests: XCTestCase {
+    private let allowedVerifierCharacters = Set(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~"
+    )
+
+    func testCodeVerifierHasRFC7636LengthOf64() {
+        let manager = BodySpecAuthManager()
+
+        for _ in 0..<10 {
+            XCTAssertEqual(manager.generateCodeVerifier().count, 64)
+        }
+    }
+
+    func testCodeVerifierUsesOnlyRFC7636UnreservedCharacters() {
+        let manager = BodySpecAuthManager()
+
+        for _ in 0..<10 {
+            let verifier = manager.generateCodeVerifier()
+            XCTAssertTrue(
+                verifier.allSatisfy(allowedVerifierCharacters.contains),
+                "Verifier contained characters outside the RFC 7636 unreserved set: \(verifier)"
+            )
+        }
+    }
+
+    func testCodeVerifierIsUniqueAcrossCalls() {
+        let manager = BodySpecAuthManager()
+
+        let verifiers = (0..<200).map { _ in manager.generateCodeVerifier() }
+
+        XCTAssertEqual(Set(verifiers).count, verifiers.count)
+    }
+
+    func testCodeChallengeMatchesRFC7636AppendixBVector() {
+        let manager = BodySpecAuthManager()
+
+        let challenge = manager.codeChallenge(for: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+
+        XCTAssertEqual(challenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    }
+
+    func testCodeChallengeAppliesBase64URLReplacementsAndStripsPadding() {
+        // Fixed vector whose plain base64 digest contains '+', '/', and '='
+        // padding, so every replacement branch is exercised deterministically.
+        let manager = BodySpecAuthManager()
+
+        let challenge = manager.codeChallenge(for: "bodyspec-pkce-vector-0")
+
+        XCTAssertEqual(challenge, "WUoBy_PYgnjGsT8YZB-3Zbaw9EALd1kC1_AuXImUvMo")
+        XCTAssertEqual(challenge.count, 43)
+        XCTAssertFalse(challenge.contains("="))
+        XCTAssertFalse(challenge.contains("+"))
+        XCTAssertFalse(challenge.contains("/"))
+    }
+
+    func testCodeChallengeIsDeterministicForSameVerifier() {
+        let manager = BodySpecAuthManager()
+        let verifier = "deterministic-verifier-123"
+
+        XCTAssertEqual(manager.codeChallenge(for: verifier), manager.codeChallenge(for: verifier))
+    }
+}

--- a/apps/ios/LogYourBodyTests/BodySpecAuthManagerTokenStateTests.swift
+++ b/apps/ios/LogYourBodyTests/BodySpecAuthManagerTokenStateTests.swift
@@ -1,0 +1,132 @@
+//
+// BodySpecAuthManagerTokenStateTests.swift
+// LogYourBodyTests
+//
+import XCTest
+@testable import LogYourBody
+
+/// Mirrors the wire format of `BodySpecAuthManager`'s private stored token so
+/// tests can seed the keychain through `KeychainManager`'s public API without
+/// reaching into app internals.
+private struct BodySpecSeedToken: Codable {
+    let accessToken: String
+    let refreshToken: String?
+    let expiresAt: Date
+    let userId: String?
+    let email: String?
+}
+
+@MainActor
+final class BodySpecAuthManagerTokenStateTests: XCTestCase {
+    private let keychain = KeychainManager.shared
+    private let tokenStorageKey = "BodySpecAuthToken"
+
+    override func setUpWithError() throws {
+        try XCTSkipUnless(
+            KeychainAvailability.isAvailable(),
+            "Keychain unavailable on unsigned CI test host (errSecMissingEntitlement); "
+                + "runs fully on signed hosts and local dev. "
+                + "TODO(@itstimwhite): enable when CI signs the test host."
+        )
+        try super.setUpWithError()
+        try? keychain.delete(forKey: tokenStorageKey)
+    }
+
+    override func tearDown() {
+        try? keychain.delete(forKey: tokenStorageKey)
+        super.tearDown()
+    }
+
+    func testManagerWithoutStoredTokenReportsDisconnectedState() async throws {
+        let manager = BodySpecAuthManager()
+
+        XCTAssertFalse(manager.isConnected)
+        XCTAssertNil(manager.connectedEmail)
+        // Nil on every host: unconfigured clients return nil, and configured
+        // clients have no token to return.
+        let token = try await manager.ensureValidToken()
+        XCTAssertNil(token)
+    }
+
+    func testStoredUnexpiredTokenLoadsOnInit() async throws {
+        try seedToken(
+            BodySpecSeedToken(
+                accessToken: "stored-access",
+                refreshToken: "stored-refresh",
+                expiresAt: Date().addingTimeInterval(3_600),
+                userId: "user-1",
+                email: "dexa@example.com"
+            )
+        )
+
+        let manager = BodySpecAuthManager()
+
+        XCTAssertTrue(manager.isConnected)
+        XCTAssertEqual(manager.connectedEmail, "dexa@example.com")
+    }
+
+    func testStoredTokenWithoutEmailReportsNilConnectedEmail() async throws {
+        try seedToken(
+            BodySpecSeedToken(
+                accessToken: "stored-access",
+                refreshToken: nil,
+                expiresAt: Date().addingTimeInterval(3_600),
+                userId: nil,
+                email: nil
+            )
+        )
+
+        let manager = BodySpecAuthManager()
+
+        XCTAssertTrue(manager.isConnected)
+        XCTAssertNil(manager.connectedEmail)
+    }
+
+    func testStoredExpiredTokenIsNotConnected() async throws {
+        try seedToken(
+            BodySpecSeedToken(
+                accessToken: "expired-access",
+                refreshToken: "stored-refresh",
+                expiresAt: Date().addingTimeInterval(-3_600),
+                userId: "user-1",
+                email: "dexa@example.com"
+            )
+        )
+
+        let manager = BodySpecAuthManager()
+
+        XCTAssertFalse(manager.isConnected)
+        // Nil on every host: unconfigured clients return nil, and configured
+        // clients reject the expired token.
+        let token = try await manager.ensureValidToken()
+        XCTAssertNil(token)
+    }
+
+    func testDisconnectClearsSessionStateAndKeychain() async throws {
+        try seedToken(
+            BodySpecSeedToken(
+                accessToken: "stored-access",
+                refreshToken: "stored-refresh",
+                expiresAt: Date().addingTimeInterval(3_600),
+                userId: "user-1",
+                email: "dexa@example.com"
+            )
+        )
+        let manager = BodySpecAuthManager()
+        XCTAssertTrue(manager.isConnected)
+
+        manager.disconnect()
+
+        XCTAssertFalse(manager.isConnected)
+        XCTAssertNil(manager.connectedEmail)
+        XCTAssertNil(try keychain.get(forKey: tokenStorageKey, as: BodySpecSeedToken.self))
+
+        let reloaded = BodySpecAuthManager()
+        XCTAssertFalse(reloaded.isConnected)
+        XCTAssertNil(reloaded.connectedEmail)
+    }
+
+    private func seedToken(_ token: BodySpecSeedToken) throws {
+        try keychain.save(token, forKey: tokenStorageKey)
+    }
+}


### PR DESCRIPTION
## Summary

Batch 7 of the iOS test-hardening effort (inventory B.1 — BodySpec DEXA integration, previously zero coverage). 28 tests across 3 classes; only the network and keychain boundaries stubbed.

- **`BodySpecAPITests` (17):** full REST contract with test-local `URLProtocol` + stubbed token provider (via the new `BodySpecAuthTokenProviding` seam) — request construction for all 4 endpoints (method/path/query incl. pagination, `Bearer`/`Accept` headers), fail-closed on nil token (zero requests), decoding incl. null/optional/empty payloads, error mapping (401/403/404/500 → `.httpError`, non-HTTP → `.invalidResponse`, malformed JSON, network passthrough).
- **`BodySpecAuthManagerPKCETests` (6):** verifier length/charset (RFC 7636), uniqueness over 200 generations, challenge determinism, and the **RFC 7636 Appendix B test vector** (verified independently) plus a second vector exercising all three base64url substitutions.
- **`BodySpecAuthManagerTokenStateTests` (5):** stored-token lifecycle against the real keychain (gated on `KeychainAvailability`) — disconnected when empty, unexpired loads on init, expired rejected, `disconnect()` clears memory + keychain.

Seam (justified, ~10 lines): `BodySpecAuthTokenProviding` protocol mirrors the existing `BodySpecDexaAPIClient` injection pattern; two PKCE methods de-privatized. No behavior change.

**Not covered (unreachable without touching the OAuth wiring — documented):** authorization-URL construction and token exchange, both inline in `connect()` behind `ASWebAuthenticationSession`.

One fix during review: the initial run pinned `/api/v1/users/me/results/` but `appendingPathComponent` normalizes away the trailing slash — the test now pins the actual wire path (noted in case BodySpec's backend strictly requires the slash; worth a manual check against the real API).

## Validation evidence

- `swiftlint lint --strict`: 0 violations (344 files)
- New classes: `** TEST SUCCEEDED **` — 28/28 (verified after fix)
- Full unit target: `** TEST SUCCEEDED **` (no fixture interference)
- Pre-push turbo lint/typecheck/test: green
