### PR TITLE
feat: add versioned iOS What’s New modal

### DIFF
--- a/apps/ios/LogYourBody/ContentView.swift
+++ b/apps/ios/LogYourBody/ContentView.swift
@@ -79,12 +79,18 @@ struct ContentView: View {
     @State private var isLoadingComplete = false
     @State private var isUnlocked = false
     @State private var showLegalConsent = false
+    @State private var showWhatsNew = false
+    @AppStorage("lyb.whatsNew.lastPresentedVersion") private var lastPresentedWhatsNewVersion: String?
     @AppStorage("biometricLockEnabled") private var biometricLockEnabled = false
 
     init() {
         // We need to initialize LoadingManager with a temporary AuthManager
         // The actual authManager will be injected from environment
         _loadingManager = StateObject(wrappedValue: LoadingManager(authManager: AuthManager.shared))
+    }
+
+    private func markWhatsNewPresented() {
+        lastPresentedWhatsNewVersion = AppVersion.current
     }
 
     private func applyProfileCompletionIfNeeded(_ completionFlag: Bool?) {
@@ -154,6 +160,9 @@ struct ContentView: View {
             )
             .interactiveDismissDisabled(true) // Prevent dismissing without accepting
         }
+        .sheet(isPresented: $showWhatsNew, onDismiss: markWhatsNewPresented) {
+            LogYourBodyWhatsNewView(version: AppVersion.current)
+        }
         .onAppear {
             // Initialize onboarding status
             currentUserId = authManager.currentUser?.id
@@ -169,6 +178,17 @@ struct ContentView: View {
                 await loadingManager.startLoading()
                 completeLaunchOverlayIfReady()
             }
+        }
+        .task(id: "\(authManager.isAuthenticated)-\(isLoadingComplete)-\(hasCompletedOnboarding)-\(isProfileComplete)") {
+            let isEligible = authManager.isAuthenticated &&
+                isLoadingComplete &&
+                hasCompletedOnboarding &&
+                !shouldShowProfileCompletion
+            showWhatsNew = WhatsNewPresentationPolicy.shouldPresent(
+                currentVersion: AppVersion.current,
+                lastPresentedVersion: lastPresentedWhatsNewVersion,
+                isEligible: isEligible
+            )
         }
         .onChange(of: loadingManager.isLoading) { _, _ in
             completeLaunchOverlayIfReady()
@@ -284,6 +304,62 @@ struct ContentView: View {
                 .transition(.opacity)
             }
         }
+    }
+}
+
+struct WhatsNewPresentationPolicy {
+    static func shouldPresent(
+        currentVersion: String,
+        lastPresentedVersion: String?,
+        isEligible: Bool
+    ) -> Bool {
+        isEligible && currentVersion != lastPresentedVersion
+    }
+}
+
+private struct LogYourBodyWhatsNewView: View {
+    let version: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: JovieTokens.sectionGap) {
+            HStack {
+                VStack(alignment: .leading, spacing: JovieTokens.itemGap) {
+                    Text("What’s New")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(Color.appTextPrimary)
+                    Text("Version \(version)")
+                        .font(.subheadline)
+                        .foregroundStyle(Color.appTextSecondary)
+                }
+                Spacer()
+                Image(systemName: "sparkles")
+                    .font(.title2)
+                    .foregroundStyle(Color.appPrimary)
+                    .accessibilityHidden(true)
+            }
+
+            VStack(alignment: .leading, spacing: JovieTokens.itemGap) {
+                Label("This update is shown once for this app version.", systemImage: "checkmark.circle")
+                Label("Dismiss it anytime with Done.", systemImage: "hand.tap")
+            }
+            .font(.body)
+            .foregroundStyle(Color.appTextSecondary)
+
+            Spacer(minLength: 0)
+
+            StandardButton("Done") {
+                dismiss()
+            }
+            .accessibilityIdentifier("whats-new-done")
+        }
+        .padding(JovieTokens.screenInset)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color.appBackground)
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("What’s New, version \(version)")
     }
 }
 

--- a/apps/ios/LogYourBodyTests/AppVersionTests.swift
+++ b/apps/ios/LogYourBodyTests/AppVersionTests.swift
@@ -33,4 +33,38 @@ final class AppVersionTests: XCTestCase {
         XCTAssertTrue(AppVersion.fullVersion.hasPrefix("Version "))
         XCTAssertTrue(AppVersion.fullVersion.hasSuffix("(\(AppVersion.build))"))
     }
+
+    func testWhatsNewPresentsOnlyForAnUnseenVersionWhenEligible() {
+        XCTAssertTrue(
+            WhatsNewPresentationPolicy.shouldPresent(
+                currentVersion: "2.4",
+                lastPresentedVersion: nil,
+                isEligible: true
+            )
+        )
+        XCTAssertTrue(
+            WhatsNewPresentationPolicy.shouldPresent(
+                currentVersion: "2.4",
+                lastPresentedVersion: "2.3",
+                isEligible: true
+            )
+        )
+        XCTAssertFalse(
+            WhatsNewPresentationPolicy.shouldPresent(
+                currentVersion: "2.4",
+                lastPresentedVersion: "2.4",
+                isEligible: true
+            )
+        )
+    }
+
+    func testWhatsNewDoesNotPresentUntilTheAppIsReady() {
+        XCTAssertFalse(
+            WhatsNewPresentationPolicy.shouldPresent(
+                currentVersion: "2.4",
+                lastPresentedVersion: nil,
+                isEligible: false
+            )
+        )
+    }
 }

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -678,7 +678,7 @@ final class LogYourBodyUITests: XCTestCase {
             app.terminate()
         }
 
-        app.launchArguments = arguments
+        app.launchArguments = arguments + ["-lyb.whatsNew.lastPresentedVersion", "1.2.0"]
         app.launch()
     }
 


### PR DESCRIPTION
## Summary
- Adds a native SwiftUI What’s New sheet for signed-in, ready iOS users.
- Presents once per CFBundleShortVersionString and remains dismissible with Done or the sheet gesture.
- Keeps copy limited to modal behavior and displayed app version; no release metadata or product claims added.

## Verification
- xcodebuild focused AppVersionTests
- swiftlint lint --strict
- git diff --check

Draft only; do not merge.