### PR TITLE
fix(ci): use octokit rest namespace in codex auto-fix workflow

### DIFF
--- a/.github/workflows/codex-auto-fix-ci.yml
+++ b/.github/workflows/codex-auto-fix-ci.yml
@@ -41,7 +41,7 @@ jobs:
               return;
             }
 
-            const { data } = await github.pulls.get({
+            const { data } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pr.number,
@@ -61,7 +61,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            await github.issues.createComment({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: Number('${{ steps.pr.outputs.number }}'),


### PR DESCRIPTION
The 'Codex Auto-Fix on Failure' workflow crashes on every run with:

```
TypeError: Cannot read properties of undefined (reading 'get')
    at eval (actions/github-script/v7 ...)
```

github-script v7 removed the legacy top-level octokit namespaces; `github.pulls.get` / `github.issues.createComment` are undefined. Use the v7-compatible `github.rest.*` API (same pattern as Jovie's main-autofix.yml / test-flakiness-report.yml).

Impact: LYB PR CI failures have no auto-fix loop (failed 3x today: 05:35, 05:42, 13:30 UTC), leaving PRs stuck for 37h+.