### PR TITLE
feat: single-source URL consumers on the product registry + report-only CSP

### DIFF
--- a/apps/ios/LogYourBody/Utils/Configuration.swift
+++ b/apps/ios/LogYourBody/Utils/Configuration.swift
@@ -143,7 +143,7 @@ enum Configuration {
         // www: the apex domain 307-redirects to www, and URLSession strips the
         // Authorization header on cross-host redirects, which breaks session
         // registration ("account could not be initialized").
-        stringValue(for: "API_BASE_URL", default: "https://www.logyourbody.com")
+        stringValue(for: "API_BASE_URL", default: ProductRegistry.Hosts.api)
     }
 
     static var apiExpectedHost: String {
@@ -153,15 +153,15 @@ enum Configuration {
     // MARK: - First-party authentication
 
     static var authIssuer: String {
-        stringValue(for: "AUTH_ISSUER", default: "https://jov.ie/api/auth")
+        stringValue(for: "AUTH_ISSUER", default: ProductRegistry.Auth.issuer)
     }
 
     static var authClientID: String {
-        stringValue(for: "AUTH_CLIENT_ID", default: "logyourbody-ios")
+        stringValue(for: "AUTH_CLIENT_ID", default: ProductRegistry.Auth.iosClientID)
     }
 
     static var authRedirectURI: String {
-        stringValue(for: "AUTH_REDIRECT_URI", default: "logyourbody://oauth")
+        stringValue(for: "AUTH_REDIRECT_URI", default: ProductRegistry.Auth.iosRedirectURI)
     }
 
     static var authCallbackScheme: String {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 import bundleAnalyzer from '@next/bundle-analyzer';
 import { version } from './package.json';
+import { cspReportOnlyDirectives } from './src/lib/generated/csp.generated';
 
 // Bundle analyzer configuration
 const withBundleAnalyzer = bundleAnalyzer({
@@ -79,6 +80,22 @@ const nextConfig: NextConfig = {
           {
             key: 'Content-Type',
             value: 'application/json',
+          },
+        ],
+      },
+      {
+        // Report-only CSP: violations are collected at /api/csp-report without
+        // blocking anything. The generated module has no report-uri directive,
+        // so the collector endpoint is appended here.
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value: `${cspReportOnlyDirectives}; report-uri /api/csp-report; report-to csp-endpoint`,
+          },
+          {
+            key: 'Reporting-Endpoints',
+            value: 'csp-endpoint="/api/csp-report"',
           },
         ],
       },

--- a/apps/web/src/app/api/csp-report/route.ts
+++ b/apps/web/src/app/api/csp-report/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+// Collector for the report-only CSP in next.config.ts. Browsers POST
+// violation reports here; nothing is blocked while the policy is report-only.
+export async function POST(request: Request) {
+  const report = await request.json().catch(() => null);
+  console.warn('CSP violation report:', report);
+  return new NextResponse(null, { status: 204 });
+}

--- a/apps/web/src/app/download/ios/metadata.ts
+++ b/apps/web/src/app/download/ios/metadata.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { endpoints } from '@/lib/generated/endpoints.generated';
 
 export const metadata: Metadata = {
   title: 'Download LogYourBody for iOS - Body Composition Tracker',
@@ -17,7 +18,7 @@ export const metadata: Metadata = {
     title: 'LogYourBody for iOS - Your Body. Decoded.',
     description:
       'The only app that tracks FFMI, body fat percentage, and progress photos with scientific accuracy. Download free on App Store.',
-    url: 'https://logyourbody.com/download/ios',
+    url: `${endpoints.hosts.marketing.url}/download/ios`,
     siteName: 'LogYourBody',
     images: [
       {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,34 +1,37 @@
 import { MinimalWaitlistLanding } from './MinimalWaitlistLanding';
 import { LegacyMinimalWaitlistLanding } from './LegacyMinimalWaitlistLanding';
 import { LANDING_FLAGS } from '@/lib/flags/landing';
+import { endpoints } from '@/lib/generated/endpoints.generated';
+
+const marketingUrl = endpoints.hosts.marketing.url;
 
 const landingStructuredData = {
   '@context': 'https://schema.org',
   '@graph': [
     {
       '@type': 'Organization',
-      '@id': 'https://logyourbody.com/#organization',
+      '@id': `${marketingUrl}/#organization`,
       name: 'LogYourBody',
-      url: 'https://logyourbody.com/',
-      logo: 'https://logyourbody.com/brand/logyourbody-app-icon.png',
+      url: `${marketingUrl}/`,
+      logo: `${marketingUrl}/brand/logyourbody-app-icon.png`,
     },
     {
       '@type': 'WebSite',
-      '@id': 'https://logyourbody.com/#website',
+      '@id': `${marketingUrl}/#website`,
       name: 'LogYourBody',
-      url: 'https://logyourbody.com/',
-      publisher: { '@id': 'https://logyourbody.com/#organization' },
+      url: `${marketingUrl}/`,
+      publisher: { '@id': `${marketingUrl}/#organization` },
     },
     {
       '@type': 'SoftwareApplication',
-      '@id': 'https://logyourbody.com/#app',
+      '@id': `${marketingUrl}/#app`,
       name: 'LogYourBody',
       applicationCategory: 'HealthApplication',
       operatingSystem: 'iOS',
       description:
         'A private iPhone timeline for weight, body fat, lean mass, and progress photos.',
-      url: 'https://logyourbody.com/',
-      publisher: { '@id': 'https://logyourbody.com/#organization' },
+      url: `${marketingUrl}/`,
+      publisher: { '@id': `${marketingUrl}/#organization` },
     },
   ],
 };

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,4 +1,7 @@
 import type { MetadataRoute } from 'next';
+import { endpoints } from '@/lib/generated/endpoints.generated';
+
+const marketingUrl = endpoints.hosts.marketing.url;
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -16,7 +19,7 @@ export default function robots(): MetadataRoute.Robots {
         '/api/',
       ],
     },
-    sitemap: 'https://logyourbody.com/sitemap.xml',
-    host: 'https://logyourbody.com',
+    sitemap: `${marketingUrl}/sitemap.xml`,
+    host: marketingUrl,
   };
 }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,10 +1,11 @@
 import type { MetadataRoute } from 'next';
+import { endpoints } from '@/lib/generated/endpoints.generated';
 
 const publicRoutes = ['', '/privacy', '/terms', '/health-disclosure', '/support'] as const;
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return publicRoutes.map((path, index) => ({
-    url: `https://logyourbody.com${path}`,
+    url: `${endpoints.hosts.marketing.url}${path}`,
     lastModified: new Date(),
     changeFrequency: index === 0 ? 'weekly' : 'monthly',
     priority: index === 0 ? 1 : 0.5,

--- a/apps/web/src/lib/auth/jovie-oauth.ts
+++ b/apps/web/src/lib/auth/jovie-oauth.ts
@@ -3,12 +3,13 @@ import 'server-only';
 import { createHash, randomBytes } from 'node:crypto';
 import type { NextRequest, NextResponse } from 'next/server';
 import { authCookies, type JovieUserInfo } from '@/lib/auth/constants';
+import { endpoints } from '@/lib/generated/endpoints.generated';
 
 export { authCookies } from '@/lib/auth/constants';
 export type { JovieUserInfo } from '@/lib/auth/constants';
 
-const DEFAULT_ISSUER = 'https://jov.ie/api/auth';
-const DEFAULT_CLIENT_ID = 'logyourbody-web';
+const DEFAULT_ISSUER = endpoints.auth.issuer;
+const DEFAULT_CLIENT_ID = endpoints.auth.clients.web.id;
 
 export type JovieTokenSet = {
   access_token: string;
@@ -30,7 +31,7 @@ export function oauthClientId() {
 export function oauthRedirectUri(request?: NextRequest) {
   if (process.env.JOVIE_AUTH_REDIRECT_URI) return process.env.JOVIE_AUTH_REDIRECT_URI;
   if (process.env.NODE_ENV === 'production') {
-    return 'https://www.logyourbody.com/api/auth/callback';
+    return endpoints.auth.clients.web.redirectUri;
   }
   return `${request?.nextUrl.origin || 'http://localhost:3000'}/api/auth/callback`;
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
     ],
     "apps/ios/**/*.{swift}": [
       "cd apps/ios && swiftlint"
+    ],
+    "*.{ts,tsx,js,jsx,mjs,cjs,swift,sh,yml,yaml,json,md,html,css,scss,rb,py,toml,xml,plist,template,xcconfig}": [
+      "node packages/product-registry/scripts/url-drift.test.mjs --staged"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "db:migrate": "scripts/web/create-migration.sh",
     "db:schema:check": "bash scripts/supabase/check-schema-drift.sh",
     "ios": "cd apps/ios && open LogYourBody.xcodeproj",
-    "prepush": "export NEXT_PUBLIC_SUPABASE_URL=\"${NEXT_PUBLIC_SUPABASE_URL:-https://placeholder.supabase.co}\" NEXT_PUBLIC_SUPABASE_ANON_KEY=\"${NEXT_PUBLIC_SUPABASE_ANON_KEY:-placeholder-anon-key}\" SUPABASE_SERVICE_ROLE_KEY=\"${SUPABASE_SERVICE_ROLE_KEY:-placeholder-service-key}\"; turbo run lint --filter='...[origin/main]' && turbo run typecheck --filter='...[origin/main]' && turbo run test --filter='...[origin/main]'",
+    "prepush": "export NEXT_PUBLIC_SUPABASE_URL=\"${NEXT_PUBLIC_SUPABASE_URL:-https://placeholder.supabase.co}\" NEXT_PUBLIC_SUPABASE_ANON_KEY=\"${NEXT_PUBLIC_SUPABASE_ANON_KEY:-placeholder-anon-key}\" SUPABASE_SERVICE_ROLE_KEY=\"${SUPABASE_SERVICE_ROLE_KEY:-placeholder-service-key}\"; turbo run lint --filter='...[origin/main]' && turbo run typecheck --filter='...[origin/main]' && turbo run test --filter='...[origin/main]' && node packages/product-registry/scripts/url-drift.test.mjs",
     "prepare": "husky install",
     "check": "pnpm --filter logyourbody check",
     "format": "prettier --write .",

--- a/packages/product-registry/scripts/url-drift.test.mjs
+++ b/packages/product-registry/scripts/url-drift.test.mjs
@@ -5,7 +5,8 @@
 // (required CI `js` job). Register new endpoints in
 // packages/product-registry/src/products/logyourbody.mjs.
 import { readdir, readFile } from 'node:fs/promises';
-import { dirname, extname, join, relative, resolve } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { basename, dirname, extname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import console from 'node:console';
 import process from 'node:process';
@@ -214,7 +215,30 @@ function normalize(raw) {
   return literal;
 }
 
-const files = await filesIn(repoRoot);
+// --staged: literal-scan only the files staged in git (pre-commit fast path).
+// The consistency assertions below always run against the full repo.
+const stagedOnly = process.argv.includes('--staged');
+
+function stagedFiles() {
+  const output = execFileSync('git', ['diff', '--cached', '--name-only', '--diff-filter=ACMR'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return output
+    .split('\n')
+    .filter(Boolean)
+    .map((path) => resolve(repoRoot, path))
+    .filter((path) => {
+      const name = basename(path);
+      if (excludedFiles.has(name)) return false;
+      if (name.startsWith('.env')) return false;
+      if (excludedExtensions.has(extname(name).toLowerCase())) return false;
+      if (excludedPaths.has(relative(repoRoot, path))) return false;
+      return true;
+    });
+}
+
+const files = stagedOnly ? stagedFiles() : await filesIn(repoRoot);
 const failures = [];
 let fileCount = 0;
 let literalCount = 0;
@@ -251,22 +275,49 @@ const consistencyTargets = [
     checks: [
       {
         name: 'API_BASE_URL default',
-        pattern: /stringValue\(for: "API_BASE_URL", default: "([^"]+)"\)/,
-        expected: endpoints.hosts.api.url,
+        pattern: /stringValue\(for: "API_BASE_URL", default: ([^)]+)\)/,
+        expected: 'ProductRegistry.Hosts.api',
       },
       {
         name: 'AUTH_ISSUER default',
-        pattern: /stringValue\(for: "AUTH_ISSUER", default: "([^"]+)"\)/,
-        expected: endpoints.auth.issuer,
+        pattern: /stringValue\(for: "AUTH_ISSUER", default: ([^)]+)\)/,
+        expected: 'ProductRegistry.Auth.issuer',
       },
       {
         name: 'AUTH_CLIENT_ID default',
-        pattern: /stringValue\(for: "AUTH_CLIENT_ID", default: "([^"]+)"\)/,
-        expected: endpoints.auth.clients.ios.id,
+        pattern: /stringValue\(for: "AUTH_CLIENT_ID", default: ([^)]+)\)/,
+        expected: 'ProductRegistry.Auth.iosClientID',
       },
       {
         name: 'AUTH_REDIRECT_URI default',
-        pattern: /stringValue\(for: "AUTH_REDIRECT_URI", default: "([^"]+)"\)/,
+        pattern: /stringValue\(for: "AUTH_REDIRECT_URI", default: ([^)]+)\)/,
+        expected: 'ProductRegistry.Auth.iosRedirectURI',
+      },
+    ],
+  },
+  // The ProductRegistry.* references above resolve through the generated Swift
+  // file; pin its values to the registry so the chain stays checked end to end.
+  {
+    file: 'apps/ios/LogYourBody/GeneratedProductRegistry.swift',
+    checks: [
+      {
+        name: 'Hosts.api',
+        pattern: /static let api = "([^"]+)"/,
+        expected: endpoints.hosts.api.url,
+      },
+      {
+        name: 'Auth.issuer',
+        pattern: /static let issuer = "([^"]+)"/,
+        expected: endpoints.auth.issuer,
+      },
+      {
+        name: 'Auth.iosClientID',
+        pattern: /static let iosClientID = "([^"]+)"/,
+        expected: endpoints.auth.clients.ios.id,
+      },
+      {
+        name: 'Auth.iosRedirectURI',
+        pattern: /static let iosRedirectURI = "([^"]+)"/,
         expected: endpoints.auth.clients.ios.redirectUri,
       },
     ],
@@ -352,17 +403,39 @@ const consistencyTargets = [
     checks: [
       {
         name: 'DEFAULT_ISSUER',
-        pattern: /const DEFAULT_ISSUER = '([^']+)';/,
-        expected: endpoints.auth.issuer,
+        pattern: /const DEFAULT_ISSUER = ([^;]+);/,
+        expected: 'endpoints.auth.issuer',
       },
       {
         name: 'DEFAULT_CLIENT_ID',
-        pattern: /const DEFAULT_CLIENT_ID = '([^']+)';/,
-        expected: endpoints.auth.clients.web.id,
+        pattern: /const DEFAULT_CLIENT_ID = ([^;]+);/,
+        expected: 'endpoints.auth.clients.web.id',
       },
       {
         name: 'production redirect URI',
-        pattern: /return '(https:\/\/[^']+\/api\/auth\/callback)';/,
+        pattern: /return (endpoints\.auth\.clients\.web\.redirectUri);/,
+        expected: 'endpoints.auth.clients.web.redirectUri',
+      },
+    ],
+  },
+  // Same chain-pinning as iOS: the endpoints.* references above resolve
+  // through the generated module, so pin its values to the registry.
+  {
+    file: 'apps/web/src/lib/generated/endpoints.generated.ts',
+    checks: [
+      {
+        name: 'auth.issuer',
+        pattern: /issuer: '([^']+)',/,
+        expected: endpoints.auth.issuer,
+      },
+      {
+        name: 'auth.clients.web.id',
+        pattern: /web: \{\s*id: '([^']+)',/,
+        expected: endpoints.auth.clients.web.id,
+      },
+      {
+        name: 'auth.clients.web.redirectUri',
+        pattern: /web: \{\s*id: '[^']+',\s*redirectUri: '([^']+)',/,
         expected: endpoints.auth.clients.web.redirectUri,
       },
     ],

--- a/scripts/web/pre-push-check.sh
+++ b/scripts/web/pre-push-check.sh
@@ -47,7 +47,19 @@ else
 fi
 echo ""
 
-# 4. Build check (optional, can be slow)
+# 4. URL drift guard
+echo "🔗 Running URL drift guard..."
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+node "$REPO_ROOT/packages/product-registry/scripts/url-drift.test.mjs"
+if [ $? -eq 0 ]; then
+    echo "✅ URL drift guard passed"
+else
+    echo "❌ URL drift guard failed"
+    exit 1
+fi
+echo ""
+
+# 5. Build check (optional, can be slow)
 if [[ "$1" == "--with-build" ]]; then
     echo "🏗️  Running build check..."
     pnpm run build


### PR DESCRIPTION
## Summary

PR 2 of the URL hardening effort (PR 1, #502, landed the registry + guard). Migrates the real consumers onto the registry, adds report-only CSP, and wires the guard into every commit and push.

**iOS consumer:** `Configuration.swift` fallback defaults now reference `ProductRegistry.Hosts.api` / `Auth.issuer` / `iosClientID` / `iosRedirectURI` — identical values, single source. The drift guard's consistency assertions were rewritten to the registry-reference form and **grew 18 → 25** (now also pinning the generated Swift/TS outputs to the registry end-to-end).

**Web consumers:** `jovie-oauth.ts` (issuer, client id, prod redirect), `robots.ts`, `sitemap.ts`, `page.tsx` JSON-LD, `download/ios/metadata.ts` now import from `@/lib/generated/endpoints.generated` (not package source — vendor boundary respected).

**CSP (report-only, per the rollout decision):** `next.config.ts` adds `Content-Security-Policy-Report-Only` on all paths from the generated directives + a `/api/csp-report` POST route (204, logs violations). Nothing is blocked; violations only log. Verified with a live build+start: header present, report endpoint 204s.

**Hook wiring:**
- lint-staged runs the guard's new `--staged` mode (~0.1s) on staged files — **blocks commits containing unregistered URL literals**
- `scripts/web/pre-push-check.sh` runs the full guard
- Root `prepush` now ends with the full guard **unconditionally on every push** (the turbo filter only ran it when the registry package changed)

## Validation evidence

- `pnpm --filter @jovieinc/product-registry test`: green — guard: 1292 files, 648 literals registered, **25 consistency assertions passed**
- `--staged` mode: green, and proven to fail on a staged unregistered URL with the same message shape
- `pnpm lint` 5/5, `pnpm typecheck` 5/5, web jest green (the 1 failing suite is the pre-existing untracked `analytics.test.ts` WIP from another lane — broken on `@vercel/analytics` ESM transform, unrelated)
- iOS: `swiftlint --strict` 0 violations; `AuthConfigurationValidationTests` TEST SUCCEEDED
- CSP smoke: build green, header present on localhost, `/api/csp-report` 204
