### PR TITLE
test(ios): cover vendor adapters and timeline helpers

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		04EB1D7AD1947D32BDE7AD70 /* BodyMetricSourceContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EBD5BF3F1671BC8D17ABE5D /* BodyMetricSourceContractTests.swift */; };
 		050A49949BCAA09D23C66035 /* DashboardViewModelHealthSyncWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1C56EE58FC0F4BEFDA1345 /* DashboardViewModelHealthSyncWiringTests.swift */; };
 		08009BD8B382A4A3372C1D2D /* ExternalServicePortsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A58DAB61B2BBDF2D4EF761B /* ExternalServicePortsTests.swift */; };
+		082DA43020A9A746031675D0 /* TimelinePhotoSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00E508C67F037B77FFA2627 /* TimelinePhotoSamplerTests.swift */; };
 		0922CA98E79021C4CB2595A5 /* SupabaseProfilePayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA82A71E77423D56A70AA46 /* SupabaseProfilePayloadTests.swift */; };
 		099DD9F0055C4CFBF7190F4B /* PhotoMetadataAndImportPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E0D5025A2839599F4E281D /* PhotoMetadataAndImportPolicyTests.swift */; };
 		0C4EFBDDCBCA1C2DBAC4DA0A /* BaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5A5D6BAAD9FB2F7B8AFACB /* BaseButton.swift */; };
@@ -24,6 +25,7 @@
 		18EBE5224556DDF573EE3E12 /* RevenueCatManager+Part02.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7148912B179107B65580E27E /* RevenueCatManager+Part02.swift */; };
 		18ED1A86B416E8821C250840 /* GlobalTimelineServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620823F9E8905856BB1B666D /* GlobalTimelineServiceTests.swift */; };
 		1C6CAB83A8724849F1FC5804 /* OnboardingFlowValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D2732D288C61F35059E6C4D /* OnboardingFlowValidationTests.swift */; };
+		1A9F2B46985D75138DA4DF89 /* MetricChartDataHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFAE7953B075E849003EA70 /* MetricChartDataHelperTests.swift */; };
 		1CCAD9C764D3D35B5BF0522B /* HealthKitAuthorizationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84A7C68943959BD45325D9B /* HealthKitAuthorizationPolicyTests.swift */; };
 		1E182FE84F374514F7F31F17 /* LegalConsentPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD03E6E0BF889812FE27D44 /* LegalConsentPolicyTests.swift */; };
 		2117B18E82C133B5150AB357 /* CoreDataManager+Part03.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88D7AC2C7FF4E14A3BB8168 /* CoreDataManager+Part03.swift */; };
@@ -34,7 +36,9 @@
 		3892032426C339D69DEF73EE /* LaunchSurfacePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47A7741CF9BBCD0F5DC0D5C /* LaunchSurfacePolicyTests.swift */; };
 		3FA11453ACB47EEEFEAFF581 /* PhotoUploadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A98EF222E91570CB37F44C0 /* PhotoUploadManagerTests.swift */; };
 		417364FB8DBF56DE4302BA11 /* SessionListOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031C0B385F7C300284AA6A5F /* SessionListOrderingTests.swift */; };
+		4212B84EECB988D56259A5FD /* ErrorTrackingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E493B38B586CB7B2C6FB452 /* ErrorTrackingServiceTests.swift */; };
 		42B0784EAF04F40C031D0186 /* DailyReminderPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D9694F1EA5B5091B0AE8B /* DailyReminderPolicyTests.swift */; };
+		437B26CA4B494BC0EF95A673 /* TimelineBucketCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86EEBD8D36DAF492B449176A /* TimelineBucketCalculatorTests.swift */; };
 		43ED1CCFAE5CC7DA20E6DB3E /* BaseTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEFB074F9FFF63EE8FD17BA /* BaseTextField.swift */; };
 		465512C30A97EB5CF09760D4 /* AppVersionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2827EFD1E859BCE7F2067D /* AppVersionManagerTests.swift */; };
 		46D2D60CC0C168272E5B0A14 /* BulkProgressPhotoImportPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060DD24271B0B2120CB0AA33 /* BulkProgressPhotoImportPolicyTests.swift */; };
@@ -43,7 +47,9 @@
 		4C64677ABA2986677DDE1389 /* LogWeightFormValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3ECAB100575E759C5A3D7A /* LogWeightFormValidatorTests.swift */; };
 		4DF78B8A5B5E0DBAF777CBC1 /* DSLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECEBC7B2B956D26BF45822F /* DSLogo.swift */; };
 		52551D9E4C3D6B89BAE63FA2 /* AccountDeletionConfirmationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C400E664F1B03F8C2556C9 /* AccountDeletionConfirmationPolicyTests.swift */; };
+		527D9570EA2700047C7D4A0E /* LRUCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF59EF3CF408329727452481 /* LRUCacheTests.swift */; };
 		5346F8338497DE5F23D6F20D /* CoreDataManager+Part05.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD612A21566CB070FFC0086 /* CoreDataManager+Part05.swift */; };
+		534844CE827E427810B5B337 /* ErrorReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE7640AD9F476ABF4DC7366 /* ErrorReporterTests.swift */; };
 		53C8F67CE6082C23B391B357 /* OnboardingFlowViewModel+Part01.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B90BFF4D5A1EE512C980386 /* OnboardingFlowViewModel+Part01.swift */; };
 		53E6E3304F26E6A2FDD435A5 /* AuthLegacyStorageMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A593DE7333C6FAE0E20815A /* AuthLegacyStorageMigrationTests.swift */; };
 		57EE5D3DE35D32DFC0A60E02 /* KeychainManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA91A028C261AEBF383794D0 /* KeychainManagerTests.swift */; };
@@ -58,6 +64,7 @@
 		73AAD5D6EADA5C5A7BEB0D4B /* HealthKitManager+Part03.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656A7105DE085AFF17E796C8 /* HealthKitManager+Part03.swift */; };
 		75A151025036A3D85388BD19 /* ValidationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3BCDDCDB314367722653A8 /* ValidationServiceTests.swift */; };
 		77AE209CC221E82496CC8771 /* OnboardingScoreDisplayPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F72F9E9548064844D56AD75 /* OnboardingScoreDisplayPolicyTests.swift */; };
+		773F3C5B9FF015B9A66418D1 /* AnalyticsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC41129661E6DC33C6C4877 /* AnalyticsServiceTests.swift */; };
 		7C37907A5334D86B6A905A8A /* EditEntrySavePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CC52C2F710012ABB7E7219 /* EditEntrySavePolicy.swift */; };
 		7D497AAAA2BAEEBCDB6A590E /* AddEntrySheet+Part02.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B717977805C943E5BA1410B /* AddEntrySheet+Part02.swift */; };
 		7E01D015B886A36E2EB5F3E1 /* LaunchAndBodyCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D15E6A333FABD14CA6405A4 /* LaunchAndBodyCompositionTests.swift */; };
@@ -326,6 +333,7 @@
 		B12671032F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12671022F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift */; };
 		B13F1CC0CFEB9076519101DB /* BodySpecAuthManagerTokenStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9C6D5CF67D9E4FA0995EC1 /* BodySpecAuthManagerTokenStateTests.swift */; };
 		B1F00834695D3233B62404FD /* BodyMetricLoggingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C639B8116483011892C95543 /* BodyMetricLoggingServiceTests.swift */; };
+		B235D5D59330A1F3BBB5ABC6 /* GlobalTimelineModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82ED4CD357E3259042DCF901 /* GlobalTimelineModelsTests.swift */; };
 		BB64CACAE821CFB2A97F53BA /* AuthSurfacePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA456B8668AB1B5DDFA6C5CA /* AuthSurfacePolicyTests.swift */; };
 		BC360577C7E72F397010D7B1 /* CachedPaywallOfferingDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AFDB2060EF2522DE93E10D /* CachedPaywallOfferingDisplayTests.swift */; };
 		BDDE3AD864DBBABF8214836A /* FullMetricChartView+Part02.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0DAD82BAAEB27B75923381 /* FullMetricChartView+Part02.swift */; };
@@ -353,6 +361,7 @@
 		E6CBDEE0211741843DCF52AA /* CoreDataManager+Part01.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF02BFDD936CBA59B3704AA3 /* CoreDataManager+Part01.swift */; };
 		E740BE7171B6D98EEC5796B5 /* ErrorStateViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E35CCA2D3778DD47C8E104 /* ErrorStateViewTests.swift */; };
 		E8BE69C83DC3F20913970568 /* CoreDataManager+Part02.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EECFD68955AD0F3633D8B32 /* CoreDataManager+Part02.swift */; };
+		E9B9E03061DB5B420BAF23AD /* TimelineCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6092432D9EAA2DAFFAABBD /* TimelineCalculatorTests.swift */; };
 		EA037983B7EEC7FE596CAC06 /* PhotoMetadataServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F0C87E07EEC9F3CCD2BAB /* PhotoMetadataServiceTests.swift */; };
 		EC190275D6A9097801551F4B /* ExportCSVBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03A26B5060721876EE70C55 /* ExportCSVBuilderTests.swift */; };
 		EF09015F35BC4EDACDDE281F /* AddEntrySheet+Part03.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0B649CA62200DAACE12AA8 /* AddEntrySheet+Part03.swift */; };
@@ -361,6 +370,7 @@
 		F44F78267E1DBA90010176C1 /* Color+Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD667EA50710CE217FD95E4C /* Color+Theme.swift */; };
 		F5374395372D2C41AF05F233 /* RealtimeSyncManager+Part02.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83531C42434F71BA31C75D89 /* RealtimeSyncManager+Part02.swift */; };
 		F5BBD3CA8052B53CA70ADDA1 /* SyncIntegrationBodyMetricSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AE830DA0CFDB1735F6894C /* SyncIntegrationBodyMetricSyncTests.swift */; };
+		F9C0344C70E72E212075D058 /* BugReportManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2193687561E33F2A080CD6A /* BugReportManagerTests.swift */; };
 		FA261B144FF5A5876CA6D0DB /* AuthConfigurationValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118D0C354059446D0FDC1EDA /* AuthConfigurationValidationTests.swift */; };
 		FCE2872B32CFB9AD2CE87012 /* MetricChartDataPointPresenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB82E4C8977D7158475EFB /* MetricChartDataPointPresenceTests.swift */; };
 		FE01A1A100000000000000B1 /* TimelineDataProviderScrubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01A1A100000000000000F1 /* TimelineDataProviderScrubTests.swift */; };
@@ -419,6 +429,7 @@
 		1C1C56EE58FC0F4BEFDA1345 /* DashboardViewModelHealthSyncWiringTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DashboardViewModelHealthSyncWiringTests.swift; sourceTree = "<group>"; };
 		1C662CF613D4755CA2B93A43 /* HealthSyncPipelineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HealthSyncPipelineTests.swift; sourceTree = "<group>"; };
 		1D7568984229530B712D2F70 /* ProfileSettingsPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProfileSettingsPolicyTests.swift; sourceTree = "<group>"; };
+		1CE7640AD9F476ABF4DC7366 /* ErrorReporterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorReporterTests.swift; sourceTree = "<group>"; };
 		22BF10E43507028B75EE0B6B /* OTPField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OTPField.swift; path = DesignSystem/Molecules/OTPField.swift; sourceTree = "<group>"; };
 		22FEDB2A6B2D920273613C82 /* Glp1WeeklyCheckInPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Glp1WeeklyCheckInPolicyTests.swift; sourceTree = "<group>"; };
 		23F9119B26AB2A527AA6E344 /* RevenueCatPurchaseRestoreFlowTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RevenueCatPurchaseRestoreFlowTests.swift; sourceTree = "<group>"; };
@@ -442,6 +453,7 @@
 		4C3BCDDCDB314367722653A8 /* ValidationServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ValidationServiceTests.swift; sourceTree = "<group>"; };
 		4C87F359CE5509C2457AB583 /* PaywallSavingsPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallSavingsPolicyTests.swift; sourceTree = "<group>"; };
 		4CD612A21566CB070FFC0086 /* CoreDataManager+Part05.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CoreDataManager+Part05.swift"; path = "CoreDataManager+Part05.swift"; sourceTree = "<group>"; };
+		4E493B38B586CB7B2C6FB452 /* ErrorTrackingServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorTrackingServiceTests.swift; sourceTree = "<group>"; };
 		4F614C8BD21F414268DB7829 /* BodySpecAuthManagerPKCETests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodySpecAuthManagerPKCETests.swift; sourceTree = "<group>"; };
 		4FE602CA4F092CAB186EE952 /* RevenueCatFlowTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RevenueCatFlowTests.swift; sourceTree = "<group>"; };
 		50EBF62AD8F9F25BB301D998 /* ProgressPhotoAttachPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProgressPhotoAttachPolicyTests.swift; sourceTree = "<group>"; };
@@ -454,10 +466,12 @@
 		629DBB90EB2F0C9F3D9D1105 /* VerificationForm.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VerificationForm.swift; path = DesignSystem/Organisms/VerificationForm.swift; sourceTree = "<group>"; };
 		62F02AB81FF64BBC27043BB9 /* CoreDataManager+Part04.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CoreDataManager+Part04.swift"; path = "CoreDataManager+Part04.swift"; sourceTree = "<group>"; };
 		656A7105DE085AFF17E796C8 /* HealthKitManager+Part03.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HealthKitManager+Part03.swift"; path = "HealthKitManager+Part03.swift"; sourceTree = "<group>"; };
+		6B6092432D9EAA2DAFFAABBD /* TimelineCalculatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelineCalculatorTests.swift; sourceTree = "<group>"; };
 		6C2827EFD1E859BCE7F2067D /* AppVersionManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppVersionManagerTests.swift; sourceTree = "<group>"; };
 		6C4817DC7BA2D43606C0D8CB /* DashboardContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DashboardContent.swift; path = DesignSystem/Organisms/DashboardContent.swift; sourceTree = "<group>"; };
 		6D2732D288C61F35059E6C4D /* OnboardingFlowValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingFlowValidationTests.swift; sourceTree = "<group>"; };
 		6EBD5BF3F1671BC8D17ABE5D /* BodyMetricSourceContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyMetricSourceContractTests.swift; sourceTree = "<group>"; };
+		6FC41129661E6DC33C6C4877 /* AnalyticsServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnalyticsServiceTests.swift; sourceTree = "<group>"; };
 		7148912B179107B65580E27E /* RevenueCatManager+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "RevenueCatManager+Part02.swift"; path = "RevenueCatManager+Part02.swift"; sourceTree = "<group>"; };
 		75034CADEA1D4697BDCB5555 /* ImageCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheService.swift; sourceTree = "<group>"; };
 		76E40D3BC9C969629954E803 /* PhaseInsightPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhaseInsightPolicyTests.swift; sourceTree = "<group>"; };
@@ -471,8 +485,10 @@
 		7E16AB6CFAC7A59EBD3B2792 /* OnboardingStepEntryPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingStepEntryPolicyTests.swift; sourceTree = "<group>"; };
 		7EF9F0EEBB2D999F7FEEF7D0 /* DSAuthLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSAuthLink.swift; path = DesignSystem/Atoms/DSAuthLink.swift; sourceTree = "<group>"; };
 		82670AD733C4BBFF727489CC /* MarkdownView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MarkdownView.swift; path = DesignSystem/Organisms/MarkdownView.swift; sourceTree = "<group>"; };
+		82ED4CD357E3259042DCF901 /* GlobalTimelineModelsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GlobalTimelineModelsTests.swift; sourceTree = "<group>"; };
 		83531C42434F71BA31C75D89 /* RealtimeSyncManager+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "RealtimeSyncManager+Part02.swift"; path = "RealtimeSyncManager+Part02.swift"; sourceTree = "<group>"; };
 		8631504046C70A4EE432C9B8 /* AccountDeletionAndShareCardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountDeletionAndShareCardTests.swift; sourceTree = "<group>"; };
+		86EEBD8D36DAF492B449176A /* TimelineBucketCalculatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelineBucketCalculatorTests.swift; sourceTree = "<group>"; };
 		898E428E2D5EE162E00B0BD7 /* DashboardHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DashboardHeader.swift; path = DesignSystem/Organisms/DashboardHeader.swift; sourceTree = "<group>"; };
 		89E358ECC97E3F08357502AC /* LegalDocumentLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LegalDocumentLoaderTests.swift; sourceTree = "<group>"; };
 		8A2D877BFA93E04F9E168FA7 /* BodySpecAPITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodySpecAPITests.swift; sourceTree = "<group>"; };
@@ -785,15 +801,18 @@
 		ADFC6A232E187717004FCE40 /* SupabaseManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupabaseManager.swift; sourceTree = "<group>"; };
 		ADFC6A2C2E188FD5004FCE40 /* HKRawSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKRawSample.swift; sourceTree = "<group>"; };
 		ADFF001D313D59B6006E3A22 /* BodyScoreOnboardingFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyScoreOnboardingFlowView.swift; sourceTree = "<group>"; };
+		AEFAE7953B075E849003EA70 /* MetricChartDataHelperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MetricChartDataHelperTests.swift; sourceTree = "<group>"; };
 		AF8F0C87E07EEC9F3CCD2BAB /* PhotoMetadataServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhotoMetadataServiceTests.swift; sourceTree = "<group>"; };
 		B12671002F16000100ABCDEF /* BodyScoreEngineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyScoreEngineTests.swift; sourceTree = "<group>"; };
 		B12671022F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyScoreHealthKitTriggerTests.swift; sourceTree = "<group>"; };
 		B1CDBFA72287938694EB369D /* CoreMetricsRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreMetricsRow.swift; path = DesignSystem/Organisms/CoreMetricsRow.swift; sourceTree = "<group>"; };
+		B2193687561E33F2A080CD6A /* BugReportManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BugReportManagerTests.swift; sourceTree = "<group>"; };
 		B4BF04D15583E3AE1CA4A836 /* View+Styles.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "View+Styles.swift"; path = "View+Styles.swift"; sourceTree = "<group>"; };
 		BBB847A2050F3135D62950A1 /* AuthFormField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthFormField.swift; path = DesignSystem/Molecules/AuthFormField.swift; sourceTree = "<group>"; };
 		BC71479CEEDEAD772518C5E9 /* BodyMetricAppIntentsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyMetricAppIntentsTests.swift; sourceTree = "<group>"; };
 		BF02BFDD936CBA59B3704AA3 /* CoreDataManager+Part01.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CoreDataManager+Part01.swift"; path = "CoreDataManager+Part01.swift"; sourceTree = "<group>"; };
 		C03A26B5060721876EE70C55 /* ExportCSVBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExportCSVBuilderTests.swift; sourceTree = "<group>"; };
+		BF59EF3CF408329727452481 /* LRUCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LRUCacheTests.swift; sourceTree = "<group>"; };
 		C0AE830DA0CFDB1735F6894C /* SyncIntegrationBodyMetricSyncTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncIntegrationBodyMetricSyncTests.swift; sourceTree = "<group>"; };
 		C0D300022F30000100ABCDEF /* GeneratedProductRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedProductRegistry.swift; sourceTree = "<group>"; };
 		C575F720A1D8D1DFDC4F1CEF /* DSCircularProgressTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DSCircularProgressTests.swift; sourceTree = "<group>"; };
@@ -826,6 +845,7 @@
 		EC645B4F52DDE739FAFF042E /* SupabaseManager+Part01.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "SupabaseManager+Part01.swift"; path = "SupabaseManager+Part01.swift"; sourceTree = "<group>"; };
 		ED6868B1C7F6167E2A9AE0A1 /* OnboardingFlowViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingFlowViewModelTests.swift; sourceTree = "<group>"; };
 		EECB82E4C8977D7158475EFB /* MetricChartDataPointPresenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MetricChartDataPointPresenceTests.swift; sourceTree = "<group>"; };
+		F00E508C67F037B77FFA2627 /* TimelinePhotoSamplerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelinePhotoSamplerTests.swift; sourceTree = "<group>"; };
 		F51C80EB60F2EA0D7AFA62AB /* EditEntrySavePolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EditEntrySavePolicyTests.swift; sourceTree = "<group>"; };
 		F7A2B3C4D5E6F70809101112 /* LogYourBodyV2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = LogYourBodyV2.xcdatamodel; sourceTree = "<group>"; };
 		F7A2B3C4D5E6F70809101113 /* LogYourBodyV2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = LogYourBodyV2.xcdatamodel; sourceTree = "<group>"; };
@@ -1116,6 +1136,16 @@
 				C03A26B5060721876EE70C55 /* ExportCSVBuilderTests.swift */,
 				1D7568984229530B712D2F70 /* ProfileSettingsPolicyTests.swift */,
 				031C0B385F7C300284AA6A5F /* SessionListOrderingTests.swift */,
+				6FC41129661E6DC33C6C4877 /* AnalyticsServiceTests.swift */,
+				B2193687561E33F2A080CD6A /* BugReportManagerTests.swift */,
+				1CE7640AD9F476ABF4DC7366 /* ErrorReporterTests.swift */,
+				4E493B38B586CB7B2C6FB452 /* ErrorTrackingServiceTests.swift */,
+				82ED4CD357E3259042DCF901 /* GlobalTimelineModelsTests.swift */,
+				BF59EF3CF408329727452481 /* LRUCacheTests.swift */,
+				AEFAE7953B075E849003EA70 /* MetricChartDataHelperTests.swift */,
+				86EEBD8D36DAF492B449176A /* TimelineBucketCalculatorTests.swift */,
+				6B6092432D9EAA2DAFFAABBD /* TimelineCalculatorTests.swift */,
+				F00E508C67F037B77FFA2627 /* TimelinePhotoSamplerTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1927,6 +1957,16 @@
 				EC190275D6A9097801551F4B /* ExportCSVBuilderTests.swift in Sources */,
 				D4974B8C3D3837CE581B978D /* ProfileSettingsPolicyTests.swift in Sources */,
 				417364FB8DBF56DE4302BA11 /* SessionListOrderingTests.swift in Sources */,
+				773F3C5B9FF015B9A66418D1 /* AnalyticsServiceTests.swift in Sources */,
+				F9C0344C70E72E212075D058 /* BugReportManagerTests.swift in Sources */,
+				534844CE827E427810B5B337 /* ErrorReporterTests.swift in Sources */,
+				4212B84EECB988D56259A5FD /* ErrorTrackingServiceTests.swift in Sources */,
+				B235D5D59330A1F3BBB5ABC6 /* GlobalTimelineModelsTests.swift in Sources */,
+				527D9570EA2700047C7D4A0E /* LRUCacheTests.swift in Sources */,
+				1A9F2B46985D75138DA4DF89 /* MetricChartDataHelperTests.swift in Sources */,
+				437B26CA4B494BC0EF95A673 /* TimelineBucketCalculatorTests.swift in Sources */,
+				E9B9E03061DB5B420BAF23AD /* TimelineCalculatorTests.swift in Sources */,
+				082DA43020A9A746031675D0 /* TimelinePhotoSamplerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/LogYourBody/Services/AnalyticsService.swift
+++ b/apps/ios/LogYourBody/Services/AnalyticsService.swift
@@ -29,7 +29,12 @@ final class AnalyticsService {
     private let client: AnalyticsClient
     private var hasStarted = false
 
-    private init(client: AnalyticsClient = StatsigAnalyticsClient()) {
+    private convenience init() {
+        self.init(client: StatsigAnalyticsClient())
+    }
+
+    /// Test seam: allows injecting a fake analytics client.
+    init(client: AnalyticsClient) {
         self.client = client
     }
 

--- a/apps/ios/LogYourBody/Services/BugReportManager.swift
+++ b/apps/ios/LogYourBody/Services/BugReportManager.swift
@@ -26,11 +26,13 @@ final class BugReportManager: ObservableObject {
     }
 
     private let userDefaults: UserDefaults
+    private let analyticsService: AnalyticsService
     private static let shakeToReportKey = "shakeToReportBugEnabled"
     private var isCapturingScreenshot = false
 
-    private init(userDefaults: UserDefaults = .standard) {
+    init(userDefaults: UserDefaults = .standard, analyticsService: AnalyticsService = .shared) {
         self.userDefaults = userDefaults
+        self.analyticsService = analyticsService
 
         if userDefaults.object(forKey: Self.shakeToReportKey) == nil {
             self.isShakeToReportEnabled = true
@@ -91,7 +93,7 @@ final class BugReportManager: ObservableObject {
             properties["user_id"] = id
         }
 
-        AnalyticsService.shared.track(
+        analyticsService.track(
             event: "bug_report_submitted",
             properties: properties
         )

--- a/apps/ios/LogYourBody/Services/ErrorTrackingService.swift
+++ b/apps/ios/LogYourBody/Services/ErrorTrackingService.swift
@@ -4,6 +4,22 @@ import Foundation
 import Sentry
 #endif
 
+/// Vendor boundary for error tracking. The default implementation forwards to
+/// Sentry; tests inject a fake to assert the app-level tag/extra/breadcrumb
+/// mapping without touching the vendor SDK.
+protocol ErrorTrackingVendor {
+    func start()
+    func setTag(value: String, key: String)
+    func setExtra(value: String, key: String)
+    func capture(error: Error)
+    func addBreadcrumb(
+        level: ErrorTrackingService.BreadcrumbLevel,
+        category: String,
+        message: String,
+        data: [String: String]?
+    )
+}
+
 final class ErrorTrackingService {
     static let shared = ErrorTrackingService()
 
@@ -12,8 +28,54 @@ final class ErrorTrackingService {
         case error
     }
 
-    private init() {}
+    private let vendor: ErrorTrackingVendor
 
+    private convenience init() {
+        self.init(vendor: SentryErrorTrackingVendor())
+    }
+
+    init(vendor: ErrorTrackingVendor) {
+        self.vendor = vendor
+    }
+
+    func start() {
+        vendor.start()
+    }
+
+    func capture(appError: AppError, context: ErrorContext) {
+        vendor.setTag(value: context.feature, key: "feature")
+        if let operation = context.operation {
+            vendor.setTag(value: operation, key: "operation")
+        }
+        if let screen = context.screen {
+            vendor.setTag(value: screen, key: "screen")
+        }
+        if let userId = context.userId {
+            vendor.setTag(value: userId, key: "userId")
+        }
+
+        let description = String(describing: appError)
+        vendor.setExtra(value: description, key: "appError")
+
+        vendor.capture(error: appError)
+    }
+
+    func addBreadcrumb(message: String, category: String, level: BreadcrumbLevel = .info, data: [String: String]? = nil) {
+        vendor.addBreadcrumb(level: level, category: category, message: message, data: data)
+    }
+
+    func updateUserId(_ userId: String?) {
+        if let userId = userId, !userId.isEmpty {
+            vendor.setTag(value: userId, key: "userId")
+        } else {
+            vendor.setTag(value: "none", key: "userId")
+        }
+    }
+}
+
+// MARK: - Sentry Adapter
+
+private final class SentryErrorTrackingVendor: ErrorTrackingVendor {
     func start() {
         #if canImport(Sentry)
         let dsn = Configuration.sentryDSN
@@ -39,29 +101,34 @@ final class ErrorTrackingService {
         #endif
     }
 
-    func capture(appError: AppError, context: ErrorContext) {
+    func setTag(value: String, key: String) {
         #if canImport(Sentry)
         SentrySDK.configureScope { scope in
-            scope.setTag(value: context.feature, key: "feature")
-            if let operation = context.operation {
-                scope.setTag(value: operation, key: "operation")
-            }
-            if let screen = context.screen {
-                scope.setTag(value: screen, key: "screen")
-            }
-            if let userId = context.userId {
-                scope.setTag(value: userId, key: "userId")
-            }
-
-            let description = String(describing: appError)
-            scope.setExtra(value: description, key: "appError")
+            scope.setTag(value: value, key: key)
         }
-
-        SentrySDK.capture(error: appError)
         #endif
     }
 
-    func addBreadcrumb(message: String, category: String, level: BreadcrumbLevel = .info, data: [String: String]? = nil) {
+    func setExtra(value: String, key: String) {
+        #if canImport(Sentry)
+        SentrySDK.configureScope { scope in
+            scope.setExtra(value: value, key: key)
+        }
+        #endif
+    }
+
+    func capture(error: Error) {
+        #if canImport(Sentry)
+        SentrySDK.capture(error: error)
+        #endif
+    }
+
+    func addBreadcrumb(
+        level: ErrorTrackingService.BreadcrumbLevel,
+        category: String,
+        message: String,
+        data: [String: String]?
+    ) {
         #if canImport(Sentry)
         let breadcrumb = Breadcrumb()
 
@@ -83,18 +150,6 @@ final class ErrorTrackingService {
         }
 
         SentrySDK.addBreadcrumb(breadcrumb)
-        #endif
-    }
-
-    func updateUserId(_ userId: String?) {
-        #if canImport(Sentry)
-        SentrySDK.configureScope { scope in
-            if let userId = userId, !userId.isEmpty {
-                scope.setTag(value: userId, key: "userId")
-            } else {
-                scope.setTag(value: "none", key: "userId")
-            }
-        }
         #endif
     }
 }

--- a/apps/ios/LogYourBody/Utils/ErrorReporter.swift
+++ b/apps/ios/LogYourBody/Utils/ErrorReporter.swift
@@ -10,7 +10,15 @@ struct ErrorContext {
 final class ErrorReporter {
     static let shared = ErrorReporter()
 
-    private init() {}
+    private let errorTracking: ErrorTrackingService
+
+    private convenience init() {
+        self.init(errorTracking: .shared)
+    }
+
+    init(errorTracking: ErrorTrackingService) {
+        self.errorTracking = errorTracking
+    }
 
     func capture(_ error: AppError, context: ErrorContext) {
         log(error: error, context: context)
@@ -25,7 +33,7 @@ final class ErrorReporter {
         let logger = loggerForFeature(context.feature)
         let message = contextDescription(context: context)
         logger.error("Error: \(error.localizedDescription). \(message)")
-        ErrorTrackingService.shared.capture(appError: error, context: context)
+        errorTracking.capture(appError: error, context: context)
     }
 
     private func loggerForFeature(_ feature: String) -> AppLogger {

--- a/apps/ios/LogYourBodyTests/AnalyticsServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/AnalyticsServiceTests.swift
@@ -1,0 +1,134 @@
+//
+// AnalyticsServiceTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import AVFoundation
+import CoreData
+import HealthKit
+import RevenueCat
+import SwiftUI
+import UIKit
+@testable import LogYourBody
+
+
+final class AnalyticsServiceTests: XCTestCase {
+    private final class FakeAnalyticsClient: AnalyticsClient {
+        private(set) var startCallCount = 0
+        private(set) var resetCallCount = 0
+        private(set) var identifiedUserIds: [String?] = []
+        private(set) var identifiedProperties: [[String: String]?] = []
+        private(set) var trackedEvents: [String] = []
+        private(set) var trackedProperties: [[String: String]?] = []
+        private(set) var queriedFlags: [String] = []
+        var gateResult = true
+
+        func start() {
+            startCallCount += 1
+        }
+
+        func identify(userId: String?, properties: [String: String]?) {
+            identifiedUserIds.append(userId)
+            identifiedProperties.append(properties)
+        }
+
+        func track(event: String, properties: [String: String]?) {
+            trackedEvents.append(event)
+            trackedProperties.append(properties)
+        }
+
+        func reset() {
+            resetCallCount += 1
+        }
+
+        func isFeatureEnabled(flagKey: String) -> Bool {
+            queriedFlags.append(flagKey)
+            return gateResult
+        }
+    }
+
+    private func makeService() -> (AnalyticsService, FakeAnalyticsClient) {
+        let client = FakeAnalyticsClient()
+        return (AnalyticsService(client: client), client)
+    }
+
+    func testStartDelegatesToClientAndPostsGateChangeNotification() async {
+        let (service, client) = makeService()
+        let notification = expectation(forNotification: .featureGatesDidChange, object: nil)
+
+        service.start()
+
+        await fulfillment(of: [notification], timeout: 5)
+        XCTAssertEqual(client.startCallCount, 1)
+    }
+
+    func testIdentifyForwardsUserIdAndPropertiesAndPostsNotification() async throws {
+        let (service, client) = makeService()
+        let notification = expectation(forNotification: .featureGatesDidChange, object: nil)
+        let properties = ["email": "user@example.com", "country": "US"]
+
+        service.identify(userId: "user-123", properties: properties)
+
+        await fulfillment(of: [notification], timeout: 5)
+        XCTAssertEqual(client.identifiedUserIds, ["user-123"])
+        XCTAssertEqual(try XCTUnwrap(client.identifiedProperties.first), properties)
+    }
+
+    func testIdentifyWithoutPropertiesForwardsNil() throws {
+        let (service, client) = makeService()
+
+        service.identify(userId: nil)
+
+        XCTAssertEqual(client.identifiedUserIds.count, 1)
+        XCTAssertNil(client.identifiedUserIds.first ?? "sentinel")
+        XCTAssertNil(try XCTUnwrap(client.identifiedProperties.first))
+    }
+
+    func testTrackForwardsEventNameAndProperties() throws {
+        let (service, client) = makeService()
+
+        service.track(event: "weight_logged", properties: ["source": "manual"])
+
+        XCTAssertEqual(client.trackedEvents, ["weight_logged"])
+        XCTAssertEqual(try XCTUnwrap(client.trackedProperties.first), ["source": "manual"])
+    }
+
+    func testTrackWithoutPropertiesForwardsNilProperties() throws {
+        let (service, client) = makeService()
+
+        service.track(event: "app_opened")
+
+        XCTAssertEqual(client.trackedEvents, ["app_opened"])
+        XCTAssertNil(try XCTUnwrap(client.trackedProperties.first))
+    }
+
+    func testResetDelegatesToClientAndPostsNotification() async {
+        let (service, client) = makeService()
+        let notification = expectation(forNotification: .featureGatesDidChange, object: nil)
+
+        service.reset()
+
+        await fulfillment(of: [notification], timeout: 5)
+        XCTAssertEqual(client.resetCallCount, 1)
+    }
+
+    func testFeatureGateReturnsFalseBeforeStart() {
+        let (service, client) = makeService()
+        client.gateResult = true
+
+        XCTAssertFalse(service.isFeatureEnabled(flagKey: "new_onboarding_v2"))
+        XCTAssertTrue(client.queriedFlags.isEmpty)
+    }
+
+    func testFeatureGateForwardsToClientAfterStart() async {
+        let (service, client) = makeService()
+        client.gateResult = true
+
+        service.start()
+        XCTAssertTrue(service.isFeatureEnabled(flagKey: "strict_reminders"))
+        XCTAssertEqual(client.queriedFlags, ["strict_reminders"])
+
+        client.gateResult = false
+        XCTAssertFalse(service.isFeatureEnabled(flagKey: "strict_reminders"))
+    }
+}

--- a/apps/ios/LogYourBodyTests/BodyMetricLoggingServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/BodyMetricLoggingServiceTests.swift
@@ -115,4 +115,60 @@ final class BodyMetricLoggingServiceTests: XCTestCase {
 
         XCTAssertNil(BodyMetricSpotlightDocument.make(for: metric, preferredSystem: .imperial))
     }
+
+    func testSpotlightDocumentWithWeightOnlyOmitsBodyFatKeyword() {
+        let metric = BodyMetrics(
+            id: "metric-weight-only",
+            userId: "user-1",
+            date: Date(timeIntervalSince1970: 0),
+            localDate: "1970-01-01",
+            weight: 80,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        let document = BodyMetricSpotlightDocument.make(for: metric, preferredSystem: .metric)
+
+        XCTAssertEqual(document?.contentDescription, "80.0 kg on 1970-01-01")
+        XCTAssertEqual(
+            document?.keywords,
+            ["LogYourBody", "body metrics", "weight", "body composition", "1970-01-01", "latest weight"]
+        )
+    }
+
+    func testSpotlightDocumentWithBodyFatOnlyOmitsLatestWeightKeyword() {
+        let metric = BodyMetrics(
+            id: "metric-bf-only",
+            userId: "user-1",
+            date: Date(timeIntervalSince1970: 0),
+            localDate: "1970-01-01",
+            weight: nil,
+            weightUnit: nil,
+            bodyFatPercentage: 15,
+            bodyFatMethod: "Manual",
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        let document = BodyMetricSpotlightDocument.make(for: metric, preferredSystem: .metric)
+
+        XCTAssertEqual(document?.contentDescription, "15.0% body fat on 1970-01-01")
+        XCTAssertEqual(
+            document?.keywords,
+            ["LogYourBody", "body metrics", "weight", "body composition", "1970-01-01", "body fat"]
+        )
+    }
 }

--- a/apps/ios/LogYourBodyTests/BugReportManagerTests.swift
+++ b/apps/ios/LogYourBodyTests/BugReportManagerTests.swift
@@ -1,0 +1,178 @@
+//
+// BugReportManagerTests.swift
+// LogYourBodyTests
+//
+import Combine
+import XCTest
+import AVFoundation
+import CoreData
+import HealthKit
+import RevenueCat
+import SwiftUI
+import UIKit
+@testable import LogYourBody
+
+
+@MainActor
+final class BugReportManagerTests: XCTestCase {
+    private static let shakeKey = "shakeToReportBugEnabled"
+
+    private final class FakeAnalyticsClient: AnalyticsClient {
+        private(set) var trackedEvents: [String] = []
+        private(set) var trackedProperties: [[String: String]?] = []
+
+        func start() {}
+
+        func identify(userId: String?, properties: [String: String]?) {}
+
+        func track(event: String, properties: [String: String]?) {
+            trackedEvents.append(event)
+            trackedProperties.append(properties)
+        }
+
+        func reset() {}
+
+        func isFeatureEnabled(flagKey: String) -> Bool {
+            false
+        }
+    }
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var analytics: FakeAnalyticsClient!
+    private var manager: BugReportManager!
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "BugReportManagerTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        analytics = FakeAnalyticsClient()
+        manager = BugReportManager(
+            userDefaults: defaults,
+            analyticsService: AnalyticsService(client: analytics)
+        )
+    }
+
+    override func tearDown() {
+        cancellables.removeAll()
+        defaults.removePersistentDomain(forName: suiteName)
+        manager = nil
+        analytics = nil
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testShakeToReportDefaultsToEnabledWhenUnset() {
+        XCTAssertTrue(manager.isShakeToReportEnabled)
+    }
+
+    func testShakeToReportReadsStoredPreference() {
+        defaults.set(false, forKey: Self.shakeKey)
+        let reloaded = BugReportManager(userDefaults: defaults, analyticsService: AnalyticsService(client: analytics))
+
+        XCTAssertFalse(reloaded.isShakeToReportEnabled)
+    }
+
+    func testShakeToReportTogglePersistsAcrossInstances() {
+        manager.isShakeToReportEnabled = false
+
+        XCTAssertFalse(defaults.bool(forKey: Self.shakeKey))
+        let reloaded = BugReportManager(userDefaults: defaults, analyticsService: AnalyticsService(client: analytics))
+        XCTAssertFalse(reloaded.isShakeToReportEnabled)
+    }
+
+    func testCanSubmitRequiresNonBlankMessage() {
+        manager.message = ""
+        XCTAssertFalse(manager.canSubmit)
+
+        manager.message = "   \n\t  "
+        XCTAssertFalse(manager.canSubmit)
+
+        manager.message = "weight chart looks wrong"
+        XCTAssertTrue(manager.canSubmit)
+    }
+
+    func testShakeGestureDoesNothingWhenDisabled() {
+        manager.isShakeToReportEnabled = false
+
+        manager.handleShakeGesture()
+
+        XCTAssertFalse(manager.isPromptPresented)
+        XCTAssertFalse(manager.isFormPresented)
+        XCTAssertNil(manager.screenshotData)
+    }
+
+    func testShakeGestureDoesNothingWhilePromptAlreadyShown() {
+        manager.isPromptPresented = true
+        manager.message = "existing draft"
+
+        manager.handleShakeGesture()
+
+        XCTAssertTrue(manager.isPromptPresented)
+        XCTAssertFalse(manager.isFormPresented)
+        XCTAssertEqual(manager.message, "existing draft")
+    }
+
+    func testShakeGesturePresentsPromptAndResetsDraft() async {
+        manager.message = "stale draft"
+        let presented = expectation(description: "Bug report prompt presented")
+        manager.$isPromptPresented
+            .dropFirst()
+            .sink { isPresented in
+                if isPresented {
+                    presented.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        manager.handleShakeGesture()
+
+        await fulfillment(of: [presented], timeout: 10)
+        XCTAssertTrue(manager.isPromptPresented)
+        XCTAssertFalse(manager.isFormPresented)
+        XCTAssertEqual(manager.message, "")
+        XCTAssertEqual(manager.includeScreenshot, manager.screenshotData != nil)
+    }
+
+    func testPromptTransitionsToFormAndCancelDismissesBoth() {
+        manager.isPromptPresented = true
+
+        manager.presentFormFromPrompt()
+
+        XCTAssertFalse(manager.isPromptPresented)
+        XCTAssertTrue(manager.isFormPresented)
+
+        manager.cancel()
+
+        XCTAssertFalse(manager.isPromptPresented)
+        XCTAssertFalse(manager.isFormPresented)
+    }
+
+    func testSubmitIgnoresBlankMessage() {
+        manager.isFormPresented = true
+        manager.message = "   "
+
+        manager.submit()
+
+        XCTAssertTrue(analytics.trackedEvents.isEmpty)
+        XCTAssertTrue(manager.isFormPresented)
+        XCTAssertEqual(manager.message, "   ")
+    }
+
+    func testSubmitTracksEventAndDismissesForm() {
+        manager.isFormPresented = true
+        manager.message = "  chart is blank after sync  "
+
+        manager.submit()
+
+        XCTAssertEqual(analytics.trackedEvents, ["bug_report_submitted"])
+        let properties = analytics.trackedProperties.first.flatMap { $0 }
+        XCTAssertEqual(properties?["has_screenshot"], "false")
+        XCTAssertEqual(properties?["user_id"], AuthManager.shared.currentUser?.id)
+        XCTAssertFalse(manager.isFormPresented)
+        XCTAssertFalse(manager.isPromptPresented)
+        XCTAssertEqual(manager.message, "")
+    }
+}

--- a/apps/ios/LogYourBodyTests/ErrorReporterTests.swift
+++ b/apps/ios/LogYourBodyTests/ErrorReporterTests.swift
@@ -1,0 +1,88 @@
+//
+// ErrorReporterTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import AVFoundation
+import CoreData
+import HealthKit
+import RevenueCat
+import SwiftUI
+import UIKit
+@testable import LogYourBody
+
+
+final class ErrorReporterTests: XCTestCase {
+    private final class RecordingVendor: ErrorTrackingVendor {
+        private(set) var capturedErrors: [Error] = []
+        private(set) var tags: [(value: String, key: String)] = []
+
+        func start() {}
+
+        func setTag(value: String, key: String) {
+            tags.append((value, key))
+        }
+
+        func setExtra(value: String, key: String) {}
+
+        func capture(error: Error) {
+            capturedErrors.append(error)
+        }
+
+        func addBreadcrumb(
+            level: ErrorTrackingService.BreadcrumbLevel,
+            category: String,
+            message: String,
+            data: [String: String]?
+        ) {}
+    }
+
+    private func makeReporter() -> (ErrorReporter, RecordingVendor) {
+        let vendor = RecordingVendor()
+        let tracking = ErrorTrackingService(vendor: vendor)
+        return (ErrorReporter(errorTracking: tracking), vendor)
+    }
+
+    func testCaptureForwardsOriginalErrorAndContextToTracking() {
+        let (reporter, vendor) = makeReporter()
+        let appError = AppError.billing(operation: "purchase", underlying: NSError(domain: "rc", code: 1))
+        let context = ErrorContext(feature: "billing", operation: "purchase", screen: "paywall", userId: "user-1")
+
+        reporter.capture(appError, context: context)
+
+        XCTAssertEqual(vendor.capturedErrors.count, 1)
+        guard case .billing(let operation, _)? = vendor.capturedErrors.first as? AppError else {
+            return XCTFail("Expected the original AppError to be forwarded unchanged")
+        }
+        XCTAssertEqual(operation, "purchase")
+        XCTAssertEqual(vendor.tags.filter { $0.key == "feature" }.map { $0.value }, ["billing"])
+    }
+
+    func testCaptureNonFatalWrapsUnderlyingErrorWithOperationContext() {
+        let (reporter, vendor) = makeReporter()
+        let underlying = NSError(domain: "sync", code: 7, userInfo: [NSLocalizedDescriptionKey: "boom"])
+        let context = ErrorContext(feature: "sync", operation: "pushMetrics", screen: nil, userId: nil)
+
+        reporter.captureNonFatal(underlying, context: context)
+
+        XCTAssertEqual(vendor.capturedErrors.count, 1)
+        guard case .unexpected(let wrappedContext, let wrappedUnderlying)? = vendor.capturedErrors.first as? AppError else {
+            return XCTFail("Expected non-fatal error to be wrapped as AppError.unexpected")
+        }
+        XCTAssertEqual(wrappedContext, "pushMetrics")
+        XCTAssertEqual((wrappedUnderlying as NSError).domain, "sync")
+        XCTAssertEqual((wrappedUnderlying as NSError).code, 7)
+    }
+
+    func testCaptureNonFatalFallsBackToFeatureWhenOperationIsNil() {
+        let (reporter, vendor) = makeReporter()
+        let context = ErrorContext(feature: "coreData", operation: nil, screen: nil, userId: nil)
+
+        reporter.captureNonFatal(NSError(domain: "cd", code: 2), context: context)
+
+        guard case .unexpected(let wrappedContext, _)? = vendor.capturedErrors.first as? AppError else {
+            return XCTFail("Expected non-fatal error to be wrapped as AppError.unexpected")
+        }
+        XCTAssertEqual(wrappedContext, "coreData")
+    }
+}

--- a/apps/ios/LogYourBodyTests/ErrorTrackingServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/ErrorTrackingServiceTests.swift
@@ -1,0 +1,146 @@
+//
+// ErrorTrackingServiceTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import AVFoundation
+import CoreData
+import HealthKit
+import RevenueCat
+import SwiftUI
+import UIKit
+@testable import LogYourBody
+
+
+final class ErrorTrackingServiceTests: XCTestCase {
+    private final class FakeErrorTrackingVendor: ErrorTrackingVendor {
+        private(set) var startCallCount = 0
+        private(set) var tags: [(value: String, key: String)] = []
+        private(set) var extras: [(value: String, key: String)] = []
+        private(set) var capturedErrors: [Error] = []
+        private(set) var breadcrumbLevels: [ErrorTrackingService.BreadcrumbLevel] = []
+        private(set) var breadcrumbCategories: [String] = []
+        private(set) var breadcrumbMessages: [String] = []
+        private(set) var breadcrumbData: [[String: String]?] = []
+
+        func start() {
+            startCallCount += 1
+        }
+
+        func setTag(value: String, key: String) {
+            tags.append((value, key))
+        }
+
+        func setExtra(value: String, key: String) {
+            extras.append((value, key))
+        }
+
+        func capture(error: Error) {
+            capturedErrors.append(error)
+        }
+
+        func addBreadcrumb(
+            level: ErrorTrackingService.BreadcrumbLevel,
+            category: String,
+            message: String,
+            data: [String: String]?
+        ) {
+            breadcrumbLevels.append(level)
+            breadcrumbCategories.append(category)
+            breadcrumbMessages.append(message)
+            breadcrumbData.append(data)
+        }
+    }
+
+    private func makeService() -> (ErrorTrackingService, FakeErrorTrackingVendor) {
+        let vendor = FakeErrorTrackingVendor()
+        return (ErrorTrackingService(vendor: vendor), vendor)
+    }
+
+    private func tagValues(_ vendor: FakeErrorTrackingVendor, forKey key: String) -> [String] {
+        vendor.tags.filter { $0.key == key }.map { $0.value }
+    }
+
+    func testStartDelegatesToVendor() {
+        let (service, vendor) = makeService()
+
+        service.start()
+
+        XCTAssertEqual(vendor.startCallCount, 1)
+    }
+
+    func testCaptureMapsFullContextToTagsAndExtra() {
+        let (service, vendor) = makeService()
+        let appError = AppError.network(operation: "fetchMetrics", underlying: NSError(domain: "test", code: 42))
+        let context = ErrorContext(feature: "sync", operation: "push", screen: "dashboard", userId: "user-1")
+
+        service.capture(appError: appError, context: context)
+
+        XCTAssertEqual(tagValues(vendor, forKey: "feature"), ["sync"])
+        XCTAssertEqual(tagValues(vendor, forKey: "operation"), ["push"])
+        XCTAssertEqual(tagValues(vendor, forKey: "screen"), ["dashboard"])
+        XCTAssertEqual(tagValues(vendor, forKey: "userId"), ["user-1"])
+        XCTAssertEqual(vendor.extras.count, 1)
+        XCTAssertEqual(vendor.extras.first?.key, "appError")
+        XCTAssertEqual(vendor.extras.first?.value, String(describing: appError))
+
+        XCTAssertEqual(vendor.capturedErrors.count, 1)
+        guard case .network(let operation, _)? = vendor.capturedErrors.first as? AppError else {
+            return XCTFail("Expected the original AppError to reach the vendor")
+        }
+        XCTAssertEqual(operation, "fetchMetrics")
+    }
+
+    func testCaptureOmitsAbsentContextFields() {
+        let (service, vendor) = makeService()
+        let context = ErrorContext(feature: "photos", operation: nil, screen: nil, userId: nil)
+
+        service.capture(appError: .unexpected(context: "photos", underlying: NSError(domain: "t", code: 1)), context: context)
+
+        XCTAssertEqual(vendor.tags.count, 1)
+        XCTAssertEqual(vendor.tags.first?.key, "feature")
+        XCTAssertEqual(vendor.capturedErrors.count, 1)
+    }
+
+    func testAddBreadcrumbForwardsLevelCategoryMessageAndData() throws {
+        let (service, vendor) = makeService()
+
+        service.addBreadcrumb(
+            message: "upload failed",
+            category: "photos",
+            level: .error,
+            data: ["photo_id": "abc"]
+        )
+
+        XCTAssertEqual(vendor.breadcrumbLevels, [.error])
+        XCTAssertEqual(vendor.breadcrumbCategories, ["photos"])
+        XCTAssertEqual(vendor.breadcrumbMessages, ["upload failed"])
+        XCTAssertEqual(try XCTUnwrap(vendor.breadcrumbData.first), ["photo_id": "abc"])
+    }
+
+    func testAddBreadcrumbDefaultsToInfoLevelWithNoData() throws {
+        let (service, vendor) = makeService()
+
+        service.addBreadcrumb(message: "sync started", category: "sync")
+
+        XCTAssertEqual(vendor.breadcrumbLevels, [.info])
+        XCTAssertNil(try XCTUnwrap(vendor.breadcrumbData.first))
+    }
+
+    func testUpdateUserIdTagsNonEmptyValue() {
+        let (service, vendor) = makeService()
+
+        service.updateUserId("user-9")
+
+        XCTAssertEqual(tagValues(vendor, forKey: "userId"), ["user-9"])
+    }
+
+    func testUpdateUserIdFallsBackToNoneForNilOrEmpty() {
+        let (service, vendor) = makeService()
+
+        service.updateUserId(nil)
+        service.updateUserId("")
+
+        XCTAssertEqual(tagValues(vendor, forKey: "userId"), ["none", "none"])
+    }
+}

--- a/apps/ios/LogYourBodyTests/GlobalTimelineModelsTests.swift
+++ b/apps/ios/LogYourBodyTests/GlobalTimelineModelsTests.swift
@@ -1,0 +1,48 @@
+//
+// GlobalTimelineModelsTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import AVFoundation
+import CoreData
+import HealthKit
+import RevenueCat
+import SwiftUI
+import UIKit
+@testable import LogYourBody
+
+
+final class GlobalTimelineModelsTests: XCTestCase {
+    private func decodePresence(_ rawValue: String) throws -> MetricPresence {
+        let data = Data("\"\(rawValue)\"".utf8)
+        return try JSONDecoder().decode(MetricPresence.self, from: data)
+    }
+
+    func testMetricPresenceDecodesCanonicalRawValues() throws {
+        XCTAssertEqual(try decodePresence("present"), .present)
+        XCTAssertEqual(try decodePresence("interpolated"), .interpolated)
+        XCTAssertEqual(try decodePresence("last_known"), .lastKnown)
+        XCTAssertEqual(try decodePresence("missing"), .missing)
+    }
+
+    func testMetricPresenceDecodesLegacyEstimatedAliasAsInterpolated() throws {
+        XCTAssertEqual(try decodePresence("estimated"), .interpolated)
+    }
+
+    func testMetricPresenceRejectsUnknownRawValues() {
+        XCTAssertThrowsError(try decodePresence("stale"))
+    }
+
+    func testMetricPresenceEncodesBackToCanonicalRawValues() throws {
+        let encoder = JSONEncoder()
+
+        let encoded = try encoder.encode(MetricPresence.interpolated)
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), "\"interpolated\"")
+    }
+
+    func testGlobalTimelineScaleRawValuesStayStableForBucketAndCursorCoding() {
+        XCTAssertEqual(GlobalTimelineScale.week.rawValue, "week")
+        XCTAssertEqual(GlobalTimelineScale.month.rawValue, "month")
+        XCTAssertEqual(GlobalTimelineScale.year.rawValue, "year")
+    }
+}

--- a/apps/ios/LogYourBodyTests/LRUCacheTests.swift
+++ b/apps/ios/LogYourBodyTests/LRUCacheTests.swift
@@ -1,0 +1,114 @@
+//
+// LRUCacheTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import AVFoundation
+import CoreData
+import HealthKit
+import RevenueCat
+import SwiftUI
+import UIKit
+@testable import LogYourBody
+
+
+final class LRUCacheTests: XCTestCase {
+    func testValueReturnsNilForMissingKey() {
+        let cache = LRUCache<String, Int>(capacity: 2)
+
+        XCTAssertNil(cache.value(for: "missing"))
+    }
+
+    func testSetThenReadRoundTripsValue() {
+        let cache = LRUCache<String, Int>(capacity: 2)
+
+        cache.setValue(7, for: "a")
+
+        XCTAssertEqual(cache.value(for: "a"), 7)
+    }
+
+    func testLeastRecentlyUsedEntryIsEvictedAtCapacity() {
+        let cache = LRUCache<String, Int>(capacity: 2)
+        cache.setValue(1, for: "a")
+        cache.setValue(2, for: "b")
+
+        cache.setValue(3, for: "c")
+
+        XCTAssertNil(cache.value(for: "a"))
+        XCTAssertEqual(cache.value(for: "b"), 2)
+        XCTAssertEqual(cache.value(for: "c"), 3)
+    }
+
+    func testReadRefreshesRecencySoReadEntrySurvivesEviction() {
+        let cache = LRUCache<String, Int>(capacity: 2)
+        cache.setValue(1, for: "a")
+        cache.setValue(2, for: "b")
+
+        XCTAssertEqual(cache.value(for: "a"), 1)
+        cache.setValue(3, for: "c")
+
+        XCTAssertEqual(cache.value(for: "a"), 1)
+        XCTAssertNil(cache.value(for: "b"))
+        XCTAssertEqual(cache.value(for: "c"), 3)
+    }
+
+    func testUpdatingExistingKeyRefreshesValueAndRecency() {
+        let cache = LRUCache<String, Int>(capacity: 2)
+        cache.setValue(1, for: "a")
+        cache.setValue(2, for: "b")
+
+        cache.setValue(9, for: "a")
+        cache.setValue(3, for: "c")
+
+        XCTAssertEqual(cache.value(for: "a"), 9)
+        XCTAssertNil(cache.value(for: "b"))
+        XCTAssertEqual(cache.value(for: "c"), 3)
+    }
+
+    func testCapacityOneKeepsOnlyNewestEntry() {
+        let cache = LRUCache<String, Int>(capacity: 1)
+        cache.setValue(1, for: "a")
+
+        cache.setValue(2, for: "b")
+
+        XCTAssertNil(cache.value(for: "a"))
+        XCTAssertEqual(cache.value(for: "b"), 2)
+    }
+
+    func testRemoveValueDeletesOnlyThatKey() {
+        let cache = LRUCache<String, Int>(capacity: 3)
+        cache.setValue(1, for: "a")
+        cache.setValue(2, for: "b")
+
+        cache.removeValue(for: "a")
+
+        XCTAssertNil(cache.value(for: "a"))
+        XCTAssertEqual(cache.value(for: "b"), 2)
+    }
+
+    func testRemoveAllClearsEveryEntry() {
+        let cache = LRUCache<String, Int>(capacity: 3)
+        cache.setValue(1, for: "a")
+        cache.setValue(2, for: "b")
+
+        cache.removeAll()
+
+        XCTAssertNil(cache.value(for: "a"))
+        XCTAssertNil(cache.value(for: "b"))
+    }
+
+    func testRemoveAllMatchingPredicateKeepsNonMatchingEntries() {
+        let cache = LRUCache<String, Int>(capacity: 5)
+        cache.setValue(1, for: "a")
+        cache.setValue(2, for: "b")
+        cache.setValue(3, for: "c")
+
+        cache.removeAll { key, value in
+            key == "b" || value > 2
+        }
+
+        XCTAssertEqual(cache.value(for: "a"), 1)
+        XCTAssertNil(cache.value(for: "b"))
+        XCTAssertNil(cache.value(for: "c"))
+    }
+}

--- a/apps/ios/LogYourBodyTests/MetricChartDataHelperTests.swift
+++ b/apps/ios/LogYourBodyTests/MetricChartDataHelperTests.swift
@@ -1,0 +1,184 @@
+//
+// MetricChartDataHelperTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import AVFoundation
+import CoreData
+import HealthKit
+import RevenueCat
+import SwiftUI
+import UIKit
+@testable import LogYourBody
+
+
+final class MetricChartDataHelperTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+        MetricChartDataHelper.clearCache()
+    }
+
+    override func tearDown() async throws {
+        MetricChartDataHelper.clearCache()
+        try await CoreDataManager.shared.deleteAllDataAndWait()
+        try await super.tearDown()
+    }
+
+    private func makeMetric(
+        id: String,
+        userId: String,
+        daysAgo: Int,
+        weight: Double? = nil,
+        waistCm: Double? = nil
+    ) -> BodyMetrics {
+        let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date()) ?? Date()
+        return BodyMetrics(
+            id: id,
+            userId: userId,
+            date: date,
+            localDate: nil,
+            weight: weight,
+            weightUnit: weight == nil ? nil : "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            waistCm: waistCm,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+
+    private func localDateString(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+
+    func testEmptyStoreProducesNoChartData() async throws {
+        let userId = "chart-empty-\(UUID().uuidString)"
+
+        let points = MetricChartDataHelper.generateChartData(for: userId, days: 7, metricType: .weight, useMetric: true)
+
+        XCTAssertTrue(points.isEmpty)
+    }
+
+    func testWeightChartConvertsKilogramsToPoundsForImperial() async throws {
+        let userId = "chart-weight-\(UUID().uuidString)"
+        let metric = makeMetric(id: "m1", userId: userId, daysAgo: 1, weight: 100)
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(metric, userId: userId, markAsSynced: true)
+
+        let imperial = MetricChartDataHelper.generateChartData(for: userId, days: 7, metricType: .weight, useMetric: false)
+        let metricSystem = MetricChartDataHelper.generateChartData(for: userId, days: 7, metricType: .weight, useMetric: true)
+
+        XCTAssertEqual(imperial.count, 1)
+        XCTAssertEqual(imperial.first?.value ?? 0, 220.462, accuracy: 0.001)
+        XCTAssertEqual(metricSystem.first?.value ?? 0, 100, accuracy: 0.001)
+        XCTAssertFalse(imperial.first?.isEstimated ?? true)
+    }
+
+    func testWeightChartSkipsMetricsWithoutWeight() async throws {
+        let userId = "chart-skip-\(UUID().uuidString)"
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(
+            makeMetric(id: "with", userId: userId, daysAgo: 1, weight: 80),
+            userId: userId,
+            markAsSynced: true
+        )
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(
+            makeMetric(id: "without", userId: userId, daysAgo: 2),
+            userId: userId,
+            markAsSynced: true
+        )
+
+        let points = MetricChartDataHelper.generateChartData(for: userId, days: 7, metricType: .weight, useMetric: true)
+
+        XCTAssertEqual(points.count, 1)
+        XCTAssertEqual(points.first?.value ?? 0, 80, accuracy: 0.001)
+    }
+
+    func testChartDataHonoursDayWindow() async throws {
+        let userId = "chart-window-\(UUID().uuidString)"
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(
+            makeMetric(id: "recent", userId: userId, daysAgo: 1, weight: 100),
+            userId: userId,
+            markAsSynced: true
+        )
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(
+            makeMetric(id: "old", userId: userId, daysAgo: 10, weight: 90),
+            userId: userId,
+            markAsSynced: true
+        )
+
+        let week = MetricChartDataHelper.generateChartData(for: userId, days: 7, metricType: .weight, useMetric: false)
+        let allTime = MetricChartDataHelper.generateChartData(for: userId, days: nil, metricType: .weight, useMetric: false)
+
+        XCTAssertEqual(week.count, 1)
+        XCTAssertEqual(week.first?.value ?? 0, 220.462, accuracy: 0.001)
+        XCTAssertEqual(allTime.count, 2)
+        XCTAssertEqual(allTime.last?.value ?? 0, 198.4158, accuracy: 0.001)
+    }
+
+    func testWaistChartConvertsCentimetersToInchesForImperial() async throws {
+        let userId = "chart-waist-\(UUID().uuidString)"
+        try await CoreDataManager.shared.saveBodyMetricsAndWait(
+            makeMetric(id: "waist", userId: userId, daysAgo: 1, waistCm: 80),
+            userId: userId,
+            markAsSynced: true
+        )
+
+        let metricSystem = MetricChartDataHelper.generateChartData(for: userId, days: 7, metricType: .waist, useMetric: true)
+        let imperial = MetricChartDataHelper.generateChartData(for: userId, days: 7, metricType: .waist, useMetric: false)
+
+        XCTAssertEqual(metricSystem.first?.value ?? 0, 80, accuracy: 0.001)
+        XCTAssertEqual(imperial.first?.value ?? 0, 31.4961, accuracy: 0.001)
+    }
+
+    func testStepsChartMapsSeededDaysAndSkipsZeroStepDays() async throws {
+        let userId = "chart-steps-\(UUID().uuidString)"
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let twoDaysAgo = calendar.date(byAdding: .day, value: -2, to: today) ?? today
+        let fiveDaysAgo = calendar.date(byAdding: .day, value: -5, to: today) ?? today
+
+        for (date, steps) in [(today, 8_000), (twoDaysAgo, 6_000), (fiveDaysAgo, 0)] {
+            let daily = DailyMetrics(
+                id: "daily-\(localDateString(for: date))",
+                userId: userId,
+                date: date,
+                steps: steps,
+                notes: nil,
+                createdAt: date,
+                updatedAt: date
+            )
+            try await CoreDataManager.shared.saveDailyMetricsAndWait(daily, userId: userId)
+        }
+
+        let points = MetricChartDataHelper.generateStepsChartData(for: userId)
+
+        XCTAssertEqual(points.count, 2)
+        XCTAssertEqual(points.first { $0.index == 6 }?.value ?? 0, 8_000)
+        XCTAssertEqual(points.first { $0.index == 4 }?.value ?? 0, 6_000)
+    }
+
+    func testLongRangeChartDataDownsamplesToTargetCount() async throws {
+        let userId = "chart-downsample-\(UUID().uuidString)"
+
+        for day in 1...170 {
+            try await CoreDataManager.shared.saveBodyMetricsAndWait(
+                makeMetric(id: "bulk-\(day)", userId: userId, daysAgo: day, weight: 80),
+                userId: userId,
+                markAsSynced: true
+            )
+        }
+
+        let points = MetricChartDataHelper.generateChartData(for: userId, days: 365, metricType: .weight, useMetric: true)
+
+        XCTAssertEqual(points.count, 150)
+    }
+}

--- a/apps/ios/LogYourBodyTests/TimelineBucketCalculatorTests.swift
+++ b/apps/ios/LogYourBodyTests/TimelineBucketCalculatorTests.swift
@@ -1,0 +1,151 @@
+//
+// TimelineBucketCalculatorTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import AVFoundation
+import CoreData
+import HealthKit
+import RevenueCat
+import SwiftUI
+import UIKit
+@testable import LogYourBody
+
+
+final class TimelineBucketCalculatorTests: XCTestCase {
+    private func makeDate(year: Int, month: Int, day: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = 12
+        return Calendar.current.date(from: components) ?? Date(timeIntervalSince1970: 0)
+    }
+
+    private func makeMetric(id: String, date: Date) -> BodyMetrics {
+        BodyMetrics(
+            id: id,
+            userId: "user-1",
+            date: date,
+            localDate: "2024-01-01",
+            weight: 80,
+            weightUnit: "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+
+    // MARK: - Zoom level calculation
+
+    func testZoomLevelBoundariesAcrossDataRanges() {
+        let start = makeDate(year: 2_024, month: 1, day: 15)
+
+        let twoMonths = Calendar.current.date(byAdding: .month, value: 2, to: start) ?? start
+        let threeMonths = Calendar.current.date(byAdding: .month, value: 3, to: start) ?? start
+        let elevenMonths = Calendar.current.date(byAdding: .month, value: 11, to: start) ?? start
+        let twelveMonths = Calendar.current.date(byAdding: .month, value: 12, to: start) ?? start
+        let sixtyMonths = Calendar.current.date(byAdding: .month, value: 60, to: start) ?? start
+
+        XCTAssertEqual(TimelineZoomLevel.calculate(from: start, to: twoMonths), .week)
+        XCTAssertEqual(TimelineZoomLevel.calculate(from: start, to: threeMonths), .month)
+        XCTAssertEqual(TimelineZoomLevel.calculate(from: start, to: elevenMonths), .month)
+        XCTAssertEqual(TimelineZoomLevel.calculate(from: start, to: twelveMonths), .year)
+        XCTAssertEqual(TimelineZoomLevel.calculate(from: start, to: sixtyMonths), .all)
+    }
+
+    func testZoomLevelBucketSizingAndMetricTickVisibility() {
+        XCTAssertEqual(TimelineZoomLevel.week.daysPerBucket, 2)
+        XCTAssertEqual(TimelineZoomLevel.month.daysPerBucket, 7)
+        XCTAssertEqual(TimelineZoomLevel.year.daysPerBucket, 30)
+        XCTAssertEqual(TimelineZoomLevel.all.daysPerBucket, 90)
+
+        XCTAssertTrue(TimelineZoomLevel.week.showMetricTicks)
+        XCTAssertTrue(TimelineZoomLevel.month.showMetricTicks)
+        XCTAssertFalse(TimelineZoomLevel.year.showMetricTicks)
+        XCTAssertFalse(TimelineZoomLevel.all.showMetricTicks)
+    }
+
+    // MARK: - Bucket creation
+
+    func testCreateBucketsReturnsEmptyForEmptyRange() {
+        let start = makeDate(year: 2_024, month: 3, day: 1)
+
+        XCTAssertTrue(TimelineBucketCalculator.createBuckets(from: start, to: start, zoomLevel: .week).isEmpty)
+    }
+
+    func testCreateBucketsBuildsContiguousBucketsCoveringRange() {
+        let start = makeDate(year: 2_024, month: 3, day: 1)
+        let end = Calendar.current.date(byAdding: .day, value: 14, to: start) ?? start
+
+        let buckets = TimelineBucketCalculator.createBuckets(from: start, to: end, zoomLevel: .week)
+
+        XCTAssertEqual(buckets.count, 7)
+        XCTAssertEqual(buckets.first?.startDate, start)
+        for (previous, next) in zip(buckets, buckets.dropFirst()) {
+            XCTAssertEqual(previous.endDate, next.startDate)
+        }
+    }
+
+    func testCreateBucketsRoundsUpPartialTrailingBucket() {
+        let start = makeDate(year: 2_024, month: 3, day: 1)
+        let end = Calendar.current.date(byAdding: .day, value: 15, to: start) ?? start
+
+        let buckets = TimelineBucketCalculator.createBuckets(from: start, to: end, zoomLevel: .week)
+
+        XCTAssertEqual(buckets.count, 8)
+    }
+
+    func testBucketIdentifiesByStartTimestamp() {
+        let start = makeDate(year: 2_024, month: 3, day: 1)
+
+        let bucket = TimelineBucket(startDate: start, days: 7)
+
+        XCTAssertEqual(bucket.id, "\(Int(start.timeIntervalSince1970))")
+    }
+
+    // MARK: - Bucket membership
+
+    func testBucketContainsIsStartInclusiveEndExclusive() {
+        let start = makeDate(year: 2_024, month: 3, day: 1)
+        let bucket = TimelineBucket(startDate: start, days: 2)
+        let middle = Calendar.current.date(byAdding: .day, value: 1, to: start) ?? start
+
+        XCTAssertTrue(bucket.contains(start))
+        XCTAssertTrue(bucket.contains(middle))
+        XCTAssertFalse(bucket.contains(bucket.endDate))
+    }
+
+    func testDistributeToBucketsPlacesMetricsInMatchingBuckets() {
+        let start = makeDate(year: 2_024, month: 3, day: 1)
+        let end = Calendar.current.date(byAdding: .day, value: 4, to: start) ?? start
+        var buckets = TimelineBucketCalculator.createBuckets(from: start, to: end, zoomLevel: .week)
+        let dayTwo = Calendar.current.date(byAdding: .day, value: 1, to: start) ?? start
+        let dayThree = Calendar.current.date(byAdding: .day, value: 3, to: start) ?? start
+        let metrics = [makeMetric(id: "early", date: dayTwo), makeMetric(id: "late", date: dayThree)]
+
+        TimelineBucketCalculator.distributeToBuckets(metrics: metrics, buckets: &buckets)
+
+        XCTAssertEqual(buckets[0].candidates.map(\.id), ["early"])
+        XCTAssertEqual(buckets[1].candidates.map(\.id), ["late"])
+    }
+
+    func testDistributeToBucketsDropsMetricsOutsideAllBuckets() {
+        let start = makeDate(year: 2_024, month: 3, day: 1)
+        let end = Calendar.current.date(byAdding: .day, value: 2, to: start) ?? start
+        var buckets = TimelineBucketCalculator.createBuckets(from: start, to: end, zoomLevel: .week)
+        let before = Calendar.current.date(byAdding: .day, value: -1, to: start) ?? start
+        let after = Calendar.current.date(byAdding: .day, value: 30, to: start) ?? start
+        let metrics = [makeMetric(id: "before", date: before), makeMetric(id: "after", date: after)]
+
+        TimelineBucketCalculator.distributeToBuckets(metrics: metrics, buckets: &buckets)
+
+        XCTAssertTrue(buckets.allSatisfy { $0.candidates.isEmpty })
+    }
+}

--- a/apps/ios/LogYourBodyTests/TimelineCalculatorTests.swift
+++ b/apps/ios/LogYourBodyTests/TimelineCalculatorTests.swift
@@ -1,0 +1,140 @@
+//
+// TimelineCalculatorTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import AVFoundation
+import CoreData
+import HealthKit
+import RevenueCat
+import SwiftUI
+import UIKit
+@testable import LogYourBody
+
+
+final class TimelineCalculatorTests: XCTestCase {
+    private func makeMetric(id: String, daysAgo: Double, weight: Double? = 80) -> BodyMetrics {
+        let date = Date().addingTimeInterval(-daysAgo * 24 * 60 * 60)
+        return BodyMetrics(
+            id: id,
+            userId: "user-1",
+            date: date,
+            localDate: "2024-01-01",
+            weight: weight,
+            weightUnit: weight == nil ? nil : "kg",
+            bodyFatPercentage: nil,
+            bodyFatMethod: nil,
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: nil,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+
+    private func makePoint(index: Int, position: Double) -> TimelineDataPoint {
+        TimelineDataPoint(
+            id: "point-\(index)",
+            index: index,
+            date: Date(timeIntervalSince1970: Double(index) * 86_400),
+            position: position,
+            displayLabel: "label-\(index)",
+            importance: .daily
+        )
+    }
+
+    func testEmptyInputProducesNoPoints() {
+        XCTAssertTrue(TimelineCalculator.calculateTimelinePoints(from: []).isEmpty)
+    }
+
+    func testSingleRecentMetricMapsToDailyImportanceNearNewestPosition() {
+        let points = TimelineCalculator.calculateTimelinePoints(from: [makeMetric(id: "m1", daysAgo: 3)])
+
+        XCTAssertEqual(points.count, 1)
+        XCTAssertEqual(points.first?.id, "m1")
+        XCTAssertEqual(points.first?.index, 0)
+        XCTAssertEqual(points.first?.importance, .daily)
+        XCTAssertEqual(points.first?.position ?? 0, 0.93, accuracy: 0.02)
+    }
+
+    func testImportanceTiersFollowAgeOfEntry() {
+        let metrics = [
+            makeMetric(id: "daily", daysAgo: 2),
+            makeMetric(id: "weekly", daysAgo: 15),
+            makeMetric(id: "monthly", daysAgo: 100),
+            makeMetric(id: "yearly", daysAgo: 500)
+        ]
+
+        let points = TimelineCalculator.calculateTimelinePoints(from: metrics)
+        var importanceById: [String: TimelineDataPoint.TimelineImportance] = [:]
+        for point in points {
+            importanceById[point.id] = point.importance
+        }
+
+        XCTAssertEqual(importanceById["daily"], .daily)
+        XCTAssertEqual(importanceById["weekly"], .weekly)
+        XCTAssertEqual(importanceById["monthly"], .monthly)
+        XCTAssertEqual(importanceById["yearly"], .yearly)
+    }
+
+    func testPositionsIncreaseWithRecencyAndStayWithinUnitRange() {
+        let metrics = [
+            makeMetric(id: "oldest", daysAgo: 500),
+            makeMetric(id: "month", daysAgo: 100),
+            makeMetric(id: "week", daysAgo: 15),
+            makeMetric(id: "day", daysAgo: 2)
+        ]
+
+        let points = TimelineCalculator.calculateTimelinePoints(from: metrics)
+
+        XCTAssertEqual(points.map(\.id), ["oldest", "month", "week", "day"])
+        for point in points {
+            XCTAssertGreaterThanOrEqual(point.position, 0)
+            XCTAssertLessThanOrEqual(point.position, 1)
+        }
+        for (previous, next) in zip(points, points.dropFirst()) {
+            XCTAssertLessThan(previous.position, next.position)
+        }
+        XCTAssertGreaterThan(points.last?.position ?? 0, 0.9)
+        XCTAssertLessThanOrEqual(points.first?.position ?? 1, 0.1)
+    }
+
+    func testDisplayLabelsReflectImportanceGranularity() {
+        let metrics = [
+            makeMetric(id: "daily", daysAgo: 2),
+            makeMetric(id: "monthly", daysAgo: 100),
+            makeMetric(id: "yearly", daysAgo: 500)
+        ]
+
+        let points = TimelineCalculator.calculateTimelinePoints(from: metrics)
+        let yearlyPoint = points.first { $0.id == "yearly" }
+        let monthlyPoint = points.first { $0.id == "monthly" }
+        let dailyPoint = points.first { $0.id == "daily" }
+
+        let yearlyYear = Calendar.current.component(.year, from: metrics[2].date)
+        let monthlyYear = Calendar.current.component(.year, from: metrics[1].date)
+        XCTAssertEqual(yearlyPoint?.displayLabel, String(yearlyYear))
+        XCTAssertTrue(monthlyPoint?.displayLabel.contains(String(monthlyYear)) == true)
+        XCTAssertNotEqual(dailyPoint?.displayLabel, yearlyPoint?.displayLabel)
+    }
+
+    func testFindNearestPointReturnsClosestByPosition() {
+        let points = [makePoint(index: 0, position: 0.1), makePoint(index: 1, position: 0.5), makePoint(index: 2, position: 0.9)]
+
+        XCTAssertEqual(TimelineCalculator.findNearestPoint(to: 0.95, in: points)?.index, 2)
+        XCTAssertEqual(TimelineCalculator.findNearestPoint(to: 0.4, in: points)?.index, 1)
+        XCTAssertEqual(TimelineCalculator.findNearestPoint(to: 0.0, in: points)?.index, 0)
+        XCTAssertNil(TimelineCalculator.findNearestPoint(to: 0.5, in: []))
+    }
+
+    func testPositionAndIndexLookupBridgeBothDirections() {
+        let points = [makePoint(index: 0, position: 0.1), makePoint(index: 1, position: 0.5), makePoint(index: 2, position: 0.9)]
+
+        XCTAssertEqual(TimelineCalculator.position(for: 1, in: points), 0.5)
+        XCTAssertNil(TimelineCalculator.position(for: 99, in: points))
+        XCTAssertEqual(TimelineCalculator.index(for: 0.85, in: points), 2)
+        XCTAssertNil(TimelineCalculator.index(for: 0.5, in: []))
+    }
+}

--- a/apps/ios/LogYourBodyTests/TimelinePhotoSamplerTests.swift
+++ b/apps/ios/LogYourBodyTests/TimelinePhotoSamplerTests.swift
@@ -1,0 +1,166 @@
+//
+// TimelinePhotoSamplerTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import AVFoundation
+import CoreData
+import HealthKit
+import RevenueCat
+import SwiftUI
+import UIKit
+@testable import LogYourBody
+
+
+final class TimelinePhotoSamplerTests: XCTestCase {
+    private func makeMetric(id: String, weight: Double? = nil, bodyFat: Double? = nil, photo: String? = nil) -> BodyMetrics {
+        BodyMetrics(
+            id: id,
+            userId: "user-1",
+            date: Date(timeIntervalSince1970: 1_000),
+            localDate: "1970-01-01",
+            weight: weight,
+            weightUnit: weight == nil ? nil : "kg",
+            bodyFatPercentage: bodyFat,
+            bodyFatMethod: bodyFat == nil ? nil : "Manual",
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: photo,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 1_000)
+        )
+    }
+
+    private func makeBucket(candidates: [BodyMetrics]) -> TimelineBucket {
+        var bucket = TimelineBucket(startDate: Date(timeIntervalSince1970: 0), days: 2)
+        for candidate in candidates {
+            bucket.addCandidate(candidate)
+        }
+        return bucket
+    }
+
+    func testSelectRepresentativeReturnsNilForEmptyBucket() {
+        XCTAssertNil(TimelinePhotoSampler.selectRepresentative(from: makeBucket(candidates: []), previousMetric: nil))
+    }
+
+    func testSelectRepresentativeReturnsOnlyCandidate() {
+        let only = makeMetric(id: "only")
+
+        XCTAssertEqual(
+            TimelinePhotoSampler.selectRepresentative(from: makeBucket(candidates: [only]), previousMetric: nil)?.id,
+            "only"
+        )
+    }
+
+    func testSignificantWeightChangeBeatsCompleteMetrics() {
+        let previous = makeMetric(id: "prev", weight: 100)
+        let milestone = makeMetric(id: "milestone", weight: 105)
+        let complete = makeMetric(id: "complete", weight: 100.5, bodyFat: 20)
+
+        let selected = TimelinePhotoSampler.selectRepresentative(
+            from: makeBucket(candidates: [complete, milestone]),
+            previousMetric: previous
+        )
+
+        XCTAssertEqual(selected?.id, "milestone")
+    }
+
+    func testSignificantBodyFatChangeBeatsCompleteMetrics() {
+        let previous = makeMetric(id: "prev", weight: 100, bodyFat: 20)
+        let milestone = makeMetric(id: "milestone", bodyFat: 21.5)
+        let complete = makeMetric(id: "complete", weight: 100, bodyFat: 20.5)
+
+        let selected = TimelinePhotoSampler.selectRepresentative(
+            from: makeBucket(candidates: [complete, milestone]),
+            previousMetric: previous
+        )
+
+        XCTAssertEqual(selected?.id, "milestone")
+    }
+
+    func testCompleteMetricsBeatPhotoOnlyCandidate() {
+        let complete = makeMetric(id: "complete", weight: 80, bodyFat: 15)
+        let photoOnly = makeMetric(id: "photo", photo: "https://example.com/p.jpg")
+
+        let selected = TimelinePhotoSampler.selectRepresentative(
+            from: makeBucket(candidates: [photoOnly, complete]),
+            previousMetric: nil
+        )
+
+        XCTAssertEqual(selected?.id, "complete")
+    }
+
+    func testPhotoCandidateBeatsMetriclessCandidate() {
+        let photo = makeMetric(id: "photo", photo: "https://example.com/p.jpg")
+        let empty = makeMetric(id: "empty")
+
+        let selected = TimelinePhotoSampler.selectRepresentative(
+            from: makeBucket(candidates: [empty, photo]),
+            previousMetric: nil
+        )
+
+        XCTAssertEqual(selected?.id, "photo")
+    }
+
+    func testSamplePhotosTakesOnePerBucketWhenBucketsFitLimit() {
+        let buckets = [
+            makeBucket(candidates: [makeMetric(id: "a", weight: 80)]),
+            makeBucket(candidates: [makeMetric(id: "b", weight: 81)]),
+            makeBucket(candidates: [])
+        ]
+
+        let sampled = TimelinePhotoSampler.samplePhotos(from: buckets, maxThumbnails: 5, sortedMetrics: [])
+
+        XCTAssertEqual(sampled.map(\.id), ["a", "b"])
+    }
+
+    func testSamplePhotosThinsBucketsByStrideWhenOverLimit() {
+        let buckets = (0..<5).map { index in
+            makeBucket(candidates: [makeMetric(id: "bucket-\(index)", weight: 80)])
+        }
+
+        let sampled = TimelinePhotoSampler.samplePhotos(from: buckets, maxThumbnails: 2, sortedMetrics: [])
+
+        XCTAssertEqual(sampled.map(\.id), ["bucket-0", "bucket-2"])
+    }
+
+    func testSamplePhotosUsesPreviouslySampledMetricForMilestoneScoring() {
+        let anchor = makeMetric(id: "anchor", weight: 100)
+        let milestone = makeMetric(id: "milestone", weight: 104)
+        let flat = makeMetric(id: "flat", weight: 100.5, photo: "https://example.com/p.jpg")
+        let buckets = [
+            makeBucket(candidates: [anchor]),
+            makeBucket(candidates: [flat, milestone])
+        ]
+
+        let sampled = TimelinePhotoSampler.samplePhotos(from: buckets, maxThumbnails: 5, sortedMetrics: [])
+
+        XCTAssertEqual(sampled.map(\.id), ["anchor", "milestone"])
+    }
+
+    func testMetricsWithPhotosFiltersMissingOrEmptyPhotoUrls() {
+        let metrics = [
+            makeMetric(id: "none"),
+            makeMetric(id: "empty", photo: ""),
+            makeMetric(id: "has", photo: "https://example.com/p.jpg")
+        ]
+
+        XCTAssertEqual(TimelinePhotoSampler.metricsWithPhotos(from: metrics).map(\.id), ["has"])
+    }
+
+    func testMetricsWithDataKeepsAnySignal() {
+        let metrics = [
+            makeMetric(id: "weight", weight: 80),
+            makeMetric(id: "bf", bodyFat: 15),
+            makeMetric(id: "photo", photo: "https://example.com/p.jpg"),
+            makeMetric(id: "empty")
+        ]
+
+        XCTAssertEqual(
+            TimelinePhotoSampler.metricsWithData(from: metrics).map(\.id),
+            ["weight", "bf", "photo"]
+        )
+    }
+}

--- a/apps/ios/TestPlans/Integration.xctestplan
+++ b/apps/ios/TestPlans/Integration.xctestplan
@@ -24,6 +24,7 @@
         "Glp1DoseCoreDataTests",
         "HealthSyncCoordinatorPipelineTests",
         "LoadingManagerHealthSyncTests",
+        "MetricChartDataHelperTests",
         "PhotoMetadataServiceTests",
         "PhotoUploadManagerTests",
         "ProgressPhotoImagePipelineTests",

--- a/apps/ios/TestPlans/Unit.xctestplan
+++ b/apps/ios/TestPlans/Unit.xctestplan
@@ -24,6 +24,7 @@
         "Glp1DoseCoreDataTests",
         "HealthSyncCoordinatorPipelineTests",
         "LoadingManagerHealthSyncTests",
+        "MetricChartDataHelperTests",
         "PhotoMetadataServiceTests",
         "PhotoUploadManagerTests",
         "ProgressPhotoImagePipelineTests",


### PR DESCRIPTION
## Summary

Batch 11a of the iOS test-hardening effort (inventory B.2 — vendor adapters + pure helpers). 78 new test methods (71 unit + 7 integration), all tier-placed; full Unit plan at **462 tests, 0 failures**.

- **Vendor adapters, boundaries faked:** `AnalyticsServiceTests` (8 — forwarding, gate-state before/after `start()`, change notifications), `ErrorTrackingServiceTests` (7 — context→tags mapping, breadcrumbs, user id), `ErrorReporterTests` (3), `BugReportManagerTests` (10 — shake guards, canSubmit, prompt flow, submit event). One justified seam beyond visibility-only: an `ErrorTrackingVendor` protocol with the Sentry calls moved **verbatim** into a private conforming type — the mapping logic was welded to `SentrySDK` statics with no boundary to fake; runtime behavior unchanged.
- **Timeline helpers (pure):** `TimelineCalculatorTests` (7 — empty/tiers/monotonicity/lookups), `LRUCacheTests` (9 — eviction/refresh/capacity), `TimelinePhotoSamplerTests` (11 — milestone priority, thinning, chaining), `TimelineBucketCalculatorTests` (9 — zoom boundaries, bucket creation, drops), `GlobalTimelineModelsTests` (5 — canonical decoding, legacy alias, unknown-throws).
- **Integration tier:** `MetricChartDataHelperTests` (7 — kg→lb, cm→in, nil-skip, windows, 365-day downsample-to-150) with real seeded Core Data; plans updated (sorted, valid).
- **Audit skips (no padding):** `BodyMetricSpotlightIndexer` (trivial CoreSpotlight wrapper; mapping already covered — added 2 missing keyword-branch tests there instead), `HKRawSample` (data struct), remaining Codable timeline structs.
- **Dead-code find:** `Services/DeviceNormalizationService.swift` is not in the pbxproj at all — never compiled, zero callers. Queued for the next deletion PR.

Behavior quirks pinned by tests (documented, not fixed): `inferMethod`'s `"dexa"` match is case-sensitive (`"DEXA"` → `.biaScale`); chart data excludes same-day entries (start-of-day upper bound).

## Validation evidence

- `swiftlint lint --strict`: 0 violations (358 files)
- New classes: 78 methods green, all ≪200ms (slowest 94.5ms) — two independent runs
- Full Unit plan: 462 tests, 0 failures; Integration plan green (7/7)
- Pre-push turbo lint/typecheck/test: green
