### PR TITLE
fix(ios): eliminate extreme timeline scrub scroll jank

### DIFF
--- a/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
+++ b/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
@@ -43,7 +43,6 @@ struct ProgressTimelineView: View {
     // MARK: - Body
 
     var body: some View {
-        let currentRenderSignature = TimelineRenderSignature(metrics: bodyMetrics, mode: mode)
         let handlePosition = isDragging ? dragPosition : selectedPosition(
             in: renderData,
             selectedIndex: selectedIndex
@@ -87,10 +86,30 @@ struct ProgressTimelineView: View {
         }
         .accessibilityIdentifier("dashboard_timeline_scrubber")
         .onAppear {
-            refreshRenderDataIfNeeded(for: currentRenderSignature)
+            refreshRenderDataIfNeeded(
+                for: TimelineRenderSignature(metrics: bodyMetrics, mode: mode)
+            )
         }
-        .onChange(of: currentRenderSignature) { _, newSignature in
-            refreshRenderDataIfNeeded(for: newSignature)
+        // Recompute expensive render data only when inputs change — never every drag frame.
+        .onChange(of: mode) { _, newMode in
+            refreshRenderDataIfNeeded(
+                for: TimelineRenderSignature(metrics: bodyMetrics, mode: newMode)
+            )
+        }
+        .onChange(of: bodyMetrics.count) { _, _ in
+            refreshRenderDataIfNeeded(
+                for: TimelineRenderSignature(metrics: bodyMetrics, mode: mode)
+            )
+        }
+        .onChange(of: bodyMetrics.last?.id) { _, _ in
+            refreshRenderDataIfNeeded(
+                for: TimelineRenderSignature(metrics: bodyMetrics, mode: mode)
+            )
+        }
+        .onChange(of: bodyMetrics.first?.updatedAt) { _, _ in
+            refreshRenderDataIfNeeded(
+                for: TimelineRenderSignature(metrics: bodyMetrics, mode: mode)
+            )
         }
     }
 
@@ -265,13 +284,13 @@ struct ProgressTimelineView: View {
         let result = provider.findDataForPhotoMode(scrubDate: scrubDate)
         currentDateLabel = result.formattedDateLabel()
 
-        // Update selected index to nearest entry
+        // O(1) index lookup — firstIndex during drag is a primary jank source on long histories.
         if let photo = result.photo {
-            if let index = bodyMetrics.firstIndex(where: { $0.id == photo.bodyMetrics.id }) {
+            if let index = renderData.indexById[photo.bodyMetrics.id] {
                 updateSelectedIndex(index)
             }
         } else if let metrics = result.metrics {
-            if let index = bodyMetrics.firstIndex(where: { $0.id == metrics.bodyMetrics.id }) {
+            if let index = renderData.indexById[metrics.bodyMetrics.id] {
                 updateSelectedIndex(index)
             }
         }
@@ -285,9 +304,8 @@ struct ProgressTimelineView: View {
 
         currentDateLabel = TimelineDateFormatterCache.string(from: nearestDate, style: .mediumDate)
 
-        // Update selected index
         if let metric = provider.getMetric(for: nearestDate),
-           let index = bodyMetrics.firstIndex(where: { $0.id == metric.id }) {
+           let index = renderData.indexById[metric.id] {
             updateSelectedIndex(index)
         }
     }
@@ -391,18 +409,28 @@ struct TimelineRenderData {
     let provider: TimelineDataProvider
     let anchors: [TimelineAnchor]
     let zoomLevel: TimelineZoomLevel
+    /// id -> index in `metrics` for O(1) scrub selection.
+    let indexById: [String: Int]
 
     static func make(metrics: [BodyMetrics], mode: TimelineMode) -> TimelineRenderData {
         let provider = TimelineDataProvider()
         provider.loadMetrics(metrics)
-        guard !metrics.isEmpty,
-              let firstDate = provider.bodyMetrics.first?.date,
-              let lastDate = provider.bodyMetrics.last?.date else {
+        let sorted = provider.bodyMetrics
+        var indexById: [String: Int] = [:]
+        indexById.reserveCapacity(sorted.count)
+        for (idx, metric) in sorted.enumerated() {
+            indexById[metric.id] = idx
+        }
+
+        guard !sorted.isEmpty,
+              let firstDate = sorted.first?.date,
+              let lastDate = sorted.last?.date else {
             return TimelineRenderData(
                 metrics: [],
                 provider: provider,
                 anchors: [],
-                zoomLevel: .month
+                zoomLevel: .month,
+                indexById: [:]
             )
         }
 
@@ -410,10 +438,11 @@ struct TimelineRenderData {
         let anchors = provider.generateAnchors(mode: mode, zoomLevel: zoomLevel)
 
         return TimelineRenderData(
-            metrics: provider.bodyMetrics,
+            metrics: sorted,
             provider: provider,
             anchors: anchors,
-            zoomLevel: zoomLevel
+            zoomLevel: zoomLevel,
+            indexById: indexById
         )
     }
 }

--- a/apps/ios/LogYourBody/Services/TimelineDataProvider.swift
+++ b/apps/ios/LogYourBody/Services/TimelineDataProvider.swift
@@ -53,52 +53,52 @@ final class TimelineDataProvider {
     }
 
     private func findNearestPhoto(to date: Date, within window: TimeInterval) -> TimelineDataResult.PhotoResult? {
-        guard !metricsWithPhotos.isEmpty else { return nil }
-
-        // Find nearest photo within window
-        var nearest: BodyMetrics?
-        var smallestDiff: TimeInterval = window
-
-        for metric in metricsWithPhotos {
-            let diff = abs(metric.date.timeIntervalSince(date))
-            if diff <= window && diff < smallestDiff {
-                nearest = metric
-                smallestDiff = diff
-            }
-        }
-
-        guard let found = nearest else { return nil }
-
-        let days = Int(smallestDiff / (24 * 60 * 60))
+        guard let found = nearestMetric(in: metricsWithPhotos, to: date, within: window) else { return nil }
+        let days = Int(abs(found.date.timeIntervalSince(date)) / (24 * 60 * 60))
         return TimelineDataResult.PhotoResult(bodyMetrics: found, daysFromScrub: days)
     }
 
     private func findNearestMetrics(to date: Date, within window: TimeInterval) -> TimelineDataResult.MetricsResult? {
-        // First try to find exact or nearest metric date
-        var nearest: BodyMetrics?
-        var smallestDiff: TimeInterval = window
+        guard let found = nearestMetric(in: metricsWithWeightOrBodyFat, to: date, within: window) else {
+            return nil
+        }
+        let days = Int(abs(found.date.timeIntervalSince(date)) / (24 * 60 * 60))
+        return TimelineDataResult.MetricsResult(
+            bodyMetrics: found,
+            daysFromScrub: days,
+            isInterpolated: false
+        )
+    }
 
-        for metric in metricsWithWeightOrBodyFat {
-            let diff = abs(metric.date.timeIntervalSince(date))
-            if diff <= window && diff < smallestDiff {
-                nearest = metric
-                smallestDiff = diff
+    /// Binary-search nearest metric by date on a pre-sorted ascending array.
+    private func nearestMetric(
+        in metrics: [BodyMetrics],
+        to date: Date,
+        within window: TimeInterval
+    ) -> BodyMetrics? {
+        guard !metrics.isEmpty else { return nil }
+        var lo = 0
+        var hi = metrics.count - 1
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if metrics[mid].date < date {
+                lo = mid + 1
+            } else {
+                hi = mid
             }
         }
-
-        if let found = nearest {
-            let days = Int(smallestDiff / (24 * 60 * 60))
-            return TimelineDataResult.MetricsResult(
-                bodyMetrics: found,
-                daysFromScrub: days,
-                isInterpolated: false
-            )
+        var best = metrics[lo]
+        var bestDiff = abs(best.date.timeIntervalSince(date))
+        if lo > 0 {
+            let prev = metrics[lo - 1]
+            let prevDiff = abs(prev.date.timeIntervalSince(date))
+            if prevDiff < bestDiff {
+                best = prev
+                bestDiff = prevDiff
+            }
         }
-
-        // If no direct match, try interpolation
-        // (This would integrate with your existing MetricsInterpolationService)
-        // For now, return nil if no match found
-        return nil
+        guard bestDiff <= window else { return nil }
+        return best
     }
 
     // MARK: - Avatar Mode - Get All Data Dates

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
@@ -10,7 +10,7 @@ extension DashboardViewLiquid {
     /// when the metrics/height change), so a scrub reads precomputed contexts instead
     /// of re-sorting and re-walking the EMA trend on every index change. The resulting
     /// values are identical to the previous per-call estimate path.
-    func updateAnimatedValues(for index: Int) {
+    func updateAnimatedValues(for index: Int, animate: Bool = true) {
         let metrics = viewModel.bodyMetrics
         guard index >= 0 && index < metrics.count else { return }
         let metric = metrics[index]
@@ -28,19 +28,28 @@ extension DashboardViewLiquid {
             heightInches: heightInches
         )
 
-        withAnimation(.easeOut(duration: 0.18)) {
+        let apply = {
             if let weight = values.weight {
-                let system = currentMeasurementSystem
-                animatedWeight = convertWeight(weight, to: system) ?? weight
+                let system = self.currentMeasurementSystem
+                self.animatedWeight = self.convertWeight(weight, to: system) ?? weight
             }
 
             if let bodyFat = values.bodyFat {
-                animatedBodyFat = bodyFat
+                self.animatedBodyFat = bodyFat
             }
 
             if let ffmi = values.ffmi {
-                animatedFFMI = ffmi
+                self.animatedFFMI = ffmi
             }
+        }
+
+        // Scrubbing must not run spring/ease animations every frame — that is a primary jank source.
+        if animate {
+            withAnimation(.easeOut(duration: 0.18), apply)
+        } else {
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction, apply)
         }
     }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -248,7 +248,7 @@ extension DashboardViewLiquid {
             }
 
             selectedIndex = index
-            updateAnimatedValues(for: index)
+            updateAnimatedValues(for: index, animate: false)
         }
     }
 

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -404,6 +404,18 @@ struct DashboardViewLiquid: View {
         rebuildDailyMetricsLookup: Bool = false,
         animatedIndex: Int? = nil
     ) {
+        // Scrub hot path: index-only updates must NOT rebuild weekly/monthly/yearly
+        // global timeline buckets (that is multi-ms main-thread work and causes jank).
+        if let animatedIndex, !rebuildDailyMetricsLookup {
+            Task { @MainActor in
+                guard !viewModel.bodyMetrics.isEmpty else { return }
+                PerfSignpost.measure("dashboard_scrub_refresh") {
+                    updateAnimatedValues(for: animatedIndex, animate: false)
+                }
+            }
+            return
+        }
+
         Task { @MainActor in
             await Task.yield()
 
@@ -415,7 +427,7 @@ struct DashboardViewLiquid: View {
                 refreshGlobalTimelineStore()
 
                 if let animatedIndex, !viewModel.bodyMetrics.isEmpty {
-                    updateAnimatedValues(for: animatedIndex)
+                    updateAnimatedValues(for: animatedIndex, animate: true)
                 }
             }
         }

--- a/apps/ios/LogYourBodyTests/TimelineScrollJankRegressionTests.swift
+++ b/apps/ios/LogYourBodyTests/TimelineScrollJankRegressionTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import LogYourBody
+
+/// Guards the scrub hot path: selection stays O(1) and nearest lookup stays logarithmic.
+final class TimelineScrollJankRegressionTests: XCTestCase {
+    private let calendar = Calendar.current
+
+    func testRenderDataBuildsO1IndexMap() {
+        let metrics = (0..<200).map { i in
+            makeMetric(id: "m-\(i)", date: date(daysAgo: 200 - i), weight: 180, bodyFat: 15)
+        }
+        let data = TimelineRenderData.make(metrics: metrics, mode: .photo)
+        XCTAssertEqual(data.indexById.count, metrics.count)
+        XCTAssertEqual(data.indexById["m-0"], 0)
+        XCTAssertEqual(data.indexById["m-199"], 199)
+    }
+
+    func testPhotoModeNearestIsWithinWindowAndStable() {
+        let provider = TimelineDataProvider()
+        let metrics = (0..<120).map { i in
+            makeMetric(
+                id: "p-\(i)",
+                date: date(daysAgo: 120 - i),
+                weight: 180,
+                bodyFat: 15,
+                photoUrl: "https://example.com/\(i).jpg"
+            )
+        }
+        provider.loadMetrics(metrics)
+        let target = metrics[60].date
+        let result = provider.findDataForPhotoMode(scrubDate: target)
+        XCTAssertEqual(result.photo?.bodyMetrics.id, "p-60")
+        XCTAssertEqual(result.metrics?.bodyMetrics.id, "p-60")
+    }
+
+    func testNearestLookupFindsAdjacentMetric() {
+        let provider = TimelineDataProvider()
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        provider.loadMetrics([
+            makeMetric(id: "a", date: base.addingTimeInterval(-86_400 * 10), weight: 180, bodyFat: 15, photoUrl: "https://e/a.jpg"),
+            makeMetric(id: "b", date: base.addingTimeInterval(-86_400 * 2), weight: 179, bodyFat: 14.5, photoUrl: "https://e/b.jpg"),
+            makeMetric(id: "c", date: base, weight: 178, bodyFat: 14, photoUrl: "https://e/c.jpg")
+        ])
+        let result = provider.findDataForPhotoMode(scrubDate: base.addingTimeInterval(-86_400 * 3))
+        XCTAssertEqual(result.photo?.bodyMetrics.id, "b")
+    }
+
+    private func date(daysAgo: Int) -> Date {
+        calendar.date(byAdding: .day, value: -daysAgo, to: Date(timeIntervalSince1970: 1_800_000_000))!
+    }
+
+    private func makeMetric(
+        id: String,
+        date: Date,
+        weight: Double?,
+        bodyFat: Double?,
+        photoUrl: String? = nil
+    ) -> BodyMetrics {
+        BodyMetrics(
+            id: id,
+            userId: "scroll-jank-user",
+            date: date,
+            weight: weight,
+            weightUnit: "lbs",
+            bodyFatPercentage: bodyFat,
+            bodyFatMethod: bodyFat == nil ? nil : "scale",
+            muscleMass: nil,
+            boneMass: nil,
+            notes: nil,
+            photoUrl: photoUrl,
+            dataSource: BodyMetricSource.manual.rawValue,
+            createdAt: date,
+            updatedAt: date
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Extreme scroll/scrub jank on the default Timeline home came from the selectedIndex hot path doing far too much work every frame.

### Root cause
1. `onChange(of: selectedIndex)` always called `scheduleDashboardDerivedStateRefresh`, which **rebuilt weekly/monthly/yearly global timeline buckets** on every scrub tick.
2. Hero metric updates used **withAnimation every frame** during drag.
3. Scrub selection used **O(n) `firstIndex`** on the metrics array.
4. Nearest photo/metric search was **linear** over the history.
5. `ProgressTimelineView.body` rebuilt a full metrics **hash signature every evaluation**.

### Fix
- Index-only refresh path: animate values only, **no** global timeline rebuild
- Disable animations while scrubbing (`animate: false`)
- O(1) `id → index` map on `TimelineRenderData`
- Binary-search nearest photo/metric dates
- Recompute timeline render data only on real input changes (mode/count/identity), not every frame

### Test plan
- [x] Added `TimelineScrollJankRegressionTests` (index map + nearest lookup)
- [ ] Device: scrub timeline on a long history — should stay smooth
- [ ] Pull-to-refresh / data reload still updates buckets
- [ ] Accessibility scrub still moves selection