### PR TITLE
feat(design-tokens): token drift guard + ratchet baseline

### DIFF
--- a/packages/design-tokens/drift-baseline.json
+++ b/packages/design-tokens/drift-baseline.json
@@ -1,0 +1,215 @@
+{
+  "version": 1,
+  "drift": [
+    {
+      "token": "color.base.purple.500",
+      "platform": "ios",
+      "target": "colors.primary",
+      "canonical": "#5b63d3",
+      "actual": "#ffffff"
+    },
+    {
+      "token": "color.base.purple.500",
+      "platform": "web",
+      "target": "--primary",
+      "canonical": "#5b63d3",
+      "actual": "#626fd0"
+    },
+    {
+      "token": "color.base.purple.500",
+      "platform": "web",
+      "target": "tailwind:accent-purple",
+      "canonical": "#5b63d3",
+      "actual": "#5e6ad2"
+    },
+    {
+      "token": "color.base.purple.500",
+      "platform": "web",
+      "target": "tailwind:linear-purple",
+      "canonical": "#5b63d3",
+      "actual": "#5e6ad2"
+    },
+    {
+      "token": "color.semantic.background",
+      "platform": "ios",
+      "target": "colors.background",
+      "canonical": "#111111",
+      "actual": "#000000"
+    },
+    {
+      "token": "color.semantic.background",
+      "platform": "web",
+      "target": "--background",
+      "canonical": "#111111",
+      "actual": "#000000"
+    },
+    {
+      "token": "color.semantic.background",
+      "platform": "web",
+      "target": "tailwind:linear-bg",
+      "canonical": "#111111",
+      "actual": "#0a0b0d"
+    },
+    {
+      "token": "color.semantic.border",
+      "platform": "ios",
+      "target": "colors.border",
+      "canonical": "#2a2a2a",
+      "actual": "#2a2a2c"
+    },
+    {
+      "token": "color.semantic.border",
+      "platform": "web",
+      "target": "--border",
+      "canonical": "#2a2a2a",
+      "actual": "#1a1a1a"
+    },
+    {
+      "token": "color.semantic.border",
+      "platform": "web",
+      "target": "tailwind:linear-border",
+      "canonical": "#2a2a2a",
+      "actual": "#1f2023"
+    },
+    {
+      "token": "color.semantic.card",
+      "platform": "ios",
+      "target": "colors.surface",
+      "canonical": "#1a1a1a",
+      "actual": "#0b0b0b"
+    },
+    {
+      "token": "color.semantic.card",
+      "platform": "web",
+      "target": "--card",
+      "canonical": "#1a1a1a",
+      "actual": "#000000"
+    },
+    {
+      "token": "color.semantic.card",
+      "platform": "web",
+      "target": "tailwind:linear-card",
+      "canonical": "#1a1a1a",
+      "actual": "#111113"
+    },
+    {
+      "token": "color.semantic.error",
+      "platform": "ios",
+      "target": "colors.error",
+      "canonical": "#f44336",
+      "actual": "#f3122d"
+    },
+    {
+      "token": "color.semantic.error",
+      "platform": "web",
+      "target": "--destructive",
+      "canonical": "#f44336",
+      "actual": "#ef4343"
+    },
+    {
+      "token": "color.semantic.success",
+      "platform": "ios",
+      "target": "colors.success",
+      "canonical": "#4caf50",
+      "actual": "#2f9e44"
+    },
+    {
+      "token": "color.semantic.success",
+      "platform": "web",
+      "target": "tailwind:accent-green",
+      "canonical": "#4caf50",
+      "actual": "#10b981"
+    },
+    {
+      "token": "color.semantic.warning",
+      "platform": "web",
+      "target": "tailwind:accent-orange",
+      "canonical": "#ff9800",
+      "actual": "#f97316"
+    },
+    {
+      "token": "radius.full",
+      "platform": "ios",
+      "target": "radius.full",
+      "canonical": 9999,
+      "actual": 48
+    },
+    {
+      "token": "radius.lg",
+      "platform": "ios",
+      "target": "radius.lg",
+      "canonical": 12,
+      "actual": 16
+    },
+    {
+      "token": "radius.md",
+      "platform": "ios",
+      "target": "radius.md",
+      "canonical": 8,
+      "actual": 12
+    },
+    {
+      "token": "radius.semantic.button",
+      "platform": "ios",
+      "target": "radius.button",
+      "canonical": 12,
+      "actual": 48
+    },
+    {
+      "token": "radius.semantic.card",
+      "platform": "ios",
+      "target": "radius.card",
+      "canonical": 12,
+      "actual": 20
+    },
+    {
+      "token": "radius.semantic.chip",
+      "platform": "ios",
+      "target": "radius.chip",
+      "canonical": 16,
+      "actual": 48
+    },
+    {
+      "token": "radius.semantic.input",
+      "platform": "ios",
+      "target": "radius.input",
+      "canonical": 8,
+      "actual": 16
+    },
+    {
+      "token": "radius.sm",
+      "platform": "ios",
+      "target": "radius.sm",
+      "canonical": 6,
+      "actual": 4
+    },
+    {
+      "token": "radius.xl",
+      "platform": "ios",
+      "target": "radius.xl",
+      "canonical": 16,
+      "actual": 48
+    },
+    {
+      "token": "radius.xs",
+      "platform": "ios",
+      "target": "radius.xs",
+      "canonical": 4,
+      "actual": 2
+    },
+    {
+      "token": "radius.xxl",
+      "platform": "ios",
+      "target": "radius.xxl",
+      "canonical": 24,
+      "actual": 48
+    },
+    {
+      "token": "spacing.semantic.screen",
+      "platform": "ios",
+      "target": "spacing.screenPadding",
+      "canonical": 16,
+      "actual": 20
+    }
+  ]
+}

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -16,7 +16,7 @@
     "build:all": "pnpm run build",
     "watch": "nodemon --watch tokens --exec \"pnpm run build\"",
     "validate": "node scripts/validate-tokens.js",
-    "test": "pnpm run validate",
+    "test": "pnpm run validate && node scripts/check-token-drift.mjs",
     "clean": "rm -rf build"
   },
   "dependencies": {

--- a/packages/design-tokens/scripts/check-token-drift.mjs
+++ b/packages/design-tokens/scripts/check-token-drift.mjs
@@ -1,0 +1,374 @@
+#!/usr/bin/env node
+
+// Token drift guard: compares the canonical token JSON (tokens/**) against the
+// iOS (Theme.swift + Color+Theme.swift) and web (tailwind.config.ts +
+// globals.css) token layers, and enforces a ratchet baseline so drift can only
+// go down. The computed drift set must exactly match drift-baseline.json:
+// new drift fails ("drift increased"), fixed drift fails ("baseline stale").
+// Re-run with --update to regenerate the baseline.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(scriptDir, '..');
+const repoRoot = path.resolve(packageRoot, '..', '..');
+
+const tokensDir = path.join(packageRoot, 'tokens');
+const mapPath = path.join(packageRoot, 'token-map.json');
+const baselinePath = path.join(packageRoot, 'drift-baseline.json');
+
+const updateMode = process.argv.includes('--update');
+
+// ---------------------------------------------------------------------------
+// Canonical tokens
+// ---------------------------------------------------------------------------
+
+function normalizeHex(hex) {
+  let value = hex.trim().toLowerCase();
+  if (!value.startsWith('#')) return value;
+  value = value.slice(1);
+  if (value.length === 3) {
+    value = value
+      .split('')
+      .map((char) => char + char)
+      .join('');
+  }
+  if (value.length === 8) {
+    value = value.slice(0, 6);
+  }
+  return `#${value}`;
+}
+
+function normalizeValue(value) {
+  if (typeof value === 'number') return value;
+  if (typeof value !== 'string') return value;
+  if (/^#[0-9a-fA-F]{3,8}$/.test(value.trim())) return normalizeHex(value);
+  if (/^-?\d+(?:\.\d+)?$/.test(value.trim())) return Number(value.trim());
+  return value;
+}
+
+function walkJsonFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkJsonFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.json')) {
+      files.push(full);
+    }
+  }
+  return files.sort();
+}
+
+function flattenTokenTree(node, prefix, out) {
+  for (const [key, child] of Object.entries(node)) {
+    if (child && typeof child === 'object' && 'value' in child) {
+      out[prefix ? `${prefix}.${key}` : key] = child.value;
+    } else if (child && typeof child === 'object') {
+      flattenTokenTree(child, prefix ? `${prefix}.${key}` : key, out);
+    }
+  }
+}
+
+function loadCanonicalTokens() {
+  const raw = {};
+  for (const file of walkJsonFiles(tokensDir)) {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    flattenTokenTree(parsed, '', raw);
+  }
+
+  const resolved = {};
+  const resolving = new Set();
+
+  function resolveToken(tokenPath) {
+    if (tokenPath in resolved) return resolved[tokenPath];
+    if (!(tokenPath in raw)) {
+      throw new Error(`Unresolved token reference: {${tokenPath}}`);
+    }
+    if (resolving.has(tokenPath)) {
+      throw new Error(`Circular token reference: {${tokenPath}}`);
+    }
+    resolving.add(tokenPath);
+    let value = raw[tokenPath];
+    if (typeof value === 'string') {
+      const refMatch = value.match(/^\{(.+)\}$/);
+      if (refMatch) {
+        value = resolveToken(refMatch[1]);
+      }
+    }
+    resolving.delete(tokenPath);
+    resolved[tokenPath] = normalizeValue(value);
+    return resolved[tokenPath];
+  }
+
+  for (const tokenPath of Object.keys(raw)) {
+    resolveToken(tokenPath);
+  }
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// iOS extraction (Theme.swift + Color+Theme.swift)
+// ---------------------------------------------------------------------------
+
+function extractBlock(content, headerPattern) {
+  const start = content.search(headerPattern);
+  if (start === -1) return null;
+  const braceStart = content.indexOf('{', start);
+  let depth = 0;
+  for (let index = braceStart; index < content.length; index += 1) {
+    if (content[index] === '{') depth += 1;
+    if (content[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return content.slice(braceStart + 1, index);
+    }
+  }
+  return null;
+}
+
+function loadIosTokens() {
+  const themePath = path.join(repoRoot, 'apps/ios/LogYourBody/DesignSystem/Theme.swift');
+  const colorExtPath = path.join(repoRoot, 'apps/ios/LogYourBody/Extensions/Color+Theme.swift');
+  const theme = fs.readFileSync(themePath, 'utf8');
+  const colorExt = fs.readFileSync(colorExtPath, 'utf8');
+
+  // Named colors from Color+Theme.swift (e.g. .jovieAction, .jovieHairline)
+  const namedColors = { white: '#ffffff', black: '#000000' };
+  for (const match of colorExt.matchAll(
+    /static let (\w+) = Color\(hex: "#([0-9a-fA-F]{3,8})"\)/g,
+  )) {
+    namedColors[match[1]] = normalizeHex(`#${match[2]}`);
+  }
+  for (const match of colorExt.matchAll(/static let (\w+) = Color\.(white|black)\b/g)) {
+    namedColors[match[1]] = namedColors[match[2]];
+  }
+
+  // JovieTokens geometry constants (screenInset, cardRadius, controlRadius, ...)
+  const jovieTokens = {};
+  const jovieBlock = extractBlock(theme, /enum JovieTokens/);
+  if (jovieBlock) {
+    for (const match of jovieBlock.matchAll(
+      /static let (\w+): (?:CGFloat|Double) = (-?\d+(?:\.\d+)?)/g,
+    )) {
+      jovieTokens[match[1]] = Number(match[2]);
+    }
+  }
+
+  function parseNumericBlock(block) {
+    const values = {};
+    if (!block) return values;
+    for (const match of block.matchAll(/let (\w+): CGFloat = ([^\n]+)/g)) {
+      const expr = match[2].trim();
+      const literal = expr.match(/^(-?\d+(?:\.\d+)?)$/);
+      const jovieRef = expr.match(/^JovieTokens\.(\w+)$/);
+      if (literal) {
+        values[match[1]] = Number(literal[1]);
+      } else if (jovieRef && jovieRef[1] in jovieTokens) {
+        values[match[1]] = jovieTokens[jovieRef[1]];
+      }
+    }
+    return values;
+  }
+
+  const spacing = parseNumericBlock(extractBlock(theme, /struct SpacingTheme/));
+  const radius = parseNumericBlock(extractBlock(theme, /struct RadiusTheme/));
+
+  // Colors from the DefaultTheme ColorTheme(...) initializer
+  const colors = {};
+  const colorsStart = theme.indexOf('let colors = ColorTheme(');
+  const colorsEnd = colorsStart === -1 ? -1 : theme.indexOf('\n    )', colorsStart);
+  const colorsBlock = colorsStart === -1 || colorsEnd === -1 ? null : theme.slice(colorsStart, colorsEnd);
+  if (colorsBlock) {
+    for (const match of colorsBlock.matchAll(
+      /(\w+): Color\(hex: "#([0-9a-fA-F]{3,8})"\)/g,
+    )) {
+      colors[match[1]] = normalizeHex(`#${match[2]}`);
+    }
+    for (const match of colorsBlock.matchAll(/(\w+): \.(\w+)(?:\.opacity\([\d.]+\))?,/g)) {
+      if (!(match[1] in colors) && match[2] in namedColors) {
+        colors[match[1]] = namedColors[match[2]];
+      }
+    }
+  }
+
+  return { colors, spacing, radius };
+}
+
+// ---------------------------------------------------------------------------
+// Web extraction (tailwind.config.ts + globals.css)
+// ---------------------------------------------------------------------------
+
+function hslToHex(h, s, l) {
+  const saturation = s / 100;
+  const lightness = l / 100;
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const huePrime = (((h % 360) + 360) % 360) / 60;
+  const x = chroma * (1 - Math.abs((huePrime % 2) - 1));
+  let rgb;
+  if (huePrime < 1) rgb = [chroma, x, 0];
+  else if (huePrime < 2) rgb = [x, chroma, 0];
+  else if (huePrime < 3) rgb = [0, chroma, x];
+  else if (huePrime < 4) rgb = [0, x, chroma];
+  else if (huePrime < 5) rgb = [x, 0, chroma];
+  else rgb = [chroma, 0, x];
+  const m = lightness - chroma / 2;
+  const toHex = (channel) =>
+    Math.round((channel + m) * 255)
+      .toString(16)
+      .padStart(2, '0');
+  return `#${toHex(rgb[0])}${toHex(rgb[1])}${toHex(rgb[2])}`;
+}
+
+function loadWebTokens() {
+  const tailwindPath = path.join(repoRoot, 'apps/web/tailwind.config.ts');
+  const globalsPath = path.join(repoRoot, 'apps/web/src/app/globals.css');
+  const tailwind = fs.readFileSync(tailwindPath, 'utf8');
+  const globals = fs.readFileSync(globalsPath, 'utf8');
+
+  // Tailwind hex literals keyed by color name
+  const tailwindColors = {};
+  for (const match of tailwind.matchAll(/'([\w-]+)':\s*'#([0-9a-fA-F]{3,8})'/g)) {
+    tailwindColors[match[1]] = normalizeHex(`#${match[2]}`);
+  }
+
+  // CSS vars from the first :root block (dark mode is the default theme)
+  const rootBlock = extractBlock(globals, /:root/);
+  const cssVars = {};
+  if (rootBlock) {
+    for (const match of rootBlock.matchAll(
+      /--([\w-]+):\s*(-?[\d.]+)\s+([\d.]+)%\s+([\d.]+)%/g,
+    )) {
+      cssVars[match[1]] = hslToHex(Number(match[2]), Number(match[3]), Number(match[4]));
+    }
+    for (const match of rootBlock.matchAll(/--([\w-]+):\s*(-?[\d.]+)px/g)) {
+      cssVars[match[1]] = Number(match[2]);
+    }
+  }
+
+  return { tailwindColors, cssVars };
+}
+
+// ---------------------------------------------------------------------------
+// Comparison + baseline
+// ---------------------------------------------------------------------------
+
+function lookupIos(ios, target) {
+  const [group, key] = target.split('.');
+  return ios[group]?.[key];
+}
+
+function lookupWeb(web, target) {
+  if (target.startsWith('tailwind:')) {
+    return web.tailwindColors[target.slice('tailwind:'.length)];
+  }
+  if (target.startsWith('--')) {
+    return web.cssVars[target.slice(2)];
+  }
+  return undefined;
+}
+
+function formatValue(value) {
+  return value === undefined ? null : value;
+}
+
+function computeDrift(canonical, ios, web, map) {
+  const drift = [];
+  let comparisons = 0;
+
+  for (const [tokenPath, targets] of Object.entries(map)) {
+    if (!(tokenPath in canonical)) {
+      throw new Error(`token-map.json references unknown canonical token: ${tokenPath}`);
+    }
+    const canonicalValue = canonical[tokenPath];
+
+    const checks = [];
+    if (targets.ios) checks.push({ platform: 'ios', target: targets.ios, actual: lookupIos(ios, targets.ios) });
+    for (const webTarget of targets.web ?? []) {
+      checks.push({ platform: 'web', target: webTarget, actual: lookupWeb(web, webTarget) });
+    }
+
+    for (const check of checks) {
+      comparisons += 1;
+      if (check.actual !== canonicalValue) {
+        drift.push({
+          token: tokenPath,
+          platform: check.platform,
+          target: check.target,
+          canonical: formatValue(canonicalValue),
+          actual: formatValue(check.actual),
+        });
+      }
+    }
+  }
+
+  drift.sort((a, b) =>
+    `${a.token}|${a.platform}|${a.target}`.localeCompare(`${b.token}|${b.platform}|${b.target}`),
+  );
+  return { drift, comparisons };
+}
+
+function driftKey(entry) {
+  return `${entry.token}|${entry.platform}|${entry.target}`;
+}
+
+function formatDriftEntry(entry) {
+  return `  - [${entry.platform}] ${entry.token} (${entry.target}): canonical=${entry.canonical} actual=${entry.actual}`;
+}
+
+function main() {
+  const canonical = loadCanonicalTokens();
+  const ios = loadIosTokens();
+  const web = loadWebTokens();
+  const { map } = JSON.parse(fs.readFileSync(mapPath, 'utf8'));
+
+  const { drift, comparisons } = computeDrift(canonical, ios, web, map);
+  const mappedTokens = Object.keys(map).length;
+
+  if (updateMode) {
+    const baseline = { version: 1, drift };
+    fs.writeFileSync(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`);
+    console.log(
+      `Token drift guard: baseline updated — ${mappedTokens} mapped tokens, ${comparisons} comparisons, ${drift.length} known drifts recorded`,
+    );
+    return;
+  }
+
+  if (!fs.existsSync(baselinePath)) {
+    console.error('Token drift guard: drift-baseline.json missing. Run with --update to create it.');
+    process.exit(1);
+  }
+
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+  const baselineByKey = new Map((baseline.drift ?? []).map((entry) => [driftKey(entry), entry]));
+  const computedByKey = new Map(drift.map((entry) => [driftKey(entry), entry]));
+
+  const newDrift = drift.filter((entry) => !baselineByKey.has(driftKey(entry)));
+  const fixedDrift = (baseline.drift ?? []).filter((entry) => !computedByKey.has(driftKey(entry)));
+
+  if (newDrift.length === 0 && fixedDrift.length === 0) {
+    console.log(
+      `Token drift guard: ok — ${mappedTokens} mapped tokens, ${drift.length} known drifts (baseline)`,
+    );
+    return;
+  }
+
+  if (newDrift.length > 0) {
+    console.error('\nToken drift guard: drift increased. New mismatches not in the baseline:');
+    for (const entry of newDrift) {
+      console.error(formatDriftEntry(entry));
+    }
+    console.error('Fix the platform value to match the canonical token, or update the mapping.');
+  }
+  if (fixedDrift.length > 0) {
+    console.error('\nToken drift guard: baseline stale. These baseline drifts are now fixed:');
+    for (const entry of fixedDrift) {
+      console.error(formatDriftEntry(entry));
+    }
+    console.error('Re-run with --update to shrink the baseline.');
+  }
+  process.exit(1);
+}
+
+main();

--- a/packages/design-tokens/token-map.json
+++ b/packages/design-tokens/token-map.json
@@ -1,0 +1,74 @@
+{
+  "comment": "Maps canonical token paths (packages/design-tokens/tokens/**) to platform token targets. iOS targets live in apps/ios/LogYourBody/DesignSystem/Theme.swift (colors.* / spacing.* / radius.*). Web targets are either CSS vars in apps/web/src/app/globals.css (:root, dark default) written as \"--var\", or Tailwind colors in apps/web/tailwind.config.ts written as \"tailwind:<key>\".",
+  "map": {
+    "color.semantic.background": {
+      "ios": "colors.background",
+      "web": ["--background", "tailwind:linear-bg"]
+    },
+    "color.semantic.card": {
+      "ios": "colors.surface",
+      "web": ["--card", "tailwind:linear-card"]
+    },
+    "color.semantic.border": {
+      "ios": "colors.border",
+      "web": ["--border", "tailwind:linear-border"]
+    },
+    "color.base.purple.500": {
+      "ios": "colors.primary",
+      "web": ["--primary", "tailwind:linear-purple", "tailwind:accent-purple"]
+    },
+    "color.semantic.primary": {
+      "ios": "colors.info",
+      "web": []
+    },
+    "color.semantic.error": {
+      "ios": "colors.error",
+      "web": ["--destructive"]
+    },
+    "color.semantic.success": {
+      "ios": "colors.success",
+      "web": ["tailwind:accent-green"]
+    },
+    "color.semantic.warning": {
+      "ios": "colors.warning",
+      "web": ["tailwind:accent-orange"]
+    },
+    "color.semantic.text.primary": {
+      "ios": "colors.text",
+      "web": ["tailwind:linear-text"]
+    },
+    "color.semantic.text.secondary": {
+      "ios": "colors.textSecondary",
+      "web": ["tailwind:linear-text-secondary"]
+    },
+    "color.semantic.text.tertiary": {
+      "ios": "colors.textTertiary",
+      "web": ["tailwind:linear-text-tertiary"]
+    },
+    "spacing.xxxs": { "ios": "spacing.xxxs", "web": [] },
+    "spacing.xxs": { "ios": "spacing.xxs", "web": [] },
+    "spacing.xs": { "ios": "spacing.xs", "web": [] },
+    "spacing.sm": { "ios": "spacing.sm", "web": [] },
+    "spacing.md": { "ios": "spacing.md", "web": [] },
+    "spacing.lg": { "ios": "spacing.lg", "web": [] },
+    "spacing.xl": { "ios": "spacing.xl", "web": [] },
+    "spacing.xxl": { "ios": "spacing.xxl", "web": [] },
+    "spacing.xxxl": { "ios": "spacing.xxxl", "web": [] },
+    "spacing.semantic.element": { "ios": "spacing.elementSpacing", "web": [] },
+    "spacing.semantic.section": { "ios": "spacing.sectionSpacing", "web": [] },
+    "spacing.semantic.screen": { "ios": "spacing.screenPadding", "web": [] },
+    "spacing.semantic.card": { "ios": "spacing.cardPadding", "web": [] },
+    "spacing.semantic.listItem": { "ios": "spacing.listItemSpacing", "web": [] },
+    "radius.xs": { "ios": "radius.xs", "web": [] },
+    "radius.sm": { "ios": "radius.sm", "web": [] },
+    "radius.md": { "ios": "radius.md", "web": ["--radius"] },
+    "radius.lg": { "ios": "radius.lg", "web": [] },
+    "radius.xl": { "ios": "radius.xl", "web": [] },
+    "radius.xxl": { "ios": "radius.xxl", "web": [] },
+    "radius.full": { "ios": "radius.full", "web": [] },
+    "radius.semantic.button": { "ios": "radius.button", "web": [] },
+    "radius.semantic.card": { "ios": "radius.card", "web": [] },
+    "radius.semantic.input": { "ios": "radius.input", "web": [] },
+    "radius.semantic.chip": { "ios": "radius.chip", "web": [] }
+  }
+}


### PR DESCRIPTION
## What

Adds a design-token drift guard to `@logyourbody/design-tokens` that compares the canonical token JSON (`packages/design-tokens/tokens/**`) against the two platform token layers and enforces a ratchet baseline so drift can only go down:

- `scripts/check-token-drift.mjs` — loads + flattens + reference-resolves the canonical tokens, extracts iOS values from `Theme.swift` / `Color+Theme.swift` and web values from `tailwind.config.ts` / `globals.css` (`:root`, dark default; HSL triplets converted to hex), and compares each mapped pair.
- `token-map.json` — the mapping table: canonical path → iOS target (`colors.*` / `spacing.*` / `radius.*`) and web targets (`--css-var`, `tailwind:<key>`). Covers semantic colors, the core + semantic spacing scale, and the core + semantic radius scale. Typography/motion intentionally out of scope for v1.
- `drift-baseline.json` — the ratchet. The computed drift set must **exactly equal** the baseline: a new mismatch fails with "drift increased"; a fixed mismatch fails with "baseline stale, re-run with `--update`". `--update` regenerates the baseline.
- Wired into the package `test` script (`pnpm run validate && node scripts/check-token-drift.mjs`), so it runs under repo-wide `pnpm test` and the CI `js` job via turbo.

## Initial drift count

**30 known drifts** across 36 mapped tokens (52 platform comparisons). Highlights:

- Brand purple `#5B63D3`: iOS primary is white (`.jovieAction`), web `--primary`/`linear-purple` is `#5E6AD2`
- Background `#111111` vs iOS/web `#000000`; border `#2A2A2A` vs iOS `#2A2A2C` / web `#1A1A1A` / `#1F2023`
- Error `#F44336` vs iOS `#F3122D` / web `--destructive` `#EF4343`; success `#4CAF50` vs iOS `#2F9E44` / web `#10B981`
- Radius scale drift throughout (canonical 4/6/8/12/16/24/9999 vs iOS 2/4/12/16/48/48/48), incl. semantic button/card/input/chip
- Semantic screen spacing: canonical 16 vs iOS `screenPadding` 20 (`JovieTokens.screenInset`)
- Core spacing scale (2/4/8/12/16/24/32/48/64) matches iOS exactly — no drift, as expected

Follow-up PRs will ratchet the baseline toward 0 (align platform values to canonical, or deliberately re-map).

## Validation

- `pnpm --filter @logyourbody/design-tokens test` ✅ (validate + drift guard)
- Verified all three ratchet paths locally: clean run exits 0, new drift exits 1 ("drift increased"), stale baseline entry exits 1 ("baseline stale")
