### PR TITLE
chore: automate post-merge main sync and stale-branch pruning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ gbrain query "what is the timeline scrubber convention?"   # hybrid
 1. **Agents and humans NEVER commit directly to `main`.**
 2. **All changes flow via PRs into `main`.**
 3. **Branches should be small and focused**, optimized for quick review and merge.
-4. **Delete branches after merge** to keep the repository clean.
+4. **Delete branches after merge** to keep the repository clean. GitHub auto-deletes head branches on merge; run `pnpm sync:main` locally to switch back to `main`, fast-forward, and prune the local copies.
 
 ---
 
@@ -168,9 +168,10 @@ When the user asks an agent to ship, land, deploy, or continue an active release
 4. Push the branch and wait for required checks and required deployments.
 5. Enqueue or merge through the configured PR/merge-queue path once gates are green.
 6. Watch `main` CI and deployment after merge.
-7. Trigger the appropriate release workflow from `main` when the release checklist says to do so.
-8. Verify the actual external state: TestFlight/App Store, Vercel, RevenueCat, Supabase, Clerk, or other provider state as applicable.
-9. Open follow-up PRs for non-blocking issues instead of holding the main PR when the product remains deployable.
+7. Run `pnpm sync:main` to fast-forward local `main`, prune remotes, and delete local branches whose upstream was auto-deleted on merge.
+8. Trigger the appropriate release workflow from `main` when the release checklist says to do so.
+9. Verify the actual external state: TestFlight/App Store, Vercel, RevenueCat, Supabase, Clerk, or other provider state as applicable.
+10. Open follow-up PRs for non-blocking issues instead of holding the main PR when the product remains deployable.
 
 Only stop before merge/release when there is a hard external blocker the agent cannot satisfy, such as missing credentials, account-owner approval, App Review rejection, provider outage, merge conflicts that cannot be resolved safely, or an unresolved failing required check.
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "product:generate": "pnpm --filter @jovieinc/product-registry generate",
     "product:check": "pnpm --filter @jovieinc/product-registry test",
     "check:vendor-boundaries": "node scripts/check-vendor-boundaries.js",
-    "check:supabase-migrations": "node scripts/check-supabase-migration-drift.js"
+    "check:supabase-migrations": "node scripts/check-supabase-migration-drift.js",
+    "sync:main": "bash scripts/sync-main.sh"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",

--- a/scripts/sync-main.sh
+++ b/scripts/sync-main.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Post-merge branch sync: fast-forward local main, prune remotes, and delete
+# local branches whose upstream is gone (i.e. merged + auto-deleted on GitHub).
+# Run this after a PR lands, or any time local branches have piled up.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "ERROR: working tree is dirty; commit or stash before syncing main" >&2
+  exit 1
+fi
+
+current_branch="$(git branch --show-current)"
+
+git fetch --prune origin
+
+git checkout main
+git pull --ff-only origin main
+
+gone_branches="$(git branch -vv | grep ': gone]' | awk '{print $1}' | grep -v '^main$' || true)"
+
+if [ -n "$gone_branches" ]; then
+  echo "Deleting local branches with gone upstreams:"
+  echo "$gone_branches"
+  echo "$gone_branches" | xargs git branch -d
+else
+  echo "No stale local branches to delete"
+fi
+
+if [ "$current_branch" != "main" ] && git show-ref --verify --quiet "refs/heads/$current_branch"; then
+  echo "NOTE: still had local branch '$current_branch' (upstream not gone); left it in place on main"
+fi
+
+echo "main is synced and stale branches are pruned"


### PR DESCRIPTION
## What

Adds `pnpm sync:main` (`scripts/sync-main.sh`) which:
1. Refuses to run on a dirty working tree
2. `git fetch --prune`, checks out `main`, fast-forwards
3. Deletes local branches whose upstream is `: gone` (merged PRs — GitHub already auto-deletes head branches via `deleteBranchOnMerge: true`)

`AGENTS.md` closeout loop now includes running `pnpm sync:main` after a merge so local branch cleanup is part of the standard flow instead of manual.

## Validation

- Pre-push gate (turbo lint/typecheck/test since origin/main + url-drift guard) passed
- Script tested locally post-merge (see PR checks)