### PR TITLE
test(ios): cover NotificationManager scheduling; audit B.3 sweep

### DIFF
--- a/apps/ios/LogYourBody.xcodeproj/project.pbxproj
+++ b/apps/ios/LogYourBody.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0922CA98E79021C4CB2595A5 /* SupabaseProfilePayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA82A71E77423D56A70AA46 /* SupabaseProfilePayloadTests.swift */; };
 		099DD9F0055C4CFBF7190F4B /* PhotoMetadataAndImportPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E0D5025A2839599F4E281D /* PhotoMetadataAndImportPolicyTests.swift */; };
 		0C4EFBDDCBCA1C2DBAC4DA0A /* BaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5A5D6BAAD9FB2F7B8AFACB /* BaseButton.swift */; };
+		0CBB5909E3CC64F747043DA7 /* NotificationManagerSchedulingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC0DDA700C8A4207B9EBC50 /* NotificationManagerSchedulingTests.swift */; };
 		0DAECF9694453077367DCB0E /* Font+Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CA7B3D87EC0BFA00AC6A9F /* Font+Custom.swift */; };
 		0EC249B0ED61CDC66976258E /* AuthManagerSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E9499CD258290C5363D52A /* AuthManagerSessionTests.swift */; };
 		1076FA3654BE00406F8AE052 /* Glp1DoseCoreDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7D800638256D10A5ACB992 /* Glp1DoseCoreDataTests.swift */; };
@@ -450,6 +451,7 @@
 		3B8B5B2EBD6BD4427633C2F5 /* HealthKitManager+Part01.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HealthKitManager+Part01.swift"; path = "HealthKitManager+Part01.swift"; sourceTree = "<group>"; };
 		3CBF4E377107434EA53A2F1B /* PaidWeightLoggerMVPPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaidWeightLoggerMVPPolicyTests.swift; sourceTree = "<group>"; };
 		3CD03E6E0BF889812FE27D44 /* LegalConsentPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LegalConsentPolicyTests.swift; sourceTree = "<group>"; };
+		3DC0DDA700C8A4207B9EBC50 /* NotificationManagerSchedulingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationManagerSchedulingTests.swift; sourceTree = "<group>"; };
 		3F2E34BC49376B87D43D81AD /* BodyMetricPhotoUpdateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyMetricPhotoUpdateTests.swift; sourceTree = "<group>"; };
 		3FF03916F06E4F2537E89838 /* BiometricLockPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BiometricLockPolicyTests.swift; sourceTree = "<group>"; };
 		458AAF24645E3634CCF88E16 /* DSIcon.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSIcon.swift; path = DesignSystem/Atoms/DSIcon.swift; sourceTree = "<group>"; };
@@ -1161,6 +1163,7 @@
 				E2715F4BF0E82E86A99821E3 /* PhotoLibraryScannerTests.swift */,
 				7E5BB7F340376DECDD7ABC3A /* SyntheticImageFixtures.swift */,
 				B229942DB1DD4D204C5428A5 /* VisionOrientationServiceTests.swift */,
+				3DC0DDA700C8A4207B9EBC50 /* NotificationManagerSchedulingTests.swift */,
 			);
 			path = LogYourBodyTests;
 			sourceTree = "<group>";
@@ -1987,6 +1990,7 @@
 				A3CFAB8A53F95BD9F8FA0B82 /* PhotoLibraryScannerTests.swift in Sources */,
 				A14230332A86E9780FEAB7F6 /* SyntheticImageFixtures.swift in Sources */,
 				DEB84964BAE75EA9D9090CF7 /* VisionOrientationServiceTests.swift in Sources */,
+				0CBB5909E3CC64F747043DA7 /* NotificationManagerSchedulingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/LogYourBodyTests/NotificationManagerSchedulingTests.swift
+++ b/apps/ios/LogYourBodyTests/NotificationManagerSchedulingTests.swift
@@ -1,0 +1,320 @@
+//
+// NotificationManagerSchedulingTests.swift
+// LogYourBodyTests
+//
+import XCTest
+@testable import LogYourBody
+
+private enum StubNotificationError: Error {
+    case requestAuthorizationFailed
+    case addFailed
+}
+
+/// `UNNotificationSettings` has no public initializer, so a base instance is
+/// decoded from an empty keyed archive and the one property
+/// `NotificationManager` reads (`authorizationStatus`) is overridden.
+private final class StubNotificationSettings: UNNotificationSettings {
+    private let stubStatus: UNAuthorizationStatus
+
+    init?(status: UNAuthorizationStatus) {
+        stubStatus = status
+        let archiver = NSKeyedArchiver(requiringSecureCoding: false)
+        archiver.finishEncoding()
+        guard let unarchiver = try? NSKeyedUnarchiver(forReadingFrom: archiver.encodedData) else {
+            return nil
+        }
+        super.init(coder: unarchiver)
+        unarchiver.finishDecoding()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override var authorizationStatus: UNAuthorizationStatus {
+        stubStatus
+    }
+}
+
+/// Records the exact sequence of scheduling calls so tests can assert
+/// replace-vs-duplicate semantics, cancellation, and error paths.
+private final class FakeNotificationSchedulingClient: NotificationSchedulingClient {
+    enum Event: Equatable {
+        case notificationSettings
+        case requestAuthorization(options: UNAuthorizationOptions)
+        case add(identifier: String)
+        case removePending(identifiers: [String])
+    }
+
+    private(set) var events: [Event] = []
+    private(set) var addedRequests: [UNNotificationRequest] = []
+    var authorizationStatus: UNAuthorizationStatus = .authorized
+    var requestAuthorizationGranted = true
+    var requestAuthorizationError: Error?
+    var addError: Error?
+
+    func notificationSettings() async -> UNNotificationSettings {
+        events.append(.notificationSettings)
+        // The archive-decoding path above is deterministic; unwrap is confined
+        // to this test fake.
+        return StubNotificationSettings(status: authorizationStatus)!
+    }
+
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool {
+        events.append(.requestAuthorization(options: options))
+        if let requestAuthorizationError {
+            throw requestAuthorizationError
+        }
+        return requestAuthorizationGranted
+    }
+
+    func add(_ request: UNNotificationRequest) async throws {
+        events.append(.add(identifier: request.identifier))
+        if let addError {
+            throw addError
+        }
+        addedRequests.append(request)
+    }
+
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+        events.append(.removePending(identifiers: identifiers))
+    }
+}
+
+/// Unit tests for `NotificationManager`'s scheduling side (the
+/// `NotificationSchedulingClient` seam). `DailyReminderPolicy` value logic is
+/// covered by `DailyReminderPolicyTests` and intentionally not repeated here.
+@MainActor
+final class NotificationManagerSchedulingTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var fake: FakeNotificationSchedulingClient!
+    private var manager: NotificationManager!
+
+    private let reminderIdentifier = NotificationReminderKind.dailyWeighIn.requestIdentifier
+    private let expectedOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "NotificationManagerSchedulingTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        fake = FakeNotificationSchedulingClient()
+        manager = NotificationManager(center: fake, defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        manager = nil
+        fake = nil
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testEnableWithGrantedAuthorizationSchedulesRepeatingDailyReminder() async throws {
+        let granted = await manager.requestDailyWeighInReminder(hour: 7, minute: 30)
+
+        XCTAssertTrue(granted)
+        XCTAssertTrue(manager.isDailyWeighInReminderEnabled)
+        XCTAssertEqual(manager.dailyWeighInHour, 7)
+        XCTAssertEqual(manager.dailyWeighInMinute, 30)
+        XCTAssertEqual(manager.authorizationStatus, .authorized)
+        XCTAssertTrue(manager.hasCompletedDailyWeighInPrompt)
+        XCTAssertEqual(
+            fake.events,
+            [
+                .requestAuthorization(options: expectedOptions),
+                .notificationSettings,
+                .removePending(identifiers: [reminderIdentifier]),
+                .add(identifier: reminderIdentifier)
+            ]
+        )
+
+        let request = try XCTUnwrap(fake.addedRequests.first)
+        XCTAssertEqual(request.identifier, reminderIdentifier)
+        XCTAssertEqual(request.content.categoryIdentifier, NotificationReminderKind.dailyWeighIn.rawValue)
+        XCTAssertFalse(request.content.title.isEmpty)
+        XCTAssertFalse(request.content.body.isEmpty)
+        XCTAssertNotNil(request.content.sound)
+
+        let trigger = try XCTUnwrap(request.trigger as? UNCalendarNotificationTrigger)
+        XCTAssertEqual(trigger.dateComponents.hour, 7)
+        XCTAssertEqual(trigger.dateComponents.minute, 30)
+        XCTAssertTrue(trigger.repeats)
+        // Only hour/minute are pinned so the trigger repeats daily.
+        XCTAssertNil(trigger.dateComponents.day)
+        XCTAssertNil(trigger.dateComponents.weekday)
+
+        XCTAssertTrue(defaults.bool(forKey: Constants.dailyWeighInReminderEnabledKey))
+        XCTAssertEqual(defaults.integer(forKey: Constants.dailyWeighInReminderHourKey), 7)
+        XCTAssertEqual(defaults.integer(forKey: Constants.dailyWeighInReminderMinuteKey), 30)
+    }
+
+    func testEnableWithDeniedAuthorizationDoesNotScheduleAndDisables() async {
+        fake.requestAuthorizationGranted = false
+        fake.authorizationStatus = .denied
+
+        let granted = await manager.requestDailyWeighInReminder(hour: 7, minute: 30)
+
+        XCTAssertFalse(granted)
+        XCTAssertFalse(manager.isDailyWeighInReminderEnabled)
+        XCTAssertEqual(manager.authorizationStatus, .denied)
+        // Asking counts as completing the prompt even when the user declines.
+        XCTAssertTrue(manager.hasCompletedDailyWeighInPrompt)
+        XCTAssertEqual(
+            fake.events,
+            [
+                .requestAuthorization(options: expectedOptions),
+                .notificationSettings
+            ]
+        )
+        XCTAssertFalse(defaults.bool(forKey: Constants.dailyWeighInReminderEnabledKey))
+    }
+
+    func testEnableWhenAuthorizationRequestThrowsDisablesAndReturnsFalse() async {
+        fake.requestAuthorizationError = StubNotificationError.requestAuthorizationFailed
+
+        let granted = await manager.requestDailyWeighInReminder(hour: 7, minute: 30)
+
+        XCTAssertFalse(granted)
+        XCTAssertFalse(manager.isDailyWeighInReminderEnabled)
+        XCTAssertTrue(fake.addedRequests.isEmpty)
+        XCTAssertFalse(fake.events.contains(.add(identifier: reminderIdentifier)))
+        XCTAssertFalse(defaults.bool(forKey: Constants.dailyWeighInReminderEnabledKey))
+    }
+
+    func testSchedulingFailureDisablesReminderAndReturnsFalse() async {
+        fake.addError = StubNotificationError.addFailed
+
+        let granted = await manager.requestDailyWeighInReminder(hour: 7, minute: 30)
+
+        XCTAssertFalse(granted)
+        XCTAssertFalse(manager.isDailyWeighInReminderEnabled)
+        XCTAssertTrue(fake.addedRequests.isEmpty)
+        // The stale pending request was cleared before the failed add, so
+        // nothing half-scheduled lingers after the error.
+        XCTAssertEqual(
+            fake.events,
+            [
+                .requestAuthorization(options: expectedOptions),
+                .notificationSettings,
+                .removePending(identifiers: [reminderIdentifier]),
+                .add(identifier: reminderIdentifier)
+            ]
+        )
+        XCTAssertFalse(defaults.bool(forKey: Constants.dailyWeighInReminderEnabledKey))
+    }
+
+    func testDisableCancelsPendingRequestWithoutScheduling() async {
+        let result = await manager.setDailyWeighInReminderEnabled(false)
+
+        XCTAssertTrue(result)
+        XCTAssertFalse(manager.isDailyWeighInReminderEnabled)
+        XCTAssertTrue(manager.hasCompletedDailyWeighInPrompt)
+        XCTAssertEqual(fake.events, [.removePending(identifiers: [reminderIdentifier])])
+        XCTAssertFalse(defaults.bool(forKey: Constants.dailyWeighInReminderEnabledKey))
+    }
+
+    func testReschedulingReplacesExistingRequest() async throws {
+        _ = await manager.requestDailyWeighInReminder(hour: 7, minute: 30)
+        let newTime = try XCTUnwrap(Calendar.current.date(from: DateComponents(hour: 21, minute: 15)))
+
+        await manager.updateDailyWeighInReminderTime(to: newTime)
+
+        XCTAssertEqual(manager.dailyWeighInHour, 21)
+        XCTAssertEqual(manager.dailyWeighInMinute, 15)
+        XCTAssertEqual(fake.addedRequests.count, 2)
+        // Every add is preceded by a remove for the same identifier: the new
+        // request replaces the old one instead of stacking duplicates.
+        XCTAssertEqual(
+            fake.events,
+            [
+                .requestAuthorization(options: expectedOptions),
+                .notificationSettings,
+                .removePending(identifiers: [reminderIdentifier]),
+                .add(identifier: reminderIdentifier),
+                .removePending(identifiers: [reminderIdentifier]),
+                .add(identifier: reminderIdentifier)
+            ]
+        )
+
+        let latest = try XCTUnwrap(fake.addedRequests.last)
+        let trigger = try XCTUnwrap(latest.trigger as? UNCalendarNotificationTrigger)
+        XCTAssertEqual(trigger.dateComponents.hour, 21)
+        XCTAssertEqual(trigger.dateComponents.minute, 15)
+        XCTAssertEqual(defaults.integer(forKey: Constants.dailyWeighInReminderHourKey), 21)
+        XCTAssertEqual(defaults.integer(forKey: Constants.dailyWeighInReminderMinuteKey), 15)
+    }
+
+    func testTimeUpdateWhileDisabledPersistsTimeWithoutScheduling() async throws {
+        let newTime = try XCTUnwrap(Calendar.current.date(from: DateComponents(hour: 6, minute: 45)))
+
+        await manager.updateDailyWeighInReminderTime(to: newTime)
+
+        XCTAssertFalse(manager.isDailyWeighInReminderEnabled)
+        XCTAssertEqual(manager.dailyWeighInHour, 6)
+        XCTAssertEqual(manager.dailyWeighInMinute, 45)
+        XCTAssertTrue(fake.events.isEmpty)
+        XCTAssertEqual(defaults.integer(forKey: Constants.dailyWeighInReminderHourKey), 6)
+        XCTAssertEqual(defaults.integer(forKey: Constants.dailyWeighInReminderMinuteKey), 45)
+    }
+
+    func testRefreshAuthorizationStatusDisablesEnabledReminderWhenDenied() async {
+        defaults.set(true, forKey: Constants.dailyWeighInReminderEnabledKey)
+        manager = NotificationManager(center: fake, defaults: defaults)
+        XCTAssertTrue(manager.isDailyWeighInReminderEnabled)
+        fake.authorizationStatus = .denied
+
+        await manager.refreshAuthorizationStatus()
+
+        XCTAssertEqual(manager.authorizationStatus, .denied)
+        XCTAssertFalse(manager.isDailyWeighInReminderEnabled)
+        XCTAssertFalse(defaults.bool(forKey: Constants.dailyWeighInReminderEnabledKey))
+    }
+
+    func testRefreshAuthorizationStatusKeepsEnabledReminderWhenAuthorized() async {
+        defaults.set(true, forKey: Constants.dailyWeighInReminderEnabledKey)
+        manager = NotificationManager(center: fake, defaults: defaults)
+        fake.authorizationStatus = .authorized
+
+        await manager.refreshAuthorizationStatus()
+
+        XCTAssertEqual(manager.authorizationStatus, .authorized)
+        XCTAssertTrue(manager.isDailyWeighInReminderEnabled)
+        XCTAssertTrue(defaults.bool(forKey: Constants.dailyWeighInReminderEnabledKey))
+    }
+
+    func testRequestNormalizesOutOfRangeTimeBeforeScheduling() async throws {
+        let granted = await manager.requestDailyWeighInReminder(hour: 25, minute: 90)
+
+        XCTAssertTrue(granted)
+        XCTAssertEqual(manager.dailyWeighInHour, 23)
+        XCTAssertEqual(manager.dailyWeighInMinute, 59)
+        let request = try XCTUnwrap(fake.addedRequests.first)
+        let trigger = try XCTUnwrap(request.trigger as? UNCalendarNotificationTrigger)
+        XCTAssertEqual(trigger.dateComponents.hour, 23)
+        XCTAssertEqual(trigger.dateComponents.minute, 59)
+        XCTAssertEqual(defaults.integer(forKey: Constants.dailyWeighInReminderHourKey), 23)
+        XCTAssertEqual(defaults.integer(forKey: Constants.dailyWeighInReminderMinuteKey), 59)
+    }
+
+    func testSkipPromptDisablesReminderWithoutSchedulerCalls() {
+        manager.skipDailyWeighInPrompt()
+
+        XCTAssertFalse(manager.isDailyWeighInReminderEnabled)
+        XCTAssertTrue(manager.hasCompletedDailyWeighInPrompt)
+        XCTAssertTrue(fake.events.isEmpty)
+    }
+
+    func testEnabledReminderStatePersistsAcrossManagerInstances() async {
+        _ = await manager.requestDailyWeighInReminder(hour: 8, minute: 5)
+
+        let reloaded = NotificationManager(center: fake, defaults: defaults)
+
+        XCTAssertTrue(reloaded.isDailyWeighInReminderEnabled)
+        XCTAssertEqual(reloaded.dailyWeighInHour, 8)
+        XCTAssertEqual(reloaded.dailyWeighInMinute, 5)
+        XCTAssertTrue(reloaded.hasCompletedDailyWeighInPrompt)
+    }
+}


### PR DESCRIPTION
## Summary

Batch 12 of the iOS test-hardening effort (B.1 leftover + B.3 audit sweep). 12 new tests; the audit-half of the batch honestly produced skips, not padding.

- **`NotificationManagerSchedulingTests` (12):** the manager's scheduling side (policy already covered elsewhere) via the existing `NotificationSchedulingClient` seam with a call-recording fake — grant path schedules a repeating 7:30 daily request with the exact event sequence `[requestAuthorization, notificationSettings, removePending, add]`; denial/throw paths disable without scheduling; `add` failure leaves nothing half-scheduled; disable sends one `removePending`; reschedules always remove-before-add (never duplicate); time update while disabled persists silently; `refreshAuthorizationStatus` auto-disables on denial; out-of-range time clamps to 23:59; skip-prompt disables; state persists across instances. (`UNNotificationSettings` has no public init — constructed via a keyed-archiver round-trip, documented in the file.)

**B.3 audit verdicts (skip, with reason):** `AppLogger`/`PerfSignpost`/`VersionInfo` (trivial wrappers), `FrameHitchMonitor` (welded to CADisplayLink), `HapticManager` (no gating logic), `DashboardMetric` (bare enum). Dead-code candidates instead of tests: `DailyLog`'s 4 computed props + mocks (zero callers), `BodyCompMeasurement` (unreferenced struct), `BodyCompMethod.infer`/`BodyCompSourceType.infer` (dead statics) — all queued for the next deletion PR.

## Validation evidence

- `swiftlint lint --strict`: 0 violations (357 files)
- New class: 12/12 green in 0.045s total (two independent runs)
- Full Unit plan: 477 tests, 0 failures
- Pre-push turbo lint/typecheck/test: green
