### PR TITLE
test(ios): gate releases on Apple auth contract

### DIFF
--- a/.github/scripts/verify-ios-auth-contract.mjs
+++ b/.github/scripts/verify-ios-auth-contract.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_ISSUER = 'https://jov.ie/api/auth';
+const DEFAULT_CLIENT_ID = 'logyourbody-ios';
+const DEFAULT_REDIRECT_URI = 'logyourbody://oauth';
+const APPLE_AUTH_HOST = 'appleid.apple.com';
+const PKCE_CHALLENGE = 'A'.repeat(43);
+
+function requireStatus(response, expected, boundary) {
+  if (response.status !== expected) {
+    throw new Error(`${boundary} returned HTTP ${response.status}; expected ${expected}.`);
+  }
+}
+
+function requireLocation(response, baseURL, boundary) {
+  const location = response.headers.get('location');
+  if (!location) {
+    throw new Error(`${boundary} did not return a Location header.`);
+  }
+  return new URL(location, baseURL);
+}
+
+async function resolveIdentityURL(response, issuerOrigin) {
+  if (response.status === 302) {
+    return requireLocation(response, issuerOrigin, 'OAuth authorize');
+  }
+  if (response.status === 200) {
+    const payload = await response.json();
+    if (payload?.redirect === true && typeof payload.url === 'string') {
+      return new URL(payload.url, issuerOrigin);
+    }
+  }
+  throw new Error(`OAuth authorize returned HTTP ${response.status} without a redirect.`);
+}
+
+function requireStateCookie(response) {
+  const setCookie = response.headers.get('set-cookie');
+  const cookie = setCookie?.split(';', 1)[0];
+  if (!cookie?.startsWith('__Secure-better-auth.state=')) {
+    throw new Error('Apple provider start did not issue the Better Auth state cookie.');
+  }
+  return cookie;
+}
+
+async function captureLiveProviderRequest(identityURL) {
+  const require = createRequire(new URL('../../apps/web/package.json', import.meta.url));
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch({
+    channel: process.env.PLAYWRIGHT_BROWSER_CHANNEL || 'chrome',
+    headless: true,
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.goto(identityURL.toString(), { waitUntil: 'networkidle' });
+    const providerRequest = page.waitForRequest((request) =>
+      request.url().endsWith('/api/auth/sign-in/social'),
+    );
+    await page.getByRole('button', { name: 'Continue with Apple' }).click();
+    const request = await providerRequest;
+    return request.postDataJSON();
+  } finally {
+    await browser.close();
+  }
+}
+
+export async function verifyIOSAuthContract({
+  fetchImpl = fetch,
+  captureProviderRequest = captureLiveProviderRequest,
+  issuer = DEFAULT_ISSUER,
+  clientID = DEFAULT_CLIENT_ID,
+  redirectURI = DEFAULT_REDIRECT_URI,
+  outerState = `ios-release-probe-${randomUUID()}`,
+} = {}) {
+  const normalizedIssuer = issuer.replace(/\/$/, '');
+  const issuerURL = new URL(normalizedIssuer);
+  if (issuerURL.protocol !== 'https:') {
+    throw new Error('The production auth issuer must use HTTPS.');
+  }
+
+  const authorizeURL = new URL(`${normalizedIssuer}/oauth2/authorize`);
+  authorizeURL.search = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientID,
+    redirect_uri: redirectURI,
+    scope: 'openid profile email offline_access',
+    state: outerState,
+    code_challenge: PKCE_CHALLENGE,
+    code_challenge_method: 'S256',
+  }).toString();
+
+  const authorizeResponse = await fetchImpl(authorizeURL, {
+    redirect: 'manual',
+    headers: { accept: 'text/html,application/xhtml+xml' },
+  });
+  const identityURL = await resolveIdentityURL(authorizeResponse, issuerURL.origin);
+  if (identityURL.origin !== issuerURL.origin || identityURL.pathname !== '/identity') {
+    throw new Error('OAuth authorize did not hand off to the production identity page.');
+  }
+
+  const providerRequest = await captureProviderRequest(identityURL);
+  if (
+    providerRequest?.provider !== 'apple' ||
+    providerRequest?.oauth_query !== identityURL.searchParams.toString()
+  ) {
+    throw new Error('Live identity page did not preserve the signed native OAuth transaction.');
+  }
+
+  const socialResponse = await fetchImpl(new URL(`${normalizedIssuer}/sign-in/social`), {
+    method: 'POST',
+    redirect: 'manual',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      origin: issuerURL.origin,
+      referer: identityURL.toString(),
+    },
+    body: JSON.stringify(providerRequest),
+  });
+  requireStatus(socialResponse, 200, 'Apple provider start');
+  const stateCookie = requireStateCookie(socialResponse);
+  const socialPayload = await socialResponse.json();
+  const appleURL = new URL(socialPayload.url);
+  const innerState = appleURL.searchParams.get('state');
+  if (appleURL.host !== APPLE_AUTH_HOST || !innerState) {
+    throw new Error('Apple provider start did not return a valid Apple authorization URL.');
+  }
+
+  const callbackProbeURL = new URL(`${normalizedIssuer}/callback/apple`);
+  callbackProbeURL.search = new URLSearchParams({
+    error: 'access_denied',
+    state: innerState,
+  }).toString();
+  const callbackResponse = await fetchImpl(callbackProbeURL, {
+    redirect: 'manual',
+    headers: {
+      accept: 'text/html',
+      cookie: stateCookie,
+    },
+  });
+  requireStatus(callbackResponse, 302, 'Apple callback');
+  const callbackURL = requireLocation(callbackResponse, issuerURL.origin, 'Apple callback');
+  const expectedRedirect = new URL(redirectURI);
+  if (
+    callbackURL.protocol !== expectedRedirect.protocol ||
+    callbackURL.host !== expectedRedirect.host ||
+    callbackURL.pathname !== expectedRedirect.pathname ||
+    callbackURL.searchParams.get('error') !== 'access_denied' ||
+    callbackURL.searchParams.get('state') !== outerState ||
+    callbackURL.searchParams.get('iss') !== normalizedIssuer ||
+    callbackURL.searchParams.has('error_description')
+  ) {
+    throw new Error('Apple callback did not safely return to the registered iOS redirect.');
+  }
+
+  return {
+    authorizeStatus: authorizeResponse.status,
+    identityPath: identityURL.pathname,
+    providerHost: appleURL.host,
+    callbackStatus: callbackResponse.status,
+    callbackScheme: callbackURL.protocol,
+    callbackHost: callbackURL.host,
+  };
+}
+
+async function main() {
+  const receipt = await verifyIOSAuthContract();
+  console.log(
+    [
+      'iOS auth contract verified',
+      `authorize=${receipt.authorizeStatus}`,
+      `identity=${receipt.identityPath}`,
+      `provider=${receipt.providerHost}`,
+      `callback=${receipt.callbackStatus}`,
+      `return=${receipt.callbackScheme}//${receipt.callbackHost}`,
+    ].join(' '),
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`iOS auth contract failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/verify-ios-auth-contract.test.mjs
+++ b/.github/scripts/verify-ios-auth-contract.test.mjs
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { verifyIOSAuthContract } from './verify-ios-auth-contract.mjs';
+
+const ISSUER = 'https://jov.ie/api/auth';
+const OUTER_STATE = 'ios-release-probe-test';
+const APPLE_PROVIDER_HOST = 'appleid.apple.com';
+const INVALID_PROVIDER_HOST = 'provider.invalid';
+const SIGNED_IDENTITY_QUERY = new URLSearchParams([
+  ['response_type', 'code'],
+  ['redirect_uri', 'logyourbody://oauth'],
+  ['scope', 'openid profile email offline_access'],
+  ['state', OUTER_STATE],
+  ['client_id', 'logyourbody-ios'],
+  ['code_challenge', 'A'.repeat(43)],
+  ['code_challenge_method', 'S256'],
+  ['exp', '2000000000'],
+  ['ba_param', 'state'],
+  ['ba_param', 'sig'],
+  ['sig', 'signed'],
+]).toString();
+
+function response(status, { body, headers = {} } = {}) {
+  return new Response(body, { status, headers });
+}
+
+function makeFetch({ callbackLocation, providerURL } = {}) {
+  const requests = [];
+  const fetchImpl = async (input, init = {}) => {
+    const url = new URL(input);
+    requests.push({ url, init });
+
+    if (url.pathname.endsWith('/oauth2/authorize')) {
+      return response(302, {
+        headers: { location: `/identity?${SIGNED_IDENTITY_QUERY}` },
+      });
+    }
+
+    if (url.pathname.endsWith('/sign-in/social')) {
+      const body = JSON.parse(init.body);
+      assert.equal(body.provider, 'apple');
+      assert.equal(body.oauth_query, SIGNED_IDENTITY_QUERY);
+      return response(200, {
+        body: JSON.stringify({
+          url: providerURL ?? `https://${APPLE_PROVIDER_HOST}/auth/authorize?state=inner-state`,
+          redirect: true,
+        }),
+        headers: {
+          'content-type': 'application/json',
+          'set-cookie': '__Secure-better-auth.state=signed-state; Path=/; HttpOnly; Secure',
+        },
+      });
+    }
+
+    assert.equal(url.pathname, '/api/auth/callback/apple');
+    assert.equal(url.searchParams.get('error'), 'access_denied');
+    assert.equal(url.searchParams.get('state'), 'inner-state');
+    assert.equal(init.headers.cookie, '__Secure-better-auth.state=signed-state');
+    return response(302, {
+      headers: {
+        location:
+          callbackLocation ??
+          `logyourbody://oauth?error=access_denied&state=${OUTER_STATE}&iss=${encodeURIComponent(ISSUER)}`,
+      },
+    });
+  };
+
+  return { fetchImpl, requests };
+}
+
+const captureProviderRequest = async () => ({
+  provider: 'apple',
+  oauth_query: SIGNED_IDENTITY_QUERY,
+});
+
+test('proves the production-like authorize, Apple, and native callback contract', async () => {
+  const { fetchImpl, requests } = makeFetch();
+
+  const receipt = await verifyIOSAuthContract({
+    fetchImpl,
+    captureProviderRequest,
+    outerState: OUTER_STATE,
+  });
+
+  assert.deepEqual(receipt, {
+    authorizeStatus: 302,
+    identityPath: '/identity',
+    providerHost: 'appleid.apple.com',
+    callbackStatus: 302,
+    callbackScheme: 'logyourbody:',
+    callbackHost: 'oauth',
+  });
+  assert.equal(requests.length, 3);
+});
+
+test('fails when the provider callback strands the user on the web error page', async () => {
+  const { fetchImpl } = makeFetch({
+    callbackLocation: `${ISSUER}/error?error=access_denied`,
+  });
+
+  await assert.rejects(
+    verifyIOSAuthContract({
+      fetchImpl,
+      captureProviderRequest,
+      outerState: OUTER_STATE,
+    }),
+    /did not safely return to the registered iOS redirect/,
+  );
+});
+
+test('fails when the configured provider does not hand off to Apple', async () => {
+  const { fetchImpl } = makeFetch({
+    providerURL: `https://${INVALID_PROVIDER_HOST}/authorize?state=inner-state`,
+  });
+
+  await assert.rejects(
+    verifyIOSAuthContract({
+      fetchImpl,
+      captureProviderRequest,
+      outerState: OUTER_STATE,
+    }),
+    /did not return a valid Apple authorization URL/,
+  );
+});
+
+test('fails when the live identity page drops the native OAuth transaction', async () => {
+  const { fetchImpl } = makeFetch();
+
+  await assert.rejects(
+    verifyIOSAuthContract({
+      fetchImpl,
+      captureProviderRequest: async () => ({ provider: 'apple' }),
+      outerState: OUTER_STATE,
+    }),
+    /did not preserve the signed native OAuth transaction/,
+  );
+});

--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -43,7 +43,7 @@ concurrency:
 
 env:
   LOGYOURBODY_APP_IDENTIFIER: com.logyourbody.app
-  LOGYOURBODY_APP_STORE_APP_ID: "6755209876"
+  LOGYOURBODY_APP_STORE_APP_ID: '6755209876'
 
 jobs:
   validate-release:
@@ -68,6 +68,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TYPE: ${{ github.event.inputs.release_type || 'testflight' }}
         run: .github/scripts/validate-release-source.sh
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install auth contract dependencies
+        run: pnpm install --frozen-lockfile --filter logyourbody...
+
+      - name: Verify production Apple auth contract
+        env:
+          PLAYWRIGHT_BROWSER_CHANNEL: chrome
+        run: |
+          node --test .github/scripts/verify-ios-auth-contract.test.mjs
+          node .github/scripts/verify-ios-auth-contract.mjs
 
       - name: Extract version info
         id: version


### PR DESCRIPTION
## Summary
- add a deterministic release-time contract probe for the production Better Auth authorize handoff, live identity page, Apple provider start, and safe `logyourbody://oauth` callback
- add negative contract tests for a web-stranded callback, wrong provider, and dropped signed OAuth transaction
- run the probe before any iOS release artifact is built or uploaded

## Why
The latest installed build reached Apple and returned an authorization code, but production token exchange failed in the Jovie provider because its Drizzle OAuth token schema was missing fields required by the pinned Better Auth provider. This PR does not mask that provider failure or claim a successful Apple login. The database repair is tracked separately in JovieInc/Jovie.

## Evidence
- `node --test .github/scripts/verify-ios-auth-contract.test.mjs` — 4/4 pass
- `PLAYWRIGHT_BROWSER_CHANNEL=chrome node .github/scripts/verify-ios-auth-contract.mjs` — authorize=200, identity=/identity, provider=appleid.apple.com, callback=302, return=logyourbody://oauth
- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm test:ci` — 10/10 Turbo tasks, web 52 suites / 338 tests, shared-lib 10 files / 41 tests
- `pnpm --filter @jovieinc/product-registry test` — pass

## Release boundary
Keep this PR draft until the Jovie OAuth schema migration is merged and verified in production. Merging this workflow change triggers the iOS release loop; the release job will now fail before upload if the live Apple OAuth handoff contract is broken. A successful physical-device/TestFlight Apple sign-in is still required after the provider deployment; no device success is claimed here.