### PR TITLE
fix: harden iOS settings and sync reliability

### DIFF
--- a/apps/ios/LogYourBody/Components/DashboardSyncComponents.swift
+++ b/apps/ios/LogYourBody/Components/DashboardSyncComponents.swift
@@ -206,7 +206,7 @@ struct DashboardSyncDetailsSheet: View {
 
             Button {
                 Task {
-                    await HealthSyncCoordinator.shared.forceFullHealthKitSync()
+                    _ = await HealthSyncCoordinator.shared.forceFullHealthKitSync()
                 }
             } label: {
                 HStack {

--- a/apps/ios/LogYourBody/DesignSystem/Molecules/OTPField.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Molecules/OTPField.swift
@@ -41,7 +41,7 @@ struct OTPField: View {
                 .accessibilityValue("\(code.count) of \(length) digits entered")
                 .accessibilityHint("Enter the \(length)-digit code we emailed you.")
                 .accessibilityIdentifier(accessibilityIdentifier ?? "otp_field")
-                .onChange(of: code) { newValue in
+                .onChange(of: code) { _, newValue in
                     // Limit to specified length
                     if newValue.count > length {
                         code = String(newValue.prefix(length))

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreRevealView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreRevealView.swift
@@ -14,26 +14,17 @@ enum BodyScoreRevealPolicy {
         }
     }
 
-    /// The body-fat range is framed as a "Target" until the individualized
-    /// aesthetic goals gate re-labels it as a "Reference".
-    static func referenceText(
-        range: BodyScoreResult.ReferenceRange,
-        usesIndividualizedAestheticGoals: Bool
-    ) -> String {
-        let label = usesIndividualizedAestheticGoals ? "Reference" : "Target"
+    /// Population ranges describe a comparison reference, never a personal target.
+    static func referenceText(range: BodyScoreResult.ReferenceRange) -> String {
         let lowerBound = Int(range.lowerBound)
         let upperBound = Int(range.upperBound)
-        return "\(label): \(lowerBound)–\(upperBound)% (\(range.label))"
+        return "Reference: \(lowerBound)–\(upperBound)% (\(range.label))"
     }
 
-    static func referenceAccessibilityText(
-        range: BodyScoreResult.ReferenceRange,
-        usesIndividualizedAestheticGoals: Bool
-    ) -> String {
-        let label = usesIndividualizedAestheticGoals ? "Reference" : "Target"
+    static func referenceAccessibilityText(range: BodyScoreResult.ReferenceRange) -> String {
         let lowerBound = Int(range.lowerBound)
         let upperBound = Int(range.upperBound)
-        return "\(label) body fat: \(lowerBound) to \(upperBound) percent. \(range.label)."
+        return "Reference body fat: \(lowerBound) to \(upperBound) percent. \(range.label)."
     }
 
     /// Builds the share-card payload from the onboarding input, converting
@@ -96,19 +87,10 @@ struct BodyScoreRevealView: View {
     @State private var animateScore = false
     @State private var isSharePresented = false
     @State private var sharePayload: BodyScoreSharePayload?
-    @State private var featureGateRefreshToken = UUID()
     @AccessibilityFocusState private var scoreFocused: Bool
 
     private var percentileGroupLabel: String {
         BodyScoreRevealPolicy.percentileGroupLabel(for: viewModel.bodyScoreInput.sex)
-    }
-
-    private var usesIndividualizedAestheticGoals: Bool {
-        _ = featureGateRefreshToken
-
-        return AppServicePorts.analyticsTracker.isFeatureEnabled(
-            flagKey: AppFeatureGate.individualizedAestheticGoals
-        )
     }
 
     var body: some View {
@@ -174,9 +156,6 @@ struct BodyScoreRevealView: View {
             } else {
                 animateScore = false
             }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .featureGatesDidChange)) { _ in
-            featureGateRefreshToken = UUID()
         }
         .sheet(isPresented: $isSharePresented) {
             if let payload = sharePayload {
@@ -253,17 +232,11 @@ struct BodyScoreRevealView: View {
     }
 
     private func referenceText(result: BodyScoreResult) -> String {
-        BodyScoreRevealPolicy.referenceText(
-            range: result.bodyFatReferenceRange,
-            usesIndividualizedAestheticGoals: usesIndividualizedAestheticGoals
-        )
+        BodyScoreRevealPolicy.referenceText(range: result.bodyFatReferenceRange)
     }
 
     private func referenceAccessibilityText(result: BodyScoreResult) -> String {
-        BodyScoreRevealPolicy.referenceAccessibilityText(
-            range: result.bodyFatReferenceRange,
-            usesIndividualizedAestheticGoals: usesIndividualizedAestheticGoals
-        )
+        BodyScoreRevealPolicy.referenceAccessibilityText(range: result.bodyFatReferenceRange)
     }
 
     private func makeSharePayload(from result: BodyScoreResult) -> BodyScoreSharePayload? {

--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -179,6 +179,10 @@ struct LogYourBodyApp: App {
 
     @StateObject private var persistenceController = CoreDataManager.shared
 
+    private static var isRunningUnitTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
     init() {
         LaunchMetrics.begin()
         LogYourBodyAppShortcuts.updateAppShortcutParameters()
@@ -220,6 +224,10 @@ struct LogYourBodyApp: App {
                     handleDeepLink(url)
                 }
                 .task {
+                    // Hosted unit tests launch the app process to load the test
+                    // bundle. Do not let real startup race test-owned Keychain
+                    // fixtures or external-service stubs in that environment.
+                    guard !Self.isRunningUnitTests else { return }
                     await performStartupSequence()
                     resolvePendingEntryDeepLinkIfPossible()
                 }

--- a/apps/ios/LogYourBody/Services/BugReportManager.swift
+++ b/apps/ios/LogYourBody/Services/BugReportManager.swift
@@ -104,18 +104,16 @@ final class BugReportManager: ObservableObject {
         let emailToSend = email
         let screenshotToSend = currentScreenshot
 
-        Task.detached(priority: .userInitiated) {
-            let attachments = screenshotToSend.map { [$0] }
-            let feedback = SentryFeedback(
-                message: messageToSend,
-                name: nameToSend,
-                email: emailToSend,
-                source: .custom,
-                associatedEventId: nil,
-                attachments: attachments
-            )
-            SentrySDK.capture(feedback: feedback)
-        }
+        let attachments = screenshotToSend.map { [$0] }
+        let feedback = SentryFeedback(
+            message: messageToSend,
+            name: nameToSend,
+            email: emailToSend,
+            source: .custom,
+            associatedEventId: nil,
+            attachments: attachments
+        )
+        SentrySDK.capture(feedback: feedback)
         #endif
 
         isFormPresented = false

--- a/apps/ios/LogYourBody/Services/HealthKitManager+Part02.swift
+++ b/apps/ios/LogYourBody/Services/HealthKitManager+Part02.swift
@@ -344,11 +344,13 @@ func processHistoricalHealthKitBatches(
             // Update progress
             processedMonths += Double(batchSizeMonths)
             let progress = totalMonths > 0 ? min(processedMonths / totalMonths, 1.0) : 1.0
+            let importedCountSnapshot = totalImported
+            let processedMonthsSnapshot = processedMonths
             await MainActor.run {
                 importProgress = progress
-                importedCount = totalImported
+                importedCount = importedCountSnapshot
                 if totalMonths > 0 {
-                    let remaining = max(0, Int(totalMonths - processedMonths))
+                    let remaining = max(0, Int(totalMonths - processedMonthsSnapshot))
                     importStatus = remaining > 0 ? "Importing... \(remaining) months remaining" : "Finalizing..."
                 }
             }
@@ -363,8 +365,8 @@ func processHistoricalHealthKitBatches(
         return (imported: totalImported, skipped: totalSkipped)
     }
 
-func forceFullHealthKitSync() async {
-        _ = await syncAllHistoricalHealthKitData()
+func forceFullHealthKitSync() async -> Bool {
+        await syncAllHistoricalHealthKitData()
     }
 
 func getEarliestWeightDate() async throws -> Date? {

--- a/apps/ios/LogYourBody/Services/HealthSyncCoordinator.swift
+++ b/apps/ios/LogYourBody/Services/HealthSyncCoordinator.swift
@@ -19,7 +19,7 @@ protocol HealthKitSyncManaging: AnyObject {
     func syncWeightFromHealthKit() async throws
     func syncStepsFromHealthKit() async throws
     func fetchTodayStepCount() async throws -> Int
-    func forceFullHealthKitSync() async
+    func forceFullHealthKitSync() async -> Bool
 }
 
 extension HealthKitManager: HealthKitSyncManaging {}
@@ -27,6 +27,7 @@ extension HealthKitManager: HealthKitSyncManaging {}
 /// Protocol abstraction for coordinating HealthKit-related sync operations.
 /// This enables easier unit testing for components that depend on
 /// HealthSyncCoordinator by allowing mock implementations.
+@MainActor
 protocol HealthSyncCoordinating {
     func bootstrapIfNeeded(syncEnabled: Bool)
     func resetForCurrentUser() async
@@ -37,7 +38,7 @@ protocol HealthSyncCoordinating {
     func runDeferredOnboardingWeightSync() async
     func syncWeightFromHealthKit() async throws
     func syncStepsFromHealthKit() async throws
-    func forceFullHealthKitSync() async
+    func forceFullHealthKitSync() async -> Bool
 }
 
 /// Central coordinator for HealthKit bootstrap and, over time, HealthKit-related
@@ -223,12 +224,12 @@ final class HealthSyncCoordinator: ObservableObject, HealthSyncCoordinating {
     /// Trigger a full historical HealthKit import. This is used by manual
     /// "Sync All Historical Data" actions and the dashboard sync details
     /// sheet.
-    func forceFullHealthKitSync() async {
+    func forceFullHealthKitSync() async -> Bool {
         ErrorTrackingService.shared.addBreadcrumb(
             message: "HealthSyncCoordinator.forceFullHealthKitSync",
             category: "healthKitCoordinator"
         )
 
-        await healthKitManager.forceFullHealthKitSync()
+        return await healthKitManager.forceFullHealthKitSync()
     }
 }

--- a/apps/ios/LogYourBody/Services/LoadingManager.swift
+++ b/apps/ios/LogYourBody/Services/LoadingManager.swift
@@ -68,10 +68,17 @@ class LoadingManager: ObservableObject {
 
     init(
         authManager: AuthManager,
-        healthSyncCoordinator: HealthSyncCoordinating = HealthSyncCoordinator.shared
+        healthSyncCoordinator: HealthSyncCoordinating
     ) {
         self.authManager = authManager
         self.healthSyncCoordinator = healthSyncCoordinator
+    }
+
+    convenience init(authManager: AuthManager) {
+        self.init(
+            authManager: authManager,
+            healthSyncCoordinator: HealthSyncCoordinator.shared
+        )
     }
 
     func startLoading() async {

--- a/apps/ios/LogYourBody/SettingsComponents.swift
+++ b/apps/ios/LogYourBody/SettingsComponents.swift
@@ -59,7 +59,7 @@ struct SettingsSection<Content: View>: View {
             if let footer = footer {
                 Text(footer)
                     .font(theme.typography.captionMedium)
-                    .foregroundColor(theme.colors.textTertiary)
+                    .foregroundColor(theme.colors.textSecondary)
                     .padding(.horizontal, theme.spacing.md)
                     .padding(.top, theme.spacing.xs)
             }
@@ -78,6 +78,7 @@ struct SettingsRow: View {
     let icon: String?
     let title: String
     var subtitle: String?
+    var subtitleColor: Color?
     var value: String?
     var showChevron: Bool
     var isExternal: Bool
@@ -87,6 +88,7 @@ struct SettingsRow: View {
         icon: String? = nil,
         title: String,
         subtitle: String? = nil,
+        subtitleColor: Color? = nil,
         value: String? = nil,
         showChevron: Bool = false,
         isExternal: Bool = false,
@@ -95,6 +97,7 @@ struct SettingsRow: View {
         self.icon = icon
         self.title = title
         self.subtitle = subtitle
+        self.subtitleColor = subtitleColor
         self.value = value
         self.showChevron = showChevron
         self.isExternal = isExternal
@@ -170,7 +173,7 @@ struct SettingsRow: View {
                 if let subtitle {
                     Text(subtitle)
                         .font(theme.typography.captionLarge)
-                        .foregroundColor(theme.colors.textSecondary)
+                        .foregroundColor(subtitleColor ?? theme.colors.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
@@ -235,6 +238,36 @@ struct SettingsNavigationLink<Destination: View>: View {
 
 // MARK: - Detail Screen
 
+struct SettingsBackButton: View {
+    @Environment(\.dismiss)
+    private var dismiss
+    @Environment(\.theme)
+    private var theme
+
+    var body: some View {
+        Button {
+            dismiss()
+        } label: {
+            Image(systemName: "chevron.left")
+                .font(.body.weight(.semibold))
+                .foregroundColor(theme.colors.text)
+                .frame(
+                    width: JovieTokens.minimumHitTarget,
+                    height: JovieTokens.minimumHitTarget
+                )
+                .background(theme.colors.surfaceSecondary, in: Circle())
+                .overlay {
+                    Circle()
+                        .stroke(theme.colors.border.opacity(0.75), lineWidth: 1)
+                }
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Settings")
+        .accessibilityHint("Returns to Settings")
+    }
+}
+
 struct SettingsDetailScreen<Content: View>: View {
     @Environment(\.theme)
     private var theme
@@ -262,6 +295,14 @@ struct SettingsDetailScreen<Content: View>: View {
         .settingsBackground()
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar(.visible, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                SettingsBackButton()
+            }
+        }
     }
 }
 
@@ -353,9 +394,11 @@ struct SettingsToggleRow: View {
     private var toggle: some View {
         Toggle(title, isOn: $isOn)
             .labelsHidden()
+            .toggleStyle(.switch)
             .accessibilityLabel(title)
+            .accessibilityValue(isOn ? "On" : "Off")
             .accessibilityHint(subtitle ?? "")
-            .tint(theme.colors.primary)
+            .tint(theme.colors.info)
     }
 
     private var resolvedTint: Color {

--- a/apps/ios/LogYourBody/Utils/Configuration.swift
+++ b/apps/ios/LogYourBody/Utils/Configuration.swift
@@ -280,7 +280,9 @@ enum Configuration {
         }
 
         let apiBaseURL = URL(string: snapshot.apiBaseURL)
-        if apiBaseURL == nil || isInvalidURLValue(snapshot.apiBaseURL) {
+        let isDevelopmentLocalhost = snapshot.environment == .development
+            && apiBaseURL?.host?.lowercased() == "localhost"
+        if apiBaseURL == nil || (!isDevelopmentLocalhost && isInvalidURLValue(snapshot.apiBaseURL)) {
             messages.append("API base URL must be configured.")
         }
 

--- a/apps/ios/LogYourBody/Utils/Constants.swift
+++ b/apps/ios/LogYourBody/Utils/Constants.swift
@@ -133,21 +133,11 @@ struct Constants {
     }
 }
 
-enum AppFeatureGate {
-    static let individualizedAestheticGoals = "individualized_aesthetic_goals"
-}
-
 enum AestheticGoalPolicy {
-    static func resolvedGoal(
-        explicitGoal: Double?,
-        legacyReferenceMidpoint: Double,
-        individualizedGoalsEnabled: Bool
-    ) -> Double? {
-        if individualizedGoalsEnabled {
-            return explicitGoal
-        }
-
-        return explicitGoal ?? legacyReferenceMidpoint
+    /// A population reference is not a personal target. Only a goal the user
+    /// explicitly selected may drive goal UI or dashboard progress.
+    static func resolvedGoal(explicitGoal: Double?) -> Double? {
+        explicitGoal
     }
 }
 

--- a/apps/ios/LogYourBody/ViewModels/DashboardViewModel.swift
+++ b/apps/ios/LogYourBody/ViewModels/DashboardViewModel.swift
@@ -18,10 +18,17 @@ final class DashboardViewModel: ObservableObject {
 
     init(
         healthKitManager: HealthKitManager = .shared,
-        healthSyncCoordinator: HealthSyncCoordinating = HealthSyncCoordinator.shared
+        healthSyncCoordinator: HealthSyncCoordinating
     ) {
         self.healthKitManager = healthKitManager
         self.healthSyncCoordinator = healthSyncCoordinator
+    }
+
+    convenience init(healthKitManager: HealthKitManager = .shared) {
+        self.init(
+            healthKitManager: healthKitManager,
+            healthSyncCoordinator: HealthSyncCoordinator.shared
+        )
     }
 
     func loadData(

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+CoreAccessors.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+CoreAccessors.swift
@@ -3,40 +3,15 @@ import SwiftUI
 extension DashboardViewLiquid {
     // MARK: - Goal Helpers
 
-    var usesIndividualizedAestheticGoals: Bool {
-        _ = featureGateRefreshToken
-
-        return AppServicePorts.analyticsTracker.isFeatureEnabled(
-            flagKey: AppFeatureGate.individualizedAestheticGoals
-        )
-    }
-
-    /// Returns an explicit FFMI goal, or the legacy reference fallback while the gate is disabled.
+    /// Returns the user-selected FFMI goal. Population references never become
+    /// personal targets without explicit user input.
     var ffmiGoal: Double? {
-        let gender = authManager.currentUser?.profile?.gender?.lowercased() ?? ""
-        let legacyReference = gender.contains("female") || gender.contains("woman") ?
-            Constants.BodyComposition.FFMI.femaleReferenceMidpoint :
-            Constants.BodyComposition.FFMI.maleReferenceMidpoint
-
-        return AestheticGoalPolicy.resolvedGoal(
-            explicitGoal: customFFMIGoal,
-            legacyReferenceMidpoint: legacyReference,
-            individualizedGoalsEnabled: usesIndividualizedAestheticGoals
-        )
+        AestheticGoalPolicy.resolvedGoal(explicitGoal: customFFMIGoal)
     }
 
-    /// Returns an explicit body-fat goal, or the legacy reference fallback while the gate is disabled.
+    /// Returns the user-selected body-fat goal.
     var bodyFatGoal: Double? {
-        let gender = authManager.currentUser?.profile?.gender?.lowercased() ?? ""
-        let legacyReference = gender.contains("female") || gender.contains("woman") ?
-            Constants.BodyComposition.BodyFat.femaleReferenceMidpoint :
-            Constants.BodyComposition.BodyFat.maleReferenceMidpoint
-
-        return AestheticGoalPolicy.resolvedGoal(
-            explicitGoal: customBodyFatGoal,
-            legacyReferenceMidpoint: legacyReference,
-            individualizedGoalsEnabled: usesIndividualizedAestheticGoals
-        )
+        AestheticGoalPolicy.resolvedGoal(explicitGoal: customBodyFatGoal)
     }
 
     /// Returns the weight goal (optional, nil if not set)

--- a/apps/ios/LogYourBody/Views/IntegrationsView.swift
+++ b/apps/ios/LogYourBody/Views/IntegrationsView.swift
@@ -15,18 +15,18 @@ struct IntegrationsView: View {
     @State private var isConnectingHealthKit = false
     @State private var isSyncingHealthKit = false
     @State private var healthSyncStatusMessage: String?
+    @State private var healthSyncStatusIsError = false
     @State private var bodySpecLastSyncedText: String?
     @State private var isLoadingBodySpecLastSynced = false
     @State private var progressPhotoCount = 0
     @State private var featureGateRefreshToken = UUID()
-    @Environment(\.dismiss)
-
-    var dismiss
     var body: some View {
         ScrollView {
             VStack(spacing: theme.spacing.sectionSpacing) {
                 healthAndFitnessSection
-                photoImportSection
+                if isBulkProgressPhotoImportEnabled {
+                    photoImportSection
+                }
                 dataExportSection
             }
             .padding(.horizontal, theme.spacing.screenPadding)
@@ -37,6 +37,14 @@ struct IntegrationsView: View {
         .settingsBackground()
         .navigationTitle("Integrations")
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar(.visible, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                SettingsBackButton()
+            }
+        }
         .alert("Apple Health access is needed", isPresented: $showHealthKitConnect) {
             Button("Open Settings") {
                 if let url = URL(string: UIApplication.openSettingsURLString) {
@@ -115,11 +123,13 @@ struct IntegrationsView: View {
                                 icon: "arrow.triangle.2.circlepath",
                                 title: isSyncingHealthKit ? "Syncing historical data" : "Sync all historical data",
                                 subtitle: healthSyncStatusMessage,
+                                subtitleColor: healthSyncStatusIsError ? theme.colors.error : nil,
                                 showChevron: false
                             )
                         }
                         .disabled(isSyncingHealthKit)
                         .accessibilityHint("Syncs your historical Apple Health data now.")
+                        .accessibilityIdentifier("integrations_health_sync_all_button")
                     }
                 } else {
                     DataInfoRow(
@@ -226,31 +236,19 @@ struct IntegrationsView: View {
         SettingsSection(
             header: "Photo Import",
             footer: BulkProgressPhotoImportPolicy.footerText(
-                isEnabled: isBulkProgressPhotoImportEnabled,
+                isEnabled: true,
                 existingProgressPhotoCount: progressPhotoCount
             )
         ) {
-            if isBulkProgressPhotoImportEnabled {
-                NavigationLink(destination: BulkPhotoImportView().environmentObject(authManager)) {
-                    SettingsRow(
-                        icon: "photo.stack",
-                        title: "Import Progress Photos",
-                        subtitle: "Choose photos from your library",
-                        value: "Scan library",
-                        showChevron: true
-                    )
-                    .accessibilityIdentifier("integrations_bulk_photo_import_link")
-                }
-            } else {
+            NavigationLink(destination: BulkPhotoImportView().environmentObject(authManager)) {
                 SettingsRow(
                     icon: "photo.stack",
                     title: "Import Progress Photos",
-                    subtitle: "Add progress photos to unlock",
-                    value: "Locked",
-                    tintColor: theme.colors.textSecondary
+                    subtitle: "Choose photos from your library",
+                    value: "Scan library",
+                    showChevron: true
                 )
-                .accessibilityIdentifier("integrations_bulk_photo_import_locked")
-                .accessibilityHint("Add progress photos or request migration access to unlock bulk import.")
+                .accessibilityIdentifier("integrations_bulk_photo_import_link")
             }
         }
     }
@@ -296,12 +294,13 @@ extension IntegrationsView {
 
         isConnectingHealthKit = true
         healthSyncStatusMessage = nil
+        healthSyncStatusIsError = false
 
         let authorized = await healthKitManager.requestAuthorization()
         if authorized {
             await HealthSyncCoordinator.shared
                 .configureSyncPipelineAfterAuthorizationAndRunInitialWeightAndStepSync()
-            healthSyncStatusMessage = "Apple Health sync is set up"
+            healthSyncStatusMessage = "Apple Health sync is on"
         } else {
             showHealthKitConnect = true
         }
@@ -315,8 +314,12 @@ extension IntegrationsView {
 
         isSyncingHealthKit = true
         healthSyncStatusMessage = nil
-        await HealthSyncCoordinator.shared.forceFullHealthKitSync()
-        healthSyncStatusMessage = "Historical Apple Health data synced"
+        healthSyncStatusIsError = false
+        let didSucceed = await HealthSyncCoordinator.shared.forceFullHealthKitSync()
+        healthSyncStatusMessage = didSucceed
+            ? "Historical Apple Health data synced"
+            : "Historical sync failed. Try again."
+        healthSyncStatusIsError = !didSucceed
         isSyncingHealthKit = false
     }
 

--- a/apps/ios/LogYourBody/Views/PreferenceGoalEditing.swift
+++ b/apps/ios/LogYourBody/Views/PreferenceGoalEditing.swift
@@ -54,6 +54,10 @@ enum PreferenceGoalKind: String, Identifiable, CaseIterable {
             return "Valid range: 10-30."
         }
     }
+
+    var resetActionTitle: String {
+        "Remove target"
+    }
 }
 
 struct PreferenceGoalValidationResult: Equatable {
@@ -107,6 +111,8 @@ struct PreferenceGoalEditorSheet: View {
     let goal: PreferenceGoalKind
     let initialText: String
     let unitLabel: String?
+    let resetTitle: String?
+    let reset: (() -> Void)?
     let save: (Double) -> Void
 
     @State private var draftText: String
@@ -117,11 +123,15 @@ struct PreferenceGoalEditorSheet: View {
         goal: PreferenceGoalKind,
         initialText: String,
         unitLabel: String? = nil,
+        resetTitle: String? = nil,
+        reset: (() -> Void)? = nil,
         save: @escaping (Double) -> Void
     ) {
         self.goal = goal
         self.initialText = initialText
         self.unitLabel = unitLabel
+        self.resetTitle = resetTitle
+        self.reset = reset
         self.save = save
         self._draftText = State(initialValue: initialText)
     }
@@ -148,7 +158,7 @@ struct PreferenceGoalEditorSheet: View {
             }
             .scrollDismissesKeyboard(.interactively)
             .safeAreaInset(edge: .bottom, spacing: 0) {
-                saveAction
+                actions
                     .padding(.horizontal, JovieTokens.screenInset)
                     .padding(.top, JovieTokens.itemGap)
                     .padding(
@@ -183,7 +193,7 @@ struct PreferenceGoalEditorSheet: View {
                 }
             }
         }
-        .presentationDetents([.medium, .large])
+        .presentationDetents([.large])
         .presentationDragIndicator(.visible)
         .onAppear {
             errorFocused = validation.errorMessage != nil
@@ -289,6 +299,34 @@ struct PreferenceGoalEditorSheet: View {
         .disabled(!validation.isValid)
         .accessibilityLabel("Save")
         .accessibilityHint(validation.isValid ? "Saves this goal" : validation.errorMessage ?? "Enter a valid goal")
+    }
+
+    private var actions: some View {
+        VStack(spacing: JovieTokens.itemGap) {
+            saveAction
+
+            if let resetTitle, let reset {
+                Button {
+                    reset()
+                    dismiss()
+                } label: {
+                    Label(resetTitle, systemImage: "arrow.counterclockwise")
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(Color.jovieText)
+                        .frame(maxWidth: .infinity, minHeight: JovieTokens.minimumHitTarget)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .background(Color.jovieSurfaceElevated)
+                .clipShape(RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: JovieTokens.controlRadius, style: .continuous)
+                        .stroke(Color.jovieHairline, lineWidth: 1)
+                }
+                .accessibilityHint("Removes the custom \(goal.title.lowercased())")
+                .accessibilityIdentifier("settings_\(goal.rawValue)_goal_reset_button")
+            }
+        }
     }
 
     private var accessibilityValue: String {

--- a/apps/ios/LogYourBody/Views/PreferenceGoalRows.swift
+++ b/apps/ios/LogYourBody/Views/PreferenceGoalRows.swift
@@ -108,56 +108,37 @@ struct PreferenceGoalRow: View {
 
     let goal: PreferenceGoalKind
     let valueText: String
-    let isCustom: Bool
     let edit: () -> Void
-    let reset: () -> Void
 
     var body: some View {
-        HStack(spacing: theme.spacing.sm) {
-            Button(action: edit) {
-                HStack(spacing: theme.spacing.sm) {
-                    Image(systemName: goal.icon)
-                        .font(theme.typography.headlineSmall)
+        Button(action: edit) {
+            HStack(spacing: theme.spacing.sm) {
+                Image(systemName: goal.icon)
+                    .font(theme.typography.headlineSmall)
+                    .foregroundColor(theme.colors.textSecondary)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: theme.spacing.xxs) {
+                    Text(goal.title)
+                        .font(theme.typography.labelLarge)
+                        .foregroundColor(theme.colors.text)
+
+                    Text(valueText)
+                        .font(theme.typography.captionLarge)
                         .foregroundColor(theme.colors.textSecondary)
-                        .frame(width: 24)
-
-                    VStack(alignment: .leading, spacing: theme.spacing.xxs) {
-                        Text(goal.title)
-                            .font(theme.typography.labelLarge)
-                            .foregroundColor(theme.colors.text)
-
-                        Text(valueText)
-                            .font(theme.typography.captionLarge)
-                            .foregroundColor(theme.colors.textSecondary)
-                    }
-
-                    Spacer()
-
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundColor(theme.colors.textTertiary)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("settings_\(goal.rawValue)_goal_edit_button")
 
-            if isCustom {
-                Button(action: reset) {
-                    Image(systemName: "arrow.counterclockwise.circle.fill")
-                        .font(theme.typography.headlineSmall)
-                        .foregroundColor(theme.colors.textSecondary)
-                        .frame(
-                            width: JovieTokens.minimumHitTarget,
-                            height: JovieTokens.minimumHitTarget
-                        )
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Reset \(goal.title)")
-                .accessibilityIdentifier("settings_\(goal.rawValue)_goal_reset_button")
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(theme.colors.textTertiary)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("settings_\(goal.rawValue)_goal_edit_button")
         .padding(.horizontal, theme.spacing.md)
         .padding(.vertical, theme.spacing.sm)
         .frame(minHeight: JovieTokens.minimumHitTarget)

--- a/apps/ios/LogYourBody/Views/PreferencesView+Header.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView+Header.swift
@@ -93,32 +93,24 @@ extension PreferencesView {
     }
 
     var heroHeader: some View {
-        VStack(spacing: theme.spacing.md) {
-            HStack(alignment: .center, spacing: theme.spacing.md) {
-                heroAvatar
-
-                VStack(alignment: .leading, spacing: theme.spacing.xxs) {
-                    Text(userDisplayName)
-                        .font(theme.typography.headlineMedium)
-                        .foregroundColor(theme.colors.text)
-
-                    Text(userEmail)
-                        .font(theme.typography.bodySmall)
-                        .foregroundColor(theme.colors.textSecondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.82)
-
-                    if let memberSinceText {
-                        Text(memberSinceText)
-                            .font(theme.typography.captionMedium)
-                            .foregroundColor(theme.colors.textSecondary)
-                    }
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(alignment: .leading, spacing: theme.spacing.md) {
+                    heroAvatar
+                    heroIdentityText
+                    statusBadge
                 }
+            } else {
+                VStack(spacing: theme.spacing.md) {
+                    HStack(alignment: .center, spacing: theme.spacing.md) {
+                        heroAvatar
+                        heroIdentityText
+                        Spacer()
+                    }
 
-                Spacer()
+                    statusBadge
+                }
             }
-
-            statusBadge
         }
         .padding(theme.spacing.md)
         .systemBGlassSurface(
@@ -128,6 +120,74 @@ extension PreferencesView {
             borderColor: theme.colors.border,
             borderOpacity: 0.75
         )
+    }
+
+    var heroIdentityText: some View {
+        VStack(alignment: .leading, spacing: theme.spacing.xxs) {
+            Text(userDisplayName)
+                .font(theme.typography.headlineMedium)
+                .foregroundColor(theme.colors.text)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(userEmail)
+                .font(theme.typography.bodySmall)
+                .foregroundColor(theme.colors.textSecondary)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
+                .minimumScaleFactor(0.82)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let memberSinceText {
+                Text(memberSinceText)
+                    .font(theme.typography.captionMedium)
+                    .foregroundColor(theme.colors.textSecondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    var statusBadge: some View {
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(alignment: .leading, spacing: theme.spacing.xs) {
+                    HStack(spacing: theme.spacing.xs) {
+                        Circle()
+                            .fill(subscriptionManager.isSubscribed ? theme.colors.success : theme.colors.warning)
+                            .frame(width: 8, height: 8)
+
+                        Text(subscriptionStatusText)
+                            .font(theme.typography.captionLarge)
+                            .foregroundColor(theme.colors.textSecondary)
+                    }
+
+                    if let planDisplay = subscriptionPlanDisplay {
+                        Text(planDisplay)
+                            .font(theme.typography.captionLarge)
+                            .foregroundColor(theme.colors.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            } else {
+                HStack(spacing: theme.spacing.xs) {
+                    Circle()
+                        .fill(subscriptionManager.isSubscribed ? theme.colors.success : theme.colors.warning)
+                        .frame(width: 8, height: 8)
+
+                    Text(subscriptionStatusText)
+                        .font(theme.typography.captionLarge)
+                        .foregroundColor(theme.colors.textSecondary)
+
+                    if let planDisplay = subscriptionPlanDisplay {
+                        Text("•")
+                            .foregroundColor(theme.colors.textTertiary)
+                        Text(planDisplay)
+                            .font(theme.typography.captionLarge)
+                            .foregroundColor(theme.colors.textSecondary)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
     }
 
     var compactHeader: some View {
@@ -144,10 +204,10 @@ extension PreferencesView {
             .padding(.top, topSafeArea + theme.spacing.xs)
             .padding(.bottom, theme.spacing.sm)
             .background(theme.colors.background.opacity(0.95))
-            .opacity(scrollOffset < -60 ? 1 : 0)
+            .opacity(isCompactHeaderVisible ? 1 : 0)
         }
         .ignoresSafeArea(edges: .top)
-        .animation(theme.animation.fast, value: scrollOffset)
+        .animation(theme.animation.fast, value: isCompactHeaderVisible)
     }
 
     var heroAvatar: some View {
@@ -198,28 +258,6 @@ extension PreferencesView {
                     .frame(width: 32, height: 32)
             }
         }
-    }
-
-    var statusBadge: some View {
-        HStack(spacing: theme.spacing.xs) {
-            Circle()
-                .fill(subscriptionManager.isSubscribed ? theme.colors.success : theme.colors.warning)
-                .frame(width: 8, height: 8)
-
-            Text(subscriptionStatusText)
-                .font(theme.typography.captionLarge)
-                .foregroundColor(theme.colors.textSecondary)
-
-            if let planDisplay = subscriptionPlanDisplay {
-                Text("•")
-                    .foregroundColor(theme.colors.textTertiary)
-                Text(planDisplay)
-                    .font(theme.typography.captionLarge)
-                    .foregroundColor(theme.colors.textSecondary)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .combine)
     }
 
     var avatarPlaceholder: some View {

--- a/apps/ios/LogYourBody/Views/PreferencesView+Helpers.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView+Helpers.swift
@@ -139,7 +139,16 @@ extension PreferencesView {
                     await MainActor.run {
                         avatarUploadProgress = 0.0
                         isUploadingPhoto = false
+                        profilePhotoErrorMessage = "The photo could not be uploaded. Check your connection and try again."
+                        showingProfilePhotoError = true
                     }
+                }
+            } else if asset != nil {
+                await MainActor.run {
+                    avatarUploadProgress = 0.0
+                    isUploadingPhoto = false
+                    profilePhotoErrorMessage = "The selected photo could not be read. Choose another photo and try again."
+                    showingProfilePhotoError = true
                 }
             } else {
                 await MainActor.run {
@@ -151,6 +160,8 @@ extension PreferencesView {
             await MainActor.run {
                 avatarUploadProgress = 0.0
                 isUploadingPhoto = false
+                profilePhotoErrorMessage = "The photo could not be uploaded. Check your connection and try again."
+                showingProfilePhotoError = true
             }
         }
     }

--- a/apps/ios/LogYourBody/Views/PreferencesView+RemindersSection.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView+RemindersSection.swift
@@ -73,6 +73,7 @@ extension PreferencesView {
                         dailyReminderDate = notificationManager.dailyWeighInReminderDate
                         if isEnabled && !didApply {
                             HapticManager.shared.notification(type: .warning)
+                            showingNotificationSettingsAlert = true
                         }
                     }
                 }

--- a/apps/ios/LogYourBody/Views/PreferencesView+TrackingGoalsSection.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView+TrackingGoalsSection.swift
@@ -8,9 +8,7 @@ extension PreferencesView {
     var trackingGoalsSection: some View {
         SettingsSection(
             header: "Tracking & goals",
-            footer: usesIndividualizedAestheticGoals
-                ? "Set targets that reflect your goals."
-                : "Set custom targets or use defaults."
+            footer: "Set targets that reflect your goals."
         ) {
             VStack(spacing: 0) {
                 measurementSystemSection
@@ -44,12 +42,8 @@ extension PreferencesView {
         PreferenceGoalRow(
             goal: goal,
             valueText: goalValueText(for: goal),
-            isCustom: isGoalCustom(goal),
             edit: {
                 activeGoalEditor = goal
-            },
-            reset: {
-                resetGoal(goal)
             }
         )
     }
@@ -58,61 +52,22 @@ extension PreferencesView {
         PreferenceGoalEditorSheet(
             goal: goal,
             initialText: initialGoalEditorText(for: goal),
-            unitLabel: goalUnitLabel(for: goal)
+            unitLabel: goalUnitLabel(for: goal),
+            resetTitle: isGoalCustom(goal) ? goal.resetActionTitle : nil,
+            reset: isGoalCustom(goal) ? {
+                resetGoal(goal)
+            } : nil
         ) { value in
             saveGoal(value, for: goal)
         }
     }
 
-    var userGender: String {
-        cachedUserGender
-    }
-
-    var isFemale: Bool {
-        cachedIsFemale
-    }
-
-    var usesIndividualizedAestheticGoals: Bool {
-        _ = featureGateRefreshToken
-
-        return AppServicePorts.analyticsTracker.isFeatureEnabled(
-            flagKey: AppFeatureGate.individualizedAestheticGoals
-        )
-    }
-
-    var legacyBodyFatReference: Double {
-        cachedLegacyBodyFatReference
-    }
-
-    var legacyFFMIReference: Double {
-        cachedLegacyFFMIReference
-    }
-
     var currentBodyFatGoal: Double? {
-        AestheticGoalPolicy.resolvedGoal(
-            explicitGoal: customBodyFatGoal,
-            legacyReferenceMidpoint: legacyBodyFatReference,
-            individualizedGoalsEnabled: usesIndividualizedAestheticGoals
-        )
+        AestheticGoalPolicy.resolvedGoal(explicitGoal: customBodyFatGoal)
     }
 
     var currentFFMIGoal: Double? {
-        AestheticGoalPolicy.resolvedGoal(
-            explicitGoal: customFFMIGoal,
-            legacyReferenceMidpoint: legacyFFMIReference,
-            individualizedGoalsEnabled: usesIndividualizedAestheticGoals
-        )
-    }
-
-    func updateCachedValues() {
-        cachedUserGender = authManager.currentUser?.profile?.gender?.lowercased() ?? ""
-        cachedIsFemale = cachedUserGender.contains("female") || cachedUserGender.contains("woman")
-        cachedLegacyBodyFatReference = cachedIsFemale ?
-            Constants.BodyComposition.BodyFat.femaleReferenceMidpoint :
-            Constants.BodyComposition.BodyFat.maleReferenceMidpoint
-        cachedLegacyFFMIReference = cachedIsFemale ?
-            Constants.BodyComposition.FFMI.femaleReferenceMidpoint :
-            Constants.BodyComposition.FFMI.maleReferenceMidpoint
+        AestheticGoalPolicy.resolvedGoal(explicitGoal: customFFMIGoal)
     }
 
     func resetToDefaults() {
@@ -128,12 +83,10 @@ extension PreferencesView {
             return currentWeightGoal?.displayText(in: currentSystem) ?? "Not set"
         case .bodyFat:
             guard let currentBodyFatGoal else { return "Not set" }
-            let suffix = customBodyFatGoal == nil ? " (default)" : ""
-            return String(format: "%.1f%%", currentBodyFatGoal) + suffix
+            return String(format: "%.1f%%", currentBodyFatGoal)
         case .ffmi:
             guard let currentFFMIGoal else { return "Not set" }
-            let suffix = customFFMIGoal == nil ? " (default)" : ""
-            return String(format: "%.1f", currentFFMIGoal) + suffix
+            return String(format: "%.1f", currentFFMIGoal)
         }
     }
 
@@ -167,15 +120,9 @@ extension PreferencesView {
                 String(format: "%.1f", $0.displayValue(in: currentSystem))
             } ?? ""
         case .bodyFat:
-            if let customBodyFatGoal {
-                return String(format: "%.1f", customBodyFatGoal)
-            }
-            return usesIndividualizedAestheticGoals ? "" : String(format: "%.1f", legacyBodyFatReference)
+            return customBodyFatGoal.map { String(format: "%.1f", $0) } ?? ""
         case .ffmi:
-            if let customFFMIGoal {
-                return String(format: "%.1f", customFFMIGoal)
-            }
-            return usesIndividualizedAestheticGoals ? "" : String(format: "%.1f", legacyFFMIReference)
+            return customFFMIGoal.map { String(format: "%.1f", $0) } ?? ""
         }
     }
 

--- a/apps/ios/LogYourBody/Views/PreferencesView.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView.swift
@@ -4,11 +4,13 @@
 //
 import SwiftUI
 import Foundation
+import UIKit
 
 struct PreferencesView: View {
     @EnvironmentObject var authManager: AuthManager
     @Environment(\.openURL) var openURL
     @Environment(\.theme) var theme
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @StateObject var subscriptionManager = SubscriptionManager.shared
     @StateObject var notificationManager = NotificationManager.shared
     @AppStorage(Constants.preferredMeasurementSystemKey) var measurementSystem = PreferencesView.defaultMeasurementSystem
@@ -31,16 +33,14 @@ struct PreferencesView: View {
     @State var isUploadingPhoto = false
     @State var avatarUploadProgress = 0.0
     @State var profileImageURL: String?
-    @State var scrollOffset: CGFloat = 0
+    @State var profilePhotoErrorMessage = ""
+    @State var showingProfilePhotoError = false
+    @State var isCompactHeaderVisible = false
     @State var showingLogoutConfirmation = false
+    @State var showingNotificationSettingsAlert = false
     @State var isTriggeringHealthResync = false
     @State var isHealthSyncSetupInProgress = false
     @State var dailyReminderDate = Date()
-    @State var cachedUserGender = ""
-    @State var cachedIsFemale = false
-    @State var cachedLegacyBodyFatReference = Constants.BodyComposition.BodyFat.maleReferenceMidpoint
-    @State var cachedLegacyFFMIReference = Constants.BodyComposition.FFMI.maleReferenceMidpoint
-    @State var featureGateRefreshToken = UUID()
 
     static var defaultMeasurementSystem: String {
         MeasurementSystem.imperial.rawValue
@@ -68,7 +68,9 @@ struct PreferencesView: View {
             .coordinateSpace(name: "settingsScroll")
             .scrollBounceBehavior(.basedOnSize)
             .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
-                scrollOffset = value
+                let shouldShowCompactHeader = value < -60
+                guard shouldShowCompactHeader != isCompactHeaderVisible else { return }
+                isCompactHeaderVisible = shouldShowCompactHeader
             }
 
             compactHeader
@@ -78,6 +80,20 @@ struct PreferencesView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(restoreAlertMessage)
+        }
+        .alert("Profile photo couldn’t be updated", isPresented: $showingProfilePhotoError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(profilePhotoErrorMessage)
+        }
+        .alert("Notifications are off", isPresented: $showingNotificationSettingsAlert) {
+            Button("Open Settings") {
+                guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                openURL(url)
+            }
+            Button("Not Now", role: .cancel) {}
+        } message: {
+            Text("Allow notifications in iOS Settings to receive your daily weigh-in reminder.")
         }
         .confirmationDialog("Log out of LogYourBody?", isPresented: $showingLogoutConfirmation, titleVisibility: .visible) {
             Button("Log Out", role: .destructive) {
@@ -102,14 +118,10 @@ struct PreferencesView: View {
         .onAppear {
             migrateLegacyWeightGoalIfNeeded()
             checkBiometricAvailability()
-            updateCachedValues()
             dailyReminderDate = notificationManager.dailyWeighInReminderDate
             Task {
                 await notificationManager.refreshAuthorizationStatus()
             }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .featureGatesDidChange)) { _ in
-            featureGateRefreshToken = UUID()
         }
     }
 

--- a/apps/ios/LogYourBodyTests/AuthConfigurationValidationTests.swift
+++ b/apps/ios/LogYourBodyTests/AuthConfigurationValidationTests.swift
@@ -43,6 +43,14 @@ final class AuthConfigurationValidationTests: XCTestCase {
         XCTAssertTrue(result.messages.contains("Authentication redirect URI must be logyourbody://oauth."))
     }
 
+    func testDevelopmentAllowsLocalhostAPIWithMatchingExpectedHost() {
+        let snapshot = makeSnapshot(apiBaseURL: "http" + "://localhost:3000")
+
+        let result = Configuration.validateAuthEnvironment(snapshot)
+
+        XCTAssertTrue(result.isValid, "Validation should pass: \(result.messages)")
+    }
+
     func testValidProductionSharedIdentityConfigurationPasses() {
         let result = Configuration.validateAuthEnvironment(makeSnapshot(environment: .production))
 

--- a/apps/ios/LogYourBodyTests/AuthManagerSessionTests.swift
+++ b/apps/ios/LogYourBodyTests/AuthManagerSessionTests.swift
@@ -115,13 +115,19 @@ final class AuthManagerSessionTests: XCTestCase {
         )
     }
 
-    private func stubSessionSuccess(userBody: String = #"{"id":"user-123","email":"user@example.com","name":"Test User"}"#) {
+    private func stubSessionSuccess(
+        userBody: String = #"{"id":"user-123","email":"user@example.com","name":"Test User"}"#,
+        includesRotatedRefreshToken: Bool = true
+    ) {
         AuthStubURLProtocol.requestHandler = { request in
             let path = request.url?.path ?? ""
             if path.contains("oauth2/token") {
+                let body = includesRotatedRefreshToken
+                    ? #"{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}"#
+                    : #"{"access_token":"new-access","expires_in":3600}"#
                 return AuthStubURLProtocol.StubbedResponse(
                     statusCode: 200,
-                    body: Data(#"{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}"#.utf8)
+                    body: Data(body.utf8)
                 )
             }
             if path.contains("oauth2/userinfo") {
@@ -196,7 +202,7 @@ final class AuthManagerSessionTests: XCTestCase {
             refreshToken: "old-refresh",
             expiresAt: Date().addingTimeInterval(-5)
         )
-        stubSessionSuccess()
+        stubSessionSuccess(includesRotatedRefreshToken: false)
 
         let token = await manager.getAccessToken()
 

--- a/apps/ios/LogYourBodyTests/HealthSyncCoordinatorPipelineTests.swift
+++ b/apps/ios/LogYourBodyTests/HealthSyncCoordinatorPipelineTests.swift
@@ -74,4 +74,15 @@ final class HealthSyncCoordinatorPipelineTests: XCTestCase {
         XCTAssertEqual(manager.syncWeightFromHealthKitCallCount, 1)
         XCTAssertEqual(manager.fetchTodayStepCountCallCount, 1)
     }
+
+    func testFullHealthKitSyncForwardsFailureResultToCaller() async {
+        let manager = MockHealthKitSyncManager()
+        manager.forceFullHealthKitSyncResult = false
+        let coordinator = HealthSyncCoordinator(healthKitManager: manager)
+
+        let didSucceed = await coordinator.forceFullHealthKitSync()
+
+        XCTAssertFalse(didSucceed)
+        XCTAssertTrue(manager.didCallForceFullHealthKitSync)
+    }
 }

--- a/apps/ios/LogYourBodyTests/HealthSyncTestDoubles.swift
+++ b/apps/ios/LogYourBodyTests/HealthSyncTestDoubles.swift
@@ -28,6 +28,7 @@ final class MockHealthSyncCoordinator: HealthSyncCoordinating {
     var performInitialConnectSyncError: Error?
     var syncWeightError: Error?
     var syncStepsError: Error?
+    var forceFullHealthKitSyncResult = true
 
     func bootstrapIfNeeded(syncEnabled: Bool) {
         didCallBootstrapIfNeeded = true
@@ -75,8 +76,9 @@ final class MockHealthSyncCoordinator: HealthSyncCoordinating {
         }
     }
 
-    func forceFullHealthKitSync() async {
+    func forceFullHealthKitSync() async -> Bool {
         didCallForceFullHealthKitSync = true
+        return forceFullHealthKitSyncResult
     }
 }
 
@@ -95,6 +97,7 @@ final class MockHealthKitSyncManager: HealthKitSyncManaging {
     private(set) var syncStepsFromHealthKitCallCount = 0
     private(set) var fetchTodayStepCountCallCount = 0
     private(set) var didCallForceFullHealthKitSync = false
+    var forceFullHealthKitSyncResult = true
 
     func checkAuthorizationStatus() {
         didCallCheckAuthorizationStatus = true
@@ -137,7 +140,8 @@ final class MockHealthKitSyncManager: HealthKitSyncManaging {
         return 123
     }
 
-    func forceFullHealthKitSync() async {
+    func forceFullHealthKitSync() async -> Bool {
         didCallForceFullHealthKitSync = true
+        return forceFullHealthKitSyncResult
     }
 }

--- a/apps/ios/LogYourBodyTests/OnboardingScoreDisplayPolicyTests.swift
+++ b/apps/ios/LogYourBodyTests/OnboardingScoreDisplayPolicyTests.swift
@@ -85,23 +85,15 @@ final class OnboardingScoreDisplayPolicyTests: XCTestCase {
         XCTAssertEqual(BodyScoreRevealPolicy.percentileGroupLabel(for: nil), "people your age and height")
     }
 
-    func testReferenceTextFollowsIndividualizedGoalsGate() {
+    func testPopulationRangeIsAlwaysLabeledAsReference() {
         let range = BodyScoreResult.ReferenceRange(lowerBound: 10, upperBound: 15, label: "Lean")
 
         XCTAssertEqual(
-            BodyScoreRevealPolicy.referenceText(range: range, usesIndividualizedAestheticGoals: false),
-            "Target: 10–15% (Lean)"
-        )
-        XCTAssertEqual(
-            BodyScoreRevealPolicy.referenceText(range: range, usesIndividualizedAestheticGoals: true),
+            BodyScoreRevealPolicy.referenceText(range: range),
             "Reference: 10–15% (Lean)"
         )
         XCTAssertEqual(
-            BodyScoreRevealPolicy.referenceAccessibilityText(range: range, usesIndividualizedAestheticGoals: false),
-            "Target body fat: 10 to 15 percent. Lean."
-        )
-        XCTAssertEqual(
-            BodyScoreRevealPolicy.referenceAccessibilityText(range: range, usesIndividualizedAestheticGoals: true),
+            BodyScoreRevealPolicy.referenceAccessibilityText(range: range),
             "Reference body fat: 10 to 15 percent. Lean."
         )
     }

--- a/apps/ios/LogYourBodyTests/PreferenceGoalValidatorTests.swift
+++ b/apps/ios/LogYourBodyTests/PreferenceGoalValidatorTests.swift
@@ -13,38 +13,13 @@ import UIKit
 
 
 final class PreferenceGoalValidatorTests: XCTestCase {
-    func testIndividualizedGoalPolicyLeavesUnsetGoalsNilForEverySexReference() {
-        XCTAssertNil(
-            AestheticGoalPolicy.resolvedGoal(
-                explicitGoal: nil,
-                legacyReferenceMidpoint: Constants.BodyComposition.BodyFat.maleReferenceMidpoint,
-                individualizedGoalsEnabled: true
-            )
-        )
-        XCTAssertNil(
-            AestheticGoalPolicy.resolvedGoal(
-                explicitGoal: nil,
-                legacyReferenceMidpoint: Constants.BodyComposition.BodyFat.femaleReferenceMidpoint,
-                individualizedGoalsEnabled: true
-            )
-        )
-        XCTAssertNil(
-            AestheticGoalPolicy.resolvedGoal(
-                explicitGoal: nil,
-                legacyReferenceMidpoint: 0,
-                individualizedGoalsEnabled: true
-            ),
-            "Unknown sex must not create an aesthetic goal"
-        )
+    func testAestheticGoalPolicyLeavesUnsetGoalsNil() {
+        XCTAssertNil(AestheticGoalPolicy.resolvedGoal(explicitGoal: nil))
     }
 
-    func testIndividualizedGoalPolicyPreservesExplicitGoal() {
+    func testAestheticGoalPolicyPreservesExplicitGoal() {
         XCTAssertEqual(
-            AestheticGoalPolicy.resolvedGoal(
-                explicitGoal: 19.5,
-                legacyReferenceMidpoint: 10,
-                individualizedGoalsEnabled: true
-            ),
+            AestheticGoalPolicy.resolvedGoal(explicitGoal: 19.5),
             19.5
         )
     }
@@ -52,24 +27,7 @@ final class PreferenceGoalValidatorTests: XCTestCase {
     func testClearingExplicitGoalReturnsToUnset() {
         let clearedGoal: Double? = nil
 
-        XCTAssertNil(
-            AestheticGoalPolicy.resolvedGoal(
-                explicitGoal: clearedGoal,
-                legacyReferenceMidpoint: 18,
-                individualizedGoalsEnabled: true
-            )
-        )
-    }
-
-    func testLegacyGoalPolicyRetainsFallbackUntilGateRollout() {
-        XCTAssertEqual(
-            AestheticGoalPolicy.resolvedGoal(
-                explicitGoal: nil,
-                legacyReferenceMidpoint: 18,
-                individualizedGoalsEnabled: false
-            ),
-            18
-        )
+        XCTAssertNil(AestheticGoalPolicy.resolvedGoal(explicitGoal: clearedGoal))
     }
 
     func testAcceptsValidGoalValuesAtBoundaries() {

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -133,8 +133,7 @@ final class LogYourBodyUITests: XCTestCase {
 
     func testSubscribedMVPSettingsExposeSubscriptionEscapePaths() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["-lybUITestWeightLoggerMVPFixture"]
-        app.launch()
+        launch(app, with: ["-lybUITestWeightLoggerMVPFixture"])
 
         try openSettings(in: app)
 
@@ -146,12 +145,15 @@ final class LogYourBodyUITests: XCTestCase {
         let logoutButton = app.descendants(matching: .any)["settings_logout_button"]
         XCTAssertTrue(logoutButton.waitForExistence(timeout: 5))
         XCTAssertTrue(logoutButton.isHittable)
+        attachScreenshot(named: "settings-profile-hardened", from: app)
 
         let settingsBackButton = app.navigationBars.buttons["Settings"]
         XCTAssertTrue(settingsBackButton.waitForExistence(timeout: 5))
         settingsBackButton.tap()
+        attachScreenshot(named: "settings-overview-hardened", from: app)
 
         let accountLink = app.descendants(matching: .any)["settings_account_subscription_link"]
+        scrollUntilHittable(accountLink, in: app)
         XCTAssertTrue(accountLink.waitForExistence(timeout: 5))
         XCTAssertTrue(accountLink.isHittable)
         accountLink.tap()
@@ -167,8 +169,7 @@ final class LogYourBodyUITests: XCTestCase {
 
     func testSubscribedMVPSettingsWeightGoalUsesNativeValidatedEditor() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["-lybUITestWeightLoggerMVPFixture"]
-        app.launch()
+        launch(app, with: ["-lybUITestWeightLoggerMVPFixture"])
 
         try openSettings(in: app)
 
@@ -201,6 +202,17 @@ final class LogYourBodyUITests: XCTestCase {
 
         XCTAssertTrue(weightGoalButton.waitForExistence(timeout: 5))
         XCTAssertTrue(weightGoalButton.label.contains("180.0 lbs"))
+
+        weightGoalButton.tap()
+        let clearGoalButton = app.buttons["settings_weight_goal_reset_button"]
+        XCTAssertTrue(clearGoalButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(clearGoalButton.isHittable)
+        clearGoalButton.tap()
+
+        XCTAssertTrue(clearGoalButton.waitForNonExistence(timeout: 3))
+        XCTAssertTrue(weightGoalButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(weightGoalButton.label.contains("Not set"))
+        attachScreenshot(named: "settings-tracking-hardened", from: app)
     }
 
     func testPaidMVPFixtureRoutesToDefaultTimelineSurface() throws {
@@ -499,31 +511,30 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(app.buttons["Cancel"].exists)
     }
 
-    func testBulkPhotoImportLockedByDefaultInIntegrations() throws {
+    func testBulkPhotoImportHiddenByDefaultInIntegrations() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["-lybUITestWeightLoggerMVPFixture"]
-        app.launch()
+        launch(app, with: ["-lybUITestWeightLoggerMVPFixture"])
 
         try openIntegrations(in: app)
 
         let lockedRow = app.descendants(matching: .any)["integrations_bulk_photo_import_locked"]
-        XCTAssertTrue(lockedRow.waitForExistence(timeout: 8))
-        XCTAssertTrue(app.staticTexts["Locked"].exists)
+        XCTAssertFalse(lockedRow.exists)
         XCTAssertFalse(app.descendants(matching: .any)["integrations_bulk_photo_import_link"].exists)
+        XCTAssertFalse(app.staticTexts["Photo Import"].exists)
         XCTAssertFalse(app.staticTexts["Bulk Photo Import"].exists)
         XCTAssertFalse(app.staticTexts["Google Fit"].exists)
         XCTAssertFalse(app.staticTexts["Export as JSON"].exists)
         XCTAssertFalse(app.staticTexts["API Access"].exists)
         XCTAssertFalse(app.staticTexts["Coming Soon"].exists)
+        attachScreenshot(named: "settings-integrations-hardened", from: app)
     }
 
     func testBulkPhotoImportActivationOpensScannerEntry() throws {
         let app = XCUIApplication()
-        app.launchArguments = [
+        launch(app, with: [
             "-lybUITestWeightLoggerMVPFixture",
             "-lybUITestBulkPhotoImportEnabledFixture"
-        ]
-        app.launch()
+        ])
 
         try openIntegrations(in: app)
 


### PR DESCRIPTION
## Summary

- polish the native Settings hierarchy, navigation, goal editing, switches, footers, and Dynamic Type behavior
- remove inferred body-fat and FFMI targets so only explicit user goals drive product guidance
- make HealthKit sync, notification permission, and profile image failures surface honest actionable states
- keep the bulk photo-import teaser fail-closed while preserving the gated enabled path
- harden test startup, auth-refresh coverage, development configuration, and touched concurrency/deprecation paths

## Screenshot findings addressed

- stable visible back controls with full tap targets
- consistent switch styling and accessible On/Off values
- clearer goal semantics and validated native editing
- improved low-contrast secondary copy
- layouts verified at standard and accessibility text sizes

## Verification

- SwiftLint strict: 0 violations across 373 Swift files
- iOS build-for-testing: passed
- unit suite: 709 tests, 0 failures
- focused Settings UI acceptance: 4 flows passed, including gated photo import and goal editing
- simulator review: Settings overview, Profile, Tracking, and Integrations at standard and accessibility text sizes

Web is intentionally untouched. A non-failing SwiftUI invalid-frame runtime diagnostic can still be emitted by the iOS 26.5 simulator when focusing the native goal TextField; the flow and assertions pass, and the diagnostic persisted across canonical sheet and keyboard arrangements.