### PR TITLE
fix(legal): sync iOS docs with canonical copies

### DIFF
--- a/apps/ios/LogYourBody/Resources/Legal/ccpa-compliance.md
+++ b/apps/ios/LogYourBody/Resources/Legal/ccpa-compliance.md
@@ -175,7 +175,7 @@ Sensitive information we collect:
 
 - **Supabase**: Database and authentication
 - **AWS**: Cloud infrastructure
-- **Jovie Better Auth**: Authentication services
+- **Clerk**: Authentication services
 - **RevenueCat**: Subscription and purchase entitlements
 - **Sentry**: Error tracking and crash reports
 

--- a/apps/ios/LogYourBody/Resources/Legal/open-source-licenses.md
+++ b/apps/ios/LogYourBody/Resources/Legal/open-source-licenses.md
@@ -45,6 +45,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+#### **Clerk iOS SDK**
+
+- **License:** MIT License
+- **Copyright:** © 2024 Clerk Inc.
+- **Repository:** https://github.com/clerk/clerk-ios
+- **Usage:** User authentication and session management
+
 #### **Factory**
 
 - **License:** MIT License
@@ -124,6 +131,13 @@ SOFTWARE.
 - **Copyright:** © 2024 Supabase
 - **Repository:** https://github.com/supabase/supabase-js
 - **Usage:** Database and authentication client
+
+#### **Clerk React**
+
+- **License:** MIT License
+- **Copyright:** © 2024 Clerk Inc.
+- **Repository:** https://github.com/clerk/javascript
+- **Usage:** Authentication components
 
 ---
 

--- a/apps/ios/LogYourBody/Resources/Legal/privacy-policy.md
+++ b/apps/ios/LogYourBody/Resources/Legal/privacy-policy.md
@@ -71,7 +71,7 @@ We use the information we collect to:
 - HTTPS/TLS encryption for all data transmission
 - Regular security audits and updates
 - Limited access to personal data (need-to-know basis)
-- Secure authentication via Jovie Better Auth
+- Secure authentication via Clerk
 
 ### Data Retention
 
@@ -85,7 +85,7 @@ We do not sell, trade, or rent your personal information. We may share your info
 
 1. **With Your Consent**: When you explicitly agree to share
 2. **Service Providers**: Third-party services that help operate our Service:
-   - Jovie Better Auth (authentication)
+   - Clerk (authentication)
    - Supabase (database hosting)
    - Neon (waitlist database hosting)
    - Vercel (web hosting)


### PR DESCRIPTION
## Summary
- Sync the three stale iOS legal-document copies from `shared/legal`.
- Preserve the existing byte-identical legal-docs guard; no guard or dependency changes.

## Root cause
`ccpa-compliance.md`, `open-source-licenses.md`, and `privacy-policy.md` in the iOS bundle lagged behind canonical `shared/legal` after the authentication provider/license metadata changed to Clerk.

## Verification
- `corepack pnpm --filter @jovieinc/product-registry test`
- `node packages/product-registry/scripts/legal-docs-sync.test.mjs`
- `git diff --check`

Closes no issue; this is a bounded prerequisite fix for dependency PRs #519 and #516.