### PR TITLE
feat: establish closed-loop App Store storefront foundation

### DIFF
--- a/.github/scripts/validate-release-source.sh
+++ b/.github/scripts/validate-release-source.sh
@@ -34,6 +34,13 @@ if [ "$RELEASE_TYPE" = "app_store" ] && [ "$REF_NAME" != "main" ]; then
   fail "App Store releases must run from main."
 fi
 
+if ! command -v node >/dev/null 2>&1; then
+  fail "Node.js is required to validate the App Store storefront."
+fi
+
+echo "Validating generated App Store storefront..."
+node packages/product-registry/scripts/storefront.test.mjs
+
 STATUS_STATE="$(gh api "repos/$REPO/commits/$SHA/status" --jq '.state')"
 case "$STATUS_STATE" in
   success)

--- a/apps/ios/fastlane/metadata/en-US/keywords.txt
+++ b/apps/ios/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-progress photos,body composition,weight tracker,body fat,fitness tracker,health log
+progress,photos,composition,fat,lean,mass,private,timeline,ffmi,tracker,measurements,recomposition

--- a/apps/ios/fastlane/storefront-manifest.generated.json
+++ b/apps/ios/fastlane/storefront-manifest.generated.json
@@ -1,0 +1,262 @@
+{
+  "generatedBy": "packages/product-registry/scripts/generate-storefront.mjs",
+  "schemaVersion": 1,
+  "productId": "logyourbody",
+  "platform": "ios",
+  "defaultLocale": "en-US",
+  "metadataLimits": {
+    "nameCharacters": 30,
+    "subtitleCharacters": 30,
+    "promotionalTextCharacters": 170,
+    "descriptionCharacters": 4000,
+    "releaseNotesCharacters": 4000,
+    "keywordsBytes": 100
+  },
+  "locales": [
+    {
+      "id": "en-US",
+      "metadata": {
+        "name": "LogYourBody",
+        "subtitle": "Weight and body metrics",
+        "keywords": "progress,photos,composition,fat,lean,mass,private,timeline,ffmi,tracker,measurements,recomposition",
+        "promotionalText": "Track progress photos, weight, body fat, and Apple Health context from a private photo-first timeline.",
+        "description": "LogYourBody is a focused body-composition tracker for people who want a private progress-photo timeline with weight, body-fat, and Apple Health context.\n\nStart with the essentials:\n\n- Add progress photos to a swipeable body timeline\n- Log weight and body-fat context in pounds or kilograms\n- Review Stats for weight, body fat, FFMI, and steps\n- Optionally connect Apple Health for weight, body-fat, height, and step context\n- Sync entries to your account\n- Export your account data\n- Keep access managed through LogYourBody Pro\n\nLogYourBody is built for consistent body-composition tracking without noisy coaching. Your photos and entries stay available on device and sync to your account when you are signed in.\n\nLogYourBody is not a medical device and does not provide medical advice. Use it for personal fitness tracking and consult a qualified professional for medical decisions.",
+        "releaseNotes": "Photo-first MVP release with paid access, progress-photo timeline, weight and body-fat logging, optional HealthKit context, account sync, restore purchases, data export, and account deletion.",
+        "supportUrl": "https://logyourbody.com/support",
+        "marketingUrl": "https://logyourbody.com",
+        "privacyUrl": "https://logyourbody.com/privacy"
+      }
+    }
+  ],
+  "searchIntents": [
+    {
+      "id": "private-progress",
+      "label": "Private progress photos",
+      "audience": "People who want visual progress without a social feed.",
+      "priority": 1,
+      "terms": [
+        "progress photos",
+        "photo tracker",
+        "private timeline"
+      ],
+      "featureIds": [
+        "progress-photos",
+        "private-timeline"
+      ],
+      "customProductPageStatus": "candidate"
+    },
+    {
+      "id": "body-composition",
+      "label": "Body composition trends",
+      "audience": "People tracking body fat, lean mass, FFMI, or recomposition.",
+      "priority": 2,
+      "terms": [
+        "body composition",
+        "body fat",
+        "lean mass",
+        "ffmi"
+      ],
+      "featureIds": [
+        "body-metrics",
+        "private-timeline"
+      ],
+      "customProductPageStatus": "candidate"
+    },
+    {
+      "id": "apple-health-weight",
+      "label": "Weight and Apple Health context",
+      "audience": "People who want weight trends with supported Apple Health data.",
+      "priority": 3,
+      "terms": [
+        "weight tracker",
+        "apple health",
+        "healthkit"
+      ],
+      "featureIds": [
+        "body-metrics",
+        "healthkit-sync"
+      ],
+      "customProductPageStatus": "candidate"
+    }
+  ],
+  "screenshotPolicy": {
+    "minimumCount": 1,
+    "maximumCount": 10,
+    "preferredPortraitSize": {
+      "width": 1320,
+      "height": 2868
+    },
+    "acceptedPortraitSizes": [
+      {
+        "width": 1260,
+        "height": 2736
+      },
+      {
+        "width": 1290,
+        "height": 2796
+      },
+      {
+        "width": 1320,
+        "height": 2868
+      },
+      {
+        "width": 1284,
+        "height": 2778
+      },
+      {
+        "width": 1242,
+        "height": 2688
+      },
+      {
+        "width": 2048,
+        "height": 2732
+      }
+    ],
+    "alphaAllowed": false,
+    "finalProductUiSource": "real-app-capture",
+    "provenanceRequired": true
+  },
+  "screenshotSets": [
+    {
+      "id": "default",
+      "locale": "en-US",
+      "target": "iphone-6.9",
+      "status": "hypothesis",
+      "frames": [
+        {
+          "id": "know-if-it-is-working",
+          "order": 1,
+          "headline": "Know if the work is working.",
+          "supportingCopy": "One private timeline for the signal that matters.",
+          "captureStateId": "timeline-overview",
+          "featureIds": [
+            "progress-photos",
+            "private-timeline",
+            "body-metrics"
+          ]
+        },
+        {
+          "id": "trend-not-one-day",
+          "order": 2,
+          "headline": "See the trend, not one day.",
+          "supportingCopy": "Keep daily noise in the context of your longer-term direction.",
+          "captureStateId": "stats-trend",
+          "featureIds": [
+            "body-metrics",
+            "private-timeline"
+          ]
+        },
+        {
+          "id": "photos-and-metrics",
+          "order": 3,
+          "headline": "Photos and metrics, together.",
+          "supportingCopy": "See each photo beside the measurements from the same moment.",
+          "captureStateId": "timeline-photo-metrics",
+          "featureIds": [
+            "progress-photos",
+            "body-metrics",
+            "private-timeline"
+          ]
+        },
+        {
+          "id": "log-in-seconds",
+          "order": 4,
+          "headline": "Log weight in seconds.",
+          "supportingCopy": "Add the measurement and get back to the work.",
+          "captureStateId": "weight-entry",
+          "featureIds": [
+            "body-metrics"
+          ]
+        },
+        {
+          "id": "composition-in-context",
+          "order": 5,
+          "headline": "Body composition, in context.",
+          "supportingCopy": "Review supported body-fat, lean-mass, and derived metrics over time.",
+          "captureStateId": "stats-composition",
+          "featureIds": [
+            "body-metrics"
+          ]
+        },
+        {
+          "id": "apple-health",
+          "order": 6,
+          "headline": "Bring in Apple Health.",
+          "supportingCopy": "Add supported weight and activity context to your timeline.",
+          "captureStateId": "healthkit-context",
+          "featureIds": [
+            "healthkit-sync",
+            "private-timeline"
+          ]
+        },
+        {
+          "id": "private-by-design",
+          "order": 7,
+          "headline": "Private by design.",
+          "supportingCopy": "Track your body without a public feed or social comparison.",
+          "captureStateId": "timeline-private",
+          "featureIds": [
+            "progress-photos",
+            "private-timeline"
+          ]
+        }
+      ]
+    }
+  ],
+  "measurement": {
+    "primaryMetric": "first-time-download-conversion-rate",
+    "guardrailMetrics": [
+      "trial-starts-per-download",
+      "paid-conversion-per-download",
+      "d7-activation",
+      "d30-retention",
+      "refund-rate",
+      "crash-free-sessions"
+    ]
+  },
+  "experiments": [],
+  "creative": {
+    "imageModel": "gpt-image-2-2026-04-21",
+    "approvedDirection": null,
+    "allowedImageUses": [
+      "art-direction exploration",
+      "non-semantic editorial backgrounds",
+      "texture and lighting exploration",
+      "comparison-board variants"
+    ],
+    "prohibitedImageUses": [
+      "product UI",
+      "localized typography",
+      "device geometry",
+      "generated body transformations",
+      "before-and-after proof",
+      "fabricated measured outcomes"
+    ]
+  },
+  "assetProvenance": {
+    "screenshots": [
+      {
+        "locale": "en-US",
+        "path": "apps/ios/fastlane/screenshots/en-US/01_APP_IPHONE_65.png",
+        "filename": "01_APP_IPHONE_65.png",
+        "width": 1242,
+        "height": 2688,
+        "hasAlpha": false,
+        "gitBlobSha": "7d2db86054ab94902e8ed8e8fc46b58f5b109033",
+        "sourceKind": "ios-fastlane-capture",
+        "truthStatus": "real-app-capture"
+      },
+      {
+        "locale": "en-US",
+        "path": "apps/ios/fastlane/screenshots/en-US/01_IPAD_PRO_3GEN_129.png",
+        "filename": "01_IPAD_PRO_3GEN_129.png",
+        "width": 2048,
+        "height": 2732,
+        "hasAlpha": false,
+        "gitBlobSha": "26c4e2fad8b20a10a4aff3cba83c4349930eeb9a",
+        "sourceKind": "ios-fastlane-capture",
+        "truthStatus": "real-app-capture"
+      }
+    ]
+  }
+}

--- a/docs/marketing/app-store/README.md
+++ b/docs/marketing/app-store/README.md
@@ -1,0 +1,107 @@
+# LogYourBody App Store Storefront
+
+This directory documents the closed-loop system that keeps the LogYourBody App Store listing truthful, current, and measurable.
+
+## Source of truth
+
+The canonical storefront definition lives at:
+
+- `packages/product-registry/src/storefronts/logyourbody.mjs`
+
+It owns:
+
+- localized App Store metadata;
+- search-intent clusters and Custom Product Page candidates;
+- screenshot narrative, order, capture-state IDs, and feature references;
+- accepted screenshot formats and dimensions;
+- GPT Image 2 guardrails.
+
+Run `pnpm product:generate` after changing storefront truth. Generated Fastlane metadata and `apps/ios/fastlane/storefront-manifest.generated.json` are checked in so changes are reviewable and deployable.
+
+`pnpm product:check` fails when:
+
+- generated metadata is stale;
+- Apple metadata limits are exceeded;
+- keywords are duplicated or waste terms already indexed from the name, subtitle, or company name;
+- copy or screenshots reference unavailable or non-marketable features;
+- screenshot order, capture states, dimensions, alpha-channel policy, or screenshot provenance drift;
+- GPT Image 2 is not pinned or is allowed to fabricate product UI or body-transformation proof.
+
+The iOS release source gate runs the same storefront validator before an App Store release can proceed.
+
+## Research contract
+
+Creative and ASO decisions are evidence-backed, not taste-only.
+
+Before approving a new narrative, keyword set, Custom Product Page, or experiment:
+
+1. Query G-Brain for prior LogYourBody product, positioning, design, screenshot, ASO, pricing, privacy, and launch decisions.
+2. Run `/last30days` for current customer language, complaints, competitor movement, privacy concerns, and App Store creative/ASO discussion.
+3. Verify platform behavior and limits against current Apple documentation.
+4. Create an evidence matrix with source, date, authority or engagement, confidence, product implication, and action.
+5. Write accepted decisions and experiment outcomes back to G-Brain.
+
+Required initial sweeps:
+
+```text
+/last30days "body composition tracker progress photo app complaints reviews" --days 30
+/last30days "weight tracker body fat app competitors complaints" --days 30
+/last30days "App Store health fitness screenshot design conversion ASO" --days 30
+/last30days "private progress photos body tracking trust privacy concerns" --days 30
+```
+
+Store raw evidence and syntheses under `docs/marketing/app-store/research/`. The current Apple platform evidence is recorded in [`research/platform-contract.md`](research/platform-contract.md).
+
+## Creative system
+
+Final product UI must always come from deterministic real-app capture with synthetic, privacy-safe demo data.
+
+GPT Image 2 may be used for:
+
+- art-direction exploration;
+- non-semantic editorial background plates;
+- texture and lighting exploration;
+- comparison-board variants.
+
+It must not generate:
+
+- product UI;
+- final typography or localization;
+- device geometry;
+- before-and-after bodies;
+- body transformations;
+- fabricated measured outcomes.
+
+The pinned production model is recorded in the storefront definition and generated manifest.
+
+## Screenshot narrative
+
+The current seven-frame narrative is a hypothesis until the research packet and human taste gate are complete. Each frame references a deterministic `captureStateId`; the capture harness and compositor must implement those IDs rather than hand-authoring screenshots.
+
+The final pipeline is:
+
+```text
+product truth + research
+        -> storefront registry
+        -> deterministic iOS capture
+        -> code-rendered composition
+        -> claim/privacy/dimension validation
+        -> Fastlane metadata and screenshots
+        -> App Store Connect
+        -> acquisition + activation + revenue outcomes
+        -> experiment decision
+        -> G-Brain and storefront registry
+```
+
+## Delivery status
+
+This foundation ships canonical metadata generation, strict validation, screenshot policy, a first narrative hypothesis, and the release freshness gate.
+
+Still required before calling the storefront system complete:
+
+- G-Brain and `/last30days` research packet;
+- deterministic `StorefrontDemoMode` and capture-state harness;
+- GPT Image 2 comparison board and approved visual direction;
+- code-rendered compositor and visual-diff gallery;
+- App Store Connect analytics ingestion;
+- Product Page Optimization and Custom Product Page experiment automation.

--- a/docs/marketing/app-store/research/platform-contract.md
+++ b/docs/marketing/app-store/research/platform-contract.md
@@ -1,0 +1,37 @@
+# Apple storefront platform contract
+
+Verified: 2026-07-29
+
+This file records the platform facts that the storefront generator and validator currently enforce. Apple documentation is authoritative; practitioner advice may inform later experiments but must not override these constraints.
+
+| Signal | Source | Recency | Authority | Confidence | Product implication | Action |
+|---|---|---:|---:|---:|---|---|
+| App name is 2–30 characters; subtitle is at most 30 characters. | [App information](https://developer.apple.com/help/app-store-connect/reference/app-information/app-information/) | Verified 2026-07-29 | Apple | High | These fields are hard limits, not creative guidelines. | Validate character counts before generation. |
+| Promotional text is at most 170 characters; description and What’s New are at most 4,000 characters. | [Platform version information](https://developer.apple.com/help/app-store-connect/reference/app-information/platform-version-information) | Verified 2026-07-29 | Apple | High | Over-limit copy must never reach Fastlane. | Validate character counts for every locale. |
+| Keywords are limited to 100 bytes, must be longer than two characters, and should not repeat app-name, subtitle, company-name, category, plural, or filler terms. Competing app names and unauthorized trademarks are prohibited. | [App Store search](https://developer.apple.com/app-store/search/) and [Platform version information](https://developer.apple.com/help/app-store-connect/reference/app-information/platform-version-information) | Verified 2026-07-29 | Apple | High | Keyword allocation is a constrained search-intent problem. | Validate UTF-8 bytes, formatting, duplicates, and indexed-word waste. Keep third-party trademarks out of the keyword field. |
+| Search results can show the name, subtitle, rating, and up to three screenshots or previews. | [App Store search](https://developer.apple.com/app-store/search/) | Verified 2026-07-29 | Apple | High | The opening three frames must work as a complete conversion story. | Treat frames 1–3 as one required narrative unit. |
+| One to ten screenshots are accepted per device size and localization. Screenshots must be RGB PNG or JPEG without transparency. | [Screenshot specifications](https://developer.apple.com/help/app-store-connect/reference/app-information/screenshot-specifications) | Verified 2026-07-29 | Apple | High | Screenshot count, dimensions, and alpha are release-blocking properties. | Parse PNG headers and fail invalid assets before Fastlane. |
+| Current 6.9-inch portrait sizes are 1260×2736, 1290×2796, or 1320×2868. Apple also accepts 6.5-inch fallbacks including 1242×2688 and 1284×2778. | [Screenshot specifications](https://developer.apple.com/help/app-store-connect/reference/app-information/screenshot-specifications) | Verified 2026-07-29 | Apple | High | Existing 1242×2688 capture remains valid, but the new canonical capture should use a current 6.9-inch export. | Accept the current fallback while making 1320×2868 the preferred target. |
+| Product Page Optimization supports up to three treatments per test, runs for at most 90 days, and evaluates conversion lift and confidence. Apple recommends waiting for at least 90% confidence before applying a result. | [Create a test](https://developer.apple.com/help/app-store-connect/create-product-page-optimization-tests/create-a-test/) and [Product Page Optimization](https://developer.apple.com/app-store/product-page-optimization/) | Verified 2026-07-29 | Apple | High | Low-volume tests must be allowed to end inconclusive rather than forcing a winner. | Record baseline, treatments, confidence, duration, and winner/loser/inconclusive state. |
+| An app can have up to 70 Custom Product Pages with localized screenshots, previews, promotional text, keywords, and unique URLs. Page metrics appear after at least five first-time downloads. | [Configure multiple product page versions](https://developer.apple.com/help/app-store-connect/create-custom-product-pages/configure-multiple-product-page-versions) | Verified 2026-07-29 | Apple | High | Capacity is not a mandate to create dozens of weak pages. | Start with only the highest-confidence intent pages and require unique keyword assignments. |
+| App Analytics exposes impressions, product-page views, downloads, conversion rate, source, proceeds, and paying users. | [App Analytics](https://developer.apple.com/app-store-connect/analytics/) and [Analytics dashboard](https://developer.apple.com/help/app-store-connect-analytics/overview/analytics-dashboard) | Verified 2026-07-29 | Apple | High | Store conversion must be joined to downstream activation and revenue before declaring a business winner. | Use first-time-download conversion as the acquisition objective, with paid conversion, retention, refunds, and stability as guardrails. |
+| App tags are generated from en-US metadata using models and human curation and currently display in the United States. | [Manage app tags](https://developer.apple.com/help/app-store-connect/manage-app-information/manage-app-tags/) | Verified 2026-07-29 | Apple | High | Metadata also influences glanceable tag assignment. | Review generated tags in App Store Connect as part of each listing release. |
+
+## Current implementation decisions
+
+- Preferred screenshot target: `1320x2868`.
+- Existing `1242x2688` iPhone screenshot remains an accepted transition fallback.
+- Final product UI must be a real-app capture with deterministic, synthetic demo data.
+- Screenshot blobs are provenance-tracked in the generated storefront manifest.
+- GPT Image 2 is pinned for art direction and non-semantic visual layers only; it cannot generate product UI, copy, device geometry, or body-transformation proof.
+- The keyword field is mechanically deduplicated against the app name, subtitle, and company name. Market-volume and customer-language ranking remains subject to the required G-Brain and `/last30days` research packet.
+
+## Evidence still required locally
+
+The connected implementation session cannot access the machine-local G-Brain database or execute the Claude `/last30days` runtime. Before approving final positioning, keywords, screenshot copy, or visual direction, the Codex/Hermes workflow must preserve:
+
+- G-Brain queries and returned decision IDs;
+- raw `/last30days` outputs for the required sweeps;
+- named-competitor follow-up sweeps;
+- conflict resolution and accepted decisions;
+- writeback IDs for new durable decisions.

--- a/packages/product-registry/package.json
+++ b/packages/product-registry/package.json
@@ -18,11 +18,11 @@
   ],
   "scripts": {
     "build": "pnpm generate && tsc -p tsconfig.json",
-    "generate": "node scripts/generate.mjs",
-    "generate:check": "node scripts/generate.mjs --check",
+    "generate": "node scripts/generate.mjs && node scripts/generate-storefront.mjs",
+    "generate:check": "node scripts/generate.mjs --check && node scripts/generate-storefront.mjs --check",
     "lint": "eslint src scripts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "node scripts/registry.test.mjs && node scripts/brand-integrity.test.mjs && pnpm generate:check && node scripts/url-drift.test.mjs && node scripts/legal-docs-sync.test.mjs && node scripts/env-surface.test.mjs && node scripts/db-entities.test.mjs"
+    "test": "node scripts/registry.test.mjs && node scripts/brand-integrity.test.mjs && node scripts/storefront.test.mjs && pnpm generate:check && node scripts/url-drift.test.mjs && node scripts/legal-docs-sync.test.mjs && node scripts/env-surface.test.mjs && node scripts/db-entities.test.mjs"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.16.0",

--- a/packages/product-registry/scripts/generate-storefront.mjs
+++ b/packages/product-registry/scripts/generate-storefront.mjs
@@ -1,7 +1,8 @@
+import console from 'node:console';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import { expectedStorefrontFiles } from './storefront-files.mjs';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');

--- a/packages/product-registry/scripts/generate-storefront.mjs
+++ b/packages/product-registry/scripts/generate-storefront.mjs
@@ -1,0 +1,29 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+import { expectedStorefrontFiles } from './storefront-files.mjs';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(packageRoot, '../..');
+const check = process.argv.includes('--check');
+const files = await expectedStorefrontFiles(repoRoot);
+
+for (const [path, content] of files) {
+  if (check) {
+    const current = await readFile(path, 'utf8').catch(() => '');
+    if (current !== content) {
+      throw new Error(`${path} is stale; run pnpm product:generate`);
+    }
+    continue;
+  }
+
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content);
+}
+
+console.log(
+  check
+    ? `Validated ${files.size} generated App Store storefront files.`
+    : `Generated ${files.size} App Store storefront files.`,
+);

--- a/packages/product-registry/scripts/storefront-assets.mjs
+++ b/packages/product-registry/scripts/storefront-assets.mjs
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import { readFile, readdir } from 'node:fs/promises';
 import { extname, relative, resolve, sep } from 'node:path';

--- a/packages/product-registry/scripts/storefront-assets.mjs
+++ b/packages/product-registry/scripts/storefront-assets.mjs
@@ -1,0 +1,82 @@
+import { createHash } from 'node:crypto';
+import { readFile, readdir } from 'node:fs/promises';
+import { extname, relative, resolve, sep } from 'node:path';
+import { logYourBodyStorefront } from '../src/storefronts/logyourbody.mjs';
+
+export function pngInfo(buffer) {
+  if (buffer.subarray(0, 8).toString('hex') !== '89504e470d0a1a0a') {
+    throw new Error('screenshot must be a PNG');
+  }
+
+  let offset = 8;
+  let width;
+  let height;
+  let colorType;
+  let hasTransparencyChunk = false;
+
+  while (offset + 12 <= buffer.length) {
+    const length = buffer.readUInt32BE(offset);
+    const type = buffer.subarray(offset + 4, offset + 8).toString('ascii');
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + length;
+
+    if (dataEnd + 4 > buffer.length) throw new Error('invalid PNG chunk length');
+
+    if (type === 'IHDR') {
+      width = buffer.readUInt32BE(dataStart);
+      height = buffer.readUInt32BE(dataStart + 4);
+      colorType = buffer[dataStart + 9];
+    } else if (type === 'tRNS') {
+      hasTransparencyChunk = true;
+    }
+
+    offset = dataEnd + 4;
+    if (type === 'IEND') break;
+  }
+
+  if (!width || !height) throw new Error('PNG is missing IHDR dimensions');
+
+  return {
+    width,
+    height,
+    hasAlpha: colorType === 4 || colorType === 6 || hasTransparencyChunk,
+  };
+}
+
+export function gitBlobSha(buffer) {
+  const header = Buffer.from(`blob ${buffer.length}\0`);
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+export async function collectScreenshotAssets(repoRoot) {
+  const assets = [];
+
+  for (const locale of logYourBodyStorefront.locales) {
+    const directory = resolve(repoRoot, 'apps/ios/fastlane/screenshots', locale.id);
+    const entries = await readdir(directory, { withFileTypes: true }).catch(() => []);
+    const filenames = entries
+      .filter((entry) => entry.isFile() && extname(entry.name).toLowerCase() === '.png')
+      .map((entry) => entry.name)
+      .sort();
+
+    for (const filename of filenames) {
+      const absolutePath = resolve(directory, filename);
+      const buffer = await readFile(absolutePath);
+      const info = pngInfo(buffer);
+
+      assets.push({
+        locale: locale.id,
+        path: relative(repoRoot, absolutePath).split(sep).join('/'),
+        filename,
+        width: info.width,
+        height: info.height,
+        hasAlpha: info.hasAlpha,
+        gitBlobSha: gitBlobSha(buffer),
+        sourceKind: 'ios-fastlane-capture',
+        truthStatus: 'real-app-capture',
+      });
+    }
+  }
+
+  return assets;
+}

--- a/packages/product-registry/scripts/storefront-files.mjs
+++ b/packages/product-registry/scripts/storefront-files.mjs
@@ -1,0 +1,47 @@
+import { resolve } from 'node:path';
+import { logYourBodyStorefront } from '../src/storefronts/logyourbody.mjs';
+import { collectScreenshotAssets } from './storefront-assets.mjs';
+
+const metadataFileNames = {
+  name: 'name.txt',
+  subtitle: 'subtitle.txt',
+  keywords: 'keywords.txt',
+  promotionalText: 'promotional_text.txt',
+  description: 'description.txt',
+  releaseNotes: 'release_notes.txt',
+  supportUrl: 'support_url.txt',
+  marketingUrl: 'marketing_url.txt',
+  privacyUrl: 'privacy_url.txt',
+};
+
+const normalizeMetadata = (value) => value.replace(/\s+$/u, '');
+
+export async function storefrontManifest(repoRoot) {
+  return {
+    generatedBy: 'packages/product-registry/scripts/generate-storefront.mjs',
+    ...logYourBodyStorefront,
+    assetProvenance: {
+      screenshots: await collectScreenshotAssets(repoRoot),
+    },
+  };
+}
+
+export async function expectedStorefrontFiles(repoRoot) {
+  const files = new Map();
+
+  for (const locale of logYourBodyStorefront.locales) {
+    for (const [field, filename] of Object.entries(metadataFileNames)) {
+      files.set(
+        resolve(repoRoot, 'apps/ios/fastlane/metadata', locale.id, filename),
+        normalizeMetadata(locale.metadata[field]),
+      );
+    }
+  }
+
+  files.set(
+    resolve(repoRoot, 'apps/ios/fastlane/storefront-manifest.generated.json'),
+    `${JSON.stringify(await storefrontManifest(repoRoot), null, 2)}\n`,
+  );
+
+  return files;
+}

--- a/packages/product-registry/scripts/storefront.test.mjs
+++ b/packages/product-registry/scripts/storefront.test.mjs
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { logYourBody } from '../src/products/logyourbody.mjs';
+import { logYourBodyStorefront } from '../src/storefronts/logyourbody.mjs';
+import { collectScreenshotAssets } from './storefront-assets.mjs';
+import { expectedStorefrontFiles } from './storefront-files.mjs';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(packageRoot, '../..');
+const storefront = logYourBodyStorefront;
+const featureById = new Map(logYourBody.features.map((feature) => [feature.id, feature]));
+
+const unique = (values, message) => {
+  assert.equal(new Set(values).size, values.length, message);
+};
+
+const characters = (value) => [...value].length;
+const normalizeWords = (value) =>
+  value
+    .replace(/([a-z])([A-Z])/gu, '$1 $2')
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter(Boolean);
+
+const assertMarketableFeatureReferences = (owner, featureIds) => {
+  unique(featureIds, `${owner} must not repeat feature references`);
+
+  for (const featureId of featureIds) {
+    const feature = featureById.get(featureId);
+    assert(feature, `${owner} references unknown feature ${featureId}`);
+    assert.equal(feature.availability, 'available', `${owner} references unavailable ${featureId}`);
+    assert.equal(feature.marketing, true, `${owner} references non-marketable ${featureId}`);
+    assert(feature.platforms.includes('ios'), `${owner} references non-iOS feature ${featureId}`);
+  }
+};
+
+assert.equal(storefront.productId, logYourBody.id);
+assert.equal(storefront.platform, 'ios');
+assert.equal(storefront.screenshotPolicy.finalProductUiSource, 'real-app-capture');
+assert.equal(storefront.screenshotPolicy.alphaAllowed, false);
+assert.equal(storefront.screenshotPolicy.provenanceRequired, true);
+assert.match(
+  storefront.creative.imageModel,
+  /^gpt-image-2-\d{4}-\d{2}-\d{2}$/u,
+  'production image generation must use a pinned GPT Image 2 snapshot',
+);
+assert(
+  storefront.creative.prohibitedImageUses.includes('product UI'),
+  'GPT Image 2 must never become the source of truth for product UI',
+);
+assert(
+  storefront.creative.prohibitedImageUses.includes('generated body transformations'),
+  'generated body transformations must remain prohibited',
+);
+
+const localeIds = storefront.locales.map((locale) => locale.id);
+unique(localeIds, 'storefront locale IDs must be unique');
+assert(localeIds.includes(storefront.defaultLocale), 'default locale must exist');
+
+for (const locale of storefront.locales) {
+  const { metadata } = locale;
+  const limits = storefront.metadataLimits;
+
+  assert(
+    characters(metadata.name) >= 2 && characters(metadata.name) <= limits.nameCharacters,
+    `${locale.id} name must be 2-${limits.nameCharacters} characters`,
+  );
+  assert(
+    characters(metadata.subtitle) <= limits.subtitleCharacters,
+    `${locale.id} subtitle exceeds ${limits.subtitleCharacters} characters`,
+  );
+  assert(
+    characters(metadata.promotionalText) <= limits.promotionalTextCharacters,
+    `${locale.id} promotional text exceeds ${limits.promotionalTextCharacters} characters`,
+  );
+  assert(
+    characters(metadata.description) <= limits.descriptionCharacters,
+    `${locale.id} description exceeds ${limits.descriptionCharacters} characters`,
+  );
+  assert(
+    characters(metadata.releaseNotes) <= limits.releaseNotesCharacters,
+    `${locale.id} release notes exceed ${limits.releaseNotesCharacters} characters`,
+  );
+  assert(
+    Buffer.byteLength(metadata.keywords, 'utf8') <= limits.keywordsBytes,
+    `${locale.id} keywords exceed ${limits.keywordsBytes} bytes`,
+  );
+
+  const keywords = metadata.keywords.split(',');
+  assert.equal(
+    metadata.keywords,
+    keywords.map((keyword) => keyword.trim()).join(','),
+    `${locale.id} keywords must be comma-separated without padding spaces`,
+  );
+  assert(
+    keywords.every((keyword) => characters(keyword) > 2),
+    `${locale.id} keywords must exceed two characters`,
+  );
+  unique(
+    keywords.map((keyword) => keyword.toLowerCase()),
+    `${locale.id} keywords must be unique`,
+  );
+
+  const indexedElsewhere = new Set([
+    ...normalizeWords(metadata.name),
+    ...normalizeWords(metadata.subtitle),
+    ...normalizeWords(logYourBody.identity.legalName),
+  ]);
+  for (const keyword of keywords) {
+    for (const word of normalizeWords(keyword)) {
+      assert(
+        !indexedElsewhere.has(word),
+        `${locale.id} keyword "${word}" duplicates the app name, subtitle, or company name`,
+      );
+    }
+  }
+
+  assert.equal(metadata.name, logYourBody.identity.name);
+  assert.equal(metadata.supportUrl, logYourBody.links.support);
+  assert.equal(metadata.marketingUrl, logYourBody.links.home);
+  assert.equal(metadata.privacyUrl, logYourBody.links.privacy);
+}
+
+const intentIds = storefront.searchIntents.map((intent) => intent.id);
+unique(intentIds, 'search-intent IDs must be unique');
+unique(
+  storefront.searchIntents.map((intent) => intent.priority),
+  'search-intent priorities must be unique',
+);
+assert.deepEqual(
+  storefront.searchIntents.map((intent) => intent.priority).sort((a, b) => a - b),
+  storefront.searchIntents.map((_, index) => index + 1),
+  'search-intent priorities must be contiguous',
+);
+for (const intent of storefront.searchIntents) {
+  assert(intent.terms.length > 0, `${intent.id} needs at least one search term`);
+  unique(
+    intent.terms.map((term) => term.toLowerCase()),
+    `${intent.id} search terms must be unique`,
+  );
+  assertMarketableFeatureReferences(`search intent ${intent.id}`, intent.featureIds);
+}
+
+const screenshotSetIds = storefront.screenshotSets.map((set) => set.id);
+unique(screenshotSetIds, 'screenshot-set IDs must be unique');
+for (const screenshotSet of storefront.screenshotSets) {
+  assert(localeIds.includes(screenshotSet.locale), `${screenshotSet.id} references an unknown locale`);
+  assert(
+    screenshotSet.frames.length >= storefront.screenshotPolicy.minimumCount &&
+      screenshotSet.frames.length <= storefront.screenshotPolicy.maximumCount,
+    `${screenshotSet.id} must contain ${storefront.screenshotPolicy.minimumCount}-${storefront.screenshotPolicy.maximumCount} frames`,
+  );
+
+  unique(
+    screenshotSet.frames.map((frame) => frame.id),
+    `${screenshotSet.id} frame IDs must be unique`,
+  );
+  unique(
+    screenshotSet.frames.map((frame) => frame.captureStateId),
+    `${screenshotSet.id} capture-state IDs must be unique`,
+  );
+  assert.deepEqual(
+    screenshotSet.frames.map((frame) => frame.order),
+    screenshotSet.frames.map((_, index) => index + 1),
+    `${screenshotSet.id} frame order must be contiguous`,
+  );
+
+  for (const frame of screenshotSet.frames) {
+    assert(frame.headline.trim(), `${frame.id} needs a headline`);
+    assert(frame.supportingCopy.trim(), `${frame.id} needs supporting copy`);
+    assertMarketableFeatureReferences(`screenshot frame ${frame.id}`, frame.featureIds);
+  }
+}
+
+const experimentIds = storefront.experiments.map((experiment) => experiment.id);
+unique(experimentIds, 'experiment IDs must be unique');
+for (const experiment of storefront.experiments) {
+  assert(intentIds.includes(experiment.intentId), `${experiment.id} references an unknown intent`);
+  assert(experiment.hypothesis.trim(), `${experiment.id} needs a hypothesis`);
+  assert(experiment.primaryMetric.trim(), `${experiment.id} needs a primary metric`);
+  assert(experiment.guardrailMetrics.length > 0, `${experiment.id} needs guardrail metrics`);
+  unique(experiment.baselineAssetIds, `${experiment.id} baseline asset IDs must be unique`);
+  unique(experiment.treatmentAssetIds, `${experiment.id} treatment asset IDs must be unique`);
+}
+
+assert(storefront.measurement.primaryMetric.trim(), 'storefront measurement needs a primary metric');
+assert(storefront.measurement.guardrailMetrics.length > 0, 'storefront measurement needs guardrails');
+unique(storefront.measurement.guardrailMetrics, 'storefront guardrail metrics must be unique');
+
+for (const [path, expected] of await expectedStorefrontFiles(repoRoot)) {
+  const current = await readFile(path, 'utf8').catch(() => '');
+  assert.equal(current, expected, `${path} is stale; run pnpm product:generate`);
+}
+
+const screenshotAssets = await collectScreenshotAssets(repoRoot);
+const acceptedSizes = new Set(
+  storefront.screenshotPolicy.acceptedPortraitSizes.map(({ width, height }) => `${width}x${height}`),
+);
+const modernRequiredSizes = new Set([
+  '1260x2736',
+  '1290x2796',
+  '1320x2868',
+  '1284x2778',
+  '1242x2688',
+]);
+
+for (const locale of storefront.locales) {
+  const screenshots = screenshotAssets.filter((asset) => asset.locale === locale.id);
+  assert(screenshots.length > 0, `${locale.id} needs at least one PNG screenshot`);
+
+  let hasModernRequiredSize = false;
+  const countBySize = new Map();
+  for (const screenshot of screenshots) {
+    const size = `${screenshot.width}x${screenshot.height}`;
+
+    assert(acceptedSizes.has(size), `${screenshot.filename} uses unsupported portrait size ${size}`);
+    assert.equal(
+      screenshot.hasAlpha,
+      false,
+      `${screenshot.filename} contains an alpha channel or transparency`,
+    );
+    assert.match(screenshot.gitBlobSha, /^[a-f0-9]{40}$/u, `${screenshot.filename} needs provenance`);
+    assert.equal(screenshot.truthStatus, 'real-app-capture');
+    countBySize.set(size, (countBySize.get(size) ?? 0) + 1);
+    hasModernRequiredSize ||= modernRequiredSizes.has(size);
+  }
+
+  for (const [size, count] of countBySize) {
+    assert(
+      count >= storefront.screenshotPolicy.minimumCount &&
+        count <= storefront.screenshotPolicy.maximumCount,
+      `${locale.id} ${size} must contain ${storefront.screenshotPolicy.minimumCount}-${storefront.screenshotPolicy.maximumCount} screenshots`,
+    );
+  }
+
+  assert(
+    hasModernRequiredSize,
+    `${locale.id} needs at least one accepted 6.9-inch screenshot or 6.5-inch fallback`,
+  );
+}
+
+console.log('App Store storefront validation passed.');

--- a/packages/product-registry/scripts/storefront.test.mjs
+++ b/packages/product-registry/scripts/storefront.test.mjs
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict';
+import { Buffer } from 'node:buffer';
+import console from 'node:console';
 import { readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/product-registry/src/index.ts
+++ b/packages/product-registry/src/index.ts
@@ -9,15 +9,35 @@ export type {
   ProductPlatform,
   SupportKind,
 } from './types.js';
+export type {
+  ProductStorefrontDefinition,
+  StorefrontExperiment,
+  StorefrontExperimentMechanism,
+  StorefrontExperimentStatus,
+  StorefrontCustomProductPageStatus,
+  StorefrontLocale,
+  StorefrontLocaleMetadata,
+  StorefrontScreenshotFrame,
+  StorefrontScreenshotSet,
+  StorefrontScreenshotStatus,
+  StorefrontSearchIntent,
+} from './storefronts/types.js';
 export { logYourBody } from './products/logyourbody.mjs';
+export { logYourBodyStorefront } from './storefronts/logyourbody.mjs';
 
 import { logYourBody } from './products/logyourbody.mjs';
+import { logYourBodyStorefront } from './storefronts/logyourbody.mjs';
 
 export const PRODUCT_REGISTRY = { logyourbody: logYourBody } as const;
+export const STOREFRONT_REGISTRY = { logyourbody: logYourBodyStorefront } as const;
 export type ProductId = keyof typeof PRODUCT_REGISTRY;
 
 export function getProduct(id: ProductId) {
   return PRODUCT_REGISTRY[id];
+}
+
+export function getStorefront(id: ProductId) {
+  return STOREFRONT_REGISTRY[id];
 }
 
 export function getFeature(id: string) {

--- a/packages/product-registry/src/storefronts/logyourbody.mjs
+++ b/packages/product-registry/src/storefronts/logyourbody.mjs
@@ -1,0 +1,189 @@
+/** @type {import('./types.js').ProductStorefrontDefinition} */
+export const logYourBodyStorefront = {
+  schemaVersion: 1,
+  productId: 'logyourbody',
+  platform: 'ios',
+  defaultLocale: 'en-US',
+  metadataLimits: {
+    nameCharacters: 30,
+    subtitleCharacters: 30,
+    promotionalTextCharacters: 170,
+    descriptionCharacters: 4000,
+    releaseNotesCharacters: 4000,
+    keywordsBytes: 100,
+  },
+  locales: [
+    {
+      id: 'en-US',
+      metadata: {
+        name: 'LogYourBody',
+        subtitle: 'Weight and body metrics',
+        keywords:
+          'progress,photos,composition,fat,lean,mass,private,timeline,ffmi,tracker,measurements,recomposition',
+        promotionalText:
+          'Track progress photos, weight, body fat, and Apple Health context from a private photo-first timeline.',
+        description: `LogYourBody is a focused body-composition tracker for people who want a private progress-photo timeline with weight, body-fat, and Apple Health context.
+
+Start with the essentials:
+
+- Add progress photos to a swipeable body timeline
+- Log weight and body-fat context in pounds or kilograms
+- Review Stats for weight, body fat, FFMI, and steps
+- Optionally connect Apple Health for weight, body-fat, height, and step context
+- Sync entries to your account
+- Export your account data
+- Keep access managed through LogYourBody Pro
+
+LogYourBody is built for consistent body-composition tracking without noisy coaching. Your photos and entries stay available on device and sync to your account when you are signed in.
+
+LogYourBody is not a medical device and does not provide medical advice. Use it for personal fitness tracking and consult a qualified professional for medical decisions.`,
+        releaseNotes:
+          'Photo-first MVP release with paid access, progress-photo timeline, weight and body-fat logging, optional HealthKit context, account sync, restore purchases, data export, and account deletion.',
+        supportUrl: 'https://logyourbody.com/support',
+        marketingUrl: 'https://logyourbody.com',
+        privacyUrl: 'https://logyourbody.com/privacy',
+      },
+    },
+  ],
+  searchIntents: [
+    {
+      id: 'private-progress',
+      label: 'Private progress photos',
+      audience: 'People who want visual progress without a social feed.',
+      priority: 1,
+      terms: ['progress photos', 'photo tracker', 'private timeline'],
+      featureIds: ['progress-photos', 'private-timeline'],
+      customProductPageStatus: 'candidate',
+    },
+    {
+      id: 'body-composition',
+      label: 'Body composition trends',
+      audience: 'People tracking body fat, lean mass, FFMI, or recomposition.',
+      priority: 2,
+      terms: ['body composition', 'body fat', 'lean mass', 'ffmi'],
+      featureIds: ['body-metrics', 'private-timeline'],
+      customProductPageStatus: 'candidate',
+    },
+    {
+      id: 'apple-health-weight',
+      label: 'Weight and Apple Health context',
+      audience: 'People who want weight trends with supported Apple Health data.',
+      priority: 3,
+      terms: ['weight tracker', 'apple health', 'healthkit'],
+      featureIds: ['body-metrics', 'healthkit-sync'],
+      customProductPageStatus: 'candidate',
+    },
+  ],
+  screenshotPolicy: {
+    minimumCount: 1,
+    maximumCount: 10,
+    preferredPortraitSize: { width: 1320, height: 2868 },
+    acceptedPortraitSizes: [
+      { width: 1260, height: 2736 },
+      { width: 1290, height: 2796 },
+      { width: 1320, height: 2868 },
+      { width: 1284, height: 2778 },
+      { width: 1242, height: 2688 },
+      { width: 2048, height: 2732 },
+    ],
+    alphaAllowed: false,
+    finalProductUiSource: 'real-app-capture',
+    provenanceRequired: true,
+  },
+  screenshotSets: [
+    {
+      id: 'default',
+      locale: 'en-US',
+      target: 'iphone-6.9',
+      status: 'hypothesis',
+      frames: [
+        {
+          id: 'know-if-it-is-working',
+          order: 1,
+          headline: 'Know if the work is working.',
+          supportingCopy: 'One private timeline for the signal that matters.',
+          captureStateId: 'timeline-overview',
+          featureIds: ['progress-photos', 'private-timeline', 'body-metrics'],
+        },
+        {
+          id: 'trend-not-one-day',
+          order: 2,
+          headline: 'See the trend, not one day.',
+          supportingCopy: 'Keep daily noise in the context of your longer-term direction.',
+          captureStateId: 'stats-trend',
+          featureIds: ['body-metrics', 'private-timeline'],
+        },
+        {
+          id: 'photos-and-metrics',
+          order: 3,
+          headline: 'Photos and metrics, together.',
+          supportingCopy: 'See each photo beside the measurements from the same moment.',
+          captureStateId: 'timeline-photo-metrics',
+          featureIds: ['progress-photos', 'body-metrics', 'private-timeline'],
+        },
+        {
+          id: 'log-in-seconds',
+          order: 4,
+          headline: 'Log weight in seconds.',
+          supportingCopy: 'Add the measurement and get back to the work.',
+          captureStateId: 'weight-entry',
+          featureIds: ['body-metrics'],
+        },
+        {
+          id: 'composition-in-context',
+          order: 5,
+          headline: 'Body composition, in context.',
+          supportingCopy: 'Review supported body-fat, lean-mass, and derived metrics over time.',
+          captureStateId: 'stats-composition',
+          featureIds: ['body-metrics'],
+        },
+        {
+          id: 'apple-health',
+          order: 6,
+          headline: 'Bring in Apple Health.',
+          supportingCopy: 'Add supported weight and activity context to your timeline.',
+          captureStateId: 'healthkit-context',
+          featureIds: ['healthkit-sync', 'private-timeline'],
+        },
+        {
+          id: 'private-by-design',
+          order: 7,
+          headline: 'Private by design.',
+          supportingCopy: 'Track your body without a public feed or social comparison.',
+          captureStateId: 'timeline-private',
+          featureIds: ['progress-photos', 'private-timeline'],
+        },
+      ],
+    },
+  ],
+  measurement: {
+    primaryMetric: 'first-time-download-conversion-rate',
+    guardrailMetrics: [
+      'trial-starts-per-download',
+      'paid-conversion-per-download',
+      'd7-activation',
+      'd30-retention',
+      'refund-rate',
+      'crash-free-sessions',
+    ],
+  },
+  experiments: [],
+  creative: {
+    imageModel: 'gpt-image-2-2026-04-21',
+    approvedDirection: null,
+    allowedImageUses: [
+      'art-direction exploration',
+      'non-semantic editorial backgrounds',
+      'texture and lighting exploration',
+      'comparison-board variants',
+    ],
+    prohibitedImageUses: [
+      'product UI',
+      'localized typography',
+      'device geometry',
+      'generated body transformations',
+      'before-and-after proof',
+      'fabricated measured outcomes',
+    ],
+  },
+};

--- a/packages/product-registry/src/storefronts/types.ts
+++ b/packages/product-registry/src/storefronts/types.ts
@@ -1,0 +1,117 @@
+export type StorefrontCustomProductPageStatus = 'candidate' | 'active' | 'deferred';
+export type StorefrontScreenshotStatus = 'hypothesis' | 'approved' | 'retired';
+export type StorefrontExperimentStatus =
+  | 'draft'
+  | 'ready'
+  | 'running'
+  | 'winner'
+  | 'loser'
+  | 'inconclusive'
+  | 'stopped';
+export type StorefrontExperimentMechanism =
+  | 'product-page-optimization'
+  | 'custom-product-page'
+  | 'metadata-release';
+
+export interface StorefrontLocaleMetadata {
+  readonly name: string;
+  readonly subtitle: string;
+  readonly keywords: string;
+  readonly promotionalText: string;
+  readonly description: string;
+  readonly releaseNotes: string;
+  readonly supportUrl: string;
+  readonly marketingUrl: string;
+  readonly privacyUrl: string;
+}
+
+export interface StorefrontLocale {
+  readonly id: string;
+  readonly metadata: StorefrontLocaleMetadata;
+}
+
+export interface StorefrontSearchIntent {
+  readonly id: string;
+  readonly label: string;
+  readonly audience: string;
+  readonly priority: number;
+  readonly terms: readonly string[];
+  readonly featureIds: readonly string[];
+  readonly customProductPageStatus: StorefrontCustomProductPageStatus;
+}
+
+export interface StorefrontScreenshotFrame {
+  readonly id: string;
+  readonly order: number;
+  readonly headline: string;
+  readonly supportingCopy: string;
+  readonly captureStateId: string;
+  readonly featureIds: readonly string[];
+}
+
+export interface StorefrontScreenshotSet {
+  readonly id: string;
+  readonly locale: string;
+  readonly target: 'iphone-6.9';
+  readonly status: StorefrontScreenshotStatus;
+  readonly frames: readonly StorefrontScreenshotFrame[];
+}
+
+export interface StorefrontExperiment {
+  readonly id: string;
+  readonly mechanism: StorefrontExperimentMechanism;
+  readonly intentId: string;
+  readonly hypothesis: string;
+  readonly status: StorefrontExperimentStatus;
+  readonly baselineAssetIds: readonly string[];
+  readonly treatmentAssetIds: readonly string[];
+  readonly primaryMetric: string;
+  readonly guardrailMetrics: readonly string[];
+  readonly startedAt: string | null;
+  readonly endedAt: string | null;
+  readonly resultSummary: string | null;
+}
+
+export interface ProductStorefrontDefinition {
+  readonly schemaVersion: 1;
+  readonly productId: string;
+  readonly platform: 'ios';
+  readonly defaultLocale: string;
+  readonly metadataLimits: {
+    readonly nameCharacters: number;
+    readonly subtitleCharacters: number;
+    readonly promotionalTextCharacters: number;
+    readonly descriptionCharacters: number;
+    readonly releaseNotesCharacters: number;
+    readonly keywordsBytes: number;
+  };
+  readonly locales: readonly StorefrontLocale[];
+  readonly searchIntents: readonly StorefrontSearchIntent[];
+  readonly screenshotPolicy: {
+    readonly minimumCount: number;
+    readonly maximumCount: number;
+    readonly preferredPortraitSize: {
+      readonly width: number;
+      readonly height: number;
+    };
+    readonly acceptedPortraitSizes: readonly {
+      readonly width: number;
+      readonly height: number;
+    }[];
+    readonly alphaAllowed: false;
+    readonly finalProductUiSource: 'real-app-capture';
+    readonly provenanceRequired: true;
+  };
+  readonly screenshotSets: readonly StorefrontScreenshotSet[];
+  readonly measurement: {
+    readonly primaryMetric: string;
+    readonly guardrailMetrics: readonly string[];
+  };
+  readonly experiments: readonly StorefrontExperiment[];
+  readonly creative: {
+    readonly imageModel: string;
+    readonly approvedDirection: string | null;
+    readonly allowedImageUses: readonly string[];
+    readonly prohibitedImageUses: readonly string[];
+  };
+}


### PR DESCRIPTION
## Outcome

Ships the first production-safe slice of #528: one canonical App Store storefront contract that generates Fastlane metadata, validates product truth and Apple limits, fingerprints real screenshot assets, and blocks stale storefronts before release.

## What changed

- Added a typed storefront registry for locales, ASO intents, screenshot narrative/capture-state IDs, measurement guardrails, experiments, and GPT Image 2 boundaries.
- Generated Fastlane metadata and a reviewable storefront manifest from the registry.
- Deduplicated the keyword field against words already indexed from the app name/subtitle and removed category/trademark waste.
- Added strict validation for metadata limits, keyword bytes/duplicates, marketable feature references, frame ordering, screenshot dimensions/count, transparency, and screenshot Git-blob provenance.
- Pinned GPT Image 2 to `gpt-image-2-2026-04-21` and prohibited generated product UI, body transformations, and fabricated outcomes.
- Added the storefront validator to the product-registry test suite and the App Store release source gate.
- Preserved the existing real TestFlight purchase/restore submission gate.
- Added an Apple-authoritative platform evidence matrix and operating runbook.

## Verification

Executed against a local repository fixture mirroring the current product registry and checked-in screenshots:

- `node packages/product-registry/scripts/generate-storefront.mjs`
- `node packages/product-registry/scripts/generate-storefront.mjs --check`
- `node packages/product-registry/scripts/storefront.test.mjs`
- `npx tsc --noEmit -p packages/product-registry/tsconfig.json`
- `node --check` for all new `.mjs` files
- `bash -n .github/scripts/validate-release-source.sh`

The validator recognizes the current real captures as RGB/no-alpha and records their existing Git blob SHAs. The preferred new capture target is 1320×2868; the current 1242×2688 image remains an Apple-accepted transition fallback.

## Deliberate boundary

This PR does **not** fabricate final creative or claim the full epic is complete. The seven-frame story remains `hypothesis` until the machine-local G-Brain and `/last30days` evidence packet is preserved and Tim approves an Image 2 comparison board. Follow-on work remains the deterministic `StorefrontDemoMode` capture harness, code compositor, visual review gallery, App Store Connect analytics ingestion, and PPO/Custom Product Page automation.

Part of #528.