### PR TITLE
test(ios): cover Vision photo pipeline with deterministic fixtures

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		1A9F2B46985D75138DA4DF89 /* MetricChartDataHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFAE7953B075E849003EA70 /* MetricChartDataHelperTests.swift */; };
 		1CCAD9C764D3D35B5BF0522B /* HealthKitAuthorizationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84A7C68943959BD45325D9B /* HealthKitAuthorizationPolicyTests.swift */; };
 		1E182FE84F374514F7F31F17 /* LegalConsentPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD03E6E0BF889812FE27D44 /* LegalConsentPolicyTests.swift */; };
+		20695853986556B10F65B6D3 /* ImageProcessingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36E73B3BA4285B178AC2CA2 /* ImageProcessingServiceTests.swift */; };
 		2117B18E82C133B5150AB357 /* CoreDataManager+Part03.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88D7AC2C7FF4E14A3BB8168 /* CoreDataManager+Part03.swift */; };
 		272AFFF5324345C4B93608F8 /* MainTabViewPolicies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3A26E632164AACAA5D77FD /* MainTabViewPolicies.swift */; };
 		2B3C4D5E6F7890ABCDEF1234 /* LoadingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF12 /* LoadingScreen.swift */; };
@@ -71,6 +72,7 @@
 		7EE44B7F0195FDD490B3D5F6 /* FullMetricChartView+Part01.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83248F0638FB24D0201A0C1 /* FullMetricChartView+Part01.swift */; };
 		841527E772D0CA94BE0D3F96 /* HealthKitManager+Part01.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B8B5B2EBD6BD4427633C2F5 /* HealthKitManager+Part01.swift */; };
 		8A693BCF3584DF89630F50C5 /* OnboardingFlowViewModel+Part02.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5586EC0657B1F9E652068FBA /* OnboardingFlowViewModel+Part02.swift */; };
+		8D090799F5F858F142B980FA /* BackgroundRemovalServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78783E098E45FCD5A47936D7 /* BackgroundRemovalServiceTests.swift */; };
 		8DDCF5DB348BB94E94C669D0 /* PhotoUploadBatchPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDF63906AA2DF9D7BEC1CA0 /* PhotoUploadBatchPolicyTests.swift */; };
 		8F1D82C327BC8A6B5FB2A6DB /* BodyMetricLoggingAndInsightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192238EEFD8161597A0B99AA /* BodyMetricLoggingAndInsightTests.swift */; };
 		8FB91216C622624E0F7815CC /* HealthSyncPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C662CF613D4755CA2B93A43 /* HealthSyncPipelineTests.swift */; };
@@ -87,6 +89,8 @@
 		9DA53BBE5C68C157C1C517F4 /* ExportCSVBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D10550744C3D80F49B32A4 /* ExportCSVBuilder.swift */; };
 		9E81C3C41951BB662ADA2C6F /* DebugResetManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE8DE6FD2A76A65AF63D2D9 /* DebugResetManagerTests.swift */; };
 		9EBBDD6AF2FF4E4FF8B9E3BC /* BodyCompositionMathGoldenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927B7D58E8E1756BB92364B6 /* BodyCompositionMathGoldenTests.swift */; };
+		A14230332A86E9780FEAB7F6 /* SyntheticImageFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5BB7F340376DECDD7ABC3A /* SyntheticImageFixtures.swift */; };
+		A3CFAB8A53F95BD9F8FA0B82 /* PhotoLibraryScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2715F4BF0E82E86A99821E3 /* PhotoLibraryScannerTests.swift */; };
 		A40A693BDA9D2826E3DE900D /* OnboardingStepEntryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E16AB6CFAC7A59EBD3B2792 /* OnboardingStepEntryPolicyTests.swift */; };
 		A4856A2B9E1FC174F9F1739F /* RevenueCatFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE602CA4F092CAB186EE952 /* RevenueCatFlowTests.swift */; };
 		A7876ACC0BAFED8A57643661 /* AccountDeletionAndShareCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8631504046C70A4EE432C9B8 /* AccountDeletionAndShareCardTests.swift */; };
@@ -355,6 +359,7 @@
 		D5F71D2685408ED4D599FC28 /* BodyMetricPhotoUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2E34BC49376B87D43D81AD /* BodyMetricPhotoUpdateTests.swift */; };
 		DB19A6EC4AA997A0EF4C5791 /* SyncIntegrationImportAndMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA338579090538FBCCA21785 /* SyncIntegrationImportAndMappingTests.swift */; };
 		DC51280D16A74D3E38D4B798 /* CoreDataManager+Part04.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F02AB81FF64BBC27043BB9 /* CoreDataManager+Part04.swift */; };
+		DEB84964BAE75EA9D9090CF7 /* VisionOrientationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B229942DB1DD4D204C5428A5 /* VisionOrientationServiceTests.swift */; };
 		DF4A68C6C15578CBB9293C37 /* Glp1WeeklyCheckInPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FEDB2A6B2D920273613C82 /* Glp1WeeklyCheckInPolicyTests.swift */; };
 		E251E204A77F2161E880A19E /* RevenueCatSubscriptionAnalyticsTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1996527170EC15B242FF4B /* RevenueCatSubscriptionAnalyticsTransitionTests.swift */; };
 		E389C2EFF4E7B92EE0A9A997 /* RealtimeSyncManager+Part01.swift in Sources */ = {isa = PBXBuildFile; fileRef = D557A5B9E670DD0A6A8BA893 /* RealtimeSyncManager+Part01.swift */; };
@@ -477,12 +482,14 @@
 		76E40D3BC9C969629954E803 /* PhaseInsightPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhaseInsightPolicyTests.swift; sourceTree = "<group>"; };
 		776620205152E0A15A875703 /* BodyMetricLocalDateContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyMetricLocalDateContractTests.swift; sourceTree = "<group>"; };
 		77CA7B3D87EC0BFA00AC6A9F /* Font+Custom.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Font+Custom.swift"; path = "Font+Custom.swift"; sourceTree = "<group>"; };
+		78783E098E45FCD5A47936D7 /* BackgroundRemovalServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundRemovalServiceTests.swift; sourceTree = "<group>"; };
 		7899ADA31AC216735A9FE299 /* RevenueCatProductConfigurationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RevenueCatProductConfigurationTests.swift; sourceTree = "<group>"; };
 		7A1DE682AE51BF7A3EFF75FF /* HealthKitManager+Part02.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HealthKitManager+Part02.swift"; path = "HealthKitManager+Part02.swift"; sourceTree = "<group>"; };
 		7A98EF222E91570CB37F44C0 /* PhotoUploadManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhotoUploadManagerTests.swift; sourceTree = "<group>"; };
 		7B5A5D6BAAD9FB2F7B8AFACB /* BaseButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BaseButton.swift; path = DesignSystem/Atoms/BaseButton.swift; sourceTree = "<group>"; };
 		7CEFB36F814C3D7E8AE709B4 /* DSCircularProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSCircularProgress.swift; path = DesignSystem/Atoms/DSCircularProgress.swift; sourceTree = "<group>"; };
 		7E16AB6CFAC7A59EBD3B2792 /* OnboardingStepEntryPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingStepEntryPolicyTests.swift; sourceTree = "<group>"; };
+		7E5BB7F340376DECDD7ABC3A /* SyntheticImageFixtures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyntheticImageFixtures.swift; sourceTree = "<group>"; };
 		7EF9F0EEBB2D999F7FEEF7D0 /* DSAuthLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSAuthLink.swift; path = DesignSystem/Atoms/DSAuthLink.swift; sourceTree = "<group>"; };
 		82670AD733C4BBFF727489CC /* MarkdownView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MarkdownView.swift; path = DesignSystem/Organisms/MarkdownView.swift; sourceTree = "<group>"; };
 		82ED4CD357E3259042DCF901 /* GlobalTimelineModelsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GlobalTimelineModelsTests.swift; sourceTree = "<group>"; };
@@ -807,6 +814,7 @@
 		B12671022F16000100ABCDEF /* BodyScoreHealthKitTriggerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyScoreHealthKitTriggerTests.swift; sourceTree = "<group>"; };
 		B1CDBFA72287938694EB369D /* CoreMetricsRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreMetricsRow.swift; path = DesignSystem/Organisms/CoreMetricsRow.swift; sourceTree = "<group>"; };
 		B2193687561E33F2A080CD6A /* BugReportManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BugReportManagerTests.swift; sourceTree = "<group>"; };
+		B229942DB1DD4D204C5428A5 /* VisionOrientationServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VisionOrientationServiceTests.swift; sourceTree = "<group>"; };
 		B4BF04D15583E3AE1CA4A836 /* View+Styles.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "View+Styles.swift"; path = "View+Styles.swift"; sourceTree = "<group>"; };
 		BBB847A2050F3135D62950A1 /* AuthFormField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthFormField.swift; path = DesignSystem/Molecules/AuthFormField.swift; sourceTree = "<group>"; };
 		BC71479CEEDEAD772518C5E9 /* BodyMetricAppIntentsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyMetricAppIntentsTests.swift; sourceTree = "<group>"; };
@@ -829,11 +837,13 @@
 		D03041E8A638B1A252407398 /* UserGreeting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserGreeting.swift; path = DesignSystem/Molecules/UserGreeting.swift; sourceTree = "<group>"; };
 		D0D288685A7D97CBCF127A7B /* DSMetricValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSMetricValue.swift; path = DesignSystem/Atoms/DSMetricValue.swift; sourceTree = "<group>"; };
 		D18AA7A0EC7327CC6EB9725D /* DSProgressBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSProgressBar.swift; path = DesignSystem/Atoms/DSProgressBar.swift; sourceTree = "<group>"; };
+		D36E73B3BA4285B178AC2CA2 /* ImageProcessingServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingServiceTests.swift; sourceTree = "<group>"; };
 		D557A5B9E670DD0A6A8BA893 /* RealtimeSyncManager+Part01.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "RealtimeSyncManager+Part01.swift"; path = "RealtimeSyncManager+Part01.swift"; sourceTree = "<group>"; };
 		D6047B9B9F0280ED4CEC0DFB /* PreferenceGoalValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PreferenceGoalValidatorTests.swift; sourceTree = "<group>"; };
 		DA456B8668AB1B5DDFA6C5CA /* AuthSurfacePolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthSurfacePolicyTests.swift; sourceTree = "<group>"; };
 		DDACB9E8EEAB1EBF446F0F02 /* HealthSyncCoordinatorPipelineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HealthSyncCoordinatorPipelineTests.swift; sourceTree = "<group>"; };
 		E2465B2ED058FAFC5389161E /* DSDivider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSDivider.swift; path = DesignSystem/Atoms/DSDivider.swift; sourceTree = "<group>"; };
+		E2715F4BF0E82E86A99821E3 /* PhotoLibraryScannerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhotoLibraryScannerTests.swift; sourceTree = "<group>"; };
 		E2AC3C23E6923176F103B414 /* StepsIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StepsIndicator.swift; path = DesignSystem/Molecules/StepsIndicator.swift; sourceTree = "<group>"; };
 		E47A7741CF9BBCD0F5DC0D5C /* LaunchSurfacePolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LaunchSurfacePolicyTests.swift; sourceTree = "<group>"; };
 		E47CB009DE7EAE53EC20AE72 /* DSAvatar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSAvatar.swift; path = DesignSystem/Atoms/DSAvatar.swift; sourceTree = "<group>"; };
@@ -1146,6 +1156,11 @@
 				86EEBD8D36DAF492B449176A /* TimelineBucketCalculatorTests.swift */,
 				6B6092432D9EAA2DAFFAABBD /* TimelineCalculatorTests.swift */,
 				F00E508C67F037B77FFA2627 /* TimelinePhotoSamplerTests.swift */,
+				78783E098E45FCD5A47936D7 /* BackgroundRemovalServiceTests.swift */,
+				D36E73B3BA4285B178AC2CA2 /* ImageProcessingServiceTests.swift */,
+				E2715F4BF0E82E86A99821E3 /* PhotoLibraryScannerTests.swift */,
+				7E5BB7F340376DECDD7ABC3A /* SyntheticImageFixtures.swift */,
+				B229942DB1DD4D204C5428A5 /* VisionOrientationServiceTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1967,6 +1982,11 @@
 				437B26CA4B494BC0EF95A673 /* TimelineBucketCalculatorTests.swift in Sources */,
 				E9B9E03061DB5B420BAF23AD /* TimelineCalculatorTests.swift in Sources */,
 				082DA43020A9A746031675D0 /* TimelinePhotoSamplerTests.swift in Sources */,
+				8D090799F5F858F142B980FA /* BackgroundRemovalServiceTests.swift in Sources */,
+				20695853986556B10F65B6D3 /* ImageProcessingServiceTests.swift in Sources */,
+				A3CFAB8A53F95BD9F8FA0B82 /* PhotoLibraryScannerTests.swift in Sources */,
+				A14230332A86E9780FEAB7F6 /* SyntheticImageFixtures.swift in Sources */,
+				DEB84964BAE75EA9D9090CF7 /* VisionOrientationServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/LogYourBody/Services/BackgroundRemovalService.swift
+++ b/apps/ios/LogYourBody/Services/BackgroundRemovalService.swift
@@ -73,7 +73,7 @@ class BackgroundRemovalService {
     }
 
     /// Apply the segmentation mask to create transparent background
-    private func applySegmentationMask(to cgImage: CGImage, mask: CVPixelBuffer, quality: Float) throws -> UIImage {
+    func applySegmentationMask(to cgImage: CGImage, mask: CVPixelBuffer, quality: Float) throws -> UIImage {
         let ciImage = CIImage(cgImage: cgImage)
         let maskImage = CIImage(cvPixelBuffer: mask)
 

--- a/apps/ios/LogYourBody/Services/ImageProcessingService.swift
+++ b/apps/ios/LogYourBody/Services/ImageProcessingService.swift
@@ -235,7 +235,7 @@ class ImageProcessingService: ObservableObject {
         return detectedBox
     }
 
-    private func cropToHuman(cgImage: CGImage, boundingBox: CGRect) throws -> UIImage {
+    func cropToHuman(cgImage: CGImage, boundingBox: CGRect) throws -> UIImage {
         // Convert normalized coordinates to pixel coordinates
         let width = CGFloat(cgImage.width)
         let height = CGFloat(cgImage.height)
@@ -254,7 +254,7 @@ class ImageProcessingService: ObservableObject {
         return UIImage(cgImage: croppedCGImage)
     }
 
-    private func aspectFillToSize(_ image: UIImage, targetSize: CGSize, centerOnPerson: Bool = true) throws -> UIImage {
+    func aspectFillToSize(_ image: UIImage, targetSize: CGSize, centerOnPerson: Bool = true) throws -> UIImage {
         guard let cgImage = image.cgImage else {
             throw ProcessingError.invalidImage
         }
@@ -330,7 +330,7 @@ class ImageProcessingService: ObservableObject {
         return centerPoint
     }
 
-    private func createThumbnail(from image: UIImage, size: CGSize) throws -> UIImage {
+    func createThumbnail(from image: UIImage, size: CGSize) throws -> UIImage {
         let format = UIGraphicsImageRendererFormat()
         format.scale = 1.0
         format.opaque = false

--- a/apps/ios/LogYourBody/Services/PhotoLibraryScanner.swift
+++ b/apps/ios/LogYourBody/Services/PhotoLibraryScanner.swift
@@ -158,7 +158,7 @@ class PhotoLibraryScanner: ObservableObject {
         scanProgress = 0
     }
 
-    private static func appAuthorizationState(from status: PHAuthorizationStatus) -> AppAuthorizationState {
+    static func appAuthorizationState(from status: PHAuthorizationStatus) -> AppAuthorizationState {
         switch status {
         case .authorized, .limited:
             return .authorized

--- a/apps/ios/LogYourBody/Services/VisionOrientationService.swift
+++ b/apps/ios/LogYourBody/Services/VisionOrientationService.swift
@@ -164,7 +164,7 @@ class VisionOrientationService {
     }
 
     /// Rotates image by specified degrees
-    private func rotateImage(_ image: UIImage, byDegrees degrees: CGFloat) -> UIImage {
+    func rotateImage(_ image: UIImage, byDegrees degrees: CGFloat) -> UIImage {
         let radians = degrees * .pi / 180
 
         // Calculate new size after rotation

--- a/apps/ios/LogYourBodyTests/BackgroundRemovalServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/BackgroundRemovalServiceTests.swift
@@ -1,0 +1,172 @@
+//
+// BackgroundRemovalServiceTests.swift
+// LogYourBodyTests
+//
+// KNOWN APP BUG (reported, not fixed): on the iOS simulator,
+// removeBackground(from:) crashes the process. Measured on iPhone 17 /
+// iOS 26.5 (2026-07): VNGeneratePersonSegmentationRequest delivers
+// com.apple.VisionCore Code=1 ("E5RT is not supported") — and BOTH the request
+// completion handler and handler.perform report the failure, so the
+// withCheckedThrowingContinuation in removeBackground is resumed twice and the
+// runtime traps ("attempted to resume a continuation more than once"). The
+// Vision path of removeBackground is therefore deliberately untested here:
+// any test calling it would kill the test host. On-device (where person
+// segmentation is supported) perform does not throw after a completion, so
+// the double-resume is latent there but still structurally possible.
+//
+import XCTest
+import UIKit
+@testable import LogYourBody
+
+final class BackgroundRemovalServiceTests: XCTestCase {
+    // MARK: - Input validation
+
+    func testRemoveBackgroundRejectsImageWithoutCGImage() async throws {
+        // This guard runs before the Vision continuation, so it is safe to
+        // exercise despite the simulator crash documented in the file header.
+        let ciBacked = UIImage(ciImage: CIImage(color: .red))
+
+        do {
+            _ = try await BackgroundRemovalService.shared.removeBackground(from: ciBacked)
+            XCTFail("CIImage-backed input must be rejected as invalid")
+        } catch {
+            XCTAssertEqual(error as? BackgroundRemovalService.BackgroundRemovalError, .invalidImage)
+        }
+    }
+
+    // MARK: - applySegmentationMask (CoreImage, deterministic)
+
+    func testApplySegmentationMaskWithFullMaskKeepsSubjectOpaque() throws {
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 64, height: 64, red: 255, green: 0, blue: 0))
+        let mask = try XCTUnwrap(SyntheticImage.constantMask(width: 64, height: 64, value: 255))
+
+        let output = try BackgroundRemovalService.shared.applySegmentationMask(to: cgImage, mask: mask, quality: 0.85)
+
+        let outputCG = try XCTUnwrap(output.cgImage)
+        XCTAssertEqual(outputCG.width, 64)
+        XCTAssertEqual(outputCG.height, 64)
+        let center = try XCTUnwrap(SyntheticImage.pixel(of: outputCG, x: 32, y: 32))
+        XCTAssertGreaterThan(center.alpha, 240, "full-strength mask must keep the subject")
+        XCTAssertGreaterThan(center.red, 200)
+        XCTAssertLessThan(center.blue, 60)
+    }
+
+    func testApplySegmentationMaskWithEmptyMaskRemovesEverything() throws {
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 64, height: 64, red: 255, green: 0, blue: 0))
+        let mask = try XCTUnwrap(SyntheticImage.constantMask(width: 64, height: 64, value: 0))
+
+        let output = try BackgroundRemovalService.shared.applySegmentationMask(to: cgImage, mask: mask, quality: 0.85)
+
+        let outputCG = try XCTUnwrap(output.cgImage)
+        let center = try XCTUnwrap(SyntheticImage.pixel(of: outputCG, x: 32, y: 32))
+        XCTAssertLessThan(center.alpha, 15, "zero mask must produce a fully transparent cutout")
+    }
+
+    func testApplySegmentationMaskScalesSmallMaskUpToImageSize() throws {
+        // Vision masks are lower-resolution than the source; the service must
+        // scale the mask to the image extent (output keeps image dimensions).
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 64, height: 64, red: 255, green: 0, blue: 0))
+        let mask = try XCTUnwrap(SyntheticImage.constantMask(width: 16, height: 16, value: 255))
+
+        let output = try BackgroundRemovalService.shared.applySegmentationMask(to: cgImage, mask: mask, quality: 0.85)
+
+        let outputCG = try XCTUnwrap(output.cgImage)
+        XCTAssertEqual(outputCG.width, 64)
+        XCTAssertEqual(outputCG.height, 64)
+        let center = try XCTUnwrap(SyntheticImage.pixel(of: outputCG, x: 32, y: 32))
+        XCTAssertGreaterThan(center.alpha, 240)
+    }
+
+    // MARK: - prepareForUpload downscale math
+
+    func testPrepareForUploadDoesNotUpscaleSmallerImages() async throws {
+        // No-upscale rule: an image already inside the bounds passes through
+        // at its original size.
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 800, height: 1_000))
+
+        let prepared = await BackgroundRemovalService.shared.prepareForUpload(UIImage(cgImage: cgImage))
+        let data = try XCTUnwrap(prepared)
+
+        let decoded = try XCTUnwrap(SyntheticImage.decodePNG(data))
+        XCTAssertEqual(decoded.width, 800)
+        XCTAssertEqual(decoded.height, 1_000)
+    }
+
+    func testPrepareForUploadDownscalesWidthConstrainedImagePreservingAspect() async throws {
+        // 2400x1600 landscape: scale = min(1200/2400, 1600/1600) = 0.5 → 1200x800.
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 2_400, height: 1_600))
+
+        let prepared = await BackgroundRemovalService.shared.prepareForUpload(UIImage(cgImage: cgImage))
+        let data = try XCTUnwrap(prepared)
+
+        let decoded = try XCTUnwrap(SyntheticImage.decodePNG(data))
+        XCTAssertEqual(decoded.width, 1_200)
+        XCTAssertEqual(decoded.height, 800)
+    }
+
+    func testPrepareForUploadDownscalesHeightConstrainedImagePreservingAspect() async throws {
+        // 1200x2400 portrait: scale = min(1200/1200, 1600/2400) = 2/3 → 800x1600.
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 1_200, height: 2_400))
+
+        let prepared = await BackgroundRemovalService.shared.prepareForUpload(UIImage(cgImage: cgImage))
+        let data = try XCTUnwrap(prepared)
+
+        let decoded = try XCTUnwrap(SyntheticImage.decodePNG(data))
+        XCTAssertEqual(decoded.width, 800)
+        XCTAssertEqual(decoded.height, 1_600)
+    }
+
+    func testPrepareForUploadHonorsCustomMaxSize() async throws {
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 2_000, height: 2_000))
+
+        let prepared = await BackgroundRemovalService.shared.prepareForUpload(
+            UIImage(cgImage: cgImage),
+            maxSize: CGSize(width: 500, height: 250)
+        )
+        let data = try XCTUnwrap(prepared)
+
+        let decoded = try XCTUnwrap(SyntheticImage.decodePNG(data))
+        XCTAssertEqual(decoded.width, 250)
+        XCTAssertEqual(decoded.height, 250)
+    }
+
+    // MARK: - prepareForUpload output format contract
+
+    func testPrepareForUploadEmitsPNGData() async throws {
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 64, height: 64))
+
+        let prepared = await BackgroundRemovalService.shared.prepareForUpload(UIImage(cgImage: cgImage))
+        let data = try XCTUnwrap(prepared)
+
+        // PNG magic bytes — the upload contract requires PNG to keep alpha.
+        XCTAssertTrue(data.starts(with: [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]))
+    }
+
+    func testPrepareForUploadPreservesTransparency() async throws {
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 4, height: 4, red: 255, green: 0, blue: 0, alpha: 0))
+
+        let prepared = await BackgroundRemovalService.shared.prepareForUpload(UIImage(cgImage: cgImage))
+        let data = try XCTUnwrap(prepared)
+
+        let decoded = try XCTUnwrap(SyntheticImage.decodePNG(data))
+        let pixel = try XCTUnwrap(SyntheticImage.pixel(of: decoded, x: 2, y: 2))
+        XCTAssertLessThan(pixel.alpha, 15, "alpha channel must survive the PNG round trip")
+    }
+
+    // MARK: - Error contract
+
+    func testBackgroundRemovalErrorDescriptionsMatchDocumentedContract() {
+        XCTAssertEqual(
+            BackgroundRemovalService.BackgroundRemovalError.noPersonFound.errorDescription,
+            "No person detected in the image"
+        )
+        XCTAssertEqual(
+            BackgroundRemovalService.BackgroundRemovalError.processingFailed.errorDescription,
+            "Failed to process the image"
+        )
+        XCTAssertEqual(
+            BackgroundRemovalService.BackgroundRemovalError.invalidImage.errorDescription,
+            "Invalid image format"
+        )
+    }
+}

--- a/apps/ios/LogYourBodyTests/ImageProcessingServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/ImageProcessingServiceTests.swift
@@ -286,8 +286,22 @@ final class ImageProcessingServiceTests: XCTestCase {
 
     func testProcessBatchImagesSwallowsItemFailuresAndRestoresBookkeeping() async throws {
         let service = ImageProcessingService()
-        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 512, height: 512))
-        let items = (0..<3).map { (image: UIImage(cgImage: cgImage), id: "batch-\($0)") }
+        // Items fail at the pipeline's step-0 guard: a CIImage-backed UIImage has
+        // no CGImage, so performImageProcessing throws invalidImage before any
+        // Vision request. That failure point is deterministic on every platform —
+        // unlike the person-less-CGImage inputs used previously, whose failure
+        // path runs through Vision's human-detection requests: on a fresh CI
+        // simulator, three CONCURRENT first-time Vision model setups blocked
+        // indefinitely inside the framework (iOS Launch Quality Gate, 2-minute
+        // hang, zero model-setup log lines during the stall), while the same
+        // setup run sequentially completes in <1s. Production devices ship the
+        // models and Vision's perform is documented thread-safe, so the app code
+        // is correct — this is a simulator-only environment hazard. The
+        // Vision-stage failure path itself stays pinned by the two single-item
+        // tests above; this test's contract is batch bookkeeping under
+        // concurrent per-item failures, which holds regardless of where the
+        // items fail.
+        let items = (0..<3).map { (image: UIImage(ciImage: CIImage(color: .red)), id: "batch-\($0)") }
 
         await service.processBatchImages(items)
 

--- a/apps/ios/LogYourBodyTests/ImageProcessingServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/ImageProcessingServiceTests.swift
@@ -1,0 +1,313 @@
+//
+// ImageProcessingServiceTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import UIKit
+@testable import LogYourBody
+
+final class ImageProcessingServiceTests: XCTestCase {
+    // MARK: - cropToHuman: normalized Vision rect → pixel rect
+
+    func testCropToHumanConvertsNormalizedRectToPixelCoordinates() throws {
+        let service = ImageProcessingService()
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 400, height: 600))
+
+        // Vision boxes are normalized with a bottom-left origin; CGImage pixels
+        // are top-left origin, so y must flip: pixelY = (1 - maxY) * height.
+        let cropped = try service.cropToHuman(
+            cgImage: cgImage,
+            boundingBox: CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5)
+        )
+
+        let croppedCG = try XCTUnwrap(cropped.cgImage)
+        XCTAssertEqual(croppedCG.width, 200)
+        XCTAssertEqual(croppedCG.height, 300)
+    }
+
+    func testCropToHumanFlipsVisionYAxisOntoImageRows() throws {
+        let service = ImageProcessingService()
+        // CG row 0 (top) is red; bottom half is blue.
+        let cgImage = try XCTUnwrap(SyntheticImage.horizontalSplitCGImage(
+            width: 400,
+            height: 600,
+            top: (red: 255, green: 0, blue: 0, alpha: 255),
+            bottom: (red: 0, green: 0, blue: 255, alpha: 255)
+        ))
+
+        // Vision's bottom half (y 0...0.5, bottom-left origin) must map to the
+        // blue (CG-bottom) rows, not the red ones.
+        let bottomHalf = try service.cropToHuman(
+            cgImage: cgImage,
+            boundingBox: CGRect(x: 0, y: 0, width: 1, height: 0.5)
+        )
+        let bottomPixel = try XCTUnwrap(SyntheticImage.pixel(of: XCTUnwrap(bottomHalf.cgImage), x: 200, y: 150))
+        XCTAssertGreaterThan(bottomPixel.blue, 200)
+        XCTAssertLessThan(bottomPixel.red, 60)
+
+        // Vision's top half must map to the red (CG-top) rows.
+        let topHalf = try service.cropToHuman(
+            cgImage: cgImage,
+            boundingBox: CGRect(x: 0, y: 0.5, width: 1, height: 0.5)
+        )
+        let topPixel = try XCTUnwrap(SyntheticImage.pixel(of: XCTUnwrap(topHalf.cgImage), x: 200, y: 150))
+        XCTAssertGreaterThan(topPixel.red, 200)
+        XCTAssertLessThan(topPixel.blue, 60)
+    }
+
+    func testCropToHumanWithRectFullyOutsideImageThrowsCropFailed() throws {
+        let service = ImageProcessingService()
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 400, height: 600))
+
+        // A normalized rect starting at (2, 2) lies entirely outside the image;
+        // CGImage.cropping returns nil and the pipeline must surface cropFailed.
+        XCTAssertThrowsError(try service.cropToHuman(
+            cgImage: cgImage,
+            boundingBox: CGRect(x: 2, y: 2, width: 0.5, height: 0.5)
+        )) { error in
+            XCTAssertEqual(error as? ProcessingError, .cropFailed)
+        }
+    }
+
+    // MARK: - aspectFillToSize: scale math
+
+    func testAspectFillToSizeFillsTargetDimensionsExactly() throws {
+        let service = ImageProcessingService()
+        let target = CGSize(width: 600, height: 800)
+        // Wide, tall, exact, and larger sources must all come out at exactly the
+        // target size: scale = max(targetW/sourceW, targetH/sourceH).
+        let sources = [
+            (width: 1_000, height: 500),
+            (width: 500, height: 1_000),
+            (width: 600, height: 800),
+            (width: 1_200, height: 1_600)
+        ]
+
+        for source in sources {
+            let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: source.width, height: source.height))
+            let output = try service.aspectFillToSize(
+                UIImage(cgImage: cgImage),
+                targetSize: target,
+                centerOnPerson: false
+            )
+            let outputCG = try XCTUnwrap(output.cgImage)
+            XCTAssertEqual(outputCG.width, 600, "source \(source.width)x\(source.height)")
+            XCTAssertEqual(outputCG.height, 800, "source \(source.width)x\(source.height)")
+        }
+    }
+
+    func testAspectFillToSizeUpscalesSmallSourcesToFillTarget() throws {
+        let service = ImageProcessingService()
+        // Aspect-fill has no no-upscale rule: a source smaller than the target
+        // is scaled up so the target is fully covered.
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 300, height: 400))
+
+        let output = try service.aspectFillToSize(
+            UIImage(cgImage: cgImage),
+            targetSize: CGSize(width: 600, height: 800),
+            centerOnPerson: false
+        )
+
+        let outputCG = try XCTUnwrap(output.cgImage)
+        XCTAssertEqual(outputCG.width, 600)
+        XCTAssertEqual(outputCG.height, 800)
+    }
+
+    func testAspectFillToSizeCentersTheCropWindowOnTheSource() throws {
+        let service = ImageProcessingService()
+        // Left half red, right half blue. Scale = max(600/1000, 800/500) = 1.6,
+        // so the 600-wide output window is centered: source x range 312.5...687.5,
+        // which straddles the red/blue seam at x=500 exactly at output center.
+        let cgImage = try XCTUnwrap(SyntheticImage.verticalSplitCGImage(
+            width: 1_000,
+            height: 500,
+            left: (red: 255, green: 0, blue: 0, alpha: 255),
+            right: (red: 0, green: 0, blue: 255, alpha: 255)
+        ))
+
+        let output = try service.aspectFillToSize(
+            UIImage(cgImage: cgImage),
+            targetSize: CGSize(width: 600, height: 800),
+            centerOnPerson: false
+        )
+        let outputCG = try XCTUnwrap(output.cgImage)
+
+        let leftPixel = try XCTUnwrap(SyntheticImage.pixel(of: outputCG, x: 150, y: 400))
+        XCTAssertGreaterThan(leftPixel.red, 200)
+        XCTAssertLessThan(leftPixel.blue, 60)
+
+        let rightPixel = try XCTUnwrap(SyntheticImage.pixel(of: outputCG, x: 450, y: 400))
+        XCTAssertGreaterThan(rightPixel.blue, 200)
+        XCTAssertLessThan(rightPixel.red, 60)
+    }
+
+    func testAspectFillToSizeWithPersonCenteringFallsBackToCenterOnPersonLessImage() throws {
+        let service = ImageProcessingService()
+        // centerOnPerson: true runs a Vision human-rectangle request; on a
+        // person-less synthetic image no observation exists, so the service
+        // falls back to its default center (0.5, 0.5) and the output is
+        // identical to plain centering. Deterministic on any platform.
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 1_000, height: 500))
+
+        let output = try service.aspectFillToSize(
+            UIImage(cgImage: cgImage),
+            targetSize: CGSize(width: 600, height: 800)
+        )
+
+        let outputCG = try XCTUnwrap(output.cgImage)
+        XCTAssertEqual(outputCG.width, 600)
+        XCTAssertEqual(outputCG.height, 800)
+    }
+
+    func testAspectFillToSizeRejectsImageWithoutCGImage() throws {
+        let service = ImageProcessingService()
+        // A UIImage backed by CIImage (not CGImage) has cgImage == nil.
+        let ciBacked = UIImage(ciImage: CIImage(color: .red))
+
+        XCTAssertThrowsError(try service.aspectFillToSize(
+            ciBacked,
+            targetSize: CGSize(width: 600, height: 800),
+            centerOnPerson: false
+        )) { error in
+            XCTAssertEqual(error as? ProcessingError, .invalidImage)
+        }
+    }
+
+    // MARK: - createThumbnail
+
+    func testCreateThumbnailProducesExactSizeAtUnitScale() throws {
+        let service = ImageProcessingService()
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 1_200, height: 1_600, red: 255, green: 0, blue: 0))
+
+        let thumbnail = try service.createThumbnail(
+            from: UIImage(cgImage: cgImage),
+            size: CGSize(width: 150, height: 200)
+        )
+
+        XCTAssertEqual(thumbnail.size, CGSize(width: 150, height: 200))
+        XCTAssertEqual(thumbnail.scale, 1)
+        let thumbnailCG = try XCTUnwrap(thumbnail.cgImage)
+        XCTAssertEqual(thumbnailCG.width, 150)
+        XCTAssertEqual(thumbnailCG.height, 200)
+        let pixel = try XCTUnwrap(SyntheticImage.pixel(of: thumbnailCG, x: 75, y: 100))
+        XCTAssertGreaterThan(pixel.red, 200, "thumbnail must render the source, not a blank canvas")
+    }
+
+    // MARK: - EXIF orientation normalization (pipeline step 0)
+
+    func testFixedOrientationReturnsUpOrientedImageUnchanged() throws {
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 100, height: 200))
+        let image = UIImage(cgImage: cgImage, scale: 1, orientation: .up)
+
+        XCTAssertTrue(image.fixedOrientation() === image)
+    }
+
+    func testFixedOrientationBakesSidewaysEXIFIntoPixels() throws {
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 100, height: 200))
+        let sideways = UIImage(cgImage: cgImage, scale: 1, orientation: .right)
+        XCTAssertEqual(sideways.size, CGSize(width: 200, height: 100))
+
+        let fixed = sideways.fixedOrientation()
+
+        XCTAssertEqual(fixed.imageOrientation, .up)
+        let fixedCG = try XCTUnwrap(fixed.cgImage)
+        XCTAssertEqual(fixedCG.width, 200)
+        XCTAssertEqual(fixedCG.height, 100)
+    }
+
+    func testFixedOrientationFlipsUpsideDownContent() throws {
+        // Top half red, bottom half blue; a 180° EXIF rotation must swap them.
+        let cgImage = try XCTUnwrap(SyntheticImage.horizontalSplitCGImage(
+            width: 100,
+            height: 200,
+            top: (red: 255, green: 0, blue: 0, alpha: 255),
+            bottom: (red: 0, green: 0, blue: 255, alpha: 255)
+        ))
+        let upsideDown = UIImage(cgImage: cgImage, scale: 1, orientation: .down)
+
+        let fixed = upsideDown.fixedOrientation()
+        let fixedCG = try XCTUnwrap(fixed.cgImage)
+        XCTAssertEqual(fixedCG.width, 100)
+        XCTAssertEqual(fixedCG.height, 200)
+
+        let topPixel = try XCTUnwrap(SyntheticImage.pixel(of: fixedCG, x: 50, y: 25))
+        XCTAssertGreaterThan(topPixel.blue, 200, "former bottom half must render on top after a 180° fix")
+        let bottomPixel = try XCTUnwrap(SyntheticImage.pixel(of: fixedCG, x: 50, y: 175))
+        XCTAssertGreaterThan(bottomPixel.red, 200, "former top half must render on the bottom after a 180° fix")
+    }
+
+    // MARK: - Full pipeline: pinned Vision-on-simulator failure
+
+    // Measured on iPhone 17 / iOS 26.5 simulator (2026-07): every detection
+    // request this pipeline uses fails at setup — VNDetectHumanRectanglesRequest,
+    // VNDetectHumanBodyPoseRequest, and VNDetectFaceRectanglesRequest all throw
+    // com.apple.Vision Code=9 ("Could not create inference context" / "Unable to
+    // setup request"). So on simulator the pipeline never reaches its
+    // noHumanDetected path; the first request throws out of
+    // detectHumanBoundingBox and processImage surfaces the raw Vision error.
+    // That failure delivery is deterministic — the assertions below pin it.
+
+    func testProcessImageSurfacesVisionSetupFailureVerbatim() async throws {
+        let service = ImageProcessingService()
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 512, height: 512))
+
+        var thrown: Error?
+        do {
+            _ = try await service.processImage(UIImage(cgImage: cgImage), imageId: "person-less")
+            XCTFail("Vision inference is unavailable on simulator; processImage must throw")
+        } catch {
+            thrown = error
+        }
+
+        let error = try XCTUnwrap(thrown)
+        let nsError = error as NSError
+        XCTAssertEqual(nsError.domain, "com.apple.Vision")
+        XCTAssertEqual(nsError.code, 9)
+        XCTAssertFalse(error is ProcessingError, "Vision's setup failure must surface raw, not remapped")
+    }
+
+    func testProcessImageFailureIsRecordedOnTheTaskAndBookkeepingResets() async throws {
+        let service = ImageProcessingService()
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 512, height: 512))
+
+        _ = try? await service.processImage(UIImage(cgImage: cgImage), imageId: "tracked-failure")
+
+        let task = await MainActor.run {
+            service.processingTasks.first { $0.imageId == "tracked-failure" }
+        }
+        let trackedTask = try XCTUnwrap(task, "failed processing must remain observable on the task list")
+        XCTAssertEqual(trackedTask.status, .failed)
+        XCTAssertNotNil(trackedTask.error)
+        XCTAssertNil(trackedTask.resultImage)
+        XCTAssertEqual(trackedTask.progress, 0.2, "failure happens at the detecting stage")
+        let activeCount = await MainActor.run { service.activeProcessingCount }
+        XCTAssertEqual(activeCount, 0, "active count must return to zero after a failure")
+    }
+
+    func testProcessBatchImagesSwallowsItemFailuresAndRestoresBookkeeping() async throws {
+        let service = ImageProcessingService()
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 512, height: 512))
+        let items = (0..<3).map { (image: UIImage(cgImage: cgImage), id: "batch-\($0)") }
+
+        await service.processBatchImages(items)
+
+        typealias TaskSnapshot = (count: Int, statuses: [ImageProcessingService.ProcessingStatus], hadErrors: [Bool])
+        let states = await MainActor.run { () -> TaskSnapshot in
+            let tasks = service.processingTasks
+            return (service.activeProcessingCount, tasks.map(\.status), tasks.map { $0.error != nil })
+        }
+        XCTAssertEqual(states.count, 0)
+        XCTAssertEqual(states.statuses.count, 3)
+        XCTAssertTrue(states.statuses.allSatisfy { $0 == .failed })
+        XCTAssertTrue(states.hadErrors.allSatisfy { $0 })
+    }
+
+    // MARK: - Error contract
+
+    func testProcessingErrorDescriptionsMatchDocumentedContract() {
+        XCTAssertEqual(ProcessingError.invalidImage.errorDescription, "Invalid image format")
+        XCTAssertEqual(ProcessingError.noHumanDetected.errorDescription, "No person detected in image")
+        XCTAssertEqual(ProcessingError.cropFailed.errorDescription, "Failed to crop image")
+        XCTAssertEqual(ProcessingError.processingFailed.errorDescription, "Image processing failed")
+    }
+}

--- a/apps/ios/LogYourBodyTests/PhotoLibraryScannerTests.swift
+++ b/apps/ios/LogYourBodyTests/PhotoLibraryScannerTests.swift
@@ -1,0 +1,104 @@
+//
+// PhotoLibraryScannerTests.swift
+// LogYourBodyTests
+//
+// Coverage boundary: PhotoLibraryScanner has no injection seam at the Photos
+// vendor boundary — fetchPhotos calls PHAsset.fetchAssets directly, analysis
+// uses a hard-wired PHCachingImageManager, and ScannedPhoto requires a concrete
+// PHAsset (no public initializer, not fabricatable in tests). That makes the
+// fetch/analyze/group pipeline (and PhotoGroup.suggestedPrimary) untestable
+// without an app-source refactor (protocol-typed fetcher + value-typed photo
+// model), which is out of scope for a visibility-only seam. These tests pin
+// the pure criteria/metadata contracts and the authorization-state mapping.
+//
+import XCTest
+import Photos
+@testable import LogYourBody
+
+final class PhotoLibraryScannerTests: XCTestCase {
+    // MARK: - Scan criteria contract
+
+    func testDefaultCriteriaMatchesDocumentedContract() {
+        let criteria = PhotoScanCriteria(dateRange: nil)
+
+        XCTAssertNil(criteria.dateRange)
+        XCTAssertEqual(criteria.minimumDaysBetween, 3)
+        XCTAssertEqual(criteria.minimumResolution, CGSize(width: 1_000, height: 1_000))
+        XCTAssertNil(criteria.preferredCameraType)
+        XCTAssertTrue(criteria.preferPortraitOrientation)
+        XCTAssertEqual(criteria.minimumConfidence, 0.7)
+        XCTAssertTrue(criteria.excludeScreenshots)
+        XCTAssertFalse(criteria.excludeEdited)
+        XCTAssertTrue(criteria.excludeLandscape)
+    }
+
+    func testDefaultFactoryCriteriaCoversLastTwoYearsEndingNow() {
+        let before = Date()
+        let criteria = PhotoScanCriteria.default
+        let after = Date()
+
+        let range = criteria.dateRange
+        XCTAssertNotNil(range)
+        guard let range else { return }
+
+        // End tracks "now" at construction time.
+        XCTAssertGreaterThanOrEqual(range.end, before.addingTimeInterval(-1))
+        XCTAssertLessThanOrEqual(range.end, after.addingTimeInterval(1))
+
+        // Start is exactly two calendar years before the end.
+        let years = Calendar.current.dateComponents([.year], from: range.start, to: range.end).year
+        XCTAssertEqual(years, 2)
+    }
+
+    // MARK: - Authorization-state mapping
+
+    func testAppAuthorizationStateMapsEveryVendorStatus() {
+        XCTAssertEqual(PhotoLibraryScanner.appAuthorizationState(from: .authorized), .authorized)
+        XCTAssertEqual(PhotoLibraryScanner.appAuthorizationState(from: .limited), .authorized)
+        XCTAssertEqual(PhotoLibraryScanner.appAuthorizationState(from: .notDetermined), .notDetermined)
+        XCTAssertEqual(PhotoLibraryScanner.appAuthorizationState(from: .denied), .denied)
+        XCTAssertEqual(PhotoLibraryScanner.appAuthorizationState(from: .restricted), .restricted)
+    }
+
+    func testScannerAuthorizationStatusTracksLiveVendorStatus() {
+        // Environment-independent: whatever PHPhotoLibrary reports, the scanner
+        // must reflect the mapped equivalent.
+        let vendorStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        XCTAssertEqual(
+            PhotoLibraryScanner.shared.authorizationStatus,
+            PhotoLibraryScanner.appAuthorizationState(from: vendorStatus)
+        )
+    }
+
+    func testScanWithoutAuthorizationStaysIdle() async throws {
+        let scanner = PhotoLibraryScanner.shared
+        guard scanner.authorizationStatus != .authorized else {
+            throw XCTSkip("Photo library is authorized for the test host in this environment")
+        }
+
+        await scanner.scanPhotoLibrary()
+
+        XCTAssertFalse(scanner.isScanning)
+        XCTAssertEqual(scanner.scanProgress, 0)
+        XCTAssertTrue(scanner.scannedPhotos.isEmpty)
+        XCTAssertTrue(scanner.photoGroups.isEmpty)
+    }
+
+    // MARK: - Metadata contract
+
+    func testPhotoMetadataRoundTripsFilterInputs() {
+        let metadata = ScannedPhoto.PhotoMetadata(
+            location: nil,
+            cameraType: .front,
+            isScreenshot: true,
+            hasBeenEdited: false
+        )
+
+        XCTAssertNil(metadata.location)
+        XCTAssertEqual(metadata.cameraType, .front)
+        XCTAssertTrue(metadata.isScreenshot)
+        XCTAssertFalse(metadata.hasBeenEdited)
+        XCTAssertNotEqual(ScannedPhoto.CameraType.front, .back)
+        XCTAssertNotEqual(ScannedPhoto.CameraType.back, .unknown)
+    }
+}

--- a/apps/ios/LogYourBodyTests/SyntheticImageFixtures.swift
+++ b/apps/ios/LogYourBodyTests/SyntheticImageFixtures.swift
@@ -1,0 +1,129 @@
+//
+// SyntheticImageFixtures.swift
+// LogYourBodyTests
+//
+// Deterministic in-memory image fixtures for Vision/photo-pipeline tests.
+// Every bitmap is generated in code with fixed pixels — no randomness and no
+// asset-catalog dependencies.
+
+import UIKit
+import CoreVideo
+
+enum SyntheticImage {
+    typealias RGBA = (red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8)
+
+    /// Solid-color CGImage with exact pixel dimensions (8-bit RGBA, premultiplied-last).
+    static func solidCGImage(
+        width: Int,
+        height: Int,
+        red: UInt8 = 160,
+        green: UInt8 = 160,
+        blue: UInt8 = 160,
+        alpha: UInt8 = 255
+    ) -> CGImage? {
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        for index in stride(from: 0, to: pixels.count, by: 4) {
+            pixels[index] = red
+            pixels[index + 1] = green
+            pixels[index + 2] = blue
+            pixels[index + 3] = alpha
+        }
+        return makeCGImage(width: width, height: height, pixels: pixels)
+    }
+
+    /// CGImage whose top half (CG row order: row 0 is the top) is `top` and bottom half is `bottom`.
+    static func horizontalSplitCGImage(width: Int, height: Int, top: RGBA, bottom: RGBA) -> CGImage? {
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        for row in 0..<height {
+            let color = row < height / 2 ? top : bottom
+            for column in 0..<width {
+                let offset = (row * width + column) * 4
+                pixels[offset] = color.red
+                pixels[offset + 1] = color.green
+                pixels[offset + 2] = color.blue
+                pixels[offset + 3] = color.alpha
+            }
+        }
+        return makeCGImage(width: width, height: height, pixels: pixels)
+    }
+
+    /// CGImage whose left half is `left` and right half is `right`.
+    static func verticalSplitCGImage(width: Int, height: Int, left: RGBA, right: RGBA) -> CGImage? {
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        for row in 0..<height {
+            for column in 0..<width {
+                let color = column < width / 2 ? left : right
+                let offset = (row * width + column) * 4
+                pixels[offset] = color.red
+                pixels[offset + 1] = color.green
+                pixels[offset + 2] = color.blue
+                pixels[offset + 3] = color.alpha
+            }
+        }
+        return makeCGImage(width: width, height: height, pixels: pixels)
+    }
+
+    /// 8-bit grayscale CVPixelBuffer filled with a constant value (Vision-style segmentation mask).
+    static func constantMask(width: Int, height: Int, value: UInt8) -> CVPixelBuffer? {
+        var buffer: CVPixelBuffer?
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            width,
+            height,
+            kCVPixelFormatType_OneComponent8,
+            nil,
+            &buffer
+        )
+        guard status == kCVReturnSuccess, let buffer else { return nil }
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+        guard let base = CVPixelBufferGetBaseAddress(buffer) else { return nil }
+        let bytesPerRow = CVPixelBufferGetBytesPerRow(buffer)
+        for row in 0..<height {
+            memset(base + row * bytesPerRow, Int32(value), width)
+        }
+        return buffer
+    }
+
+    /// Exact pixel readback: draws 1:1 into a known RGBA bitmap and returns the pixel at (x, y).
+    static func pixel(of cgImage: CGImage, x: Int, y: Int) -> RGBA? {
+        let width = cgImage.width
+        let height = cgImage.height
+        guard x >= 0, y >= 0, x < width, y < height else { return nil }
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        let offset = (y * width + x) * 4
+        return (pixels[offset], pixels[offset + 1], pixels[offset + 2], pixels[offset + 3])
+    }
+
+    /// Decodes PNG data back into a CGImage (round-trip assertions for upload payloads).
+    static func decodePNG(_ data: Data) -> CGImage? {
+        UIImage(data: data)?.cgImage
+    }
+
+    private static func makeCGImage(width: Int, height: Int, pixels: [UInt8]) -> CGImage? {
+        guard let provider = CGDataProvider(data: Data(pixels) as CFData) else { return nil }
+        return CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        )
+    }
+}

--- a/apps/ios/LogYourBodyTests/VisionOrientationServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/VisionOrientationServiceTests.swift
@@ -1,0 +1,99 @@
+//
+// VisionOrientationServiceTests.swift
+// LogYourBodyTests
+//
+import XCTest
+import UIKit
+@testable import LogYourBody
+
+@MainActor
+final class VisionOrientationServiceTests: XCTestCase {
+    // MARK: - Fallback behavior (deterministic on simulator)
+
+    func testCorrectImageOrientationReturnsCIImageBackedInputAsIs() async throws {
+        // The pre-Vision guard returns the input untouched when no CGImage exists.
+        let ciBacked = UIImage(ciImage: CIImage(color: .red))
+
+        let result = try await VisionOrientationService.shared.correctImageOrientation(ciBacked)
+
+        XCTAssertTrue(result === ciBacked)
+    }
+
+    func testCorrectImageOrientationOnPersonLessImageReturnsOriginalUnrotated() async throws {
+        // Pinned simulator behavior (measured 2026-07, iPhone 17 / iOS 26.5):
+        // VNDetectHumanBodyPoseRequest.perform throws com.apple.Vision Code=9
+        // ("Unable to setup request"), the service catches it and falls back to
+        // VNDetectFaceRectanglesRequest, whose perform also throws Code=9, that
+        // fallback catches too, and the contract is "return the caller's image
+        // unmodified". Every Vision failure path in this service funnels to
+        // returning the original instance, so identity is the stable assertion.
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 512, height: 512))
+        let image = UIImage(cgImage: cgImage)
+
+        let result = try await VisionOrientationService.shared.correctImageOrientation(image)
+
+        XCTAssertTrue(result === image, "no body/face detected must return the original image instance")
+    }
+
+    // MARK: - rotateImage geometry
+
+    func testRotateImageByRightAnglesSwapsDimensionsOnlyForQuarterTurns() throws {
+        let cgImage = try XCTUnwrap(SyntheticImage.solidCGImage(width: 100, height: 200))
+        let image = UIImage(cgImage: cgImage)
+
+        XCTAssertEqual(
+            VisionOrientationService.shared.rotateImage(image, byDegrees: 90).size,
+            CGSize(width: 200, height: 100)
+        )
+        XCTAssertEqual(
+            VisionOrientationService.shared.rotateImage(image, byDegrees: -90).size,
+            CGSize(width: 200, height: 100)
+        )
+        XCTAssertEqual(
+            VisionOrientationService.shared.rotateImage(image, byDegrees: 270).size,
+            CGSize(width: 200, height: 100)
+        )
+        XCTAssertEqual(
+            VisionOrientationService.shared.rotateImage(image, byDegrees: 180).size,
+            CGSize(width: 100, height: 200)
+        )
+    }
+
+    func testRotateImageByZeroKeepsContentIntact() throws {
+        let cgImage = try XCTUnwrap(SyntheticImage.horizontalSplitCGImage(
+            width: 100,
+            height: 200,
+            top: (red: 255, green: 0, blue: 0, alpha: 255),
+            bottom: (red: 0, green: 0, blue: 255, alpha: 255)
+        ))
+        let image = UIImage(cgImage: cgImage)
+
+        let rotated = VisionOrientationService.shared.rotateImage(image, byDegrees: 0)
+
+        XCTAssertEqual(rotated.size, CGSize(width: 100, height: 200))
+        let rotatedCG = try XCTUnwrap(rotated.cgImage)
+        let topPixel = try XCTUnwrap(SyntheticImage.pixel(of: rotatedCG, x: 50, y: 25))
+        XCTAssertGreaterThan(topPixel.red, 200)
+        XCTAssertLessThan(topPixel.blue, 60)
+        let bottomPixel = try XCTUnwrap(SyntheticImage.pixel(of: rotatedCG, x: 50, y: 175))
+        XCTAssertGreaterThan(bottomPixel.blue, 200)
+        XCTAssertLessThan(bottomPixel.red, 60)
+    }
+
+    // MARK: - Error contract
+
+    func testVisionErrorDescriptionsMatchDocumentedContract() {
+        XCTAssertEqual(
+            VisionOrientationService.VisionError.insufficientConfidence.errorDescription,
+            "Could not confidently detect body orientation"
+        )
+        XCTAssertEqual(
+            VisionOrientationService.VisionError.noBodyDetected.errorDescription,
+            "No human body detected in image"
+        )
+        XCTAssertEqual(
+            VisionOrientationService.VisionError.noFaceDetected.errorDescription,
+            "No face detected in image"
+        )
+    }
+}

--- a/apps/ios/docs/testing/FEATURE_INVENTORY.md
+++ b/apps/ios/docs/testing/FEATURE_INVENTORY.md
@@ -198,7 +198,9 @@ contracts, RevenueCat manager, RealtimeSyncManager + sync integration,
 CoreDataManager (+migration tests), HealthKitManager + coordinator,
 BodyScore engine/cache/recalc, OnboardingFlowViewModel, DashboardViewModel,
 TimelineDataProvider, interpolation + caches, image cache, bulk import
-manager, validation/logging services, launch/auth surface policies.
+manager, validation/logging services, launch/auth surface policies,
+Vision/photo pipeline (ImageProcessingService, BackgroundRemovalService,
+VisionOrientationService, PhotoLibraryScanner criteria/auth mapping).
 
 ### B.1 High-risk untested/partial (priority queue)
 
@@ -217,20 +219,19 @@ manager, validation/logging services, launch/auth surface policies.
 
 ### B.2 Medium-risk untested
 
-| File                                                                                                                                                | Responsibility                                | Layer                   |
-| --------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------------------- |
-| `Services/AnalyticsService.swift`                                                                                                                   | Statsig event adapter                         | unit (fake client)      |
-| `Services/ErrorTrackingService.swift`, `Utils/ErrorReporter.swift`                                                                                  | Sentry wrappers                               | unit (fake client)      |
-| `Services/BugReportManager.swift`                                                                                                                   | Shake-to-report capture/submit                | unit                    |
-| `Services/DeviceNormalizationService.swift` + `Models/HKRawSample.swift`                                                                            | Device confidence inference                   | unit                    |
-| `Services/ImageProcessingService.swift`, `BackgroundRemovalService.swift`, `VisionOrientationService.swift`, `PhotoLibraryScanner.swift`            | Vision/photo pipeline                         | unit (synthetic images) |
-| `Services/BodyMetricSpotlightIndexer.swift`                                                                                                         | Spotlight indexing (document mapping covered) | unit                    |
-| `Helpers/TimelineCalculator.swift`, `LRUCache.swift`, `TimelinePhotoSampler.swift`, `MetricChartDataHelper.swift`, `TimelineBucketCalculator.swift` | Timeline/chart helpers                        | unit                    |
-| `Models/GlobalTimelineModels.swift` (bucket/cursor/scale)                                                                                           | Timeline models                               | unit                    |
-| `Utils/AppVersion.swift`, `Utils/AppError.swift`                                                                                                    | Semver + error taxonomy                       | unit                    |
-| `Utils/ShakeDetector.swift` (incl. `DebugResetManager` — data-loss risk)                                                                            | Shake/screenshot/debug reset                  | unit                    |
-| `Models/Changelog.swift`                                                                                                                            | What's-new tracking                           | unit                    |
-| `Models/TimelineMode.swift`                                                                                                                         | Timeline mode + formatter cache               | unit                    |
+| File                                                                                                                                                | Responsibility                                | Layer              |
+| --------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ------------------ |
+| `Services/AnalyticsService.swift`                                                                                                                   | Statsig event adapter                         | unit (fake client) |
+| `Services/ErrorTrackingService.swift`, `Utils/ErrorReporter.swift`                                                                                  | Sentry wrappers                               | unit (fake client) |
+| `Services/BugReportManager.swift`                                                                                                                   | Shake-to-report capture/submit                | unit               |
+| `Services/DeviceNormalizationService.swift` + `Models/HKRawSample.swift`                                                                            | Device confidence inference                   | unit               |
+| `Services/BodyMetricSpotlightIndexer.swift`                                                                                                         | Spotlight indexing (document mapping covered) | unit               |
+| `Helpers/TimelineCalculator.swift`, `LRUCache.swift`, `TimelinePhotoSampler.swift`, `MetricChartDataHelper.swift`, `TimelineBucketCalculator.swift` | Timeline/chart helpers                        | unit               |
+| `Models/GlobalTimelineModels.swift` (bucket/cursor/scale)                                                                                           | Timeline models                               | unit               |
+| `Utils/AppVersion.swift`, `Utils/AppError.swift`                                                                                                    | Semver + error taxonomy                       | unit               |
+| `Utils/ShakeDetector.swift` (incl. `DebugResetManager` — data-loss risk)                                                                            | Shake/screenshot/debug reset                  | unit               |
+| `Models/Changelog.swift`                                                                                                                            | What's-new tracking                           | unit               |
+| `Models/TimelineMode.swift`                                                                                                                         | Timeline mode + formatter cache               | unit               |
 
 ### B.3 Low-risk untested (sweep last)
 
@@ -317,7 +318,15 @@ Progress tracker: mark batches here as PRs merge.
   (`OnboardingStepEntryPolicyTests`, `OnboardingScoreDisplayPolicyTests`,
   `OnboardingFlowValidationTests`; hook→reveal XCUITest golden path deferred)
 - Batch 10 — settings cluster (ProfileSettingsViewV2, SecuritySessionsView,
-  DeleteAccountView gating, ExportDataView CSV): this PR
+  DeleteAccountView gating, ExportDataView CSV): ✅ #492
+- Batch 11a — vendor adapters + timeline helpers: ✅ #493
+- Batch 11b — Vision/photo pipeline: this PR (`ImageProcessingServiceTests`,
+  `BackgroundRemovalServiceTests`, `VisionOrientationServiceTests`,
+  `PhotoLibraryScannerTests` + `SyntheticImageFixtures`; pins
+  Vision-on-simulator setup failures, documents a
+  `BackgroundRemovalService.removeBackground` double-continuation-resume crash
+  on simulator as a known app bug — not fixed here)
+- Batch 12 — NotificationManager scheduling + B.3 audit sweep: in review (#495)
 - Dead-code deletion (section C sweep): this PR — ~4,068 app-target lines
   removed against the 92,243-line baseline denominator (coverage % rises
   accordingly)

--- a/apps/ios/docs/testing/FEATURE_INVENTORY.md
+++ b/apps/ios/docs/testing/FEATURE_INVENTORY.md
@@ -327,6 +327,11 @@ Progress tracker: mark batches here as PRs merge.
   `BackgroundRemovalService.removeBackground` double-continuation-resume crash
   on simulator as a known app bug — not fixed here)
 - Batch 12 — NotificationManager scheduling + B.3 audit sweep: in review (#495)
+- Batch 11b follow-up — batch-test determinism: this PR. Batch items now fail
+  at the pipeline's step-0 `invalidImage` guard (CIImage-backed inputs):
+  three concurrent first-time Vision model setups deadlock on fresh CI
+  simulators (simulator-only framework hazard; serialized setups and
+  production devices are unaffected). No app-code change.
 - Dead-code deletion (section C sweep): this PR — ~4,068 app-target lines
   removed against the 92,243-line baseline denominator (coverage % rises
   accordingly)


### PR DESCRIPTION
## Summary

Batch 11b of the iOS test-hardening effort (inventory B.2 — Vision/photo pipeline, zero coverage). 38 tests across 4 suites + a shared synthetic-image fixture file (deterministic in-memory bitmaps, no asset dependencies).

Vision framework behavior on simulator was **measured and pinned** (probe suite, since deleted): human-rectangles/body-pose/face requests throw `com.apple.Vision` Code=9, person-segmentation throws `VisionCore` Code=1 ("E5RT is not supported"). Tests assert the pipeline's real handling of those deterministic platform facts instead of faking Vision internals.

- **`ImageProcessingServiceTests` (16):** crop normalized→pixel math incl. the Vision→CG Y-flip (split-color bitmaps), out-of-bounds → `cropFailed`, aspect-fill exact-target math, centered-crop pixel proof, person-centering fallback, EXIF orientation fixes, thumbnail contract, error descriptions.
- **`BackgroundRemovalServiceTests` (11):** mask application via synthetic CVPixelBuffers (full/empty/upscaled), `prepareForUpload` no-upscale/downscale-aspect rules, PNG round-trip, error contract.
- **`VisionOrientationServiceTests` (5):** rotation quarter-turns + identity, pinned fallback chain (body-pose Code=9 → face Code=9 → returns original).
- **`PhotoLibraryScannerTests` (6):** criteria defaults, 2-year date range, full authorization-status mapping, unauthorized-scan idle. Grouping/dedup unreachable without a fetcher seam (hard-wired `PHAsset.fetchAssets`) — documented as a follow-up seam recommendation, not padded.

Seams: 4 one-keyword ACL relaxations (`private`→internal) on pure helpers. No behavior change.

**Real app bug found (deliberately not fixed here — needs its own PR):** `BackgroundRemovalService.removeBackground` **double-resumes a `CheckedContinuation`** when the Vision completion fires with an error *and* `handler.perform` also throws → runtime trap (kills the test host on simulator; structurally latent on device). Fix = resume-once guard; then the error path becomes testable. The Vision path of `removeBackground` is deliberately untested because calling it crashes the runner.

## Validation evidence

- `swiftlint lint --strict`: 0 violations (356 files)
- New suites: 38/38 green — 34/38 <100ms, 4 image-heavy renders 0.17–0.33s (two independent runs)
- Full unit target: **576 tests, 0 failures**
- Pre-push turbo lint/typecheck/test: green
