### PR TITLE
fix: make sync:main prune squash-merged branches correctly

### DIFF
--- a/scripts/sync-main.sh
+++ b/scripts/sync-main.sh
@@ -21,14 +21,31 @@ git fetch --prune origin
 git checkout main
 git pull --ff-only origin main
 
-gone_branches="$(git branch -vv | grep ': gone]' | awk '{print $1}' | grep -v '^main$' || true)"
+# Strip the leading '*'/'+ '/' column git branch -vv adds for current/worktree
+# branches, then keep only branches whose upstream is gone.
+gone_branches="$(git branch -vv | sed -e 's/^[*+] //' | awk '/: gone]/ {print $1}' | grep -v '^main$' || true)"
 
+skipped=""
 if [ -n "$gone_branches" ]; then
-  echo "Deleting local branches with gone upstreams:"
-  echo "$gone_branches"
-  echo "$gone_branches" | xargs git branch -d
+  echo "Pruning local branches with gone upstreams:"
+  while IFS= read -r branch; do
+    # PRs squash-merge, so merged branches are not ancestors of main and
+    # `git branch -d` always refuses. `git cherry` compares patches instead:
+    # no '+' lines means every change is already in main and -D is safe.
+    if [ -z "$(git cherry main "$branch" 2>/dev/null | grep '^+' || true)" ]; then
+      echo "  deleting $branch (all changes are in main)"
+      git branch -D "$branch"
+    else
+      echo "  keeping $branch (has commits not in main)"
+      skipped="$skipped $branch"
+    fi
+  done <<< "$gone_branches"
 else
   echo "No stale local branches to delete"
+fi
+
+if [ -n "$skipped" ]; then
+  echo "WARNING: branches with work not in main were left in place:$skipped" >&2
 fi
 
 if [ "$current_branch" != "main" ] && git show-ref --verify --quiet "refs/heads/$current_branch"; then

--- a/scripts/sync-main.sh
+++ b/scripts/sync-main.sh
@@ -34,7 +34,11 @@ if [ -n "$gone_branches" ]; then
     # no '+' lines means every change is already in main and -D is safe.
     if [ -z "$(git cherry main "$branch" 2>/dev/null | grep '^+' || true)" ]; then
       echo "  deleting $branch (all changes are in main)"
-      git branch -D "$branch"
+      # A branch checked out in a linked worktree cannot be deleted; keep it.
+      if ! git branch -D "$branch" 2>/dev/null; then
+        echo "  keeping $branch (checked out in another worktree)"
+        skipped="$skipped $branch"
+      fi
     else
       echo "  keeping $branch (has commits not in main)"
       skipped="$skipped $branch"


### PR DESCRIPTION
## What

Follow-up to #508. The first dogfood run exposed three bugs in `scripts/sync-main.sh`:

1. **`git branch -d` refuses squash-merged branches** — squash merges mean local branch commits are never ancestors of `main`, so `-d` failed on every one of ~30 stale branches. Now uses `git cherry main <branch>` patch-equivalence: no `+` lines means every change is already in main and `-D` is safe.
2. **`awk '{print $1}'` picked up worktree `+` markers** from `git branch -vv` — now stripped with sed.
3. **Branches checked out in linked worktrees cannot be deleted** — the failure aborted the script under `set -e`; now warn-and-keep.

Branches with commits not in main are kept and reported as a warning (no force-delete of real work).

## Validation

- Ran the fixed script against the real pile of ~30 stale branches: correctly deleted all squash-merged ones, kept the one active in another worktree, exited 0.