### PR TITLE
fix: make Supabase deploy gate actionable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,17 +67,25 @@ jobs:
         run: |
           test -n "$SUPABASE_ACCESS_TOKEN"
           test -n "$SUPABASE_PROJECT_REF"
-          configured_secrets=$(supabase secrets list \
+          if ! configured_secrets=$(supabase secrets list \
             --project-ref "$SUPABASE_PROJECT_REF" \
-            --output-format json)
+            --output-format json); then
+            echo "::error::Unable to list Supabase function secrets"
+            exit 1
+          fi
+          missing_secrets=0
           for required_secret in \
             CLOUDINARY_CLOUD_NAME \
             CLOUDINARY_API_KEY \
             CLOUDINARY_API_SECRET; do
-            printf '%s' "$configured_secrets" | jq -e \
+            if ! printf '%s' "$configured_secrets" | jq -e \
               --arg name "$required_secret" \
-              '.[] | select(.name == $name)' > /dev/null
+              'map(.name) | index($name) != null' > /dev/null; then
+              echo "::error::Missing required Supabase function secret: $required_secret"
+              missing_secrets=1
+            fi
           done
+          test "$missing_secrets" -eq 0
           for function_name in delete-user-assets process-progress-photo; do
             supabase functions deploy "$function_name" \
               --project-ref "$SUPABASE_PROJECT_REF"


### PR DESCRIPTION
## Summary

- distinguish a Supabase management API failure from missing function secrets
- report only missing secret names, never values
- validate all three Cloudinary prerequisites before deploying either Edge Function

## Why

The post-merge deploy for #673 failed closed at the secret-presence gate without an actionable error. Web production correctly remained blocked. This patch makes the protected rerun identify the exact prerequisite safely.

## Verification

- actionlint .github/workflows/deploy.yml
- positive and negative jq fixtures for the secret-name gate
- git diff --check
- pre-commit and pre-push hooks