### PR TITLE
fix(auth): use Better Auth get-session endpoint

### DIFF
--- a/apps/ios/LogYourBody/Services/AuthManager.swift
+++ b/apps/ios/LogYourBody/Services/AuthManager.swift
@@ -400,8 +400,11 @@ final class AuthManager: NSObject, ObservableObject {
     }
 
     private func validateStoredSession(_ stored: ProductAuthSession) async -> Bool {
+        // Better Auth exposes this operation as `get-session`. `session` is
+        // the legacy LogYourBody web route and returns 404 from the Jovie
+        // issuer used by native clients.
         guard let response = try? await requestBetterAuth(
-            path: "session", method: "GET", accessToken: stored.accessToken
+            path: "get-session", method: "GET", accessToken: stored.accessToken
         ) else { return false }
         return response.user != nil || response.session != nil
     }

--- a/apps/ios/LogYourBodyTests/AuthManagerSessionTests.swift
+++ b/apps/ios/LogYourBodyTests/AuthManagerSessionTests.swift
@@ -130,7 +130,7 @@ final class AuthManagerSessionTests: XCTestCase {
                     body: Data(#"{"sub":"user-123","email":"user@example.com","name":"Test User"}"#.utf8)
                 )
             }
-            if path.hasSuffix("/session") {
+            if path.hasSuffix("/get-session") {
                 let body = "{\"session\":{\"id\":\"session-123\",\"expiresAt\":\"2030-01-01T00:00:00Z\"},\"user\":"
                     + userBody + "}"
                 return AuthStubURLProtocol.StubbedResponse(statusCode: 200, body: Data(body.utf8))
@@ -142,6 +142,21 @@ final class AuthManagerSessionTests: XCTestCase {
             // Profile bootstrap and any other call: fail closed, tests don't depend on it.
             return AuthStubURLProtocol.StubbedResponse(statusCode: 404, body: Data("{}".utf8))
         }
+    }
+
+    func testInitializeValidatesStoredSessionWithCanonicalBetterAuthRoute() async throws {
+        let stored = makeSession(expiresAt: Date().addingTimeInterval(3_600))
+        try keychain.save(stored, forKey: storedSessionKey)
+        stubSessionSuccess()
+        let manager = makeManager()
+
+        await manager.initialize()
+
+        XCTAssertTrue(manager.isAuthenticated)
+        XCTAssertEqual(
+            AuthStubURLProtocol.recordedRequests.first?.url?.path,
+            "/api/auth/get-session"
+        )
     }
 
     func testGetAccessTokenReturnsCachedTokenWithoutNetworkWhenSessionUnexpired() async {


### PR DESCRIPTION
## Summary
- Fix native session validation to call Better Auth's canonical `GET /api/auth/get-session` endpoint.
- Update the session regression fixture to cover the canonical route.

## Root cause / repro
The TestFlight client used `GET https://jov.ie/api/auth/session` when validating a cached session. Better Auth exposes this operation as `get-session`; production returned `404` for `/session` and `200` for `/get-session`. A cached valid session was therefore discarded and the app surfaced the generic sign-in failure path.

The other native provider seams were also probed:
- `GET /api/auth/oauth2/authorize` → `302` for `logyourbody-ios` + `logyourbody://oauth` + PKCE parameters.
- `POST /api/auth/sign-in/social` → `400` validation response (route exists; GET is not the supported method).
- `POST https://www.logyourbody.com/api/auth/mobile/session` with an invalid bearer → `401` (route exists; no token was used in the probe).

## Test plan
- `git diff --check`
- `xcodebuild -list -project apps/ios/LogYourBody.xcodeproj`
- Attempted targeted `AuthManagerSessionTests` on iPhone 17 Pro simulator. Build could not complete within 10 minutes in this checkout; initial attempt also exposed the expected ignored local `Config.xcconfig` requirement. No test assertion failure was observed.

## Risk / follow-up
This fixes the confirmed client/provider path mismatch. A real-device TestFlight verification still requires a new iOS build and a successful Apple/email login against production. This PR does not change provider credentials, OAuth registration, or server routes.
