### PR TITLE
fix(security): complete account erasure and redact telemetry

### DIFF
--- a/apps/ios/LogYourBody/Services/ErrorTrackingService.swift
+++ b/apps/ios/LogYourBody/Services/ErrorTrackingService.swift
@@ -50,23 +50,30 @@ final class ErrorTrackingService {
         if let screen = context.screen {
             vendor.setTag(value: screen, key: "screen")
         }
-        if let userId = context.userId {
-            vendor.setTag(value: userId, key: "userId")
+        if context.userId != nil {
+            vendor.setTag(value: ErrorTrackingRedactor.filteredValue, key: "userId")
         }
 
         let description = String(describing: appError)
-        vendor.setExtra(value: description, key: "appError")
+        vendor.setExtra(value: ErrorTrackingRedactor.sanitize(description), key: "appError")
 
         vendor.capture(error: appError)
     }
 
     func addBreadcrumb(message: String, category: String, level: BreadcrumbLevel = .info, data: [String: String]? = nil) {
-        vendor.addBreadcrumb(level: level, category: category, message: message, data: data)
+        vendor.addBreadcrumb(
+            level: level,
+            category: category,
+            message: ErrorTrackingRedactor.sanitize(message),
+            data: data?.reduce(into: [String: String]()) { result, entry in
+                result[entry.key] = ErrorTrackingRedactor.sanitize(entry.value, key: entry.key)
+            }
+        )
     }
 
     func updateUserId(_ userId: String?) {
         if let userId = userId, !userId.isEmpty {
-            vendor.setTag(value: userId, key: "userId")
+            vendor.setTag(value: ErrorTrackingRedactor.filteredValue, key: "userId")
         } else {
             vendor.setTag(value: "none", key: "userId")
         }
@@ -86,6 +93,13 @@ private final class SentryErrorTrackingVendor: ErrorTrackingVendor {
         SentrySDK.start { options in
             options.dsn = dsn
             options.environment = Configuration.sentryEnvironment
+            options.sendDefaultPii = false
+            options.beforeSend = { event in
+                ErrorTrackingRedactor.redact(event: event)
+            }
+            options.beforeBreadcrumb = { breadcrumb in
+                ErrorTrackingRedactor.redact(breadcrumb: breadcrumb)
+            }
 
             let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
             let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
@@ -152,4 +166,51 @@ private final class SentryErrorTrackingVendor: ErrorTrackingVendor {
         SentrySDK.addBreadcrumb(breadcrumb)
         #endif
     }
+}
+
+enum ErrorTrackingRedactor {
+    static let filteredValue = "[Filtered]"
+
+    private static let sensitiveKeys = [
+        "email", "user", "userid", "user_id", "health", "weight", "height",
+        "body_fat", "bmi", "glp1", "dose", "medication", "dexa", "metric",
+        "photo", "token", "authorization", "phone", "name", "profile"
+    ]
+
+    private static let emailPattern = #"(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"#
+    private static let uuidPattern = #"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b"#
+
+    static func sanitize(_ value: String, key: String? = nil) -> String {
+        if let key, sensitiveKeys.contains(where: { key.lowercased().contains($0) }) {
+            return filteredValue
+        }
+        if value.range(of: emailPattern, options: .regularExpression) != nil ||
+            value.range(of: uuidPattern, options: .regularExpression) != nil {
+            return filteredValue
+        }
+        return value
+    }
+
+    #if canImport(Sentry)
+    static func redact(event: Event) -> Event? {
+        event.extra = event.extra?.reduce(into: [String: Any]()) { result, entry in
+            result[entry.key] = sanitize(String(describing: entry.value), key: entry.key)
+        }
+        event.tags = event.tags?.reduce(into: [String: String]()) { result, entry in
+            result[entry.key] = sanitize(entry.value, key: entry.key)
+        }
+        event.message = event.message.map { sanitize($0) }
+        event.user = nil
+        event.breadcrumbs = event.breadcrumbs?.compactMap { redact(breadcrumb: $0) }
+        return event
+    }
+
+    static func redact(breadcrumb: Breadcrumb) -> Breadcrumb? {
+        breadcrumb.message = breadcrumb.message.map { sanitize($0) }
+        breadcrumb.data = breadcrumb.data?.reduce(into: [String: Any]()) { result, entry in
+            result[entry.key] = sanitize(String(describing: entry.value), key: entry.key)
+        }
+        return breadcrumb
+    }
+    #endif
 }

--- a/apps/ios/LogYourBody/Services/ErrorTrackingService.swift
+++ b/apps/ios/LogYourBody/Services/ErrorTrackingService.swift
@@ -199,7 +199,7 @@ enum ErrorTrackingRedactor {
         event.tags = event.tags?.reduce(into: [String: String]()) { result, entry in
             result[entry.key] = sanitize(entry.value, key: entry.key)
         }
-        event.message = event.message.map { sanitize($0) }
+        event.message = event.message.map { SentryMessage(formatted: sanitize($0.formatted)) }
         event.user = nil
         event.breadcrumbs = event.breadcrumbs?.compactMap { redact(breadcrumb: $0) }
         return event

--- a/apps/ios/LogYourBodyTests/ErrorTrackingServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/ErrorTrackingServiceTests.swift
@@ -109,7 +109,7 @@ final class ErrorTrackingServiceTests: XCTestCase {
             message: "upload failed",
             category: "photos",
             level: .error,
-            data: ["photo_id": "[Filtered]"]
+            data: ["photo_id": "abc"]
         )
 
         XCTAssertEqual(vendor.breadcrumbLevels, [.error])

--- a/apps/ios/LogYourBodyTests/ErrorTrackingServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/ErrorTrackingServiceTests.swift
@@ -79,7 +79,7 @@ final class ErrorTrackingServiceTests: XCTestCase {
         XCTAssertEqual(tagValues(vendor, forKey: "feature"), ["sync"])
         XCTAssertEqual(tagValues(vendor, forKey: "operation"), ["push"])
         XCTAssertEqual(tagValues(vendor, forKey: "screen"), ["dashboard"])
-        XCTAssertEqual(tagValues(vendor, forKey: "userId"), ["user-1"])
+        XCTAssertEqual(tagValues(vendor, forKey: "userId"), ["[Filtered]"])
         XCTAssertEqual(vendor.extras.count, 1)
         XCTAssertEqual(vendor.extras.first?.key, "appError")
         XCTAssertEqual(vendor.extras.first?.value, String(describing: appError))
@@ -109,7 +109,7 @@ final class ErrorTrackingServiceTests: XCTestCase {
             message: "upload failed",
             category: "photos",
             level: .error,
-            data: ["photo_id": "abc"]
+            data: ["photo_id": "[Filtered]"]
         )
 
         XCTAssertEqual(vendor.breadcrumbLevels, [.error])
@@ -132,7 +132,7 @@ final class ErrorTrackingServiceTests: XCTestCase {
 
         service.updateUserId("user-9")
 
-        XCTAssertEqual(tagValues(vendor, forKey: "userId"), ["user-9"])
+        XCTAssertEqual(tagValues(vendor, forKey: "userId"), ["[Filtered]"])
     }
 
     func testUpdateUserIdFallsBackToNoneForNilOrEmpty() {
@@ -142,5 +142,20 @@ final class ErrorTrackingServiceTests: XCTestCase {
         service.updateUserId("")
 
         XCTAssertEqual(tagValues(vendor, forKey: "userId"), ["none", "none"])
+    }
+
+    func testRedactorFiltersEmailHealthValuesAndIdentifiers() {
+        XCTAssertEqual(
+            ErrorTrackingRedactor.sanitize("tim@example.com"),
+            ErrorTrackingRedactor.filteredValue
+        )
+        XCTAssertEqual(
+            ErrorTrackingRedactor.sanitize("72.5", key: "weight_kg"),
+            ErrorTrackingRedactor.filteredValue
+        )
+        XCTAssertEqual(
+            ErrorTrackingRedactor.sanitize("user-123", key: "user_id"),
+            ErrorTrackingRedactor.filteredValue
+        )
     }
 }

--- a/apps/ios/LogYourBodyTests/ErrorTrackingServiceTests.swift
+++ b/apps/ios/LogYourBodyTests/ErrorTrackingServiceTests.swift
@@ -115,7 +115,7 @@ final class ErrorTrackingServiceTests: XCTestCase {
         XCTAssertEqual(vendor.breadcrumbLevels, [.error])
         XCTAssertEqual(vendor.breadcrumbCategories, ["photos"])
         XCTAssertEqual(vendor.breadcrumbMessages, ["upload failed"])
-        XCTAssertEqual(try XCTUnwrap(vendor.breadcrumbData.first), ["photo_id": "abc"])
+        XCTAssertEqual(try XCTUnwrap(vendor.breadcrumbData.first), ["photo_id": "[Filtered]"])
     }
 
     func testAddBreadcrumbDefaultsToInfoLevelWithNoData() throws {

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -12,6 +12,10 @@ WAITLIST_DATABASE_URL=postgresql://user:password@host/neondb?sslmode=require
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
 
+# Server-only Supabase service role. Required for exact-user health-data erasure on account deletion.
+# Never expose to the browser.
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+
 # Optional: Version (auto-populated in CI)
 NEXT_PUBLIC_VERSION=local-dev
 

--- a/apps/web/src/app/api/auth/delete-account/__tests__/route.node.test.ts
+++ b/apps/web/src/app/api/auth/delete-account/__tests__/route.node.test.ts
@@ -4,12 +4,16 @@
 import { DELETE } from '../route';
 import { neonUserDirectory } from '@/lib/neon/user-directory-adapter';
 import { getServerAuthSession } from '@/lib/ports/server-auth-runtime';
+import { deleteUserHealthData } from '@/lib/supabase/account-deletion';
 
 jest.mock('@/lib/ports/server-auth-runtime', () => ({
   getServerAuthSession: jest.fn(),
 }));
 jest.mock('@/lib/neon/user-directory-adapter', () => ({
   neonUserDirectory: { deleteUser: jest.fn() },
+}));
+jest.mock('@/lib/supabase/account-deletion', () => ({
+  deleteUserHealthData: jest.fn(),
 }));
 
 describe('DELETE /api/auth/delete-account', () => {
@@ -33,11 +37,31 @@ describe('DELETE /api/auth/delete-account', () => {
     expect(neonUserDirectory.deleteUser).toHaveBeenCalledWith('user_123');
   });
 
+  it('deletes health data before removing the product principal', async () => {
+    const response = await DELETE();
+
+    expect(response.status).toBe(200);
+    expect(deleteUserHealthData).toHaveBeenCalledWith('user_123');
+    expect(neonUserDirectory.deleteUser).toHaveBeenCalledWith('user_123');
+    expect(jest.mocked(deleteUserHealthData).mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(neonUserDirectory.deleteUser).mock.invocationCallOrder[0],
+    );
+  });
+
   it('fails closed when Neon cannot complete deletion', async () => {
     jest.mocked(neonUserDirectory.deleteUser).mockRejectedValue(new Error('database unavailable'));
 
     const response = await DELETE();
 
     expect(response.status).toBe(500);
+  });
+
+  it('fails closed when health-data deletion cannot complete', async () => {
+    jest.mocked(deleteUserHealthData).mockRejectedValue(new Error('database unavailable'));
+
+    const response = await DELETE();
+
+    expect(response.status).toBe(500);
+    expect(neonUserDirectory.deleteUser).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/auth/delete-account/route.ts
+++ b/apps/web/src/app/api/auth/delete-account/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from 'next/server';
 import { neonUserDirectory } from '@/lib/neon/user-directory-adapter';
 import { getServerAuthSession } from '@/lib/ports/server-auth-runtime';
+import { deleteUserHealthData } from '@/lib/supabase/account-deletion';
 
 export async function DELETE() {
   try {
     const { userId } = await getServerAuthSession();
     if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    await deleteUserHealthData(userId);
     await neonUserDirectory.deleteUser(userId);
     return NextResponse.json({ message: 'Account deleted successfully' }, { status: 200 });
   } catch (error) {

--- a/apps/web/src/lib/supabase/account-deletion.ts
+++ b/apps/web/src/lib/supabase/account-deletion.ts
@@ -1,0 +1,43 @@
+import 'server-only';
+
+import { createClient } from '@supabase/supabase-js';
+
+/**
+ * Every table in the Supabase health-data schema that is owned by one account.
+ * Keep this list in dependency-safe order and update the migration guard test
+ * whenever a new user-owned table is added.
+ */
+export const accountDeletionTargets = [
+  { table: 'data_exports', column: 'user_id' },
+  { table: 'progress_photos', column: 'user_id' },
+  { table: 'dexa_results', column: 'user_id' },
+  { table: 'glp1_dose_logs', column: 'user_id' },
+  { table: 'glp1_medications', column: 'user_id' },
+  { table: 'daily_metrics', column: 'user_id' },
+  { table: 'body_metrics', column: 'user_id' },
+  { table: 'email_subscriptions', column: 'user_id' },
+  { table: 'profiles', column: 'id' },
+] as const;
+
+export async function deleteUserHealthData(userId: string): Promise<void> {
+  if (!userId.trim()) throw new Error('Cannot delete health data without a user id');
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceRoleKey) {
+    throw new Error('Supabase account-deletion service is not configured');
+  }
+
+  // This module is server-only. The service role is used only for this
+  // authenticated, exact-user deletion chain; clients never receive it.
+  const supabase = createClient(url, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  for (const target of accountDeletionTargets) {
+    const { error } = await supabase.from(target.table).delete().eq(target.column, userId);
+    if (error) {
+      throw new Error(`Failed to delete ${target.table}: ${error.message}`);
+    }
+  }
+}

--- a/packages/shared-lib/src/asc-key-fixture-secret-scan.test.ts
+++ b/packages/shared-lib/src/asc-key-fixture-secret-scan.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const fixturePath = new URL('../../../scripts/test-asc-json.sh', import.meta.url);
+
+describe('App Store Connect fixture secret guard', () => {
+  it('contains only an explicitly fake, non-parseable key value', () => {
+    const source = readFileSync(fixturePath, 'utf8');
+
+    expect(source).toContain('NOT_A_REAL_PRIVATE_KEY_FIXTURE');
+    expect(source).not.toMatch(/BEGIN (?:EC )?PRIVATE KEY/);
+    expect(source).not.toMatch(/-----[A-Z ]+-----/);
+  });
+});

--- a/scripts/test-asc-json.sh
+++ b/scripts/test-asc-json.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+set -euo pipefail
+
 echo "Testing ASC API Key JSON format..."
 
-# Create a test JSON file
+# This fixture intentionally uses a non-parseable placeholder. Real ASC keys
+# must only be supplied through CI/local secret storage.
 cat > test_asc.json << 'EOF'
-{"key_id":"A76CPV6UUL","issuer_id":"c195f569-ff16-40fa-aaff-4fe94e8139ad","key":"-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgX+9p5JYj1dqGLqLr\n8CB3UlnMs0BBi+qw8pDl0gLlNcigCgYIKoZIzj0DAQehRANCAATn8smgverE5wVl\nqLjMUKyabZRClj0dBSmWYRhZLlNRKDOT0K7joMOyBahlJts1oA6rZLATULdmr3BM\ndPqjz5sV\n-----END PRIVATE KEY-----","in_house":false}
+{"key_id":"TEST_KEY_ID","issuer_id":"00000000-0000-0000-0000-000000000000","key":"NOT_A_REAL_PRIVATE_KEY_FIXTURE","in_house":false}
 EOF
 
 # Check if JSON is valid
@@ -17,9 +20,10 @@ if jq . test_asc.json > /dev/null 2>&1; then
     echo "issuer_id: $(jq -r .issuer_id test_asc.json)"
     echo "in_house: $(jq -r .in_house test_asc.json)"
     echo ""
-    echo "Key (first 50 chars): $(jq -r .key test_asc.json | head -c 50)..."
+    echo "Key fixture is intentionally not a PEM/private key."
 else
     echo "❌ JSON is invalid"
+    exit 1
 fi
 
 # Test with ruby (what Fastlane uses)
@@ -27,14 +31,10 @@ echo ""
 echo "Testing with Ruby (Fastlane's language)..."
 ruby -e "
 require 'json'
-begin
-  data = JSON.parse(File.read('test_asc.json'))
-  puts '✅ Ruby can parse the JSON'
-  puts \"key_id: #{data['key_id']}\"
-  puts \"issuer_id: #{data['issuer_id']}\"
-rescue => e
-  puts '❌ Ruby error: ' + e.message
-end
+data = JSON.parse(File.read('test_asc.json'))
+puts '✅ Ruby can parse the JSON'
+puts \"key_id: #{data['key_id']}\"
+puts \"issuer_id: #{data['issuer_id']}\"
 "
 
 rm -f test_asc.json


### PR DESCRIPTION
## Summary
- Replace the tracked App Store Connect test fixture with an explicitly fake, non-parseable key and add a regression secret-scan test.
- Route web account deletion through a server-only, exact-user health-data deletion chain before removing the product principal. The existing iOS deletion flow already calls this canonical product-account endpoint, so both platforms now share the server-side path.
- Add iOS Sentry `beforeSend`/`beforeBreadcrumb` redaction, disable default PII, and redact user IDs, emails, identifiers, and health-adjacent values in app-level context and breadcrumbs.

## Privacy / safety
- No production data deletion was executed.
- RLS policies and user-scoped predicates are preserved; the web service-role client is server-only and used solely for the authenticated deletion chain.
- Apple credentials were not revoked or changed.

## Test plan
- `bash scripts/test-asc-json.sh`
- `pnpm --filter @logyourbody/shared-lib test -- asc-key-fixture-secret-scan delete-user-assets-account-deletion` (passed before dependency cleanup)
- `pnpm --filter @logyourbody/shared-lib typecheck` (passed)
- `pnpm --filter logyourbody exec jest src/app/api/auth/delete-account/__tests__/route.node.test.ts --runInBand` (passed before dependency cleanup)
- `swiftlint lint --strict apps/ios/LogYourBody/Services/ErrorTrackingService.swift` (passed)

## Known environment limits
- Full iOS `xcodebuild test` timed out during package graph resolution.
- A later rerun after cleanup could not run Jest/Vitest because the temporary checkout was disk-cleaned after the first successful targeted runs; the recorded successful runs above were on this commit's working tree before cleanup.
- Full web typecheck remains blocked by pre-existing workspace package-registry generation/type errors and Node 22 vs repository Node 20 engine mismatch.
