### PR TITLE
feat(design-tokens): reconcile canonical tokens to shipped values (drift 30 → 10)

### DIFF
--- a/packages/design-tokens/drift-baseline.json
+++ b/packages/design-tokens/drift-baseline.json
@@ -3,121 +3,58 @@
   "drift": [
     {
       "token": "color.base.purple.500",
-      "platform": "ios",
-      "target": "colors.primary",
-      "canonical": "#5b63d3",
-      "actual": "#ffffff"
-    },
-    {
-      "token": "color.base.purple.500",
       "platform": "web",
       "target": "--primary",
-      "canonical": "#5b63d3",
+      "canonical": "#5e6ad2",
       "actual": "#626fd0"
-    },
-    {
-      "token": "color.base.purple.500",
-      "platform": "web",
-      "target": "tailwind:accent-purple",
-      "canonical": "#5b63d3",
-      "actual": "#5e6ad2"
-    },
-    {
-      "token": "color.base.purple.500",
-      "platform": "web",
-      "target": "tailwind:linear-purple",
-      "canonical": "#5b63d3",
-      "actual": "#5e6ad2"
-    },
-    {
-      "token": "color.semantic.background",
-      "platform": "ios",
-      "target": "colors.background",
-      "canonical": "#111111",
-      "actual": "#000000"
-    },
-    {
-      "token": "color.semantic.background",
-      "platform": "web",
-      "target": "--background",
-      "canonical": "#111111",
-      "actual": "#000000"
     },
     {
       "token": "color.semantic.background",
       "platform": "web",
       "target": "tailwind:linear-bg",
-      "canonical": "#111111",
+      "canonical": "#000000",
       "actual": "#0a0b0d"
-    },
-    {
-      "token": "color.semantic.border",
-      "platform": "ios",
-      "target": "colors.border",
-      "canonical": "#2a2a2a",
-      "actual": "#2a2a2c"
     },
     {
       "token": "color.semantic.border",
       "platform": "web",
       "target": "--border",
-      "canonical": "#2a2a2a",
+      "canonical": "#2a2a2c",
       "actual": "#1a1a1a"
     },
     {
       "token": "color.semantic.border",
       "platform": "web",
       "target": "tailwind:linear-border",
-      "canonical": "#2a2a2a",
+      "canonical": "#2a2a2c",
       "actual": "#1f2023"
-    },
-    {
-      "token": "color.semantic.card",
-      "platform": "ios",
-      "target": "colors.surface",
-      "canonical": "#1a1a1a",
-      "actual": "#0b0b0b"
     },
     {
       "token": "color.semantic.card",
       "platform": "web",
       "target": "--card",
-      "canonical": "#1a1a1a",
+      "canonical": "#0b0b0b",
       "actual": "#000000"
     },
     {
       "token": "color.semantic.card",
       "platform": "web",
       "target": "tailwind:linear-card",
-      "canonical": "#1a1a1a",
+      "canonical": "#0b0b0b",
       "actual": "#111113"
-    },
-    {
-      "token": "color.semantic.error",
-      "platform": "ios",
-      "target": "colors.error",
-      "canonical": "#f44336",
-      "actual": "#f3122d"
     },
     {
       "token": "color.semantic.error",
       "platform": "web",
       "target": "--destructive",
-      "canonical": "#f44336",
+      "canonical": "#f3122d",
       "actual": "#ef4343"
-    },
-    {
-      "token": "color.semantic.success",
-      "platform": "ios",
-      "target": "colors.success",
-      "canonical": "#4caf50",
-      "actual": "#2f9e44"
     },
     {
       "token": "color.semantic.success",
       "platform": "web",
       "target": "tailwind:accent-green",
-      "canonical": "#4caf50",
+      "canonical": "#2f9e44",
       "actual": "#10b981"
     },
     {
@@ -128,88 +65,11 @@
       "actual": "#f97316"
     },
     {
-      "token": "radius.full",
-      "platform": "ios",
-      "target": "radius.full",
-      "canonical": 9999,
-      "actual": 48
-    },
-    {
-      "token": "radius.lg",
-      "platform": "ios",
-      "target": "radius.lg",
-      "canonical": 12,
-      "actual": 16
-    },
-    {
       "token": "radius.md",
-      "platform": "ios",
-      "target": "radius.md",
-      "canonical": 8,
-      "actual": 12
-    },
-    {
-      "token": "radius.semantic.button",
-      "platform": "ios",
-      "target": "radius.button",
+      "platform": "web",
+      "target": "--radius",
       "canonical": 12,
-      "actual": 48
-    },
-    {
-      "token": "radius.semantic.card",
-      "platform": "ios",
-      "target": "radius.card",
-      "canonical": 12,
-      "actual": 20
-    },
-    {
-      "token": "radius.semantic.chip",
-      "platform": "ios",
-      "target": "radius.chip",
-      "canonical": 16,
-      "actual": 48
-    },
-    {
-      "token": "radius.semantic.input",
-      "platform": "ios",
-      "target": "radius.input",
-      "canonical": 8,
-      "actual": 16
-    },
-    {
-      "token": "radius.sm",
-      "platform": "ios",
-      "target": "radius.sm",
-      "canonical": 6,
-      "actual": 4
-    },
-    {
-      "token": "radius.xl",
-      "platform": "ios",
-      "target": "radius.xl",
-      "canonical": 16,
-      "actual": 48
-    },
-    {
-      "token": "radius.xs",
-      "platform": "ios",
-      "target": "radius.xs",
-      "canonical": 4,
-      "actual": 2
-    },
-    {
-      "token": "radius.xxl",
-      "platform": "ios",
-      "target": "radius.xxl",
-      "canonical": 24,
-      "actual": 48
-    },
-    {
-      "token": "spacing.semantic.screen",
-      "platform": "ios",
-      "target": "spacing.screenPadding",
-      "canonical": 16,
-      "actual": 20
+      "actual": 8
     }
   ]
 }

--- a/packages/design-tokens/token-map.json
+++ b/packages/design-tokens/token-map.json
@@ -14,8 +14,12 @@
       "web": ["--border", "tailwind:linear-border"]
     },
     "color.base.purple.500": {
-      "ios": "colors.primary",
+      "ios": "",
       "web": ["--primary", "tailwind:linear-purple", "tailwind:accent-purple"]
+    },
+    "color.semantic.action": {
+      "ios": "colors.primary",
+      "web": []
     },
     "color.semantic.primary": {
       "ios": "colors.info",
@@ -65,7 +69,6 @@
     "radius.lg": { "ios": "radius.lg", "web": [] },
     "radius.xl": { "ios": "radius.xl", "web": [] },
     "radius.xxl": { "ios": "radius.xxl", "web": [] },
-    "radius.full": { "ios": "radius.full", "web": [] },
     "radius.semantic.button": { "ios": "radius.button", "web": [] },
     "radius.semantic.card": { "ios": "radius.card", "web": [] },
     "radius.semantic.input": { "ios": "radius.input", "web": [] },

--- a/packages/design-tokens/tokens/core/colors.json
+++ b/packages/design-tokens/tokens/core/colors.json
@@ -48,8 +48,8 @@
           "value": "#6B73DD"
         },
         "500": {
-          "value": "#5B63D3",
-          "comment": "Primary brand purple"
+          "value": "#5E6AD2",
+          "comment": "Primary brand purple (as shipped on web)"
         },
         "600": {
           "value": "#4B52C3",
@@ -99,16 +99,20 @@
     },
     "semantic": {
       "background": {
-        "value": "#111111",
-        "comment": "Premium near-black background"
+        "value": "#000000",
+        "comment": "Premium true-black background (as shipped)"
       },
       "card": {
-        "value": "#1A1A1A",
-        "comment": "Card background (slightly lighter)"
+        "value": "#0B0B0B",
+        "comment": "Card background, slightly lighter (as shipped on iOS)"
       },
       "border": {
-        "value": "#2A2A2A",
-        "comment": "Subtle border color"
+        "value": "#2A2A2C",
+        "comment": "Subtle hairline border color (as shipped on iOS)"
+      },
+      "action": {
+        "value": "#FFFFFF",
+        "comment": "Primary action foreground (white-on-black action pair, as shipped on iOS)"
       },
       "primary": {
         "value": "{color.base.blue.500}",
@@ -118,13 +122,15 @@
         "value": "{color.base.blue.600}"
       },
       "error": {
-        "value": "{color.base.red.500}"
+        "value": "#F3122D",
+        "comment": "Error red (as shipped on iOS)"
       },
       "errorHover": {
         "value": "{color.base.red.600}"
       },
       "success": {
-        "value": "{color.base.green.500}"
+        "value": "#2F9E44",
+        "comment": "Success green (as shipped on iOS)"
       },
       "successHover": {
         "value": "{color.base.green.600}"

--- a/packages/design-tokens/tokens/core/radii.json
+++ b/packages/design-tokens/tokens/core/radii.json
@@ -1,28 +1,28 @@
 {
   "radius": {
     "xs": {
-      "value": "4",
-      "comment": "Extra small corner radius - 4px"
+      "value": "2",
+      "comment": "Extra small corner radius - 2px"
     },
     "sm": {
-      "value": "6",
-      "comment": "Small corner radius - 6px"
+      "value": "4",
+      "comment": "Small corner radius - 4px"
     },
     "md": {
-      "value": "8",
-      "comment": "Medium corner radius - 8px"
+      "value": "12",
+      "comment": "Medium corner radius - 12px"
     },
     "lg": {
-      "value": "12",
-      "comment": "Large corner radius - 12px"
+      "value": "16",
+      "comment": "Large corner radius - 16px"
     },
     "xl": {
-      "value": "16",
-      "comment": "Extra large corner radius - 16px"
+      "value": "48",
+      "comment": "Extra large corner radius - 48px (pill on standard control height)"
     },
     "xxl": {
-      "value": "24",
-      "comment": "Extra extra large corner radius - 24px"
+      "value": "48",
+      "comment": "Extra extra large corner radius - 48px"
     },
     "full": {
       "value": "9999",
@@ -30,15 +30,15 @@
     },
     "semantic": {
       "button": {
-        "value": "{radius.lg}",
-        "comment": "Standard button radius"
+        "value": "{radius.xl}",
+        "comment": "Standard button radius (pill)"
       },
       "card": {
-        "value": "{radius.lg}",
-        "comment": "Card corner radius"
+        "value": "20",
+        "comment": "Card corner radius (as shipped on iOS)"
       },
       "input": {
-        "value": "{radius.md}",
+        "value": "{radius.lg}",
         "comment": "Input field radius"
       },
       "chip": {

--- a/packages/design-tokens/tokens/core/spacing.json
+++ b/packages/design-tokens/tokens/core/spacing.json
@@ -46,8 +46,8 @@
         "comment": "Section spacing"
       },
       "screen": {
-        "value": "{spacing.md}",
-        "comment": "Screen edge padding"
+        "value": "20",
+        "comment": "Screen edge padding (as shipped on iOS)"
       },
       "card": {
         "value": "{spacing.md}",


### PR DESCRIPTION
## What

Ratchet PR 1 for design-token drift (guard from #509). The canonical JSON in `packages/design-tokens/tokens/` had drifted from the values that actually ship in the iOS Theme and web layers. Since the generated build outputs are not consumed by either app yet, this PR updates **only the canonical layer** to match shipped reality — zero visual change on any surface.

- **colors**: background `#000000`, card `#0B0B0B`, border `#2A2A2C`, error `#F3122D`, success `#2F9E44`, purple.500 `#5E6AD2`; new `color.semantic.action` (white action foreground) — iOS `colors.primary` is the intentional white-on-black action pair, remapped from purple.500 to it
- **spacing**: semantic.screen `20` (iOS `screenInset`)
- **radii**: core scale to iOS values (2/4/12/16/48/48); semantic button/chip pill 48, card 20, input 16
- **token-map**: dropped `radius.full` (9999px pill vs 48pt capsule is the same semantic in different units, not drift)

## Result

`Token drift guard: ok — 36 mapped tokens, 10 known drifts (baseline)` (was 30).

The remaining 10 are all web-layer values (`--border`, `--card`, `--destructive`, `--primary` HSL rounding, `--radius`, tailwind `linear-*`/`accent-*`); a follow-up PR aligns the web layer to canonical to reach 0.

## Validation

- `pnpm --filter @logyourbody/design-tokens test` passes (validate + drift guard)
- Ratchet semantics verified: baseline regenerated with `--update` in this PR