### PR TITLE
fix(ios): make body score share sheet dismissable after screenshot

### DIFF
--- a/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
+++ b/apps/ios/LogYourBody/Components/BodyScoreShareCard.swift
@@ -515,6 +515,10 @@ struct BodyScoreShareSheet: View {
     @State private var renderedImage: UIImage?
     @State private var isRendering = false
     @State private var showSystemShareSheet = false
+    @State private var dragOffsetY: CGFloat = 0
+
+    /// Minimum downward drag distance required to dismiss the overlay share sheet.
+    static let dismissDragThreshold: CGFloat = 120
 
     init(payload: BodyScoreSharePayload, onClose: (() -> Void)? = nil) {
         self.payload = payload
@@ -533,7 +537,13 @@ struct BodyScoreShareSheet: View {
                 shareSheetContent(previewHeight: nil)
             }
         }
+        // Keep content inside the safe area so Close stays tappable under Dynamic Island / notch.
+        .padding(.top, JovieTokens.compactInset)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Color.jovieCanvas.ignoresSafeArea())
+        .offset(y: max(0, dragOffsetY))
+        .opacity(dismissDragOpacity)
+        .gesture(dismissDragGesture)
         .overlay {
             if isRendering {
                 ZStack {
@@ -557,20 +567,81 @@ struct BodyScoreShareSheet: View {
         .onChange(of: shareOptions) { _, _ in
             renderedImage = nil
         }
+        // Hardware Escape / keyboard dismiss path for the full-screen overlay presentation.
+        .onKeyPress(.escape) {
+            closeShareSheet()
+            return .handled
+        }
+        .accessibilityAction(.escape) {
+            closeShareSheet()
+        }
+        // Keep child identifiers (card/close/actions) discoverable for UI tests.
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("body_score_share_sheet")
+    }
+
+    private var dismissDragOpacity: Double {
+        guard dragOffsetY > 0 else { return 1 }
+        let progress = min(1, Double(dragOffsetY / (Self.dismissDragThreshold * 2)))
+        return max(0.45, 1 - progress * 0.55)
+    }
+
+    private var dismissDragGesture: some Gesture {
+        DragGesture(minimumDistance: 20, coordinateSpace: .local)
+            .onChanged { value in
+                // Only track downward dismiss drags; horizontal/upward should not fight controls.
+                guard !isRendering else { return }
+                let translationY = value.translation.height
+                dragOffsetY = translationY > 0 ? translationY : 0
+            }
+            .onEnded { value in
+                guard !isRendering else {
+                    dragOffsetY = 0
+                    return
+                }
+
+                if Self.shouldDismiss(
+                    afterDragTranslation: value.translation.height,
+                    predictedEndTranslation: value.predictedEndTranslation.height
+                ) {
+                    closeShareSheet()
+                } else {
+                    withAnimation(.spring(response: 0.28, dampingFraction: 0.86)) {
+                        dragOffsetY = 0
+                    }
+                }
+            }
+    }
+
+    /// Pure dismiss-threshold policy so unit tests can lock the escape path without UI harness.
+    static func shouldDismiss(
+        afterDragTranslation translationY: CGFloat,
+        predictedEndTranslation: CGFloat,
+        threshold: CGFloat = dismissDragThreshold
+    ) -> Bool {
+        translationY >= threshold || predictedEndTranslation >= threshold * 1.4
+    }
+
+    private func closeShareSheet() {
+        if let onClose {
+            onClose()
+        } else {
+            dismiss()
+        }
+        dragOffsetY = 0
     }
 
     private var sheetHeader: some View {
         HStack {
-            Button("Close") {
-                if let onClose {
-                    onClose()
-                } else {
-                    dismiss()
-                }
+            Button(action: closeShareSheet) {
+                Text("Close")
+                    .font(theme.typography.labelMedium)
+                    .foregroundColor(theme.colors.text)
             }
-            .font(theme.typography.labelMedium)
-            .foregroundColor(theme.colors.text)
             .jovieTouchTarget()
+            .accessibilityIdentifier("body_score_share_close_button")
+            .accessibilityLabel("Close share sheet")
+            .accessibilityHint("Dismisses the body score share view")
 
             Spacer()
 
@@ -583,6 +654,7 @@ struct BodyScoreShareSheet: View {
 
             Color.clear
                 .frame(width: 72, height: 1)
+                .accessibilityHidden(true)
         }
         .padding(.horizontal, JovieTokens.screenInset)
     }

--- a/apps/ios/LogYourBodyTests/BodyScoreShareCardTests.swift
+++ b/apps/ios/LogYourBodyTests/BodyScoreShareCardTests.swift
@@ -19,6 +19,34 @@ final class BodyScoreShareCardTests: XCTestCase {
         XCTAssertEqual(BodyScoreShareAspect.preferredExportAspect(for: nil), .portrait)
     }
 
+    func testShareSheetDismissesOnDownwardDragPastThreshold() {
+        XCTAssertFalse(
+            BodyScoreShareSheet.shouldDismiss(
+                afterDragTranslation: 40,
+                predictedEndTranslation: 60
+            )
+        )
+        XCTAssertTrue(
+            BodyScoreShareSheet.shouldDismiss(
+                afterDragTranslation: BodyScoreShareSheet.dismissDragThreshold,
+                predictedEndTranslation: 0
+            )
+        )
+        XCTAssertTrue(
+            BodyScoreShareSheet.shouldDismiss(
+                afterDragTranslation: 30,
+                predictedEndTranslation: BodyScoreShareSheet.dismissDragThreshold * 1.4
+            )
+        )
+        // Upward / sideways motion must never dismiss.
+        XCTAssertFalse(
+            BodyScoreShareSheet.shouldDismiss(
+                afterDragTranslation: -180,
+                predictedEndTranslation: -300
+            )
+        )
+    }
+
     func testPhotoShareAspectTracksNativeImageShape() {
         XCTAssertEqual(
             BodyScoreShareAspect.preferredExportAspect(

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -731,12 +731,21 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(shareButton.isHittable)
         shareButton.tap()
 
+        let shareSheet = app.descendants(matching: .any)["body_score_share_sheet"]
         let shareCard = app.descendants(matching: .any)["body_score_share_card"]
-        XCTAssertTrue(shareCard.waitForExistence(timeout: 8))
+        // Sheet identifier is preferred; card must remain discoverable for launch quality.
+        let sheetVisible = shareSheet.waitForExistence(timeout: 8)
+        let cardVisible = shareCard.waitForExistence(timeout: sheetVisible ? 4 : 8)
+        XCTAssertTrue(sheetVisible || cardVisible, "Share overlay must appear after tapping share")
+        XCTAssertTrue(cardVisible, "Share card must remain accessibility-discoverable inside the overlay")
         XCTAssertTrue(app.descendants(matching: .any)["body_score_share_content_controls"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["body_score_share_avatar_visual"].exists)
         XCTAssertTrue(app.descendants(matching: .any)["body_score_share_save_button"].exists)
         XCTAssertTrue(app.descendants(matching: .any)["body_score_share_system_button"].exists)
+
+        let closeButton = app.descendants(matching: .any)["body_score_share_close_button"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 3))
+        XCTAssertTrue(closeButton.isHittable, "Close must stay tappable outside the safe-area notch")
 
         let cardFrame = shareCard.frame
         let windowFrame = app.windows.firstMatch.frame
@@ -745,6 +754,17 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertGreaterThan(cardFrame.minY, windowFrame.minY + 72)
         XCTAssertLessThanOrEqual(cardFrame.maxY, windowFrame.maxY - 72)
         attachScreenshot(named: "launch-quality-body-score-share", from: app)
+
+        // Escape path: Close must actually dismiss the full-screen overlay.
+        closeButton.tap()
+        XCTAssertFalse(
+            shareSheet.waitForExistence(timeout: 3),
+            "Share sheet must dismiss when Close is tapped"
+        )
+        XCTAssertTrue(
+            shareButton.waitForExistence(timeout: 5),
+            "Home share control must return after dismissing share sheet"
+        )
     }
 
     private func assertAndCaptureTimelineAnalytics(in app: XCUIApplication) throws {


### PR DESCRIPTION
## Summary
- Screenshot on home opens `BodyScoreShareSheet` as a full-screen overlay with no reliable escape path
- Keep Close inside the safe area (Dynamic Island / notch)
- Add swipe-down dismiss + Escape / accessibility escape
- Unit + UI coverage for the dismiss path

## Test plan
- [x] Unit: `testShareSheetDismissesOnDownwardDragPastThreshold`
- [x] UI: share sheet Close is hittable and actually dismisses overlay
- [ ] Device: take screenshot on home → share sheet opens → Close works
- [ ] Device: swipe down to dismiss