### PR TITLE
test(ios): cover settings profile, sessions, delete-account gating, export CSV

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		327C8C9174FEC7C23E350270 /* OnboardingFlowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6868B1C7F6167E2A9AE0A1 /* OnboardingFlowViewModelTests.swift */; };
 		3892032426C339D69DEF73EE /* LaunchSurfacePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47A7741CF9BBCD0F5DC0D5C /* LaunchSurfacePolicyTests.swift */; };
 		3FA11453ACB47EEEFEAFF581 /* PhotoUploadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A98EF222E91570CB37F44C0 /* PhotoUploadManagerTests.swift */; };
+		417364FB8DBF56DE4302BA11 /* SessionListOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031C0B385F7C300284AA6A5F /* SessionListOrderingTests.swift */; };
 		42B0784EAF04F40C031D0186 /* DailyReminderPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D9694F1EA5B5091B0AE8B /* DailyReminderPolicyTests.swift */; };
 		43ED1CCFAE5CC7DA20E6DB3E /* BaseTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB074F9FFF63EE8FD17BA /* BaseTextField.swift */; };
 		465512C30A97EB5CF09760D4 /* AppVersionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2827EFD1E859BCE7F2067D /* AppVersionManagerTests.swift */; };
@@ -41,6 +42,7 @@
 		4C2DA948F919366D436CEF26 /* DSIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458AAF24645E3634CCF88E16 /* DSIcon.swift */; };
 		4C64677ABA2986677DDE1389 /* LogWeightFormValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3ECAB100575E759C5A3D7A /* LogWeightFormValidatorTests.swift */; };
 		4DF78B8A5B5E0DBAF777CBC1 /* DSLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECEBC7B2B956D26BF45822F /* DSLogo.swift */; };
+		52551D9E4C3D6B89BAE63FA2 /* AccountDeletionConfirmationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C400E664F1B03F8C2556C9 /* AccountDeletionConfirmationPolicyTests.swift */; };
 		5346F8338497DE5F23D6F20D /* CoreDataManager+Part05.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD612A21566CB070FFC0086 /* CoreDataManager+Part05.swift */; };
 		53C8F67CE6082C23B391B357 /* OnboardingFlowViewModel+Part01.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B90BFF4D5A1EE512C980386 /* OnboardingFlowViewModel+Part01.swift */; };
 		53E6E3304F26E6A2FDD435A5 /* AuthLegacyStorageMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A593DE7333C6FAE0E20815A /* AuthLegacyStorageMigrationTests.swift */; };
@@ -75,6 +77,7 @@
 		98DAEAD9993013F8C7C81764 /* DashboardTimelineAndPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B95EB9919EA722470321074 /* DashboardTimelineAndPolicyTests.swift */; };
 		9B5611E2F8314E22A5BF7889 /* ImageCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75034CADEA1D4697BDCB5555 /* ImageCacheService.swift */; };
 		9BCEB21BE7B69676BCA5C211 /* HealthSyncCoordinatorPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDACB9E8EEAB1EBF446F0F02 /* HealthSyncCoordinatorPipelineTests.swift */; };
+		9DA53BBE5C68C157C1C517F4 /* ExportCSVBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D10550744C3D80F49B32A4 /* ExportCSVBuilder.swift */; };
 		9E81C3C41951BB662ADA2C6F /* DebugResetManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE8DE6FD2A76A65AF63D2D9 /* DebugResetManagerTests.swift */; };
 		9EBBDD6AF2FF4E4FF8B9E3BC /* BodyCompositionMathGoldenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927B7D58E8E1756BB92364B6 /* BodyCompositionMathGoldenTests.swift */; };
 		A40A693BDA9D2826E3DE900D /* OnboardingStepEntryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E16AB6CFAC7A59EBD3B2792 /* OnboardingStepEntryPolicyTests.swift */; };
@@ -340,6 +343,7 @@
 		CEA13DB06DA2A2D160A48D1D /* LegalDocumentLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E358ECC97E3F08357502AC /* LegalDocumentLoaderTests.swift */; };
 		D2184ADBFB25DEB92514F85D /* DSCircularProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C575F720A1D8D1DFDC4F1CEF /* DSCircularProgressTests.swift */; };
 		D47F9BD18CBEE2413DF244FC /* RevenueCatProductConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7899ADA31AC216735A9FE299 /* RevenueCatProductConfigurationTests.swift */; };
+		D4974B8C3D3837CE581B978D /* ProfileSettingsPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7568984229530B712D2F70 /* ProfileSettingsPolicyTests.swift */; };
 		D5F71D2685408ED4D599FC28 /* BodyMetricPhotoUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2E34BC49376B87D43D81AD /* BodyMetricPhotoUpdateTests.swift */; };
 		DB19A6EC4AA997A0EF4C5791 /* SyncIntegrationImportAndMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA338579090538FBCCA21785 /* SyncIntegrationImportAndMappingTests.swift */; };
 		DC51280D16A74D3E38D4B798 /* CoreDataManager+Part04.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F02AB81FF64BBC27043BB9 /* CoreDataManager+Part04.swift */; };
@@ -350,6 +354,7 @@
 		E740BE7171B6D98EEC5796B5 /* ErrorStateViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E35CCA2D3778DD47C8E104 /* ErrorStateViewTests.swift */; };
 		E8BE69C83DC3F20913970568 /* CoreDataManager+Part02.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EECFD68955AD0F3633D8B32 /* CoreDataManager+Part02.swift */; };
 		EA037983B7EEC7FE596CAC06 /* PhotoMetadataServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F0C87E07EEC9F3CCD2BAB /* PhotoMetadataServiceTests.swift */; };
+		EC190275D6A9097801551F4B /* ExportCSVBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03A26B5060721876EE70C55 /* ExportCSVBuilderTests.swift */; };
 		EF09015F35BC4EDACDDE281F /* AddEntrySheet+Part03.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0B649CA62200DAACE12AA8 /* AddEntrySheet+Part03.swift */; };
 		F0451813784DE99328797E5F /* DSText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F19CFBFEA440516AFCE98B /* DSText.swift */; };
 		F0A6090ABF6B0497684F9816 /* DSLoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D90F6DA60C58AF02CF23737 /* DSLoadingIndicator.swift */; };
@@ -393,6 +398,7 @@
 
 /* Begin PBXFileReference section */
 		012FFE30028F04055FFF6538 /* DSTrendIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSTrendIndicator.swift; path = DesignSystem/Atoms/DSTrendIndicator.swift; sourceTree = "<group>"; };
+		031C0B385F7C300284AA6A5F /* SessionListOrderingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SessionListOrderingTests.swift; sourceTree = "<group>"; };
 		05F19CFBFEA440516AFCE98B /* DSText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSText.swift; path = DesignSystem/Atoms/DSText.swift; sourceTree = "<group>"; };
 		060DD24271B0B2120CB0AA33 /* BulkProgressPhotoImportPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BulkProgressPhotoImportPolicyTests.swift; sourceTree = "<group>"; };
 		07AFDB2060EF2522DE93E10D /* CachedPaywallOfferingDisplayTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CachedPaywallOfferingDisplayTests.swift; sourceTree = "<group>"; };
@@ -412,6 +418,7 @@
 		1A2B3C4D5E6F7890ABCDEF12 /* LoadingScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoadingScreen.swift; path = DesignSystem/Organisms/LoadingScreen.swift; sourceTree = "<group>"; };
 		1C1C56EE58FC0F4BEFDA1345 /* DashboardViewModelHealthSyncWiringTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DashboardViewModelHealthSyncWiringTests.swift; sourceTree = "<group>"; };
 		1C662CF613D4755CA2B93A43 /* HealthSyncPipelineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HealthSyncPipelineTests.swift; sourceTree = "<group>"; };
+		1D7568984229530B712D2F70 /* ProfileSettingsPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProfileSettingsPolicyTests.swift; sourceTree = "<group>"; };
 		22BF10E43507028B75EE0B6B /* OTPField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OTPField.swift; path = DesignSystem/Molecules/OTPField.swift; sourceTree = "<group>"; };
 		22FEDB2A6B2D920273613C82 /* Glp1WeeklyCheckInPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Glp1WeeklyCheckInPolicyTests.swift; sourceTree = "<group>"; };
 		23F9119B26AB2A527AA6E344 /* RevenueCatPurchaseRestoreFlowTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RevenueCatPurchaseRestoreFlowTests.swift; sourceTree = "<group>"; };
@@ -440,6 +447,7 @@
 		50EBF62AD8F9F25BB301D998 /* ProgressPhotoAttachPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProgressPhotoAttachPolicyTests.swift; sourceTree = "<group>"; };
 		55090E3269B8A8F8E45E46D0 /* SecondaryMetricsRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SecondaryMetricsRow.swift; path = DesignSystem/Organisms/SecondaryMetricsRow.swift; sourceTree = "<group>"; };
 		5586EC0657B1F9E652068FBA /* OnboardingFlowViewModel+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "OnboardingFlowViewModel+Part02.swift"; path = "OnboardingFlowViewModel+Part02.swift"; sourceTree = "<group>"; };
+		59C400E664F1B03F8C2556C9 /* AccountDeletionConfirmationPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountDeletionConfirmationPolicyTests.swift; sourceTree = "<group>"; };
 		5D15E6A333FABD14CA6405A4 /* LaunchAndBodyCompositionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LaunchAndBodyCompositionTests.swift; sourceTree = "<group>"; };
 		5F1996527170EC15B242FF4B /* RevenueCatSubscriptionAnalyticsTransitionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RevenueCatSubscriptionAnalyticsTransitionTests.swift; sourceTree = "<group>"; };
 		620823F9E8905856BB1B666D /* GlobalTimelineServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GlobalTimelineServiceTests.swift; sourceTree = "<group>"; };
@@ -476,6 +484,7 @@
 		91C10C0E4F8B40568047DA88 /* AddEntrySheet+Part01.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AddEntrySheet+Part01.swift"; path = "AddEntrySheet+Part01.swift"; sourceTree = "<group>"; };
 		927B7D58E8E1756BB92364B6 /* BodyCompositionMathGoldenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyCompositionMathGoldenTests.swift; sourceTree = "<group>"; };
 		95E35CCA2D3778DD47C8E104 /* ErrorStateViewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorStateViewTests.swift; sourceTree = "<group>"; };
+		98D10550744C3D80F49B32A4 /* ExportCSVBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExportCSVBuilder.swift; sourceTree = "<group>"; };
 		9A58DAB61B2BBDF2D4EF761B /* ExternalServicePortsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExternalServicePortsTests.swift; sourceTree = "<group>"; };
 		9C89CCE0BFAE9B2ACB9A017B /* UserHeaderSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserHeaderSection.swift; path = DesignSystem/Organisms/UserHeaderSection.swift; sourceTree = "<group>"; };
 		9ED9F05E697F00813F824903 /* LogoutButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LogoutButton.swift; path = DesignSystem/Molecules/LogoutButton.swift; sourceTree = "<group>"; };
@@ -784,6 +793,7 @@
 		BBB847A2050F3135D62950A1 /* AuthFormField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthFormField.swift; path = DesignSystem/Molecules/AuthFormField.swift; sourceTree = "<group>"; };
 		BC71479CEEDEAD772518C5E9 /* BodyMetricAppIntentsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyMetricAppIntentsTests.swift; sourceTree = "<group>"; };
 		BF02BFDD936CBA59B3704AA3 /* CoreDataManager+Part01.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CoreDataManager+Part01.swift"; path = "CoreDataManager+Part01.swift"; sourceTree = "<group>"; };
+		C03A26B5060721876EE70C55 /* ExportCSVBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExportCSVBuilderTests.swift; sourceTree = "<group>"; };
 		C0AE830DA0CFDB1735F6894C /* SyncIntegrationBodyMetricSyncTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncIntegrationBodyMetricSyncTests.swift; sourceTree = "<group>"; };
 		C0D300022F30000100ABCDEF /* GeneratedProductRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedProductRegistry.swift; sourceTree = "<group>"; };
 		C575F720A1D8D1DFDC4F1CEF /* DSCircularProgressTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DSCircularProgressTests.swift; sourceTree = "<group>"; };
@@ -1102,6 +1112,10 @@
 				6D2732D288C61F35059E6C4D /* OnboardingFlowValidationTests.swift */,
 				9F72F9E9548064844D56AD75 /* OnboardingScoreDisplayPolicyTests.swift */,
 				7E16AB6CFAC7A59EBD3B2792 /* OnboardingStepEntryPolicyTests.swift */,
+				59C400E664F1B03F8C2556C9 /* AccountDeletionConfirmationPolicyTests.swift */,
+				C03A26B5060721876EE70C55 /* ExportCSVBuilderTests.swift */,
+				1D7568984229530B712D2F70 /* ProfileSettingsPolicyTests.swift */,
+				031C0B385F7C300284AA6A5F /* SessionListOrderingTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1235,6 +1249,7 @@
 				AD723AEF2E15FA5C002376C6 /* Constants.swift */,
 				AD050C402EBFD8160082A313 /* HapticManager.swift */,
 				C7CC52C2F710012ABB7E7219 /* EditEntrySavePolicy.swift */,
+				98D10550744C3D80F49B32A4 /* ExportCSVBuilder.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1908,6 +1923,10 @@
 				1C6CAB83A8724849F1FC5804 /* OnboardingFlowValidationTests.swift in Sources */,
 				77AE209CC221E82496CC8771 /* OnboardingScoreDisplayPolicyTests.swift in Sources */,
 				A40A693BDA9D2826E3DE900D /* OnboardingStepEntryPolicyTests.swift in Sources */,
+				52551D9E4C3D6B89BAE63FA2 /* AccountDeletionConfirmationPolicyTests.swift in Sources */,
+				EC190275D6A9097801551F4B /* ExportCSVBuilderTests.swift in Sources */,
+				D4974B8C3D3837CE581B978D /* ProfileSettingsPolicyTests.swift in Sources */,
+				417364FB8DBF56DE4302BA11 /* SessionListOrderingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2172,6 +2191,7 @@
 				8A693BCF3584DF89630F50C5 /* OnboardingFlowViewModel+Part02.swift in Sources */,
 				2EEA145D3CD52D5D72ECB544 /* Collection+Safe.swift in Sources */,
 				7C37907A5334D86B6A905A8A /* EditEntrySavePolicy.swift in Sources */,
+				9DA53BBE5C68C157C1C517F4 /* ExportCSVBuilder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/LogYourBody/Utils/ExportCSVBuilder.swift
+++ b/apps/ios/LogYourBody/Utils/ExportCSVBuilder.swift
@@ -1,0 +1,86 @@
+//
+// ExportCSVBuilder.swift
+// LogYourBody
+//
+
+import Foundation
+
+/// Pure CSV generation for the data-export flow, extracted from `ExportDataView`
+/// with no behavior change. The default date formatter and FFMI resolution match
+/// the historical export output exactly.
+enum ExportCSVBuilder {
+    static let bodyMetricsHeader = "Date,Weight,Weight Unit,Body Fat %,FFMI,Muscle Mass,Bone Mass,Notes,Photo URL"
+    static let dailyLogsHeader = "Date,Weight,Weight Unit,Steps,Notes"
+
+    /// Row-date formatter matching the historical export format (locale short date).
+    static func makeRowDateFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        return formatter
+    }
+
+    /// Builds the body-metrics CSV: header plus one row per metric, oldest first.
+    /// - Parameters:
+    ///   - metrics: Metrics to export, in any order.
+    ///   - heightInches: User height used for FFMI estimation; `nil` yields 0 in the FFMI column.
+    ///   - dateFormatter: Row-date formatter (defaults to the historical locale short-date style).
+    ///   - ffmiValue: FFMI override for a metric date; defaults to `MetricsInterpolationService`.
+    static func makeBodyMetricsCSV(
+        metrics: [BodyMetrics],
+        heightInches: Double?,
+        dateFormatter: DateFormatter = makeRowDateFormatter(),
+        ffmiValue: ((Date, [BodyMetrics]) -> Double?)? = nil
+    ) -> String {
+        var csv = bodyMetricsHeader + "\n"
+
+        let sortedMetrics = metrics.sorted { $0.date < $1.date }
+
+        for metric in sortedMetrics {
+            let date = dateFormatter.string(from: metric.date)
+            let weight = metric.weight ?? 0
+            let weightUnit = metric.weightUnit ?? "lbs"
+            let bodyFat = metric.bodyFatPercentage ?? 0
+            let ffmi: Double
+            if let ffmiValue {
+                ffmi = ffmiValue(metric.date, sortedMetrics) ?? 0
+            } else if let heightInches,
+                      let ffmiResult = MetricsInterpolationService.shared.estimateFFMI(
+                          for: metric.date,
+                          metrics: sortedMetrics,
+                          heightInches: heightInches
+                      ) {
+                ffmi = ffmiResult.value
+            } else {
+                ffmi = 0
+            }
+            let muscleMass = metric.muscleMass ?? 0
+            let boneMass = metric.boneMass ?? 0
+            let notes = metric.notes ?? ""
+            let photoURL = metric.photoUrl ?? ""
+
+            csv += "\(date),\(weight),\(weightUnit),\(bodyFat),\(ffmi),\(muscleMass),\(boneMass),\"\(notes)\",\(photoURL)\n"
+        }
+
+        return csv
+    }
+
+    /// Builds the daily-logs CSV: header plus one row per log, oldest first.
+    static func makeDailyLogsCSV(
+        logs: [DailyLog],
+        dateFormatter: DateFormatter = makeRowDateFormatter()
+    ) -> String {
+        var csv = dailyLogsHeader + "\n"
+
+        for log in logs.sorted(by: { $0.date < $1.date }) {
+            let date = dateFormatter.string(from: log.date)
+            let weight = log.weight ?? 0
+            let weightUnit = log.weightUnit ?? ""
+            let steps = log.stepCount ?? 0
+            let notes = log.notes ?? ""
+
+            csv += "\(date),\(weight),\(weightUnit),\(steps),\"\(notes)\"\n"
+        }
+
+        return csv
+    }
+}

--- a/apps/ios/LogYourBody/Views/DeleteAccountView.swift
+++ b/apps/ios/LogYourBody/Views/DeleteAccountView.swift
@@ -5,6 +5,21 @@
 import SwiftUI
 import UIKit
 
+enum AccountDeletionConfirmationPolicy {
+    static let confirmationPhrase = "DELETE"
+
+    /// The delete action is armed only by an exact, case-sensitive match of the phrase.
+    static func isValidConfirmation(_ text: String) -> Bool {
+        text == confirmationPhrase
+    }
+
+    /// Guidance shown once the user has typed something that does not match the phrase.
+    static func validationMessage(for text: String) -> String? {
+        guard !text.isEmpty, !isValidConfirmation(text) else { return nil }
+        return "Type \(confirmationPhrase) exactly to enable account deletion."
+    }
+}
+
 struct DeleteAccountView: View {
     @EnvironmentObject var authManager: AuthManager
     @Environment(\.theme)
@@ -16,15 +31,14 @@ struct DeleteAccountView: View {
     @State private var errorMessage = ""
     @FocusState private var isTextFieldFocused: Bool
 
-    private let confirmationPhrase = "DELETE"
+    private let confirmationPhrase = AccountDeletionConfirmationPolicy.confirmationPhrase
 
     private var hasValidConfirmation: Bool {
-        confirmationText == confirmationPhrase
+        AccountDeletionConfirmationPolicy.isValidConfirmation(confirmationText)
     }
 
     private var confirmationValidationMessage: String? {
-        guard !confirmationText.isEmpty, !hasValidConfirmation else { return nil }
-        return "Type DELETE exactly to enable account deletion."
+        AccountDeletionConfirmationPolicy.validationMessage(for: confirmationText)
     }
 
     var body: some View {

--- a/apps/ios/LogYourBody/Views/ExportDataView.swift
+++ b/apps/ios/LogYourBody/Views/ExportDataView.swift
@@ -509,11 +509,6 @@ struct ExportDataView: View {
     }
 
     private func createBodyMetricsCSV(from metrics: [BodyMetrics]) -> String {
-        var csv = "Date,Weight,Weight Unit,Body Fat %,FFMI,Muscle Mass,Bone Mass,Notes,Photo URL\n"
-
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .short
-
         let heightCm = authManager.currentUser?.profile?.height
         let heightInches: Double?
         if let heightCm, heightCm > 0 {
@@ -521,53 +516,11 @@ struct ExportDataView: View {
         } else {
             heightInches = nil
         }
-
-        let sortedMetrics = metrics.sorted { $0.date < $1.date }
-
-        for metric in sortedMetrics {
-            let date = dateFormatter.string(from: metric.date)
-            let weight = metric.weight ?? 0
-            let weightUnit = metric.weightUnit ?? "lbs"
-            let bodyFat = metric.bodyFatPercentage ?? 0
-            let ffmiValue: Double
-            if let heightInches,
-               let ffmiResult = MetricsInterpolationService.shared.estimateFFMI(
-                   for: metric.date,
-                   metrics: sortedMetrics,
-                   heightInches: heightInches
-               ) {
-                ffmiValue = ffmiResult.value
-            } else {
-                ffmiValue = 0
-            }
-            let muscleMass = metric.muscleMass ?? 0
-            let boneMass = metric.boneMass ?? 0
-            let notes = metric.notes ?? ""
-            let photoURL = metric.photoUrl ?? ""
-
-            csv += "\(date),\(weight),\(weightUnit),\(bodyFat),\(ffmiValue),\(muscleMass),\(boneMass),\"\(notes)\",\(photoURL)\n"
-        }
-
-        return csv
+        return ExportCSVBuilder.makeBodyMetricsCSV(metrics: metrics, heightInches: heightInches)
     }
 
     private func createDailyLogsCSV(from logs: [DailyLog]) -> String {
-        var csv = "Date,Weight,Weight Unit,Steps,Notes\n"
-
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .short
-
-        for log in logs.sorted(by: { $0.date < $1.date }) {
-            let date = dateFormatter.string(from: log.date)
-            let weight = log.weight ?? 0
-            let weightUnit = log.weightUnit ?? ""
-            let steps = log.stepCount ?? 0
-            let notes = log.notes ?? ""
-
-            csv += "\(date),\(weight),\(weightUnit),\(steps),\"\(notes)\"\n"
-        }
-
-        return csv
+        ExportCSVBuilder.makeDailyLogsCSV(logs: logs)
     }
 
     private func extractPhotoURLs(from metrics: [BodyMetrics]) -> [String] {

--- a/apps/ios/LogYourBody/Views/ProfileSettingsViewV2.swift
+++ b/apps/ios/LogYourBody/Views/ProfileSettingsViewV2.swift
@@ -6,6 +6,63 @@ import SwiftUI
 import OSLog
 import UIKit
 
+enum ProfileSettingsPolicy {
+    /// Joins first/last names into a display name, trimming blanks and dropping empty parts.
+    static func joinedDisplayName(first: String, last: String) -> String {
+        let trimmedFirst = first.trimmingCharacters(in: .whitespaces)
+        let trimmedLast = last.trimmingCharacters(in: .whitespaces)
+        return [trimmedFirst, trimmedLast]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    /// Base string used to prefill the name fields: the stored display name, or the email local-part.
+    static func displayNameBase(name: String, email: String) -> String {
+        if !name.isEmpty {
+            return name
+        }
+        return email.components(separatedBy: "@").first ?? ""
+    }
+
+    /// Splits a display name into (first, last); everything after the first word becomes the last name.
+    static func splitDisplayName(_ base: String) -> (first: String, last: String) {
+        let parts = base.split(separator: " ")
+        let first = parts.first.map { String($0) } ?? ""
+        let last = parts.count > 1 ? parts.dropFirst().joined(separator: " ") : ""
+        return (first, last)
+    }
+
+    /// Formats a height stored in cm for the profile row and picker sheet display.
+    static func formattedHeight(heightCm: Int, useMetric: Bool) -> String {
+        if useMetric {
+            return "\(heightCm) cm"
+        }
+        let totalInches = Int(Double(heightCm) / 2.54)
+        let feet = totalInches / 12
+        let inches = totalInches % 12
+        return "\(feet)'\(inches)\""
+    }
+
+    /// Formats the age row label from a date of birth.
+    static func formattedAge(dateOfBirth: Date, now: Date = Date(), calendar: Calendar = .current) -> String {
+        let age = calendar.dateComponents([.year], from: dateOfBirth, to: now).year ?? 0
+        return age > 0 ? "\(age) years" : "Not set"
+    }
+
+    /// Imperial wheel components for a height stored in cm.
+    static func imperialHeightComponents(heightCm: Int) -> (feet: Int, inches: Int) {
+        let totalInches = Double(heightCm) / 2.54
+        let feet = Int(totalInches / 12)
+        let inches = Int(totalInches.truncatingRemainder(dividingBy: 12))
+        return (feet, inches)
+    }
+
+    /// Height in cm from imperial wheel components.
+    static func heightCm(feet: Int, inches: Int) -> Int {
+        Int((Double(feet) * 12 + Double(inches)) * 2.54)
+    }
+}
+
 struct ProfileSettingsViewV2: View {
     @EnvironmentObject var authManager: AuthManager
     @Environment(\.dismiss)
@@ -305,29 +362,17 @@ struct ProfileSettingsViewV2: View {
     }
 
     private func updateEditableName() {
-        let first = editableFirstName.trimmingCharacters(in: .whitespaces)
-        let last = editableLastName.trimmingCharacters(in: .whitespaces)
-        editableName = [first, last]
-            .filter { !$0.isEmpty }
-            .joined(separator: " ")
+        editableName = ProfileSettingsPolicy.joinedDisplayName(first: editableFirstName, last: editableLastName)
     }
 
     // MARK: - Computed Properties
 
     private var formattedHeight: String {
-        if useMetricHeight {
-            return "\(editableHeightCm) cm"
-        } else {
-            let totalInches = Int(Double(editableHeightCm) / 2.54)
-            let feet = totalInches / 12
-            let inches = totalInches % 12
-            return "\(feet)'\(inches)\""
-        }
+        ProfileSettingsPolicy.formattedHeight(heightCm: editableHeightCm, useMetric: useMetricHeight)
     }
 
     private var formattedAge: String {
-        let age = Calendar.current.dateComponents([.year], from: editableDateOfBirth, to: Date()).year ?? 0
-        return age > 0 ? "\(age) years" : "Not set"
+        ProfileSettingsPolicy.formattedAge(dateOfBirth: editableDateOfBirth)
     }
 
     // MARK: - Methods
@@ -336,15 +381,10 @@ struct ProfileSettingsViewV2: View {
         guard let user = authManager.currentUser else { return }
 
         editableName = user.name ?? user.profile?.fullName ?? ""
-        let baseName: String
-        if !editableName.isEmpty {
-            baseName = editableName
-        } else {
-            baseName = user.email.components(separatedBy: "@").first ?? ""
-        }
-        let parts = baseName.split(separator: " ")
-        editableFirstName = parts.first.map { String($0) } ?? ""
-        editableLastName = parts.count > 1 ? parts.dropFirst().joined(separator: " ") : ""
+        let baseName = ProfileSettingsPolicy.displayNameBase(name: editableName, email: user.email)
+        let nameParts = ProfileSettingsPolicy.splitDisplayName(baseName)
+        editableFirstName = nameParts.first
+        editableLastName = nameParts.last
         editableDateOfBirth = user.profile?.dateOfBirth ?? Date()
 
         if let height = user.profile?.height {
@@ -516,23 +556,21 @@ struct ProfileHeightPickerSheet: View {
     }
 
     private var imperialHeightPicker: some View {
-        let totalInches = Double(heightCm) / 2.54
-        let feet = Int(totalInches / 12)
-        let inches = Int(totalInches.truncatingRemainder(dividingBy: 12))
+        let components = ProfileSettingsPolicy.imperialHeightComponents(heightCm: heightCm)
+        let feet = components.feet
+        let inches = components.inches
 
         let feetBinding = Binding<Int>(
             get: { feet },
             set: { newFeet in
-                let newHeightCm = (Double(newFeet) * 12 + Double(inches)) * 2.54
-                heightCm = Int(newHeightCm)
+                heightCm = ProfileSettingsPolicy.heightCm(feet: newFeet, inches: inches)
             }
         )
 
         let inchesBinding = Binding<Int>(
             get: { inches },
             set: { newInches in
-                let newHeightCm = (Double(feet) * 12 + Double(newInches)) * 2.54
-                heightCm = Int(newHeightCm)
+                heightCm = ProfileSettingsPolicy.heightCm(feet: feet, inches: newInches)
             }
         )
 
@@ -556,22 +594,12 @@ struct ProfileHeightPickerSheet: View {
     }
 
     private var formattedHeight: String {
-        if useMetric {
-            return "\(heightCm) cm"
-        } else {
-            let totalInches = Int(Double(heightCm) / 2.54)
-            let feet = totalInches / 12
-            let inches = totalInches % 12
-            return "\(feet)'\(inches)\""
-        }
+        ProfileSettingsPolicy.formattedHeight(heightCm: heightCm, useMetric: useMetric)
     }
 
     private var alternateHeight: String {
         if useMetric {
-            let totalInches = Int(Double(heightCm) / 2.54)
-            let feet = totalInches / 12
-            let inches = totalInches % 12
-            return "\(feet)'\(inches)\" in imperial"
+            return ProfileSettingsPolicy.formattedHeight(heightCm: heightCm, useMetric: false) + " in imperial"
         } else {
             return "\(heightCm) cm in metric"
         }

--- a/apps/ios/LogYourBody/Views/SecuritySessionsView.swift
+++ b/apps/ios/LogYourBody/Views/SecuritySessionsView.swift
@@ -4,6 +4,18 @@
 //
 import SwiftUI
 
+enum SessionListOrdering {
+    /// Orders sessions for display: the current session pinned first, then most-recently-active first.
+    static func sorted(_ sessions: [SessionInfo]) -> [SessionInfo] {
+        sessions.sorted { session1, session2 in
+            if session1.isCurrentSession != session2.isCurrentSession {
+                return session1.isCurrentSession
+            }
+            return session1.lastActiveAt > session2.lastActiveAt
+        }
+    }
+}
+
 struct SecuritySessionsView: View {
     @EnvironmentObject var authManager: AuthManager
     @Environment(\.dismiss)
@@ -145,13 +157,7 @@ struct SecuritySessionsView: View {
         do {
             let fetchedSessions = try await AuthManager.shared.fetchActiveSessions()
             await MainActor.run {
-                self.sessions = fetchedSessions.sorted { session1, session2 in
-                    // Current session first, then by last active
-                    if session1.isCurrentSession != session2.isCurrentSession {
-                        return session1.isCurrentSession
-                    }
-                    return session1.lastActiveAt > session2.lastActiveAt
-                }
+                self.sessions = SessionListOrdering.sorted(fetchedSessions)
                 isLoading = false
                 refreshing = false
             }

--- a/apps/ios/LogYourBodyTests/AccountDeletionConfirmationPolicyTests.swift
+++ b/apps/ios/LogYourBodyTests/AccountDeletionConfirmationPolicyTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import LogYourBody
+
+final class AccountDeletionConfirmationPolicyTests: XCTestCase {
+    func testConfirmationPhraseIsDelete() {
+        XCTAssertEqual(AccountDeletionConfirmationPolicy.confirmationPhrase, "DELETE")
+    }
+
+    func testExactPhraseArmsDeletion() {
+        XCTAssertTrue(AccountDeletionConfirmationPolicy.isValidConfirmation("DELETE"))
+    }
+
+    func testNearMissesDoNotArmDeletion() {
+        XCTAssertFalse(AccountDeletionConfirmationPolicy.isValidConfirmation("delete"))
+        XCTAssertFalse(AccountDeletionConfirmationPolicy.isValidConfirmation("Delete"))
+        XCTAssertFalse(AccountDeletionConfirmationPolicy.isValidConfirmation("DELET"))
+        XCTAssertFalse(AccountDeletionConfirmationPolicy.isValidConfirmation("DELETEE"))
+        XCTAssertFalse(AccountDeletionConfirmationPolicy.isValidConfirmation("DELETE "))
+        XCTAssertFalse(AccountDeletionConfirmationPolicy.isValidConfirmation(" DELETE"))
+        XCTAssertFalse(AccountDeletionConfirmationPolicy.isValidConfirmation(""))
+    }
+
+    func testValidationMessageHiddenWhenFieldEmpty() {
+        XCTAssertNil(AccountDeletionConfirmationPolicy.validationMessage(for: ""))
+    }
+
+    func testValidationMessageHiddenWhenPhraseMatches() {
+        XCTAssertNil(AccountDeletionConfirmationPolicy.validationMessage(for: "DELETE"))
+    }
+
+    func testValidationMessageShownForNonMatchingInput() {
+        XCTAssertEqual(
+            AccountDeletionConfirmationPolicy.validationMessage(for: "dele"),
+            "Type DELETE exactly to enable account deletion."
+        )
+    }
+}

--- a/apps/ios/LogYourBodyTests/ExportCSVBuilderTests.swift
+++ b/apps/ios/LogYourBodyTests/ExportCSVBuilderTests.swift
@@ -1,0 +1,240 @@
+import XCTest
+@testable import LogYourBody
+
+final class ExportCSVBuilderTests: XCTestCase {
+    // MARK: - Deterministic fixtures
+
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private func makeDate(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        let components = DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day
+        )
+        guard let date = calendar.date(from: components) else {
+            XCTFail("Failed to build date \(year)-\(month)-\(day)")
+            return Date(timeIntervalSince1970: 0)
+        }
+        return date
+    }
+
+    private func makeFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
+        formatter.dateStyle = .short
+        return formatter
+    }
+
+    private func makeMetric(
+        id: String,
+        date: Date,
+        weight: Double? = nil,
+        weightUnit: String? = nil,
+        bodyFatPercentage: Double? = nil,
+        muscleMass: Double? = nil,
+        boneMass: Double? = nil,
+        notes: String? = nil,
+        photoUrl: String? = nil
+    ) -> BodyMetrics {
+        BodyMetrics(
+            id: id,
+            userId: "user-1",
+            date: date,
+            weight: weight,
+            weightUnit: weightUnit,
+            bodyFatPercentage: bodyFatPercentage,
+            bodyFatMethod: nil,
+            muscleMass: muscleMass,
+            boneMass: boneMass,
+            notes: notes,
+            photoUrl: photoUrl,
+            dataSource: "manual",
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+
+    private func rows(of csv: String) -> [String] {
+        csv.components(separatedBy: "\n").filter { !$0.isEmpty }
+    }
+
+    // MARK: - Body metrics CSV
+
+    func testBodyMetricsEmptyStoreProducesHeaderOnly() {
+        let csv = ExportCSVBuilder.makeBodyMetricsCSV(
+            metrics: [],
+            heightInches: nil,
+            dateFormatter: makeFormatter()
+        )
+
+        XCTAssertEqual(
+            csv,
+            "Date,Weight,Weight Unit,Body Fat %,FFMI,Muscle Mass,Bone Mass,Notes,Photo URL\n"
+        )
+    }
+
+    func testBodyMetricsRowsSortAscendingByDate() {
+        let jan5 = makeDate(2_024, 1, 5)
+        let mar10 = makeDate(2_024, 3, 10)
+        let feb20 = makeDate(2_024, 2, 20)
+        let metrics = [
+            makeMetric(id: "march", date: mar10, weight: 180.0, weightUnit: "lbs"),
+            makeMetric(id: "january", date: jan5, weight: 185.0, weightUnit: "lbs"),
+            makeMetric(id: "february", date: feb20, weight: 182.5, weightUnit: "lbs")
+        ]
+
+        let csv = ExportCSVBuilder.makeBodyMetricsCSV(
+            metrics: metrics,
+            heightInches: nil,
+            dateFormatter: makeFormatter()
+        )
+
+        let lines = rows(of: csv)
+        XCTAssertEqual(lines.count, 4)
+        XCTAssertEqual(lines[1], "1/5/24,185.0,lbs,0.0,0.0,0.0,0.0,\"\",")
+        XCTAssertEqual(lines[2], "2/20/24,182.5,lbs,0.0,0.0,0.0,0.0,\"\",")
+        XCTAssertEqual(lines[3], "3/10/24,180.0,lbs,0.0,0.0,0.0,0.0,\"\",")
+    }
+
+    func testBodyMetricsRowRendersAllColumnsAndUnits() {
+        let metric = makeMetric(
+            id: "full",
+            date: makeDate(2_024, 1, 5),
+            weight: 80.25,
+            weightUnit: "kg",
+            bodyFatPercentage: 21.5,
+            muscleMass: 60.5,
+            boneMass: 3.1,
+            notes: "Felt strong",
+            photoUrl: "https://example.com/photo.jpg"
+        )
+
+        let csv = ExportCSVBuilder.makeBodyMetricsCSV(
+            metrics: [metric],
+            heightInches: nil,
+            dateFormatter: makeFormatter()
+        ) { _, _ in 22.4 }
+
+        XCTAssertEqual(
+            rows(of: csv).last,
+            "1/5/24,80.25,kg,21.5,22.4,60.5,3.1,\"Felt strong\",https://example.com/photo.jpg"
+        )
+    }
+
+    func testBodyMetricsDefaultsMissingWeightAndUnitToZeroAndLbs() {
+        let metric = makeMetric(id: "sparse", date: makeDate(2_024, 1, 5))
+
+        let csv = ExportCSVBuilder.makeBodyMetricsCSV(
+            metrics: [metric],
+            heightInches: nil,
+            dateFormatter: makeFormatter()
+        )
+
+        XCTAssertEqual(rows(of: csv).last, "1/5/24,0.0,lbs,0.0,0.0,0.0,0.0,\"\",")
+    }
+
+    func testBodyMetricsFFMIIsZeroWhenHeightUnavailable() {
+        let metric = makeMetric(
+            id: "no-height",
+            date: makeDate(2_024, 1, 5),
+            weight: 180.0,
+            weightUnit: "lbs",
+            bodyFatPercentage: 20.0
+        )
+
+        let csv = ExportCSVBuilder.makeBodyMetricsCSV(
+            metrics: [metric],
+            heightInches: nil,
+            dateFormatter: makeFormatter()
+        )
+
+        XCTAssertEqual(rows(of: csv).last, "1/5/24,180.0,lbs,20.0,0.0,0.0,0.0,\"\",")
+    }
+
+    func testBodyMetricsFFMINilFromProviderBecomesZero() {
+        let metric = makeMetric(
+            id: "nil-ffmi",
+            date: makeDate(2_024, 1, 5),
+            weight: 180.0,
+            weightUnit: "lbs",
+            bodyFatPercentage: 20.0
+        )
+
+        let csv = ExportCSVBuilder.makeBodyMetricsCSV(
+            metrics: [metric],
+            heightInches: 70,
+            dateFormatter: makeFormatter()
+        ) { _, _ in nil }
+
+        XCTAssertEqual(rows(of: csv).last, "1/5/24,180.0,lbs,20.0,0.0,0.0,0.0,\"\",")
+    }
+
+    func testBodyMetricsNotesContainingCommaStayInsideQuotedField() {
+        let metric = makeMetric(
+            id: "comma-notes",
+            date: makeDate(2_024, 1, 5),
+            notes: "Felt strong, slept well"
+        )
+
+        let csv = ExportCSVBuilder.makeBodyMetricsCSV(
+            metrics: [metric],
+            heightInches: nil,
+            dateFormatter: makeFormatter()
+        )
+
+        XCTAssertEqual(rows(of: csv).count, 2)
+        XCTAssertEqual(
+            rows(of: csv).last,
+            "1/5/24,0.0,lbs,0.0,0.0,0.0,0.0,\"Felt strong, slept well\","
+        )
+    }
+
+    // MARK: - Daily logs CSV
+
+    func testDailyLogsEmptyStoreProducesHeaderOnly() {
+        let csv = ExportCSVBuilder.makeDailyLogsCSV(logs: [], dateFormatter: makeFormatter())
+
+        XCTAssertEqual(csv, "Date,Weight,Weight Unit,Steps,Notes\n")
+    }
+
+    func testDailyLogsRowsSortAscendingAndRenderValues() {
+        let jan5 = makeDate(2_024, 1, 5)
+        let jan3 = makeDate(2_024, 1, 3)
+        let logs = [
+            DailyLog(id: "later", userId: "user-1", date: jan5, weight: 75.5, weightUnit: "kg", stepCount: 8_200),
+            DailyLog(
+                id: "earlier",
+                userId: "user-1",
+                date: jan3,
+                weight: 76.0,
+                weightUnit: "kg",
+                stepCount: 10_050,
+                notes: "Morning"
+            )
+        ]
+
+        let csv = ExportCSVBuilder.makeDailyLogsCSV(logs: logs, dateFormatter: makeFormatter())
+
+        let lines = rows(of: csv)
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertEqual(lines[1], "1/3/24,76.0,kg,10050,\"Morning\"")
+        XCTAssertEqual(lines[2], "1/5/24,75.5,kg,8200,\"\"")
+    }
+
+    func testDailyLogsDefaultsMissingValues() {
+        let log = DailyLog(id: "sparse", userId: "user-1", date: makeDate(2_024, 1, 5))
+
+        let csv = ExportCSVBuilder.makeDailyLogsCSV(logs: [log], dateFormatter: makeFormatter())
+
+        XCTAssertEqual(rows(of: csv).last, "1/5/24,0.0,,0,\"\"")
+    }
+}

--- a/apps/ios/LogYourBodyTests/ProfileSettingsPolicyTests.swift
+++ b/apps/ios/LogYourBodyTests/ProfileSettingsPolicyTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import LogYourBody
+
+final class ProfileSettingsPolicyTests: XCTestCase {
+    // MARK: - joinedDisplayName
+
+    func testJoinedDisplayNameCombinesFirstAndLast() {
+        XCTAssertEqual(
+            ProfileSettingsPolicy.joinedDisplayName(first: "John", last: "Doe"),
+            "John Doe"
+        )
+    }
+
+    func testJoinedDisplayNameDropsEmptySide() {
+        XCTAssertEqual(ProfileSettingsPolicy.joinedDisplayName(first: "John", last: ""), "John")
+        XCTAssertEqual(ProfileSettingsPolicy.joinedDisplayName(first: "", last: "Doe"), "Doe")
+    }
+
+    func testJoinedDisplayNameTrimsWhitespaceAndDropsBlankParts() {
+        XCTAssertEqual(
+            ProfileSettingsPolicy.joinedDisplayName(first: "  John  ", last: "   "),
+            "John"
+        )
+        XCTAssertEqual(ProfileSettingsPolicy.joinedDisplayName(first: "   ", last: "  "), "")
+    }
+
+    func testJoinedDisplayNamePreservesInternalSpaces() {
+        XCTAssertEqual(
+            ProfileSettingsPolicy.joinedDisplayName(first: "Mary Jane", last: "Watson"),
+            "Mary Jane Watson"
+        )
+    }
+
+    // MARK: - displayNameBase
+
+    func testDisplayNameBasePrefersStoredName() {
+        XCTAssertEqual(
+            ProfileSettingsPolicy.displayNameBase(name: "John Doe", email: "john@example.com"),
+            "John Doe"
+        )
+    }
+
+    func testDisplayNameBaseFallsBackToEmailLocalPart() {
+        XCTAssertEqual(
+            ProfileSettingsPolicy.displayNameBase(name: "", email: "jane.doe+tag@example.com"),
+            "jane.doe+tag"
+        )
+    }
+
+    func testDisplayNameBaseHandlesEmailWithoutAtSign() {
+        XCTAssertEqual(ProfileSettingsPolicy.displayNameBase(name: "", email: "localpart"), "localpart")
+        XCTAssertEqual(ProfileSettingsPolicy.displayNameBase(name: "", email: ""), "")
+    }
+
+    // MARK: - splitDisplayName
+
+    func testSplitDisplayNameSplitsOnFirstWord() {
+        let parts = ProfileSettingsPolicy.splitDisplayName("Mary Jane Watson")
+        XCTAssertEqual(parts.first, "Mary")
+        XCTAssertEqual(parts.last, "Jane Watson")
+    }
+
+    func testSplitDisplayNameHandlesSingleWordAndEmpty() {
+        XCTAssertEqual(ProfileSettingsPolicy.splitDisplayName("John").first, "John")
+        XCTAssertEqual(ProfileSettingsPolicy.splitDisplayName("John").last, "")
+
+        let empty = ProfileSettingsPolicy.splitDisplayName("")
+        XCTAssertEqual(empty.first, "")
+        XCTAssertEqual(empty.last, "")
+    }
+
+    func testSplitDisplayNameCollapsesRepeatedSpaces() {
+        let parts = ProfileSettingsPolicy.splitDisplayName("  John   Doe  ")
+        XCTAssertEqual(parts.first, "John")
+        XCTAssertEqual(parts.last, "Doe")
+    }
+
+    // MARK: - formattedHeight
+
+    func testFormattedHeightMetric() {
+        XCTAssertEqual(ProfileSettingsPolicy.formattedHeight(heightCm: 170, useMetric: true), "170 cm")
+        XCTAssertEqual(ProfileSettingsPolicy.formattedHeight(heightCm: 100, useMetric: true), "100 cm")
+    }
+
+    func testFormattedHeightImperialTruncatesToWholeInches() {
+        XCTAssertEqual(ProfileSettingsPolicy.formattedHeight(heightCm: 170, useMetric: false), "5'6\"")
+        XCTAssertEqual(ProfileSettingsPolicy.formattedHeight(heightCm: 183, useMetric: false), "6'0\"")
+        XCTAssertEqual(ProfileSettingsPolicy.formattedHeight(heightCm: 152, useMetric: false), "4'11\"")
+    }
+
+    // MARK: - formattedAge
+
+    private func makeFixedCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private func makeDate(_ year: Int, _ month: Int, _ day: Int, calendar: Calendar) -> Date {
+        let components = DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day
+        )
+        guard let date = calendar.date(from: components) else {
+            XCTFail("Failed to build date \(year)-\(month)-\(day)")
+            return Date(timeIntervalSince1970: 0)
+        }
+        return date
+    }
+
+    func testFormattedAgeCountsWholeYears() {
+        let calendar = makeFixedCalendar()
+        let now = makeDate(2_026, 7, 20, calendar: calendar)
+        let dob = makeDate(2_000, 7, 20, calendar: calendar)
+        XCTAssertEqual(
+            ProfileSettingsPolicy.formattedAge(dateOfBirth: dob, now: now, calendar: calendar),
+            "26 years"
+        )
+    }
+
+    func testFormattedAgeDoesNotRoundUpBeforeBirthday() {
+        let calendar = makeFixedCalendar()
+        let now = makeDate(2_026, 7, 20, calendar: calendar)
+        let dob = makeDate(2_000, 7, 21, calendar: calendar)
+        XCTAssertEqual(
+            ProfileSettingsPolicy.formattedAge(dateOfBirth: dob, now: now, calendar: calendar),
+            "25 years"
+        )
+    }
+
+    func testFormattedAgeShowsNotSetForZeroOrFutureDates() {
+        let calendar = makeFixedCalendar()
+        let now = makeDate(2_026, 7, 20, calendar: calendar)
+        XCTAssertEqual(
+            ProfileSettingsPolicy.formattedAge(dateOfBirth: now, now: now, calendar: calendar),
+            "Not set"
+        )
+        let future = makeDate(2_027, 7, 20, calendar: calendar)
+        XCTAssertEqual(
+            ProfileSettingsPolicy.formattedAge(dateOfBirth: future, now: now, calendar: calendar),
+            "Not set"
+        )
+    }
+
+    // MARK: - Imperial picker conversions
+
+    func testImperialHeightComponents() {
+        XCTAssertEqual(ProfileSettingsPolicy.imperialHeightComponents(heightCm: 170).feet, 5)
+        XCTAssertEqual(ProfileSettingsPolicy.imperialHeightComponents(heightCm: 170).inches, 6)
+        XCTAssertEqual(ProfileSettingsPolicy.imperialHeightComponents(heightCm: 183).feet, 6)
+        XCTAssertEqual(ProfileSettingsPolicy.imperialHeightComponents(heightCm: 183).inches, 0)
+        XCTAssertEqual(ProfileSettingsPolicy.imperialHeightComponents(heightCm: 213).feet, 6)
+        XCTAssertEqual(ProfileSettingsPolicy.imperialHeightComponents(heightCm: 213).inches, 11)
+    }
+
+    func testHeightCmFromImperialComponents() {
+        XCTAssertEqual(ProfileSettingsPolicy.heightCm(feet: 5, inches: 6), 167)
+        XCTAssertEqual(ProfileSettingsPolicy.heightCm(feet: 6, inches: 0), 182)
+        XCTAssertEqual(ProfileSettingsPolicy.heightCm(feet: 4, inches: 11), 149)
+    }
+}

--- a/apps/ios/LogYourBodyTests/SessionListOrderingTests.swift
+++ b/apps/ios/LogYourBodyTests/SessionListOrderingTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import LogYourBody
+
+final class SessionListOrderingTests: XCTestCase {
+    private func makeSession(
+        id: String,
+        lastActiveAt: Date,
+        isCurrentSession: Bool = false
+    ) -> SessionInfo {
+        SessionInfo(
+            id: id,
+            deviceName: "Device \(id)",
+            deviceType: "iPhone",
+            location: "Test",
+            ipAddress: "",
+            lastActiveAt: lastActiveAt,
+            createdAt: lastActiveAt,
+            isCurrentSession: isCurrentSession
+        )
+    }
+
+    func testCurrentSessionPinnedFirstEvenWhenLeastRecentlyActive() {
+        let old = Date(timeIntervalSince1970: 1_000)
+        let new = Date(timeIntervalSince1970: 2_000)
+        let sessions = [
+            makeSession(id: "other-new", lastActiveAt: new),
+            makeSession(id: "current", lastActiveAt: old, isCurrentSession: true)
+        ]
+
+        let ordered = SessionListOrdering.sorted(sessions)
+
+        XCTAssertEqual(ordered.map(\.id), ["current", "other-new"])
+    }
+
+    func testNonCurrentSessionsSortByLastActiveDescending() {
+        let base = Date(timeIntervalSince1970: 1_000)
+        let sessions = [
+            makeSession(id: "oldest", lastActiveAt: base),
+            makeSession(id: "newest", lastActiveAt: base.addingTimeInterval(2_000)),
+            makeSession(id: "middle", lastActiveAt: base.addingTimeInterval(1_000))
+        ]
+
+        let ordered = SessionListOrdering.sorted(sessions)
+
+        XCTAssertEqual(ordered.map(\.id), ["newest", "middle", "oldest"])
+    }
+
+    func testCurrentSessionFirstThenRemainingByRecency() {
+        let base = Date(timeIntervalSince1970: 1_000)
+        let sessions = [
+            makeSession(id: "older-other", lastActiveAt: base),
+            makeSession(id: "newer-other", lastActiveAt: base.addingTimeInterval(1_000)),
+            makeSession(id: "current", lastActiveAt: base, isCurrentSession: true)
+        ]
+
+        let ordered = SessionListOrdering.sorted(sessions)
+
+        XCTAssertEqual(ordered.map(\.id), ["current", "newer-other", "older-other"])
+    }
+
+    func testEmptyAndSingleSessionInputsPassThrough() {
+        XCTAssertTrue(SessionListOrdering.sorted([]).isEmpty)
+
+        let single = [makeSession(id: "only", lastActiveAt: Date(timeIntervalSince1970: 1_000), isCurrentSession: true)]
+        XCTAssertEqual(SessionListOrdering.sorted(single).map(\.id), ["only"])
+    }
+}

--- a/apps/ios/docs/testing/FEATURE_INVENTORY.md
+++ b/apps/ios/docs/testing/FEATURE_INVENTORY.md
@@ -133,14 +133,14 @@ candidate (propose deletion, not tests).
 
 ### A.7 Settings / preferences
 
-| Surface                                                                       | File                                | Risk | Layer           | Status / existing                                       |
-| ----------------------------------------------------------------------------- | ----------------------------------- | ---- | --------------- | ------------------------------------------------------- |
-| `PreferencesView` (hub)                                                       | `Views/PreferencesView.swift`       | M    | unit + XCUITest | 🔶 UI settings fixtures, `DailyReminderPolicyTests`     |
-| `ProfileSettingsViewV2` (+2 picker sheets)                                    | `Views/ProfileSettingsViewV2.swift` | M    | unit            | ❌                                                      |
-| `PreferenceGoalEditorSheet`                                                   | `Views/PreferenceGoalEditing.swift` | M    | unit            | 🔶 `PreferenceGoalValidatorTests`, UI goal-editor tests |
-| `SecuritySessionsView`                                                        | `Views/SecuritySessionsView.swift`  | M    | unit            | ❌                                                      |
-| `DeleteAccountView`                                                           | `Views/DeleteAccountView.swift`     | H    | integration     | 🔶 `AccountDeletionCleanupServiceTests` (service-level) |
-| `LegalView`, `WhatsNewView`, `SyncStatusView`/`SyncDetailsView`, `VersionRow` | `Views/`                            | —    | —               | 🗑 all orphaned                                         |
+| Surface                                                                       | File                                | Risk | Layer           | Status / existing                                                                                               |
+| ----------------------------------------------------------------------------- | ----------------------------------- | ---- | --------------- | --------------------------------------------------------------------------------------------------------------- |
+| `PreferencesView` (hub)                                                       | `Views/PreferencesView.swift`       | M    | unit + XCUITest | 🔶 UI settings fixtures, `DailyReminderPolicyTests`                                                             |
+| `ProfileSettingsViewV2` (+2 picker sheets)                                    | `Views/ProfileSettingsViewV2.swift` | M    | unit            | 🔶 `ProfileSettingsPolicyTests`                                                                                 |
+| `PreferenceGoalEditorSheet`                                                   | `Views/PreferenceGoalEditing.swift` | M    | unit            | 🔶 `PreferenceGoalValidatorTests`, UI goal-editor tests                                                         |
+| `SecuritySessionsView`                                                        | `Views/SecuritySessionsView.swift`  | M    | unit            | 🔶 `SessionListOrderingTests` (view states declarative; no HTTP boundary — sessions synthesized locally)        |
+| `DeleteAccountView`                                                           | `Views/DeleteAccountView.swift`     | H    | integration     | 🔶 `AccountDeletionCleanupServiceTests` (service-level), `AccountDeletionConfirmationPolicyTests` (view gating) |
+| `LegalView`, `WhatsNewView`, `SyncStatusView`/`SyncDetailsView`, `VersionRow` | `Views/`                            | —    | —               | 🗑 all orphaned                                                                                                 |
 
 ### A.8 HealthKit / integrations
 
@@ -152,10 +152,10 @@ candidate (propose deletion, not tests).
 
 ### A.9 Data export / import
 
-| Surface               | File                              | Risk | Layer              | Status / existing                                            |
-| --------------------- | --------------------------------- | ---- | ------------------ | ------------------------------------------------------------ |
-| `ExportDataView`      | `Views/ExportDataView.swift`      | M    | unit (CSV builder) | ❌                                                           |
-| `BulkPhotoImportView` | `Views/BulkPhotoImportView.swift` | M    | unit + XCUITest    | 🔶 `BulkImportManagerBoundsTests`, policy tests, UI fixtures |
+| Surface               | File                              | Risk | Layer              | Status / existing                                                         |
+| --------------------- | --------------------------------- | ---- | ------------------ | ------------------------------------------------------------------------- |
+| `ExportDataView`      | `Views/ExportDataView.swift`      | M    | unit (CSV builder) | 🔶 `ExportCSVBuilderTests` (CSV builder; email-export edge call untested) |
+| `BulkPhotoImportView` | `Views/BulkPhotoImportView.swift` | M    | unit + XCUITest    | 🔶 `BulkImportManagerBoundsTests`, policy tests, UI fixtures              |
 
 ### A.10 Legal / consent
 
@@ -310,9 +310,14 @@ Progress tracker: mark batches here as PRs merge.
 - Batch 3 — auth hardening: ✅ #483 (in review)
 - Batch 4 — legal consent gate: ✅ #485
 - Batch 5 — photo upload pipeline: ✅ #486
-- Batch 9 (unit part) — onboarding step-policy + VM validation gaps: this PR
+- Batch 6 — version migrations + debug reset: ✅ #488
+- Batch 7 — BodySpec API + OAuth: ✅ #489
+- Batch 8 — App Intents: ✅ #490
+- Batch 9 — onboarding step-policy + VM validation gaps: ✅ #491
   (`OnboardingStepEntryPolicyTests`, `OnboardingScoreDisplayPolicyTests`,
   `OnboardingFlowValidationTests`; hook→reveal XCUITest golden path deferred)
+- Batch 10 — settings cluster (ProfileSettingsViewV2, SecuritySessionsView,
+  DeleteAccountView gating, ExportDataView CSV): this PR
 - Dead-code deletion (section C sweep): this PR — ~4,068 app-target lines
   removed against the 92,243-line baseline denominator (coverage % rises
   accordingly)


### PR DESCRIPTION
## Summary

Batch 10 of the iOS test-hardening effort (inventory A.7/A.9 — settings cluster, near-zero coverage). 37 new unit tests; 5 zero-behavior-change policy extractions in the repo's `*Policy` idiom.

- **`ProfileSettingsPolicyTests` (17):** display-name join/split + email-local-part prefill fallback, height formatting (cm vs truncated ft/in — distinct from `UnitConversion` rounding), injectable age formatting, picker-wheel conversions.
- **`SessionListOrderingTests` (4):** current session pinned first, then `lastActiveAt` desc. (Audit found no HTTP boundary — `fetchActiveSessions()` synthesizes locally; HTTP stubbing deliberately skipped.)
- **`AccountDeletionConfirmationPolicyTests` (6):** exact-phrase gating (case/whitespace near-misses), validation-message suppression when empty. Service itself already covered.
- **`ExportCSVBuilderTests` (10):** exact headers, row ordering, column rendering, nil/defaults, comma-quoting, empty-store header-only — for both body-metrics and daily-logs CSVs. Builder extracted to pure `Utils/ExportCSVBuilder.swift`; defaults reproduce historical output byte-for-byte.

## App bugs found — pinned by tests, NOT fixed here (follow-up candidates)

1. **CSV escaping is broken for quotes/newlines** (pre-existing, preserved verbatim): embedded quotes aren't doubled and newlines aren't escaped → malformed CSV per RFC 4180 when notes contain them. Deserves a small fix PR (failing test first).
2. Nil metrics export as literal `0` — indistinguishable from a real zero measurement; weight-unit default inconsistent between the two CSVs.
3. FFMI column is an interpolated estimate dependent on current height — questionable for an export artifact (measured-vs-estimate standard).
4. Session revocation UI is effectively dead: the list can only ever contain the current session; view also mixes `AuthManager.shared` (load) with environment `authManager` (revoke).

## Validation evidence

- `swiftlint lint --strict`: 0 violations (352 files)
- New classes: 37/37 green (two independent runs)
- Full unit target: `** TEST SUCCEEDED **`
- Pre-push turbo lint/typecheck/test: green
