### PR TITLE
fix(ios): land responsive, quality, and design cleanup

### DIFF
--- a/apps/ios/LogYourBody/Components/FullMetricChartView+Part01.swift
+++ b/apps/ios/LogYourBody/Components/FullMetricChartView+Part01.swift
@@ -8,15 +8,15 @@ var body: some View {
 
             ScrollViewReader { proxy in
                 ScrollView(showsIndicators: false) {
-                    VStack(alignment: .leading, spacing: 20) {
+                    VStack(alignment: .leading, spacing: 16) {
                         headlineBlock
                         chartCard
                         relatedMetricsRow
                         historyBlock
                     }
                     .padding(.horizontal, 16)
-                    .padding(.bottom, 32)
-                    .padding(.top, 12)
+                    .padding(.bottom, 24)
+                    .padding(.top, 8)
                 }
                 .overlay(alignment: .trailing) {
                     historyScrubber(proxy: proxy)
@@ -76,7 +76,7 @@ var body: some View {
     }
 
 var headlineBlock: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 10) {
                 Image(systemName: icon)
                     .font(.system(size: 16, weight: .semibold))
@@ -167,7 +167,7 @@ var headlineBlock: some View {
         }
         .frame(maxWidth: .infinity, alignment: alignRight ? .trailing : .leading)
         .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.vertical, 8)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .fill(Color.white.opacity(0.06))
@@ -206,50 +206,23 @@ var displayedHistorySections: [HistorySection] {
     }
 
 var timeRangeSelector: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack {
-                HStack(spacing: 4) {
-                    ForEach(TimeRange.allCases, id: \.self) { range in
-                        let isSelected = selectedTimeRange == range
-
-                        Button {
-                            selectedTimeRange = range
-                        } label: {
-                            Text(range.rawValue)
-                                .font(.subheadline.weight(.semibold))
-                                .foregroundColor(
-                                    isSelected ? Color.black : Color.metricTextPrimary
-                                )
-                                .padding(.vertical, 8)
-                                .padding(.horizontal, 14)
-                                .frame(minWidth: 44, minHeight: 44)
-                                .background(
-                                    Capsule()
-                                        .fill(isSelected ? Color.white : Color.clear)
-                                )
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityElement(children: .ignore)
-                        .accessibilityLabel(range.accessibilityLabel)
-                        .accessibilityValue(isSelected ? "Selected" : "Not selected")
-                        .accessibilityHint("Shows \(range.accessibilityLabel.lowercased()) of data")
-                        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
-                        .accessibilityIdentifier("metric_detail_range_\(range.rawValue)")
-                    }
-                }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 6)
-                .background(
-                    Capsule()
-                        .fill(Color.white.opacity(0.08))
-                )
-            }
-            .padding(.vertical, 6)
-        }
+        JovieSegmentedControl(
+            selection: $selectedTimeRange,
+            items: Array(TimeRange.allCases),
+            title: { $0.rawValue },
+            accessibilityLabel: { $0.accessibilityLabel },
+            accessibilityHint: { "Shows \($0.accessibilityLabel.lowercased()) of data" },
+            accessibilityIdentifier: { "metric_detail_range_\($0.rawValue)" },
+            selectedTint: .white,
+            selectedForeground: .black,
+            unselectedForeground: .metricTextPrimary
+        )
+        .frame(maxWidth: .infinity)
+        .accessibilityIdentifier("metric_detail_range_selector")
     }
 
 var chartCard: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 12) {
             chartHeader
             if isLoadingData {
                 chartSkeleton
@@ -384,7 +357,7 @@ var chartSkeleton: some View {
     }
 
 var chartHeader: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 6) {
             timeRangeSelector
                 .fixedSize(horizontal: false, vertical: true)
 

--- a/apps/ios/LogYourBody/Components/FullMetricChartView+Part02.swift
+++ b/apps/ios/LogYourBody/Components/FullMetricChartView+Part02.swift
@@ -271,7 +271,13 @@ func historyScrubber(proxy: ScrollViewProxy) -> some View {
     }
 
 var smoothedSeries: [MetricChartDataPoint] {
-        movingAverage(for: displayedSeries, windowSize: 7)
+        if trendChartData != nil,
+           let cached = cachedTrendSeries[selectedTimeRange],
+           !cached.isEmpty {
+            return cached
+        }
+
+        return movingAverage(for: displayedSeries, windowSize: 7)
     }
 
 var activeSeries: [MetricChartDataPoint] {
@@ -364,9 +370,9 @@ var headlineDateText: String {
 
 var chartDataFingerprint: String {
         guard let first = chartData.first, let last = chartData.last else {
-            return "empty-\(chartData.count)"
+            return "empty-\(chartData.count)-trend-\(trendChartData?.count ?? 0)"
         }
-        return [
+        let rawFingerprint = [
             "\(chartData.count)",
             "\(first.date.timeIntervalSince1970)",
             "\(last.date.timeIntervalSince1970)",
@@ -375,6 +381,25 @@ var chartDataFingerprint: String {
             first.presence.rawValue,
             last.presence.rawValue
         ].joined(separator: "-")
+
+        let trendFingerprint: String
+        if let trendChartData,
+           let trendFirst = trendChartData.first,
+           let trendLast = trendChartData.last {
+            trendFingerprint = [
+                "\(trendChartData.count)",
+                "\(trendFirst.date.timeIntervalSince1970)",
+                "\(trendLast.date.timeIntervalSince1970)",
+                "\(trendFirst.value)",
+                "\(trendLast.value)",
+                trendFirst.presence.rawValue,
+                trendLast.presence.rawValue
+            ].joined(separator: "-")
+        } else {
+            trendFingerprint = "none"
+        }
+
+        return "\(rawFingerprint)|trend-\(trendFingerprint)"
     }
 
 // MARK: - Helpers
@@ -636,26 +661,39 @@ var isStepsMetric: Bool {
     func preprocessChartDataIfNeeded() async {
         guard !chartData.isEmpty else {
             cachedSeries = [:]
+            cachedTrendSeries = [:]
             lastFingerprint = chartDataFingerprint
             return
         }
 
         let fingerprint = chartDataFingerprint
-        if fingerprint == lastFingerprint, !cachedSeries.isEmpty {
+        if fingerprint == lastFingerprint,
+           !cachedSeries.isEmpty,
+           trendChartData == nil || !cachedTrendSeries.isEmpty {
             return
         }
 
         isLoadingData = true
         let data = chartData
+        let trendData = trendChartData
         let referenceDate = data.last?.date ?? Date()
 
-        let newSeries = await Task.detached(priority: .userInitiated) {
+        let (newSeries, newTrendSeries) = await Task.detached(priority: .userInitiated) {
             let preprocessor = ChartSeriesPreprocessor(referenceDate: referenceDate)
-            return preprocessor.seriesByRange(from: data)
+            let rawSeries = preprocessor.seriesByRange(from: data)
+
+            guard let trendData, !trendData.isEmpty else {
+                return (rawSeries, [TimeRange: [MetricChartDataPoint]]())
+            }
+
+            let trendReferenceDate = trendData.last?.date ?? referenceDate
+            let trendPreprocessor = ChartSeriesPreprocessor(referenceDate: trendReferenceDate)
+            return (rawSeries, trendPreprocessor.seriesByRange(from: trendData))
         }.value
 
         if fingerprint == chartDataFingerprint {
             cachedSeries = newSeries
+            cachedTrendSeries = newTrendSeries
             lastFingerprint = fingerprint
         }
 

--- a/apps/ios/LogYourBody/Components/FullMetricChartView+Part02.swift
+++ b/apps/ios/LogYourBody/Components/FullMetricChartView+Part02.swift
@@ -133,7 +133,7 @@ func historyRow(for entry: MetricHistoryEntry, config: MetricEntriesConfiguratio
                 }
             }
         }
-        .padding(.vertical, 14)
+        .padding(.vertical, 12)
     }
 
 func primaryHistoryValue(_ entry: MetricHistoryEntry, config: MetricEntriesConfiguration) -> String {

--- a/apps/ios/LogYourBody/Components/FullMetricChartView.swift
+++ b/apps/ios/LogYourBody/Components/FullMetricChartView.swift
@@ -321,6 +321,10 @@ struct FullMetricChartView: View {
     let unit: String
     let currentDate: String
     let chartData: [MetricChartDataPoint]
+    /// Optional canonical trend series. Raw data remains the source for the
+    /// Raw mode while the default Smoothed mode can use the same series as the
+    /// dashboard headline.
+    let trendChartData: [MetricChartDataPoint]?
     let onAdd: (() -> Void)?
     let metricEntries: MetricEntriesPayload?
     let relatedMetrics: [MetricDetailRelatedMetric]
@@ -330,6 +334,7 @@ struct FullMetricChartView: View {
     @Binding var selectedTimeRange: TimeRange
     @Binding var selectedTimelineDate: Date?
     @State var cachedSeries: [TimeRange: [MetricChartDataPoint]] = [:]
+    @State var cachedTrendSeries: [TimeRange: [MetricChartDataPoint]] = [:]
     @State var isLoadingData = false
     @State var lastFingerprint: String = ""
     @State var chartMode: ChartMode = .trend
@@ -356,12 +361,14 @@ struct FullMetricChartView: View {
         unit: String,
         currentDate: String,
         chartData: [MetricChartDataPoint],
+        trendChartData: [MetricChartDataPoint]? = nil,
         onAdd: (() -> Void)?,
         metricEntries: MetricEntriesPayload?,
         relatedMetrics: [MetricDetailRelatedMetric] = [],
         goalValue: Double?,
         selectedTimeRange: Binding<TimeRange>,
-        selectedTimelineDate: Binding<Date?> = .constant(nil)
+        selectedTimelineDate: Binding<Date?> = .constant(nil),
+        initialChartMode: ChartMode = .trend
     ) {
         self.title = title
         self.icon = icon
@@ -370,12 +377,14 @@ struct FullMetricChartView: View {
         self.unit = unit
         self.currentDate = currentDate
         self.chartData = chartData
+        self.trendChartData = trendChartData
         self.onAdd = onAdd
         self.metricEntries = metricEntries
         self.relatedMetrics = relatedMetrics
         self.goalValue = goalValue
         _selectedTimeRange = selectedTimeRange
         _selectedTimelineDate = selectedTimelineDate
+        _chartMode = State(initialValue: initialChartMode)
     }
 }
 

--- a/apps/ios/LogYourBody/Components/PeriodSelector.swift
+++ b/apps/ios/LogYourBody/Components/PeriodSelector.swift
@@ -40,6 +40,150 @@ enum TimePeriod: String, CaseIterable, Identifiable {
     }
 }
 
+// MARK: - Shared Liquid Glass Segmented Control
+
+/// A compact, equal-width segmented control for narrow iPhone layouts.
+///
+/// iOS 26 gets the native Liquid Glass treatment while earlier OS versions use
+/// the app's existing material fallback. Keeping both selectors on this
+/// primitive prevents mobile spacing and accessibility behavior from drifting
+/// between screens.
+struct JovieSegmentedControl<Selection: Hashable>: View {
+    @Binding var selection: Selection
+
+    let items: [Selection]
+    let title: (Selection) -> String
+    let systemImage: (Selection) -> String?
+    let accessibilityLabel: (Selection) -> String
+    let accessibilityHint: (Selection) -> String
+    let accessibilityIdentifier: (Selection) -> String
+    let selectedTint: Color
+    let selectedForeground: Color
+    let unselectedForeground: Color
+    let onSelection: ((Selection) -> Void)?
+
+    init(
+        selection: Binding<Selection>,
+        items: [Selection],
+        title: @escaping (Selection) -> String,
+        systemImage: @escaping (Selection) -> String? = { _ in nil },
+        accessibilityLabel: @escaping (Selection) -> String,
+        accessibilityHint: @escaping (Selection) -> String,
+        accessibilityIdentifier: @escaping (Selection) -> String,
+        selectedTint: Color,
+        selectedForeground: Color,
+        unselectedForeground: Color,
+        onSelection: ((Selection) -> Void)? = nil
+    ) {
+        _selection = selection
+        self.items = items
+        self.title = title
+        self.systemImage = systemImage
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityHint = accessibilityHint
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.selectedTint = selectedTint
+        self.selectedForeground = selectedForeground
+        self.unselectedForeground = unselectedForeground
+        self.onSelection = onSelection
+    }
+
+    var body: some View {
+        Group {
+            if #available(iOS 26.0, *) {
+                GlassEffectContainer(spacing: 4) {
+                    HStack(spacing: 4) {
+                        ForEach(items, id: \.self) { item in
+                            nativeSegment(for: item)
+                        }
+                    }
+                    .padding(4)
+                }
+            } else {
+                fallbackSegments
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    @available(iOS 26.0, *)
+    private func nativeSegment(for item: Selection) -> some View {
+        segmentButton(for: item)
+            // Apply glass after sizing and content modifiers so the material
+            // follows the actual 44pt hit target rather than clipping it.
+            .glassEffect(
+                selectedGlass(for: item),
+                in: Capsule(style: .continuous)
+            )
+    }
+
+    @available(iOS 26.0, *)
+    private func selectedGlass(for item: Selection) -> Glass {
+        if selection == item {
+            return .regular
+                .tint(selectedTint.opacity(0.2))
+                .interactive()
+        }
+
+        return .regular.interactive()
+    }
+
+    private var fallbackSegments: some View {
+        HStack(spacing: 4) {
+            ForEach(items, id: \.self) { item in
+                fallbackSegment(for: item)
+            }
+        }
+        .padding(4)
+        .systemBGlassSurface(
+            cornerRadius: JovieTokens.controlRadius,
+            tint: selectedTint,
+            tintOpacity: 0.025,
+            borderColor: Color.white.opacity(0.12),
+            borderOpacity: 1
+        )
+    }
+
+    private func fallbackSegment(for item: Selection) -> some View {
+        segmentButton(for: item)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(selection == item ? selectedTint : Color.clear)
+            )
+    }
+
+    private func segmentButton(for item: Selection) -> some View {
+        let isSelected = selection == item
+
+        return Button {
+            withAnimation(.easeInOut(duration: JovieTokens.subtleDuration)) {
+                selection = item
+            }
+            onSelection?(item)
+        } label: {
+            Group {
+                if let systemImageName = systemImage(item) {
+                    Label(title(item), systemImage: systemImageName)
+                } else {
+                    Text(title(item))
+                }
+            }
+            .font(.subheadline.weight(.semibold))
+            .lineLimit(1)
+            .minimumScaleFactor(0.78)
+            .frame(maxWidth: .infinity, minHeight: JovieTokens.compactControlHeight)
+            .foregroundStyle(isSelected ? selectedForeground : unselectedForeground)
+            .contentShape(Capsule(style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel(item))
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityHint(accessibilityHint(item))
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityIdentifier(accessibilityIdentifier(item))
+    }
+}
+
 // MARK: - Period Selector Component
 
 struct PeriodSelector: View {

--- a/apps/ios/LogYourBody/Components/SkeletonLoaders.swift
+++ b/apps/ios/LogYourBody/Components/SkeletonLoaders.swift
@@ -106,24 +106,32 @@ struct TimelineSliderSkeleton: View {
 // MARK: - Core Metrics Row Skeleton
 
 struct CoreMetricsRowSkeleton: View {
+    let measurementSystem: MeasurementSystem
+
+    init(measurementSystem: MeasurementSystem = .localeDefault) {
+        self.measurementSystem = measurementSystem
+    }
+
     var body: some View {
         HStack(spacing: 16) {
             // Weight metric skeleton
             metricCardSkeleton(
                 icon: "scalemass",
-                title: "Weight"
+                title: "Weight",
+                unit: measurementSystem.weightUnit
             )
 
             // Body fat metric skeleton
             metricCardSkeleton(
                 icon: "percent",
-                title: "Body Fat"
+                title: "Body Fat",
+                unit: nil
             )
         }
         .padding(.horizontal, 20)
     }
 
-    private func metricCardSkeleton(icon: String, title: String) -> some View {
+    private func metricCardSkeleton(icon: String, title: String, unit: String?) -> some View {
         VStack(spacing: 0) {
             // Value placeholder
             HStack(alignment: .bottom, spacing: 6) {
@@ -132,9 +140,11 @@ struct CoreMetricsRowSkeleton: View {
                     .frame(width: 80, height: 36)
                     .shimmer()
 
-                Text("lbs")
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(.white.opacity(0.3))
+                if let unit {
+                    Text(unit)
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(.white.opacity(0.3))
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -261,6 +271,12 @@ struct SecondaryMetricsRowSkeleton: View {
 // MARK: - Full Dashboard Skeleton
 
 struct DashboardSkeleton: View {
+    let measurementSystem: MeasurementSystem
+
+    init(measurementSystem: MeasurementSystem = .localeDefault) {
+        self.measurementSystem = measurementSystem
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Progress photo skeleton
@@ -274,7 +290,7 @@ struct DashboardSkeleton: View {
                 TimelineSliderSkeleton()
 
                 // Core metrics row
-                CoreMetricsRowSkeleton()
+                CoreMetricsRowSkeleton(measurementSystem: measurementSystem)
 
                 // Secondary metrics row
                 SecondaryMetricsRowSkeleton()

--- a/apps/ios/LogYourBody/Features/Onboarding/BodyScoreModels.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/BodyScoreModels.swift
@@ -23,6 +23,10 @@ enum WeightUnit: String, Codable, CaseIterable, CustomStringConvertible {
             return "LBS"
         }
     }
+
+    static var localeDefault: WeightUnit {
+        MeasurementSystem.localeDefault == .metric ? .kilograms : .pounds
+    }
 }
 
 enum HeightUnit: String, Codable, CaseIterable, CustomStringConvertible {
@@ -45,6 +49,10 @@ enum HeightUnit: String, Codable, CaseIterable, CustomStringConvertible {
         case .inches:
             return "FT/IN"
         }
+    }
+
+    static var localeDefault: HeightUnit {
+        MeasurementSystem.localeDefault == .metric ? .centimeters : .inches
     }
 }
 
@@ -75,7 +83,7 @@ struct HeightValue: Codable, Equatable {
     var value: Double?
     var unit: HeightUnit
 
-    init(value: Double? = nil, unit: HeightUnit = .inches) {
+    init(value: Double? = nil, unit: HeightUnit = .localeDefault) {
         self.value = value
         self.unit = unit
     }
@@ -105,7 +113,7 @@ struct WeightValue: Codable, Equatable {
     var value: Double?
     var unit: WeightUnit
 
-    init(value: Double? = nil, unit: WeightUnit = .pounds) {
+    init(value: Double? = nil, unit: WeightUnit = .localeDefault) {
         self.value = value
         self.unit = unit
     }
@@ -170,7 +178,7 @@ struct BodyScoreInput: Codable, Equatable {
         height: HeightValue = HeightValue(),
         weight: WeightValue = WeightValue(),
         bodyFat: BodyFatValue = BodyFatValue(),
-        measurementPreference: MeasurementSystem = .imperial,
+        measurementPreference: MeasurementSystem = .localeDefault,
         healthSnapshot: HealthImportSnapshot = HealthImportSnapshot()
     ) {
         self.sex = sex

--- a/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingAtoms.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingAtoms.swift
@@ -130,6 +130,34 @@ struct OnboardingTextButton: View {
     }
 }
 
+/// The shared disclosure affordance for short onboarding explanations.
+/// Keep the label, icon, hit target, and expanded state consistent across pages.
+struct OnboardingDisclosureLink: View {
+    @Environment(\.theme)
+    private var theme
+
+    let title: String
+    let isExpanded: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: theme.spacing.xs) {
+                Image(systemName: "questionmark.circle")
+                    .font(theme.typography.captionLarge.weight(.semibold))
+
+                Text(title)
+                    .font(theme.typography.captionLarge)
+            }
+            .foregroundStyle(theme.colors.primary)
+        }
+        .buttonStyle(.plain)
+        .jovieTouchTarget()
+        .accessibilityValue(isExpanded ? "Expanded" : "Collapsed")
+        .accessibilityHint(isExpanded ? "Hides more information." : "Shows more information.")
+    }
+}
+
 // MARK: - Supporting Atoms
 
 struct OnboardingBulletItem: Identifiable, Hashable {
@@ -195,7 +223,7 @@ struct OnboardingCard<Content: View>: View {
 
     var body: some View {
         content
-            .padding(20)
+            .padding(theme.spacing.md)
             .systemBGlassSurface(
                 cornerRadius: theme.radius.card,
                 tint: theme.colors.text,

--- a/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingMolecules.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingMolecules.swift
@@ -27,8 +27,8 @@ struct OnboardingOptionButton: View {
 
     var body: some View {
         Button(action: action, label: {
-            HStack(alignment: .center, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .center, spacing: theme.spacing.sm) {
+                VStack(alignment: .leading, spacing: theme.spacing.xxs) {
                     Text(title)
                         .font(OnboardingTypography.headline)
                         .foregroundStyle(theme.colors.text)
@@ -51,9 +51,9 @@ struct OnboardingOptionButton: View {
                     .font(.system(size: 22, weight: .semibold))
                     .foregroundStyle(isSelected ? theme.colors.primary : theme.colors.textSecondary.opacity(0.6))
             }
-            .padding(20)
+            .padding(theme.spacing.md)
             .systemBGlassSurface(
-                cornerRadius: 20,
+                cornerRadius: theme.radius.card,
                 tint: isSelected ? theme.colors.primary : theme.colors.text,
                 tintOpacity: isSelected ? 0.16 : 0.035,
                 borderColor: isSelected ? theme.colors.primary : theme.colors.border,
@@ -79,7 +79,7 @@ struct OnboardingSegmentedControl<Option: Hashable & CustomStringConvertible>: V
     @Binding var selection: Option
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: theme.spacing.xs) {
             ForEach(options, id: \.self) { option in
                 Button(action: { selection = option }, label: {
                     Text(option.description)
@@ -88,7 +88,7 @@ struct OnboardingSegmentedControl<Option: Hashable & CustomStringConvertible>: V
                         .frame(minHeight: JovieTokens.compactControlHeight)
                         .foregroundStyle(selection == option ? theme.colors.text : theme.colors.textSecondary)
                         .systemBGlassSurface(
-                            cornerRadius: 14,
+                            cornerRadius: theme.radius.input,
                             tint: selection == option ? theme.colors.primary : theme.colors.text,
                             tintOpacity: selection == option ? 0.28 : 0.02,
                             borderColor: selection == option ? theme.colors.primary : theme.colors.border,
@@ -100,9 +100,9 @@ struct OnboardingSegmentedControl<Option: Hashable & CustomStringConvertible>: V
                 .accessibilityAddTraits(selection == option ? .isSelected : [])
             }
         }
-        .padding(4)
+        .padding(theme.spacing.xxs)
         .systemBGlassSurface(
-            cornerRadius: 18,
+            cornerRadius: theme.radius.input,
             tint: theme.colors.text,
             tintOpacity: 0.02,
             borderColor: theme.colors.border,
@@ -118,7 +118,7 @@ struct OnboardingInfoRow: View {
     let text: String
 
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
+        HStack(alignment: .top, spacing: theme.spacing.xs) {
             Image(systemName: "questionmark.circle")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(theme.colors.textSecondary)
@@ -146,7 +146,7 @@ struct OnboardingTextFieldRow: View {
     @FocusState private var isFocused: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: theme.spacing.xs) {
             Text(title)
                 .font(OnboardingTypography.caption)
                 .foregroundStyle(theme.colors.textSecondary)
@@ -156,7 +156,7 @@ struct OnboardingTextFieldRow: View {
                 .autocorrectionDisabled(true)
                 .textInputAutocapitalization(.never)
                 .focused($isFocused)
-                .padding(.horizontal, 14)
+                .padding(.horizontal, theme.spacing.sm)
                 .frame(minHeight: JovieTokens.compactControlHeight)
                 .systemBGlassSurface(
                     cornerRadius: theme.radius.input,
@@ -180,8 +180,8 @@ struct OnboardingValueRow: View {
     let action: (() -> Void)?
 
     var body: some View {
-        HStack(alignment: .top, spacing: 16) {
-            VStack(alignment: .leading, spacing: 6) {
+        HStack(alignment: .top, spacing: theme.spacing.md) {
+            VStack(alignment: .leading, spacing: theme.spacing.xxs) {
                 Text(label.uppercased())
                     .font(theme.typography.labelSmall)
                     .foregroundStyle(theme.colors.textSecondary)
@@ -209,9 +209,9 @@ struct OnboardingValueRow: View {
                 .jovieTouchTarget()
             }
         }
-        .padding(20)
+        .padding(theme.spacing.md)
         .systemBGlassSurface(
-            cornerRadius: 20,
+            cornerRadius: theme.radius.card,
             tint: theme.colors.text,
             tintOpacity: 0.035,
             borderColor: theme.colors.border,
@@ -237,7 +237,7 @@ struct OnboardingFormSection<Content: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: theme.spacing.sm) {
             if let title {
                 Text(title)
                     .font(OnboardingTypography.headline)
@@ -250,12 +250,12 @@ struct OnboardingFormSection<Content: View>: View {
                     .foregroundStyle(theme.colors.textSecondary)
             }
 
-            VStack(spacing: 16) {
+            VStack(spacing: theme.spacing.md) {
                 content
             }
-            .padding(20)
+            .padding(theme.spacing.md)
             .systemBGlassSurface(
-                cornerRadius: 24,
+                cornerRadius: theme.radius.card,
                 tint: theme.colors.text,
                 tintOpacity: 0.035,
                 borderColor: theme.colors.border,
@@ -274,8 +274,8 @@ struct OnboardingProgressIndicator: View {
     let context: OnboardingFlowViewModel.ProgressContext
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("\(context.label) · \(Int((context.fractionComplete * 100).rounded()))% complete")
+        VStack(alignment: .leading, spacing: theme.spacing.xs) {
+            Text("\(context.label) · \(Int((context.fractionComplete * 100).rounded()))%")
                 .font(theme.typography.labelSmall)
                 .foregroundStyle(theme.colors.textSecondary)
 
@@ -332,8 +332,8 @@ struct OnboardingScaffold<Content: View, CTA: View>: View {
                 content
                     .frame(maxWidth: .infinity, alignment: .topLeading)
                     .padding(.horizontal, JovieTokens.screenInset)
-                    .padding(.top, 16)
-                    .padding(.bottom, showsCTA ? 24 : 40)
+                    .padding(.top, JovieTokens.compactInset)
+                    .padding(.bottom, showsCTA ? theme.spacing.lg : theme.spacing.xl)
             }
             .scrollIndicators(.hidden)
             .scrollBounceBehavior(.basedOnSize, axes: .vertical)
@@ -355,8 +355,7 @@ struct OnboardingScaffold<Content: View, CTA: View>: View {
 
             cta
                 .padding(.horizontal, JovieTokens.screenInset)
-                .padding(.top, 14)
-                .padding(.bottom, 12)
+                .padding(.vertical, theme.spacing.sm)
         }
         .background(
             theme.colors.background
@@ -407,7 +406,7 @@ struct OnboardingPageTemplate<Content: View, Footer: View>: View {
     }
 
     private var contentStack: some View {
-        VStack(alignment: .leading, spacing: 24) {
+        VStack(alignment: .leading, spacing: theme.spacing.lg) {
             header
 
             content
@@ -416,17 +415,17 @@ struct OnboardingPageTemplate<Content: View, Footer: View>: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: theme.spacing.md) {
             if showsBackButton {
                 Button(action: {
                     onBack?()
                 }, label: {
                     Image(systemName: "chevron.left")
-                        .font(.system(size: 18, weight: .semibold))
+                        .font(theme.typography.labelLarge)
                         .foregroundStyle(theme.colors.text)
-                        .padding(10)
+                        .padding(theme.spacing.xs)
                         .systemBGlassSurface(
-                            cornerRadius: 14,
+                            cornerRadius: theme.radius.input,
                             tint: theme.colors.text,
                             tintOpacity: 0.05,
                             borderColor: theme.colors.border,

--- a/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/ViewModels/OnboardingFlowViewModel.swift
@@ -121,10 +121,10 @@ final class OnboardingFlowViewModel: ObservableObject {
     @Published var showEmailCaptureSheet = false
     @Published var isLoading = false
     @Published var errorMessage: String?
-    @Published var heightUnit: HeightUnit = .centimeters {
+    @Published var heightUnit: HeightUnit = .localeDefault {
         didSet { persistProgress() }
     }
-    @Published var weightUnit: WeightUnit = .pounds {
+    @Published var weightUnit: WeightUnit = .localeDefault {
         didSet { persistProgress() }
     }
     @Published var heightCentimetersText: String = "" {

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBasicsView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBasicsView.swift
@@ -32,20 +32,11 @@ struct BodyScoreBasicsView: View {
                             }
                         }
 
-                        Button {
-                            toggleWhyWeAsk()
-                        } label: {
-                            HStack(spacing: 6) {
-                                Image(systemName: "questionmark.circle")
-                                    .font(.system(.footnote, design: .default).weight(.semibold))
-                                Text("Why we ask")
-                                    .font(OnboardingTypography.caption)
-                            }
-                            .foregroundStyle(theme.colors.primary)
-                        }
-                        .buttonStyle(.plain)
-                        .jovieTouchTarget()
-                        .accessibilityValue(showWhyWeAsk ? "Expanded" : "Collapsed")
+                        OnboardingDisclosureLink(
+                            title: "Why we ask",
+                            isExpanded: showWhyWeAsk,
+                            action: toggleWhyWeAsk
+                        )
 
                         if showWhyWeAsk {
                             OnboardingInfoRow(

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatNumericView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreBodyFatNumericView.swift
@@ -83,23 +83,14 @@ struct BodyScoreBodyFatNumericView: View {
                     }
 
                     VStack(alignment: .leading, spacing: 8) {
-                        Button {
-                            toggleHelp()
-                        } label: {
-                            HStack(spacing: 6) {
-                                Image(systemName: "questionmark.circle")
-                                    .font(.system(.footnote, design: .default).weight(.semibold))
-                                Text("Not sure your %?")
-                                    .font(OnboardingTypography.caption)
-                            }
-                            .foregroundStyle(theme.colors.primary)
-                        }
-                        .buttonStyle(.plain)
-                        .jovieTouchTarget()
-                        .accessibilityValue(showHelp ? "Expanded" : "Collapsed")
+                        OnboardingDisclosureLink(
+                            title: "Need an estimate?",
+                            isExpanded: showHelp,
+                            action: toggleHelp
+                        )
 
                         if showHelp {
-                            Text("You can go back and choose visual estimate instead. We’ll guide you with reference photos.")
+                            Text("Go back to use reference photos instead.")
                                 .font(OnboardingTypography.body)
                                 .foregroundStyle(theme.colors.textSecondary)
                                 .transition(.opacity.combined(with: .move(edge: .top)))

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
@@ -37,11 +37,11 @@ struct BodyScoreFirstProgressPhotoView: View {
     var body: some View {
         OnboardingPageTemplate(
             title: "Start your visual timeline.",
-            subtitle: "Add a first progress photo now, or skip and add one from Home.",
+            subtitle: "Add a photo now, or do it later from Home.",
             onBack: { viewModel.goBack() },
             progress: viewModel.progress(for: .firstPhoto),
             content: {
-                VStack(alignment: .leading, spacing: 20) {
+                VStack(alignment: .leading, spacing: theme.spacing.lg) {
                     previewCard
                     actionStack
                 }
@@ -63,39 +63,37 @@ struct BodyScoreFirstProgressPhotoView: View {
     }
 
     private var previewCard: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: theme.spacing.md) {
             Image(systemName: "camera.metering.center.weighted")
-                .font(.system(.title, design: .rounded).weight(.semibold))
+                .font(theme.typography.headlineMedium)
                 .foregroundStyle(theme.colors.text.opacity(0.82))
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Photos make the timeline useful.")
+            VStack(alignment: .leading, spacing: theme.spacing.xxs) {
+                Text("Start with a photo.")
                     .font(theme.typography.headlineSmall)
                     .foregroundStyle(theme.colors.text)
 
-                Text(
-                    "We attach the photo to the baseline metrics you just entered, so Home opens with your first visual check-in."
-                )
+                Text("We’ll pair it with the baseline metrics you just entered, so Home starts with a visual check-in.")
                     .font(OnboardingTypography.body)
                     .foregroundStyle(theme.colors.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            HStack(alignment: .top, spacing: 10) {
+            HStack(alignment: .top, spacing: theme.spacing.sm) {
                 Image(systemName: "lock.shield")
                     .font(.system(.footnote, design: .default).weight(.semibold))
                     .foregroundStyle(theme.colors.text)
 
-                Text("Camera and photo library access are optional. You choose what to add, and can skip this for now.")
+                Text("Camera and photo library access are optional.")
                     .font(OnboardingTypography.caption)
                     .foregroundStyle(theme.colors.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .padding(20)
+        .padding(theme.spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
         .systemBGlassSurface(
-            cornerRadius: 22,
+            cornerRadius: theme.radius.card,
             tint: theme.colors.text,
             tintOpacity: 0.04,
             borderColor: theme.colors.border,
@@ -108,7 +106,7 @@ struct BodyScoreFirstProgressPhotoView: View {
     }
 
     private var actionStack: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: theme.spacing.sm) {
             Button {
                 presentAttachSheet()
             } label: {
@@ -138,12 +136,6 @@ struct BodyScoreFirstProgressPhotoView: View {
             .buttonStyle(OnboardingSecondaryButtonStyle())
             .disabled(actionState.disablesActions)
             .accessibilityIdentifier("onboarding_first_photo_skip_button")
-
-                Text("You can add progress photos later from Home.")
-                    .font(OnboardingTypography.caption)
-                .foregroundStyle(theme.colors.textTertiary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: .infinity)
 
             if let errorMessage = viewModel.firstPhotoErrorMessage {
                 Text(errorMessage)

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHeightView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHeightView.swift
@@ -184,20 +184,11 @@ struct BodyScoreHeightView: View {
 
     private var helperCard: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Button {
-                toggleWhyWeAsk()
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "questionmark.circle")
-                        .font(.system(.footnote, design: .default).weight(.semibold))
-                    Text("Why we ask")
-                        .font(OnboardingTypography.caption)
-                }
-                .foregroundStyle(theme.colors.primary)
-            }
-            .buttonStyle(.plain)
-            .jovieTouchTarget()
-            .accessibilityValue(showWhyWeAsk ? "Expanded" : "Collapsed")
+            OnboardingDisclosureLink(
+                title: "Why we ask",
+                isExpanded: showWhyWeAsk,
+                action: toggleWhyWeAsk
+            )
 
             if showWhyWeAsk {
                 VStack(alignment: .leading, spacing: 8) {

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreManualWeightView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreManualWeightView.swift
@@ -149,20 +149,11 @@ struct BodyScoreManualWeightView: View {
                                 .accessibilityFocused($weightErrorFocused)
                         }
 
-                        Button {
-                            toggleWhyWeAsk()
-                        } label: {
-                            HStack(spacing: 6) {
-                                Image(systemName: "questionmark.circle")
-                                    .font(.system(.footnote, design: .default).weight(.semibold))
-                                Text("Why we ask")
-                                    .font(OnboardingTypography.caption)
-                            }
-                            .foregroundStyle(theme.colors.primary)
-                        }
-                        .buttonStyle(.plain)
-                        .jovieTouchTarget()
-                        .accessibilityValue(showWhyWeAsk ? "Expanded" : "Collapsed")
+                        OnboardingDisclosureLink(
+                            title: "Why we ask",
+                            isExpanded: showWhyWeAsk,
+                            action: toggleWhyWeAsk
+                        )
 
                         if showWhyWeAsk {
                             VStack(alignment: .leading, spacing: 8) {

--- a/apps/ios/LogYourBody/LogYourBodyApp.swift
+++ b/apps/ios/LogYourBody/LogYourBodyApp.swift
@@ -166,6 +166,38 @@ private struct PersistentStoreRecoveryView: View {
     }
 }
 
+#if DEBUG
+/// Test-only viewport constraint used to exercise layouts narrower than the
+/// iOS 26 simulator device catalog exposes. It is activated only by a UI-test
+/// launch argument and never changes a production build or user layout.
+private struct UITestViewportModifier: ViewModifier {
+    private var requestedWidth: CGFloat? {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let index = arguments.firstIndex(of: "-lybUITestViewportWidth"),
+              arguments.indices.contains(index + 1),
+              let value = Double(arguments[index + 1]),
+              value > 0 else {
+            return nil
+        }
+
+        return CGFloat(value)
+    }
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if let requestedWidth {
+            content
+                .frame(width: requestedWidth)
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("lyb_ui_test_viewport")
+                .frame(maxWidth: .infinity)
+        } else {
+            content
+        }
+    }
+}
+#endif
+
 @main
 struct LogYourBodyApp: App {
     @StateObject private var authManager = AuthManager.shared
@@ -196,6 +228,9 @@ struct LogYourBodyApp: App {
             switch persistenceController.persistentStoreLoadState {
             case .ready:
                 ContentView()
+#if DEBUG
+                .modifier(UITestViewportModifier())
+#endif
                 .environment(\.managedObjectContext, persistenceController.viewContext)
                 .environmentObject(authManager)
                 .environmentObject(realtimeSyncManager)

--- a/apps/ios/LogYourBody/Services/AppVersionManager.swift
+++ b/apps/ios/LogYourBody/Services/AppVersionManager.swift
@@ -300,7 +300,10 @@ class AppVersionManager {
     private func setupDefaultSettings() {
         // Set up any default settings for fresh installs
         if UserDefaults.standard.object(forKey: Constants.preferredWeightUnitKey) == nil {
-            UserDefaults.standard.set("lbs", forKey: Constants.preferredWeightUnitKey)
+            UserDefaults.standard.set(
+                MeasurementSystem.localeDefault.weightUnit,
+                forKey: Constants.preferredWeightUnitKey
+            )
         }
 
         if UserDefaults.standard.object(forKey: Constants.healthKitSyncEnabledKey) == nil {

--- a/apps/ios/LogYourBody/Services/BackgroundPhotoUploadService.swift
+++ b/apps/ios/LogYourBody/Services/BackgroundPhotoUploadService.swift
@@ -155,7 +155,7 @@ class BackgroundPhotoUploadService: ObservableObject {
             date: date,
             localDate: localDate,
             weight: nil,
-            weightUnit: "lbs",
+            weightUnit: nil,
             bodyFatPercentage: nil,
             bodyFatMethod: nil,
             muscleMass: nil,

--- a/apps/ios/LogYourBody/Services/BodyMetricAppIntents.swift
+++ b/apps/ios/LogYourBody/Services/BodyMetricAppIntents.swift
@@ -40,8 +40,12 @@ struct LogWeightIntent: AppIntent {
     )
     var weight: Double
 
-    @Parameter(title: "Unit", default: .pounds)
+    @Parameter(title: "Unit")
     var unit: BodyMetricIntentWeightUnit
+
+    init() {
+        unit = MeasurementSystem.preferredFromDefaults == .metric ? .kilograms : .pounds
+    }
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let result = try await BodyMetricLoggingService.shared.log(

--- a/apps/ios/LogYourBody/Services/CoreDataManager+Part04.swift
+++ b/apps/ios/LogYourBody/Services/CoreDataManager+Part04.swift
@@ -70,11 +70,14 @@ extension CoreDataManager {
                     hipCm = 0
                 }
 
+                // Cached iOS metrics are canonicalized to kg/cm. The server
+                // may return display-unit values (for example, 180 lbs), but
+                // every local writer and calculator expects normalized values.
                 metric.weight = weightKg
-                metric.weightUnit = rawWeightUnit
+                metric.weightUnit = rawWeight > 0 ? "kg" : nil
                 metric.waistCircumference = waistCm
                 metric.hipCircumference = hipCm
-                metric.waistUnit = rawWaistUnit
+                metric.waistUnit = rawWaistValue > 0 || rawHipValue > 0 ? "cm" : nil
                 metric.bodyFatPercentage = data["body_fat_percentage"] as? Double ?? 0
                 metric.bodyFatMethod = data["body_fat_method"] as? String
                 metric.muscleMass = data["muscle_mass"] as? Double ?? 0

--- a/apps/ios/LogYourBody/Utils/ExportCSVBuilder.swift
+++ b/apps/ios/LogYourBody/Utils/ExportCSVBuilder.swift
@@ -38,7 +38,10 @@ enum ExportCSVBuilder {
         for metric in sortedMetrics {
             let date = dateFormatter.string(from: metric.date)
             let weight = metric.weight ?? 0
-            let weightUnit = metric.weightUnit ?? "lbs"
+            // BodyMetrics stores weight canonically in kilograms. Keep the
+            // export truthful for older sparse records and photo-only
+            // placeholders that carry no weight value.
+            let weightUnit = metric.weight == nil ? "kg" : (metric.weightUnit ?? "kg")
             let bodyFat = metric.bodyFatPercentage ?? 0
             let ffmi: Double
             if let ffmiValue {

--- a/apps/ios/LogYourBody/Utils/UnitConversion.swift
+++ b/apps/ios/LogYourBody/Utils/UnitConversion.swift
@@ -306,11 +306,21 @@ struct UnitConversion {
 // MARK: - Extensions for Convenience
 
 extension MeasurementSystem {
+    /// The locale is only used when a user has not explicitly chosen a
+    /// measurement system. Persisted preferences always take precedence.
+    static func measurementSystem(for locale: Locale) -> MeasurementSystem {
+        locale.measurementSystem == .metric ? .metric : .imperial
+    }
+
+    static var localeDefault: MeasurementSystem {
+        measurementSystem(for: .current)
+    }
+
     static func fromStored(rawValue: String?) -> MeasurementSystem {
         if let rawValue, let system = MeasurementSystem(rawValue: rawValue) {
             return system
         }
-        return .imperial
+        return .localeDefault
     }
 
     static var preferredFromDefaults: MeasurementSystem {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -406,7 +406,10 @@ private struct DashboardHomeTimelineAvatarPlaceholder: View {
                     verticalPadding: 0,
                     horizontalFillScale: 1.0,
                     alignment: .bottom,
-                    renderMode: .fillWidth
+                    // Avatar assets do not share one aspect ratio. Fit the
+                    // native asset inside the hero so narrow screens never
+                    // crop the head, feet, or side silhouette.
+                    renderMode: .fit
                 )
                 .frame(width: geometry.size.width, height: geometry.size.height, alignment: .bottom)
                 .accessibilityHidden(true)

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+FullScreenMetricData.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+FullScreenMetricData.swift
@@ -44,6 +44,14 @@ extension DashboardViewLiquid {
         )
     }
 
+    func generateFullScreenWeightTrendChartData() -> [MetricChartDataPoint] {
+        buildFullScreenWeightTrendChartData(
+            from: sortedBodyMetricsAscending,
+            bodyMetrics: bodyMetrics,
+            measurementSystem: currentMeasurementSystem
+        )
+    }
+
     func generateFullScreenBodyFatChartData() -> [MetricChartDataPoint] {
         buildFullScreenBodyFatChartData(
             sortedBodyMetrics: sortedBodyMetricsAscending,
@@ -115,11 +123,13 @@ extension DashboardViewLiquid {
     func prewarmMetricCaches() async {
         guard !sortedBodyMetricsAscending.isEmpty || !recentDailyMetrics.isEmpty || !glp1DoseLogs.isEmpty else {
             fullChartCache = [:]
+            fullTrendChartCache = [:]
             metricEntriesCache = [:]
             return
         }
 
         fullChartCache = [:]
+        fullTrendChartCache = [:]
         metricEntriesCache = [:]
 
         let sortedMetrics = sortedBodyMetricsAscending
@@ -134,10 +144,11 @@ extension DashboardViewLiquid {
             heightUnit: heightUnitSnapshot
         )
 
-        let (chartCache, bodyScoreEntries) = await Task.detached(
+        let (chartCache, trendChartCache, bodyScoreEntries) = await Task.detached(
             priority: .utility
-        ) { () -> ([MetricType: [MetricChartDataPoint]], MetricEntriesPayload?) in
+        ) { () -> ([MetricType: [MetricChartDataPoint]], [MetricType: [MetricChartDataPoint]], MetricEntriesPayload?) in
             var cache: [MetricType: [MetricChartDataPoint]] = [:]
+            var trendCache: [MetricType: [MetricChartDataPoint]] = [:]
             var bodyScoreEntries: MetricEntriesPayload?
 
             let stepsData = buildFullScreenStepsChartData(from: recentDailySnapshot)
@@ -151,6 +162,15 @@ extension DashboardViewLiquid {
             )
             if !weightData.isEmpty {
                 cache[.weight] = weightData
+            }
+
+            let weightTrendData = buildFullScreenWeightTrendChartData(
+                from: sortedMetrics,
+                bodyMetrics: bodyMetricsSnapshot,
+                measurementSystem: measurementSystemSnapshot
+            )
+            if !weightTrendData.isEmpty {
+                trendCache[.weight] = weightTrendData
             }
 
             let bodyFatData = buildFullScreenBodyFatChartData(
@@ -187,10 +207,11 @@ extension DashboardViewLiquid {
                 bodyScoreEntries = bodyScoreResult.entriesPayload
             }
 
-            return (cache, bodyScoreEntries)
+            return (cache, trendCache, bodyScoreEntries)
         }.value
 
         fullChartCache = chartCache
+        fullTrendChartCache = trendChartCache
 
         if let bodyScoreEntries {
             metricEntriesCache[.bodyScore] = bodyScoreEntries
@@ -356,6 +377,47 @@ private func buildFullScreenWeightChartData(
                 value: converted
             )
         }
+}
+
+private func buildFullScreenWeightTrendChartData(
+    from sortedBodyMetricsAscending: [BodyMetrics],
+    bodyMetrics: [BodyMetrics],
+    measurementSystem: MeasurementSystem
+) -> [MetricChartDataPoint] {
+    guard let interpolationContext = MetricsInterpolationService.shared
+        .makeWeightInterpolationContext(for: bodyMetrics) else {
+        return []
+    }
+
+    return sortedBodyMetricsAscending.compactMap { metric in
+        guard metric.weight != nil,
+              let trend = interpolationContext.trendWeight(for: metric.date) else {
+            return nil
+        }
+
+        let converted: Double
+        switch measurementSystem {
+        case .metric:
+            converted = trend.value
+        case .imperial:
+            converted = trend.value * 2.20462
+        }
+
+        let presence: MetricPresence
+        if trend.isLastKnown {
+            presence = .lastKnown
+        } else if trend.isInterpolated {
+            presence = .interpolated
+        } else {
+            presence = .present
+        }
+
+        return MetricChartDataPoint(
+            date: metric.date,
+            value: converted,
+            presence: presence
+        )
+    }
 }
 
 private func buildFullScreenBodyFatChartData(

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HeroAndActions.swift
@@ -151,7 +151,9 @@ extension DashboardViewLiquid {
     }
 
     func heroWeightValue() -> String {
-        let base = formatWeightValue(currentMetric?.weight)
+        let base = currentMetric.map {
+            formatTrendWeightHeadline($0, usesTrend: weightUsesTrend)
+        } ?? "–"
         guard base != "–" else { return base }
         return "\(base) \(weightUnit)"
     }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HomeTimelineControls.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HomeTimelineControls.swift
@@ -25,47 +25,24 @@ extension DashboardViewLiquid {
     }
 
     var homeModeSwitch: some View {
-        HStack(spacing: 4) {
-            ForEach(DefaultHomeMode.allCases) { mode in
-                homeModeButton(mode)
-            }
-        }
-        .padding(4)
-        .systemBGlassSurface(
-            cornerRadius: theme.radius.full,
-            tint: theme.colors.text,
-            tintOpacity: 0.025,
-            borderColor: theme.colors.border,
-            borderOpacity: 0.85
+        JovieSegmentedControl(
+            selection: Binding(
+                get: { selectedDefaultHomeMode },
+                set: { defaultHomeModeRawValue = $0.rawValue }
+            ),
+            items: Array(DefaultHomeMode.allCases),
+            title: { $0.title },
+            systemImage: { $0.iconName },
+            accessibilityLabel: { $0.title },
+            accessibilityHint: { "Shows the \($0.title.lowercased()) home timeline" },
+            accessibilityIdentifier: { "home_mode_\($0.rawValue)_button" },
+            selectedTint: theme.colors.text,
+            selectedForeground: theme.colors.background,
+            unselectedForeground: theme.colors.textSecondary,
+            onSelection: { _ in HapticManager.shared.selection() }
         )
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("home_mode_switch")
-    }
-
-    func homeModeButton(_ mode: DefaultHomeMode) -> some View {
-        let isSelected = selectedDefaultHomeMode == mode
-
-        return Button {
-            defaultHomeModeRawValue = mode.rawValue
-            HapticManager.shared.selection()
-        } label: {
-            Label(mode.title, systemImage: mode.iconName)
-                .font(.subheadline.weight(.semibold))
-                .lineLimit(1)
-                .frame(maxWidth: .infinity)
-                .frame(minHeight: 44)
-                .foregroundColor(isSelected ? theme.colors.background : theme.colors.textSecondary)
-                .background(
-                    Capsule(style: .continuous)
-                        .fill(isSelected ? theme.colors.text : Color.clear)
-                )
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(mode.title)
-        .accessibilityValue(isSelected ? "Selected" : "Not selected")
-        .accessibilityHint("Shows the \(mode.title.lowercased()) home timeline")
-        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
-        .accessibilityIdentifier("home_mode_\(mode.rawValue)_button")
     }
 
     func homeTimelineHero(metric: BodyMetrics) -> some View {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+HomeTimelineControls.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+HomeTimelineControls.swift
@@ -41,6 +41,13 @@ extension DashboardViewLiquid {
             unselectedForeground: theme.colors.textSecondary,
             onSelection: { _ in HapticManager.shared.selection() }
         )
+        .systemBGlassSurface(
+            cornerRadius: theme.radius.full,
+            tint: theme.colors.text,
+            tintOpacity: 0.025,
+            borderColor: theme.colors.border,
+            borderOpacity: 0.85
+        )
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("home_mode_switch")
     }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricViews.swift
@@ -106,10 +106,16 @@ extension DashboardViewLiquid {
                 title: "Weight",
                 icon: "figure.stand",
                 iconColor: theme.colors.accentViolet,
-                currentValue: currentMetric.flatMap { formatWeightValue($0.weight) } ?? "–",
+                currentValue: currentMetric.map {
+                    formatTrendWeightHeadline($0, usesTrend: weightUsesTrend)
+                } ?? "–",
                 unit: weightUnit,
                 currentDate: formatDate(currentMetric?.date ?? Date()),
                 chartData: cachedChartData(for: .weight, generator: generateFullScreenWeightChartData),
+                trendChartData: cachedTrendChartData(
+                    for: .weight,
+                    generator: generateFullScreenWeightTrendChartData
+                ),
                 onAdd: {
                     presentAddEntrySheet(initialTab: 0)
                 },
@@ -117,7 +123,8 @@ extension DashboardViewLiquid {
                 relatedMetrics: metricDetailRelatedMetrics(excluding: .weight),
                 goalValue: weightGoal.flatMap { convertWeight($0, to: currentMeasurementSystem) },
                 selectedTimeRange: $selectedRange,
-                selectedTimelineDate: metricDetailSelectedDateBinding
+                selectedTimelineDate: metricDetailSelectedDateBinding,
+                initialChartMode: weightUsesTrend ? .trend : .raw
             )
 
         case .bodyFat:

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+MetricsHelpers.swift
@@ -549,6 +549,16 @@ extension DashboardViewLiquid {
         return generator()
     }
 
+    func cachedTrendChartData(
+        for type: MetricType,
+        generator: () -> [MetricChartDataPoint]
+    ) -> [MetricChartDataPoint] {
+        if let cached = fullTrendChartCache[type] {
+            return cached
+        }
+        return generator()
+    }
+
     func weightRangeStats() -> MetricRangeStats? {
         let system = currentMeasurementSystem
         return computeRangeStats(metrics: filteredMetrics(for: selectedRange)) { metric in

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -10,7 +10,7 @@ extension DashboardViewLiquid {
             let heroWidth = max(1, viewportWidth - heroHorizontalInset * 2)
 
             ScrollView(showsIndicators: false) {
-                VStack(spacing: 16) {
+                VStack(spacing: 12) {
                     compactHeader
                         .padding(.horizontal, 20)
                         .padding(.top, 8)
@@ -161,7 +161,7 @@ extension DashboardViewLiquid {
                 timelineMode: homeTimelineModeBinding
             )
         }
-        .padding(.vertical, 10)
+        .padding(.vertical, 8)
         .systemBGlassSurface(
             cornerRadius: theme.radius.card,
             tint: theme.colors.text,

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -47,6 +47,7 @@ struct DashboardViewLiquid: View {
     @State private var coreDataReloadTask: Task<Void, Never>?
     @State var metricEntriesCache: [MetricType: MetricEntriesPayload] = [:]
     @State var fullChartCache: [MetricType: [MetricChartDataPoint]] = [:]
+    @State var fullTrendChartCache: [MetricType: [MetricChartDataPoint]] = [:]
     @State var glp1DoseLogs: [Glp1DoseLog] = []
     @State var glp1Medications: [Glp1Medication] = []
     @State var dailyMetricsLookupCache: [Date: DailyMetrics] = [:]
@@ -205,6 +206,18 @@ struct DashboardViewLiquid: View {
             }
             .onChange(of: selectedRange) { _, newValue in
                 storedTimeRangeRawValue = newValue.rawValue
+            }
+            .onChange(of: measurementSystem) { _, _ in
+                // Full-screen chart and entry caches contain display-unit values;
+                // discard them immediately when Settings changes units so a
+                // returning user cannot see a mixed kg/lbs detail screen while
+                // the next cache build completes.
+                fullChartCache = [:]
+                fullTrendChartCache = [:]
+                metricEntriesCache = [:]
+                Task { @MainActor in
+                    await prewarmMetricCaches()
+                }
             }
             .onChange(of: selectedIndex) { _, newIndex in
                 scheduleDashboardDerivedStateRefresh(animatedIndex: newIndex)
@@ -565,7 +578,7 @@ struct DashboardViewLiquid: View {
     @ViewBuilder
     private var dashboardContent: some View {
         if viewModel.bodyMetrics.isEmpty && !viewModel.hasLoadedInitialData {
-            DashboardSkeleton()
+            DashboardSkeleton(measurementSystem: currentMeasurementSystem)
         } else if layoutMode == .photoTimelineHUD {
             photoTimelineRoot
         } else if viewModel.bodyMetrics.isEmpty {

--- a/apps/ios/LogYourBody/Views/PreferencesView.swift
+++ b/apps/ios/LogYourBody/Views/PreferencesView.swift
@@ -43,7 +43,7 @@ struct PreferencesView: View {
     @State var dailyReminderDate = Date()
 
     static var defaultMeasurementSystem: String {
-        MeasurementSystem.imperial.rawValue
+        MeasurementSystem.localeDefault.rawValue
     }
 
     var currentSystem: MeasurementSystem {

--- a/apps/ios/LogYourBody/Views/ProfileSettingsViewV2.swift
+++ b/apps/ios/LogYourBody/Views/ProfileSettingsViewV2.swift
@@ -106,6 +106,18 @@ struct ProfileSettingsViewV2: View {
         .navigationTitle("Edit Profile")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Cancel")
+                        .fixedSize()
+                }
+                .frame(minWidth: 64, minHeight: JovieTokens.minimumHitTarget)
+                .contentShape(Rectangle())
+                .accessibilityIdentifier("profile_editor_cancel_button")
+            }
+
             ToolbarItem(placement: .navigationBarTrailing) {
                 if isSaving {
                     ProgressView()
@@ -204,34 +216,37 @@ struct ProfileSettingsViewV2: View {
     }
 
     private var genderSelector: some View {
-        Picker(selection: $editableGender) {
-            ForEach(BiologicalSex.allCases, id: \.self) { gender in
-                Text(gender.description).tag(gender)
+        HStack(spacing: 0) {
+            Text("Biological sex")
+                .foregroundColor(theme.colors.text)
+                .font(theme.typography.labelLarge)
+                .accessibilityHidden(true)
+
+            Spacer(minLength: theme.spacing.sm)
+
+            Picker(selection: $editableGender) {
+                ForEach(BiologicalSex.allCases, id: \.self) { gender in
+                    Text(gender.description).tag(gender)
+                }
+            } label: {
+                HStack(spacing: theme.spacing.xs) {
+                    Text(editableGender.description)
+                        .font(theme.typography.labelMedium)
+                        .foregroundColor(theme.colors.textSecondary)
+                        .lineLimit(1)
+
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(theme.typography.captionMedium.weight(.semibold))
+                        .foregroundColor(theme.colors.textTertiary)
+                }
             }
-        } label: {
-            HStack(spacing: theme.spacing.xs) {
-                Text("Biological sex")
-                    .foregroundColor(theme.colors.text)
-                    .font(theme.typography.labelLarge)
-
-                Spacer(minLength: theme.spacing.sm)
-
-                Text(editableGender.description)
-                    .font(theme.typography.labelMedium)
-                    .foregroundColor(theme.colors.textSecondary)
-                    .lineLimit(1)
-
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(theme.typography.captionMedium.weight(.semibold))
-                    .foregroundColor(theme.colors.textTertiary)
-            }
+            .pickerStyle(.menu)
+            .tint(theme.colors.text)
+            .accessibilityLabel("Biological sex")
+            .accessibilityValue(editableGender.description)
         }
-        .pickerStyle(.menu)
-        .tint(theme.colors.text)
         .padding(.horizontal, theme.spacing.md)
         .frame(minHeight: JovieTokens.minimumHitTarget)
-        .accessibilityLabel("Biological sex")
-        .accessibilityValue(editableGender.description)
         .onChange(of: editableGender) { _, _ in
             hasChanges = true
         }

--- a/apps/ios/LogYourBodyTests/AppVersionManagerTests.swift
+++ b/apps/ios/LogYourBodyTests/AppVersionManagerTests.swift
@@ -72,7 +72,10 @@ final class AppVersionManagerTests: XCTestCase {
 
         let firstLaunch = try XCTUnwrap(UserDefaults.standard.object(forKey: "firstLaunchDate") as? Date)
         XCTAssertEqual(firstLaunch.timeIntervalSinceNow, 0, accuracy: 5)
-        XCTAssertEqual(UserDefaults.standard.string(forKey: Constants.preferredWeightUnitKey), "lbs")
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: Constants.preferredWeightUnitKey),
+            MeasurementSystem.localeDefault.weightUnit
+        )
         XCTAssertEqual(UserDefaults.standard.object(forKey: "healthKitSyncEnabled") as? Bool, true)
 
         // Every launch records the current version/build.

--- a/apps/ios/LogYourBodyTests/BodyCompositionMathGoldenTests.swift
+++ b/apps/ios/LogYourBodyTests/BodyCompositionMathGoldenTests.swift
@@ -82,6 +82,21 @@ final class BodyCompositionMathGoldenTests: XCTestCase {
         }
     }
 
+    func testMeasurementSystemDefaultsFollowLocaleUntilUserPreferenceExists() {
+        XCTAssertEqual(
+            MeasurementSystem.measurementSystem(for: Locale(identifier: "en_US")),
+            .imperial
+        )
+        XCTAssertEqual(
+            MeasurementSystem.measurementSystem(for: Locale(identifier: "de_DE")),
+            .metric
+        )
+        XCTAssertEqual(MeasurementSystem.fromStored(rawValue: "Metric"), .metric)
+        XCTAssertEqual(MeasurementSystem.fromStored(rawValue: "Imperial"), .imperial)
+        XCTAssertEqual(WeightUnit.localeDefault.measurementSystem, MeasurementSystem.localeDefault)
+        XCTAssertEqual(HeightUnit.localeDefault.measurementSystem, MeasurementSystem.localeDefault)
+    }
+
     func testWeightGoalStoresKilogramsAndPresentsOncePerSelectedUnit() throws {
         let goal = try XCTUnwrap(WeightGoal(displayValue: 180, measurementSystem: .imperial))
 

--- a/apps/ios/LogYourBodyTests/BodyMetricAppIntentsTests.swift
+++ b/apps/ios/LogYourBodyTests/BodyMetricAppIntentsTests.swift
@@ -250,6 +250,20 @@ final class BodyMetricAppIntentsTests: XCTestCase {
         XCTAssertEqual(BodyMetricIntentWeightUnit.kilograms.storageUnit, "kg")
     }
 
+    func testLogWeightIntentDefaultsToPreferredMeasurementSystem() {
+        UserDefaults.standard.set(
+            MeasurementSystem.metric.rawValue,
+            forKey: Constants.preferredMeasurementSystemKey
+        )
+        XCTAssertEqual(LogWeightIntent().unit, .kilograms)
+
+        UserDefaults.standard.set(
+            MeasurementSystem.imperial.rawValue,
+            forKey: Constants.preferredMeasurementSystemKey
+        )
+        XCTAssertEqual(LogWeightIntent().unit, .pounds)
+    }
+
     // MARK: - Helpers
 
     @discardableResult

--- a/apps/ios/LogYourBodyTests/ExportCSVBuilderTests.swift
+++ b/apps/ios/LogYourBodyTests/ExportCSVBuilderTests.swift
@@ -130,7 +130,7 @@ final class ExportCSVBuilderTests: XCTestCase {
         )
     }
 
-    func testBodyMetricsDefaultsMissingWeightAndUnitToZeroAndLbs() {
+    func testBodyMetricsDefaultsMissingWeightAndUnitToCanonicalKilograms() {
         let metric = makeMetric(id: "sparse", date: makeDate(2_024, 1, 5))
 
         let csv = ExportCSVBuilder.makeBodyMetricsCSV(
@@ -139,7 +139,24 @@ final class ExportCSVBuilderTests: XCTestCase {
             dateFormatter: makeFormatter()
         )
 
-        XCTAssertEqual(rows(of: csv).last, "1/5/24,0.0,lbs,0.0,0.0,0.0,0.0,\"\",")
+        XCTAssertEqual(rows(of: csv).last, "1/5/24,0.0,kg,0.0,0.0,0.0,0.0,\"\",")
+    }
+
+    func testBodyMetricsMissingWeightIgnoresLegacyDisplayUnit() {
+        let metric = makeMetric(
+            id: "photo-only",
+            date: makeDate(2_024, 1, 5),
+            weight: nil,
+            weightUnit: "lbs"
+        )
+
+        let csv = ExportCSVBuilder.makeBodyMetricsCSV(
+            metrics: [metric],
+            heightInches: nil,
+            dateFormatter: makeFormatter()
+        )
+
+        XCTAssertEqual(rows(of: csv).last, "1/5/24,0.0,kg,0.0,0.0,0.0,0.0,\"\",")
     }
 
     func testBodyMetricsFFMIIsZeroWhenHeightUnavailable() {
@@ -194,7 +211,7 @@ final class ExportCSVBuilderTests: XCTestCase {
         XCTAssertEqual(rows(of: csv).count, 2)
         XCTAssertEqual(
             rows(of: csv).last,
-            "1/5/24,0.0,lbs,0.0,0.0,0.0,0.0,\"Felt strong, slept well\","
+            "1/5/24,0.0,kg,0.0,0.0,0.0,0.0,\"Felt strong, slept well\","
         )
     }
 

--- a/apps/ios/LogYourBodyTests/SyncIntegrationImportAndMappingTests.swift
+++ b/apps/ios/LogYourBodyTests/SyncIntegrationImportAndMappingTests.swift
@@ -390,4 +390,33 @@ final class SyncIntegrationImportAndMappingTests: XCTestCase {
         XCTAssertEqual(metric.createdAt.timeIntervalSince(createdAt), 0, accuracy: 0.001)
         XCTAssertEqual(metric.updatedAt.timeIntervalSince(updatedAt), 0, accuracy: 0.001)
     }
+
+    func testUpdateOrCreateBodyMetricNormalizesDisplayUnitsForLocalStorage() async throws {
+        let coreData = CoreDataManager.shared
+        let id = UUID().uuidString
+        let userId = "sync_test_user_body_imperial_\(UUID().uuidString)"
+        let date = wholeSecondDate(1_500)
+        let formatter = ISO8601DateFormatter()
+
+        let payload: [String: Any] = [
+            "id": id,
+            "user_id": userId,
+            "date": formatter.string(from: date),
+            "weight": 180.0,
+            "weight_unit": "lbs",
+            "waist_circumference": 40.0,
+            "hip_circumference": 42.0,
+            "waist_unit": "in"
+        ]
+
+        coreData.updateOrCreateBodyMetric(from: payload)
+
+        let cachedMetric = await cachedBodyMetric(id: id)
+        let metric = try XCTUnwrap(cachedMetric)
+        XCTAssertEqual(metric.weight, UnitConversion.lbsToKg(180), accuracy: 0.0001)
+        XCTAssertEqual(metric.weightUnit, "kg")
+        XCTAssertEqual(metric.waistCircumference, 101.6, accuracy: 0.0001)
+        XCTAssertEqual(metric.hipCircumference, 106.68, accuracy: 0.0001)
+        XCTAssertEqual(metric.waistUnit, "cm")
+    }
 }

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -282,6 +282,114 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertFalse(app.descendants(matching: .any)["dashboard_home_timeline_photo_stage"].exists)
     }
 
+    func testNarrowIPhoneSegmentedControlsKeepNativeHitTargets() throws {
+        try assertNarrowSegmentedControls(
+            launchArguments: ["-lybUITestPhotoTimelineHUDFixture"],
+            expectedViewportWidth: nil,
+            screenshotPrefix: "narrow-segmented-controls"
+        )
+    }
+
+    func test320PointViewportSegmentedControlsKeepNativeHitTargets() throws {
+        try assertNarrowSegmentedControls(
+            launchArguments: [
+                "-lybUITestPhotoTimelineHUDFixture",
+                "-lybUITestViewportWidth",
+                "320"
+            ],
+            expectedViewportWidth: 320,
+            screenshotPrefix: "narrow-segmented-controls-320"
+        )
+    }
+
+    private func assertNarrowSegmentedControls(
+        launchArguments: [String],
+        expectedViewportWidth: CGFloat?,
+        screenshotPrefix: String
+    ) throws {
+        let app = XCUIApplication()
+        launch(app, with: launchArguments)
+
+        XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 20))
+        let home = app.descendants(matching: .any)["dashboard_home_timeline_hero"]
+        XCTAssertTrue(home.waitForExistence(timeout: 10))
+
+        let windowFrame = app.windows.firstMatch.frame
+        let homeViewportFrame = assertViewport(
+            in: app,
+            expectedWidth: expectedViewportWidth,
+            fallback: windowFrame
+        )
+        let homeModeSwitch = app.descendants(matching: .any)["home_mode_switch"]
+        XCTAssertTrue(homeModeSwitch.waitForExistence(timeout: 5))
+        XCTAssertGreaterThanOrEqual(homeModeSwitch.frame.minX, homeViewportFrame.minX - 1)
+        XCTAssertLessThanOrEqual(homeModeSwitch.frame.maxX, homeViewportFrame.maxX + 1)
+
+        for mode in ["avatar", "photo"] {
+            let button = app.buttons["home_mode_\(mode)_button"]
+            XCTAssertTrue(button.waitForExistence(timeout: 5))
+            XCTAssertTrue(button.isHittable)
+            XCTAssertGreaterThanOrEqual(button.frame.height + 0.1, 44)
+            XCTAssertGreaterThanOrEqual(button.frame.minX, homeViewportFrame.minX - 1)
+            XCTAssertLessThanOrEqual(button.frame.maxX, homeViewportFrame.maxX + 1)
+        }
+        attachScreenshot(named: "\(screenshotPrefix)-home", from: app)
+
+        // Start the detail surface from its deterministic analytics fixture so
+        // this geometry check does not depend on the root-page transition.
+        launch(app, with: launchArguments + [
+            "-lybUITestPhaseInsightFixture",
+            "-lybUITestPhotoTimelineAnalyticsFixture"
+        ])
+
+        let analyticsPage = app.descendants(matching: .any)["photo_timeline_root_page_analytics"]
+        XCTAssertTrue(analyticsPage.waitForExistence(timeout: 10))
+
+        let weightCard = app.descendants(matching: .any)["photo_timeline_stats_metric_card_weight"]
+        scrollUntilHittable(weightCard, in: app)
+        XCTAssertTrue(weightCard.waitForExistence(timeout: 8))
+        XCTAssertTrue(weightCard.isHittable)
+        weightCard.tap()
+
+        XCTAssertTrue(app.descendants(matching: .any)["metric_detail_screen"].waitForExistence(timeout: 8))
+
+        let detailViewportFrame = assertViewport(
+            in: app,
+            expectedWidth: expectedViewportWidth,
+            fallback: windowFrame
+        )
+        let rangeIDs = ["1W", "1M", "3M", "6M", "1Y", "All"]
+        let rangeButtons = rangeIDs.map { app.buttons["metric_detail_range_\($0)"] }
+        for button in rangeButtons {
+            XCTAssertTrue(button.waitForExistence(timeout: 5))
+            XCTAssertTrue(button.isHittable)
+            XCTAssertGreaterThanOrEqual(button.frame.height + 0.1, 44)
+            XCTAssertGreaterThanOrEqual(button.frame.minX, detailViewportFrame.minX - 1)
+            XCTAssertLessThanOrEqual(button.frame.maxX, detailViewportFrame.maxX + 1)
+        }
+
+        let orderedFrames = rangeButtons.map(\.frame).sorted { $0.minX < $1.minX }
+        for pair in zip(orderedFrames, orderedFrames.dropFirst()) {
+            XCTAssertGreaterThanOrEqual(pair.1.minX, pair.0.maxX - 1)
+        }
+
+        attachScreenshot(named: "\(screenshotPrefix)-detail", from: app)
+    }
+
+    @discardableResult
+    private func assertViewport(
+        in app: XCUIApplication,
+        expectedWidth: CGFloat?,
+        fallback: CGRect
+    ) -> CGRect {
+        guard let expectedWidth else { return fallback }
+
+        let viewport = app.descendants(matching: .any)["lyb_ui_test_viewport"]
+        XCTAssertTrue(viewport.waitForExistence(timeout: 5))
+        XCTAssertEqual(viewport.frame.width, expectedWidth, accuracy: 1)
+        return viewport.frame
+    }
+
     func testHorizontalSwipeOnTimelineHeroDoesNotOpenStatsPage() throws {
         let app = XCUIApplication()
         app.launchArguments = ["-lybUITestPhotoTimelineHUDFixture"]

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -167,6 +167,31 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(restoreButton.exists)
     }
 
+    func testProfileEditorProvidesAnEscapeRoute() throws {
+        let app = XCUIApplication()
+        launch(app, with: ["-lybUITestWeightLoggerMVPFixture"])
+
+        try openSettings(in: app)
+
+        let profileLink = app.descendants(matching: .any)["settings_profile_link"]
+        XCTAssertTrue(profileLink.waitForExistence(timeout: 5))
+        profileLink.tap()
+
+        let fullNameRow = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS %@", "Full name")
+        ).firstMatch
+        XCTAssertTrue(fullNameRow.waitForExistence(timeout: 5))
+        fullNameRow.tap()
+
+        let cancelButton = app.buttons["profile_editor_cancel_button"]
+        XCTAssertTrue(cancelButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(cancelButton.isHittable)
+        cancelButton.tap()
+
+        XCTAssertFalse(app.staticTexts["Edit Profile"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.navigationBars["Profile"].waitForExistence(timeout: 5))
+    }
+
     func testSubscribedMVPSettingsWeightGoalUsesNativeValidatedEditor() throws {
         let app = XCUIApplication()
         launch(app, with: ["-lybUITestWeightLoggerMVPFixture"])
@@ -432,11 +457,25 @@ final class LogYourBodyUITests: XCTestCase {
         scrollUntilHittable(weightCard, in: app)
         XCTAssertTrue(weightCard.waitForExistence(timeout: 8))
         XCTAssertTrue(weightCard.isHittable)
+        let weightValue = try XCTUnwrap(
+            weightCard.label
+                .split(separator: ",", maxSplits: 2, omittingEmptySubsequences: true)
+                .dropFirst()
+                .first?
+                .split(separator: " ")
+                .first
+        )
         weightCard.tap()
 
         let detail = app.descendants(matching: .any)["metric_detail_screen"]
         XCTAssertTrue(detail.waitForExistence(timeout: 8))
-        XCTAssertTrue(app.descendants(matching: .any)["metric_detail_headline"].waitForExistence(timeout: 5))
+        let detailHeadline = app.descendants(matching: .any)["metric_detail_headline"]
+        XCTAssertTrue(detailHeadline.waitForExistence(timeout: 5))
+        let trendHeadlineExpectation = expectation(
+            for: NSPredicate(format: "label == %@", String(weightValue)),
+            evaluatedWith: detailHeadline
+        )
+        wait(for: [trendHeadlineExpectation], timeout: 8)
         XCTAssertTrue(app.descendants(matching: .any)["metric_detail_chart"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.descendants(matching: .any)["metric_detail_related_metrics"].exists)
         let relatedMetricIds = ["steps", "weight", "body_fat", "ffmi", "body_score"]
@@ -843,7 +882,10 @@ final class LogYourBodyUITests: XCTestCase {
     }
 
     private func assertAndCaptureBodyScoreShareSheet(in app: XCUIApplication) throws {
-        XCTAssertTrue(app.descendants(matching: .any)["dashboard_home_timeline_hero"].waitForExistence(timeout: 10))
+        XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 20))
+
+        let hero = app.descendants(matching: .any)["dashboard_home_timeline_hero"]
+        XCTAssertTrue(hero.waitForExistence(timeout: 20))
 
         let shareButton = app.descendants(matching: .any)["body_score_hero_share_button"]
         XCTAssertTrue(shareButton.waitForExistence(timeout: 5))
@@ -868,7 +910,10 @@ final class LogYourBodyUITests: XCTestCase {
 
         let cardFrame = shareCard.frame
         let windowFrame = app.windows.firstMatch.frame
-        XCTAssertGreaterThan(cardFrame.width, windowFrame.width * 0.88)
+        // The portrait preview is fitted into the remaining vertical space
+        // below the controls, so its width is intentionally below the full
+        // sheet width on compact iPhones.
+        XCTAssertGreaterThan(cardFrame.width, windowFrame.width * 0.80)
         XCTAssertGreaterThan(cardFrame.height, cardFrame.width * 1.18)
         XCTAssertGreaterThan(cardFrame.minY, windowFrame.minY + 72)
         XCTAssertLessThanOrEqual(cardFrame.maxY, windowFrame.maxY - 72)

--- a/scripts/ios/launch-ui-regression-audit.py
+++ b/scripts/ios/launch-ui-regression-audit.py
@@ -107,7 +107,7 @@ def write_outputs(artifact_dir: Path, violations: list[AuditViolation]) -> None:
                 "- Body Score share cards expose layout anchors for UI assertions.",
                 "- Body Score share cards preserve actual photo aspect defaults instead of forcing one crop.",
                 "- Body Score sharing resolves the actual progress photo before presenting the sheet.",
-                "- The dashboard avatar visual fills a full-width black stage with transparent assets.",
+                "- The dashboard avatar visual fills a full-width black stage while preserving each transparent asset's native aspect ratio.",
                 "- Dashboard/HUD launch surfaces stay on System B theme colors and real glass material.",
                 "- Timeline/Stats swipe navigation changes page on release, not during drag updates.",
                 "- Paid users default directly into the timeline HUD without a Statsig or legacy fallback gate.",
@@ -179,14 +179,14 @@ def main() -> int:
         ".background(theme.colors.background)",
         "padding: 0,",
         "horizontalFillScale: 1.0",
-        "renderMode: .fillWidth",
+        "renderMode: .fit",
     ]:
         require_token(
             root=root,
             path=dashboard_components,
             token=token,
             check="avatar.full_width_transparent_stage",
-            detail=f"Missing avatar full-width hero-stage contract `{token}`.",
+            detail=f"Missing avatar full-width, native-aspect hero-stage contract `{token}`.",
             violations=violations,
         )
 


### PR DESCRIPTION
## Summary
- harden narrow iPhone geometry: aspect-fit avatar media, compact shared range controls, native Liquid Glass segmented controls with availability-gated fallback, reduced detail padding, and 320pt regression coverage
- normalize measurement defaults, remote metric units, trend caches, skeleton labels, App Intent defaults, photo-only export placeholders, and profile-editor escape behavior
- simplify onboarding copy, spacing, disclosure links, and shared design tokens without changing product flow

## Verification
- SwiftLint strict: 0 violations across 375 Swift files
- Debug iOS Simulator build: passed on LogYourBody QA iPhone 16 / iOS 26.5
- LogYourBodyTests: 715 executed, 0 failures; 4 UI-target cases not selected
- focused UI: 2 responsive tests passed (320pt and narrow iPhone); 4 quality/onboarding tests passed (metric detail, profile escape, onboarding golden path, first-photo CTA)
- rendered UI attachments captured in the result bundles for the responsive home/detail and onboarding paths

## Scope boundary
- simulator evidence only; no physical-device, VoiceOver/Dynamic Type hardware, iPad-specific, or TestFlight/App Store proof was performed in this PR
- existing unrelated Stats-route transition flakiness remains outside the deterministic responsive checks

This is a bounded iOS quality/responsive/design cleanup; no new product capability or release workflow configuration is introduced.