### PR TITLE
fix(ios): scope first photo loading indicators

### DIFF
--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
@@ -1,5 +1,23 @@
 import SwiftUI
 
+enum OnboardingFirstPhotoAction: Equatable {
+    case add
+    case skip
+}
+
+struct OnboardingFirstPhotoActionState: Equatable {
+    let isBusy: Bool
+    let activeAction: OnboardingFirstPhotoAction?
+
+    var disablesActions: Bool {
+        isBusy || activeAction != nil
+    }
+
+    func showsLoader(for action: OnboardingFirstPhotoAction) -> Bool {
+        activeAction == action
+    }
+}
+
 struct BodyScoreFirstProgressPhotoView: View {
     @Environment(\.theme)
     private var theme
@@ -7,6 +25,14 @@ struct BodyScoreFirstProgressPhotoView: View {
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @EnvironmentObject private var authManager: AuthManager
     @State private var isAttachSheetPresented = false
+    @State private var activeAction: OnboardingFirstPhotoAction?
+
+    private var actionState: OnboardingFirstPhotoActionState {
+        OnboardingFirstPhotoActionState(
+            isBusy: viewModel.isPreparingFirstPhotoMetric || viewModel.isCompletingOnboarding,
+            activeAction: activeAction
+        )
+    }
 
     var body: some View {
         OnboardingPageTemplate(
@@ -29,7 +55,7 @@ struct BodyScoreFirstProgressPhotoView: View {
                 targetMetric: viewModel.onboardingFirstPhotoMetric,
                 fallbackDate: Date(),
                 onComplete: {
-                    await viewModel.completeFirstPhotoStep()
+                    await completeFirstPhotoStep(from: .add)
                 }
             )
             .environmentObject(authManager)
@@ -86,7 +112,7 @@ struct BodyScoreFirstProgressPhotoView: View {
             Button {
                 presentAttachSheet()
             } label: {
-                if viewModel.isPreparingFirstPhotoMetric || viewModel.isCompletingOnboarding {
+                if actionState.showsLoader(for: .add) {
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle(tint: .white))
                 } else {
@@ -94,15 +120,15 @@ struct BodyScoreFirstProgressPhotoView: View {
                 }
             }
             .buttonStyle(OnboardingPrimaryButtonStyle())
-            .disabled(viewModel.isPreparingFirstPhotoMetric || viewModel.isCompletingOnboarding)
+            .disabled(actionState.disablesActions)
             .accessibilityIdentifier("onboarding_first_photo_add_button")
 
             Button {
                 Task {
-                    await viewModel.completeFirstPhotoStep()
+                    await completeFirstPhotoStep(from: .skip)
                 }
             } label: {
-                if viewModel.isCompletingOnboarding {
+                if actionState.showsLoader(for: .skip) {
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle(tint: Color.appTextSecondary))
                 } else {
@@ -110,7 +136,7 @@ struct BodyScoreFirstProgressPhotoView: View {
                 }
             }
             .buttonStyle(OnboardingSecondaryButtonStyle())
-            .disabled(viewModel.isCompletingOnboarding)
+            .disabled(actionState.disablesActions)
             .accessibilityIdentifier("onboarding_first_photo_skip_button")
 
             Text("You can add progress photos later from Home.")
@@ -131,12 +157,20 @@ struct BodyScoreFirstProgressPhotoView: View {
 
     private func presentAttachSheet() {
         Task {
+            activeAction = .add
+            defer { activeAction = nil }
             guard await viewModel.prepareFirstPhotoBaselineMetric() != nil else { return }
             await MainActor.run {
                 HapticManager.shared.selection()
                 isAttachSheetPresented = true
             }
         }
+    }
+
+    private func completeFirstPhotoStep(from action: OnboardingFirstPhotoAction) async {
+        activeAction = action
+        defer { activeAction = nil }
+        await viewModel.completeFirstPhotoStep()
     }
 }
 

--- a/apps/ios/LogYourBodyTests/OnboardingFlowViewModelTests.swift
+++ b/apps/ios/LogYourBodyTests/OnboardingFlowViewModelTests.swift
@@ -605,4 +605,20 @@ final class OnboardingFlowViewModelTests: XCTestCase {
 
         XCTAssertEqual(updates["onboardingCompleted"] as? Bool, true)
     }
+
+    func testFirstPhotoAddActionOnlyShowsItsOwnLoader() {
+        let state = OnboardingFirstPhotoActionState(isBusy: true, activeAction: .add)
+
+        XCTAssertTrue(state.disablesActions)
+        XCTAssertTrue(state.showsLoader(for: .add))
+        XCTAssertFalse(state.showsLoader(for: .skip))
+    }
+
+    func testFirstPhotoSkipActionOnlyShowsItsOwnLoader() {
+        let state = OnboardingFirstPhotoActionState(isBusy: true, activeAction: .skip)
+
+        XCTAssertTrue(state.disablesActions)
+        XCTAssertFalse(state.showsLoader(for: .add))
+        XCTAssertTrue(state.showsLoader(for: .skip))
+    }
 }


### PR DESCRIPTION
## Summary
- show the loading spinner only on the first-photo action the user invoked
- keep the other action disabled and label-visible while the request is in flight
- add focused state tests for Add and Skip

## Verification
- `swiftlint lint --strict …` passed
- focused `xcodebuild` could not build in this clean worktree because the gitignored `apps/ios/LogYourBody/Config.xcconfig` is absent; result bundle records this as the sole build error before tests ran
- `pnpm run prepush` could not start because this worktree has no `node_modules` (`turbo: command not found`; current Node 26 also differs from the repo engine 20.x)

JOV-3323