### PR TITLE
fix(ios): point API at www host to stop auth session 401s

### DIFF
--- a/apps/ios/LogYourBody/Config-Production.xcconfig.template
+++ b/apps/ios/LogYourBody/Config-Production.xcconfig.template
@@ -10,7 +10,7 @@ AUTH_CLIENT_ID = logyourbody-ios
 AUTH_REDIRECT_URI = logyourbody:/$()/oauth
 
 // Production API.
-API_BASE_URL = https:/$()/logyourbody.com
+API_BASE_URL = https:/$()/www.logyourbody.com
 API_EXPECTED_HOST = logyourbody.com
 
 // Production paid/analytics/error reporting providers.

--- a/apps/ios/LogYourBody/Utils/Configuration.swift
+++ b/apps/ios/LogYourBody/Utils/Configuration.swift
@@ -140,7 +140,10 @@ enum Configuration {
     // MARK: - API Configuration
 
     static var apiBaseURL: String {
-        stringValue(for: "API_BASE_URL", default: "https://logyourbody.com")
+        // www: the apex domain 307-redirects to www, and URLSession strips the
+        // Authorization header on cross-host redirects, which breaks session
+        // registration ("account could not be initialized").
+        stringValue(for: "API_BASE_URL", default: "https://www.logyourbody.com")
     }
 
     static var apiExpectedHost: String {


### PR DESCRIPTION
## Summary

Fixes TestFlight login failing with *"something went wrong — your LogYourBody account could not be initialized"* after the Apple sheet + browser flow complete.

**Root cause (verified end-to-end):**

1. Production config points `API_BASE_URL` at the apex domain (`https://logyourbody.com`), changed from `www` in #469.
2. The apex domain **307-redirects all API traffic to `www.logyourbody.com`** (confirmed: `curl -I` on `POST /api/auth/mobile/session`).
3. **URLSession strips the `Authorization` header on cross-host redirects** — proven empirically with a redirect echo test (header absent at the target).
4. So `registerProductSession`'s POST arrives at `/api/auth/mobile/session` with **no Bearer token** → route returns 401 → app throws `AuthError.server("Your LogYourBody account could not be initialized.")`.

**Fix:** point both the production config template and the `Configuration.apiBaseURL` code default at `https://www.logyourbody.com` (where the API is actually served — pre-#469 behavior), avoiding the cross-host redirect entirely.

Note: users on the current TestFlight build stay broken until a new build ships via the iOS Release Loop after this merges — the fix is in the config template consumed at build time.

## Validation evidence

- Reproduced the full failure chain against production: apex 307 → www; route returns proper JSON 401 on www
- URLSession header-drop reproduced with an external redirect echo
- `swiftlint lint --strict`: 0 violations (373 files)
- `AuthConfigurationValidationTests`: TEST SUCCEEDED
