### PR TITLE
fix: detect multi-commit squash merges in sync:main prune

### DIFF
--- a/scripts/sync-main.sh
+++ b/scripts/sync-main.sh
@@ -30,9 +30,13 @@ if [ -n "$gone_branches" ]; then
   echo "Pruning local branches with gone upstreams:"
   while IFS= read -r branch; do
     # PRs squash-merge, so merged branches are not ancestors of main and
-    # `git branch -d` always refuses. `git cherry` compares patches instead:
-    # no '+' lines means every change is already in main and -D is safe.
-    if [ -z "$(git cherry main "$branch" 2>/dev/null | grep '^+' || true)" ]; then
+    # `git branch -d` always refuses. Simulate merging the branch into main:
+    # if the resulting tree equals main's tree, every change is already in
+    # main and -D is safe. This works for multi-commit branches too (unlike
+    # git cherry, which compares per-commit patch-ids). Conflicts or errors
+    # mean "keep".
+    merged_tree="$(git merge-tree --write-tree main "$branch" 2>/dev/null || true)"
+    if [ -n "$merged_tree" ] && [ "$merged_tree" = "$(git rev-parse 'main^{tree}')" ]; then
       echo "  deleting $branch (all changes are in main)"
       # A branch checked out in a linked worktree cannot be deleted; keep it.
       if ! git branch -D "$branch" 2>/dev/null; then
@@ -40,7 +44,7 @@ if [ -n "$gone_branches" ]; then
         skipped="$skipped $branch"
       fi
     else
-      echo "  keeping $branch (has commits not in main)"
+      echo "  keeping $branch (has changes not in main)"
       skipped="$skipped $branch"
     fi
   done <<< "$gone_branches"


### PR DESCRIPTION
## What

Third and final `sync:main` correctness fix. `git cherry` compares per-commit patch-ids, so any branch with 2+ commits that was squash-merged into a single commit on main was never pruned (e.g. `feat/drift-registry-extensions` from #507).

Now simulates the merge with `git merge-tree --write-tree main <branch>`: if the resulting tree equals main's tree, all branch content is provably in main and deletion is safe. Conflicts/errors keep the branch (conservative).

## Validation

Ran against the real stale-branch pile: correctly pruned the multi-commit squash-merged branches the previous version kept (`feat/drift-registry-extensions`, `fix/sync-main-squash-branches`, `feat/url-registry-consumers`, `feat/ios-auth-tests`, `feat/ios-onboarding-uitest`), kept genuinely unmerged branches and the branch checked out in another worktree.