### PR TITLE
test(ios): cover App Intents logging paths

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0183C845E0301D4B10100ACE /* BodyMetricAppIntentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC71479CEEDEAD772518C5E9 /* BodyMetricAppIntentsTests.swift */; };
 		022D79AC5B1840BC58FB7D70 /* BodyMetricContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB121088934BE398599BE39A /* BodyMetricContractTests.swift */; };
 		04BF4BAC82CF6B37F817592F /* CoreDataModelMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA050E7DCEBA5BAF62341363 /* CoreDataModelMigrationTests.swift */; };
 		04EB1D7AD1947D32BDE7AD70 /* BodyMetricSourceContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EBD5BF3F1671BC8D17ABE5D /* BodyMetricSourceContractTests.swift */; };
@@ -775,6 +776,7 @@
 		B1CDBFA72287938694EB369D /* CoreMetricsRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreMetricsRow.swift; path = DesignSystem/Organisms/CoreMetricsRow.swift; sourceTree = "<group>"; };
 		B4BF04D15583E3AE1CA4A836 /* View+Styles.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "View+Styles.swift"; path = "View+Styles.swift"; sourceTree = "<group>"; };
 		BBB847A2050F3135D62950A1 /* AuthFormField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthFormField.swift; path = DesignSystem/Molecules/AuthFormField.swift; sourceTree = "<group>"; };
+		BC71479CEEDEAD772518C5E9 /* BodyMetricAppIntentsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyMetricAppIntentsTests.swift; sourceTree = "<group>"; };
 		BF02BFDD936CBA59B3704AA3 /* CoreDataManager+Part01.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CoreDataManager+Part01.swift"; path = "CoreDataManager+Part01.swift"; sourceTree = "<group>"; };
 		C0AE830DA0CFDB1735F6894C /* SyncIntegrationBodyMetricSyncTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncIntegrationBodyMetricSyncTests.swift; sourceTree = "<group>"; };
 		C0D300022F30000100ABCDEF /* GeneratedProductRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedProductRegistry.swift; sourceTree = "<group>"; };
@@ -1090,6 +1092,7 @@
 				8A2D877BFA93E04F9E168FA7 /* BodySpecAPITests.swift */,
 				4F614C8BD21F414268DB7829 /* BodySpecAuthManagerPKCETests.swift */,
 				FE9C6D5CF67D9E4FA0995EC1 /* BodySpecAuthManagerTokenStateTests.swift */,
+				BC71479CEEDEAD772518C5E9 /* BodyMetricAppIntentsTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1892,6 +1895,7 @@
 				93335DCBFB7D09586F330149 /* BodySpecAPITests.swift in Sources */,
 				CD05B6509260D3FC351104B4 /* BodySpecAuthManagerPKCETests.swift in Sources */,
 				B13F1CC0CFEB9076519101DB /* BodySpecAuthManagerTokenStateTests.swift in Sources */,
+				0183C845E0301D4B10100ACE /* BodyMetricAppIntentsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/LogYourBodyTests/BodyMetricAppIntentsTests.swift
+++ b/apps/ios/LogYourBodyTests/BodyMetricAppIntentsTests.swift
@@ -1,0 +1,307 @@
+//
+// BodyMetricAppIntentsTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import AVFoundation
+import CoreData
+import HealthKit
+import RevenueCat
+import SwiftUI
+import UIKit
+@testable import LogYourBody
+
+/// Integration coverage for the Siri/App Shortcuts logging path in
+/// `BodyMetricAppIntents.swift`. Each intent's `perform()` is called directly
+/// against the shared Core Data stack with an authenticated test user.
+///
+/// Reachability limit: `perform()` returns an opaque `some IntentResult`
+/// whose dialog (`IntentDialog`) and snippet view expose no public accessors,
+/// so the user-facing text cannot be read back from the result. The dialog
+/// and snippet both render the exact `dialog` string of the
+/// `BodyMetricLoggingService` result/summary the intent awaits, so these
+/// tests assert that content through the same service call the intent makes,
+/// plus the persisted Core Data outcome of `perform()` itself.
+///
+/// `LogYourBodyAppShortcuts` is intentionally not asserted: `AppShortcut` is
+/// an init-only value type with no public accessors for its intent, phrases,
+/// shortTitle, or systemImageName, so nothing beyond an existence/count check
+/// is reachable — that would be an implementation-wiring check, not behavior.
+@MainActor
+final class BodyMetricAppIntentsTests: XCTestCase {
+    private var previousUser: User?
+    private var previousIsAuthenticated = false
+    private var previousMeasurementSystem: String?
+    private var previousHealthKitAuthorization = false
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+
+        // Complete the one-time auth initialization before installing test
+        // state so a stored-session restore cannot overwrite it mid-test.
+        await AuthManager.shared.ensureAuthInitializationTask().value
+
+        previousUser = AuthManager.shared.currentUser
+        previousIsAuthenticated = AuthManager.shared.isAuthenticated
+        // Signed out by default; keeps RealtimeSyncManager.syncIfNeeded inert.
+        AuthManager.shared.currentUser = nil
+        AuthManager.shared.isAuthenticated = false
+
+        previousMeasurementSystem = UserDefaults.standard.string(
+            forKey: Constants.preferredMeasurementSystemKey
+        )
+        UserDefaults.standard.set(
+            MeasurementSystem.imperial.rawValue,
+            forKey: Constants.preferredMeasurementSystemKey
+        )
+
+        previousHealthKitAuthorization = HealthKitManager.shared.isAuthorized
+        HealthKitManager.shared.isAuthorized = false
+    }
+
+    override func tearDown() async throws {
+        AuthManager.shared.currentUser = previousUser
+        AuthManager.shared.isAuthenticated = previousIsAuthenticated
+
+        if let previousMeasurementSystem {
+            UserDefaults.standard.set(
+                previousMeasurementSystem,
+                forKey: Constants.preferredMeasurementSystemKey
+            )
+        } else {
+            UserDefaults.standard.removeObject(forKey: Constants.preferredMeasurementSystemKey)
+        }
+
+        HealthKitManager.shared.isAuthorized = previousHealthKitAuthorization
+
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+        try await super.tearDown()
+    }
+
+    // MARK: - LogWeightIntent
+
+    func testLogWeightIntentPersistsPoundsAsKilograms() async throws {
+        let userId = installTestUser(named: "log-weight-lbs")
+        var intent = LogWeightIntent()
+        intent.weight = 180
+        intent.unit = .pounds
+
+        let startedAt = Date()
+        _ = try await intent.perform()
+
+        let metrics = await CoreDataManager.shared.fetchAllBodyMetrics(for: userId)
+        XCTAssertEqual(metrics.count, 1)
+
+        let metric = try XCTUnwrap(metrics.first)
+        XCTAssertEqual(metric.userId, userId)
+        XCTAssertEqual(metric.weight ?? 0, 81.6467, accuracy: 0.001)
+        XCTAssertEqual(metric.weightUnit, "kg")
+        XCTAssertNil(metric.bodyFatPercentage)
+        XCTAssertEqual(metric.dataSource, BodyMetricSource.manual.rawValue)
+        XCTAssertGreaterThanOrEqual(metric.date, startedAt)
+        XCTAssertEqual(metric.localDate, BodyMetricLocalDate.key(for: metric.date))
+    }
+
+    func testLogWeightIntentPersistsKilogramsWithoutConversion() async throws {
+        let userId = installTestUser(named: "log-weight-kg")
+        var intent = LogWeightIntent()
+        intent.weight = 82.5
+        intent.unit = .kilograms
+
+        _ = try await intent.perform()
+
+        let metrics = await CoreDataManager.shared.fetchAllBodyMetrics(for: userId)
+        XCTAssertEqual(metrics.count, 1)
+        XCTAssertEqual(metrics.first?.weight, 82.5)
+        XCTAssertEqual(metrics.first?.weightUnit, "kg")
+        XCTAssertEqual(metrics.first?.dataSource, BodyMetricSource.manual.rawValue)
+    }
+
+    func testLogWeightIntentRejectsOutOfRangeWeight() async throws {
+        let userId = installTestUser(named: "log-weight-range")
+        var intent = LogWeightIntent()
+        intent.weight = 700
+        intent.unit = .pounds
+
+        let message = await captureValidationError {
+            _ = try await intent.perform()
+        }
+
+        XCTAssertEqual(message, "Enter a weight between 70 and 660 lbs")
+        let metrics = await CoreDataManager.shared.fetchAllBodyMetrics(for: userId)
+        XCTAssertTrue(metrics.isEmpty)
+    }
+
+    func testLogWeightIntentRequiresSignedInUser() async throws {
+        let userId = "appintents-signed-out-\(UUID().uuidString)"
+        var intent = LogWeightIntent()
+        intent.weight = 180
+        intent.unit = .pounds
+
+        do {
+            _ = try await intent.perform()
+            XCTFail("Expected logging without a signed-in user to fail")
+        } catch let error as BodyMetricLoggingError {
+            guard case .notAuthenticated = error else {
+                return XCTFail("Unexpected logging error: \(error)")
+            }
+            XCTAssertEqual(
+                error.errorDescription,
+                "Sign in to LogYourBody before logging body metrics."
+            )
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let metrics = await CoreDataManager.shared.fetchAllBodyMetrics(for: userId)
+        XCTAssertTrue(metrics.isEmpty)
+    }
+
+    // MARK: - LogBodyFatIntent
+
+    func testLogBodyFatIntentPersistsPercentage() async throws {
+        let userId = installTestUser(named: "log-bodyfat")
+        var intent = LogBodyFatIntent()
+        intent.bodyFatPercentage = 15.5
+
+        _ = try await intent.perform()
+
+        let metrics = await CoreDataManager.shared.fetchAllBodyMetrics(for: userId)
+        XCTAssertEqual(metrics.count, 1)
+
+        let metric = try XCTUnwrap(metrics.first)
+        XCTAssertEqual(metric.bodyFatPercentage, 15.5)
+        XCTAssertEqual(metric.bodyFatMethod, "Manual")
+        XCTAssertNil(metric.weight)
+        XCTAssertEqual(metric.dataSource, BodyMetricSource.manual.rawValue)
+    }
+
+    func testLogBodyFatIntentRejectsOutOfRangePercentage() async throws {
+        let userId = installTestUser(named: "log-bodyfat-range")
+        var intent = LogBodyFatIntent()
+        intent.bodyFatPercentage = 61
+
+        let message = await captureValidationError {
+            _ = try await intent.perform()
+        }
+
+        XCTAssertEqual(message, "Body fat must be between 3-60%")
+        let metrics = await CoreDataManager.shared.fetchAllBodyMetrics(for: userId)
+        XCTAssertTrue(metrics.isEmpty)
+    }
+
+    // MARK: - ShowLatestMetricsIntent
+
+    func testShowLatestMetricsIntentSurfacesMostRecentSeededMetric() async throws {
+        let userId = installTestUser(named: "latest-metrics")
+
+        let older = seedMetric(
+            userId: userId,
+            date: Date(timeIntervalSince1970: 1_735_000_000),
+            weight: 80,
+            bodyFatPercentage: nil
+        )
+        let newer = seedMetric(
+            userId: userId,
+            date: Date(timeIntervalSince1970: 1_736_000_000),
+            weight: 75,
+            bodyFatPercentage: 12.5
+        )
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(older, userId: userId, markAsSynced: true)
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(newer, userId: userId, markAsSynced: true)
+
+        _ = try await ShowLatestMetricsIntent().perform()
+
+        // The intent's dialog/snippet are not readable headlessly; assert the
+        // exact summary the intent renders via the same call it makes.
+        let summary = try await BodyMetricLoggingService.shared.latestMetricsSummary()
+        XCTAssertEqual(summary.metrics.id, newer.id)
+        XCTAssertEqual(summary.metrics.bodyFatPercentage, 12.5)
+        XCTAssertEqual(
+            summary.dialog,
+            "Your latest metrics are 165.3 lbs and 12.5% body fat."
+        )
+    }
+
+    func testShowLatestMetricsIntentWithoutMetricsThrowsNoMetrics() async throws {
+        _ = installTestUser(named: "latest-empty")
+
+        do {
+            _ = try await ShowLatestMetricsIntent().perform()
+            XCTFail("Expected the empty store to fail")
+        } catch let error as BodyMetricLoggingError {
+            guard case .noMetrics = error else {
+                return XCTFail("Unexpected logging error: \(error)")
+            }
+            XCTAssertEqual(
+                error.errorDescription,
+                "No body metrics have been logged yet."
+            )
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Parameter glue
+
+    func testWeightUnitStorageUnitMatchesValidationContract() {
+        XCTAssertEqual(BodyMetricIntentWeightUnit.pounds.storageUnit, "lbs")
+        XCTAssertEqual(BodyMetricIntentWeightUnit.kilograms.storageUnit, "kg")
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func installTestUser(named name: String) -> String {
+        let userId = "appintents-\(name)-\(UUID().uuidString)"
+        AuthManager.shared.currentUser = User(
+            id: userId,
+            email: "\(name)@example.com",
+            name: "App Intents Test",
+            avatarUrl: nil,
+            profile: nil,
+            onboardingCompleted: true
+        )
+        return userId
+    }
+
+    private func seedMetric(
+        userId: String,
+        date: Date,
+        weight: Double,
+        bodyFatPercentage: Double?
+    ) -> BodyMetrics {
+        BodyMetrics(
+            id: UUID().uuidString,
+            userId: userId,
+            date: date,
+            weight: weight,
+            weightUnit: "kg",
+            bodyFatPercentage: bodyFatPercentage,
+            bodyFatMethod: bodyFatPercentage != nil ? "Manual" : nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+
+    private func captureValidationError(
+        from expression: () async throws -> Void
+    ) async -> String? {
+        do {
+            try await expression()
+            XCTFail("Expected validation to fail")
+            return nil
+        } catch let error as ValidationError {
+            return error.errorDescription
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+            return nil
+        }
+    }
+}

--- a/apps/ios/TestPlans/Integration.xctestplan
+++ b/apps/ios/TestPlans/Integration.xctestplan
@@ -15,6 +15,7 @@
     {
       "selectedTests" : [
         "AppVersionManagerTests",
+        "BodyMetricAppIntentsTests",
         "BodyMetricPhotoUpdateTests",
         "BodyScoreHealthKitTriggerTests",
         "CoreDataModelMigrationTests",

--- a/apps/ios/TestPlans/Unit.xctestplan
+++ b/apps/ios/TestPlans/Unit.xctestplan
@@ -15,6 +15,7 @@
     {
       "skippedTests" : [
         "AppVersionManagerTests",
+        "BodyMetricAppIntentsTests",
         "BodyMetricPhotoUpdateTests",
         "BodyScoreHealthKitTriggerTests",
         "CoreDataModelMigrationTests",


### PR DESCRIPTION
## Summary

Batch 8 of the iOS test-hardening effort (inventory A.12/B.1 — Siri/App Shortcuts logging path, previously zero coverage). 9 integration tests calling each intent's `perform()` directly and asserting persisted Core Data state.

- **`LogWeightIntent` (4):** lbs→kg conversion persisted correctly (`81.6467 kg`, `weightUnit "kg"`, `dataSource "manual"`), kg input stored as-is, out-of-range (700 lbs) throws the documented `ValidationError` with nothing persisted, signed-out throws `notAuthenticated` with nothing persisted.
- **`LogBodyFatIntent` (2):** valid % persisted with manual method, out-of-range (61%) throws, nothing persisted.
- **`ShowLatestMetricsIntent` (2):** returns the *newer* of two seeded metrics in imperial formatting (pinned via UserDefaults), empty store throws `.noMetrics` instead of crashing.
- **Parameter glue (1):** `BodyMetricIntentWeightUnit.storageUnit` contract.

Platform-boundary honesty, per the quality bar: `IntentResult`/`IntentDialog` expose no public accessors (verified against the SDK swiftinterface), so result text can't be read headlessly — assertions land on persisted state + the identical service call the intents await. `LogYourBodyAppShortcuts` is deliberately unasserted (init-only value type; only an existence check is reachable — padding).

Pinned, not fixed (pre-existing oddity, follow-up candidate): body-fat validation failures are wrapped as `ValidationError.invalidWeight` instead of `.invalidBodyFat` in `BodyMetricLoggingService.log`.

## Validation evidence

- `swiftlint lint --strict`: 0 violations (345 files)
- New class: `** TEST SUCCEEDED **` — 9/9, 5–33ms each (two independent runs)
- Full Integration plan: 110 tests, 0 failures (tier placement wired into both plans)
- Pre-push turbo lint/typecheck/test: green
