### PR TITLE
fix: restore timeline navigation and scrubber

### DIFF
--- a/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
+++ b/apps/ios/LogYourBody/Components/ProgressTimelineView.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct ProgressTimelineView: View {
     // MARK: - Properties
@@ -22,6 +23,8 @@ struct ProgressTimelineView: View {
     @State private var currentDateLabel: String = ""
     @State private var renderSignature: TimelineRenderSignature
     @State private var renderData: TimelineRenderData
+    @State private var selectionFeedbackGenerator = UISelectionFeedbackGenerator()
+    @State private var lastHapticTime = Date.distantPast
 
     private let timelineHeight: CGFloat = 50
     private let scrubberHandleSize: CGFloat = 44
@@ -57,25 +60,34 @@ struct ProgressTimelineView: View {
 
             // Timeline strip
             GeometryReader { geometry in
+                let trackInset = scrubberHandleSize / 2
+                let trackWidth = max(1, geometry.size.width - scrubberHandleSize)
+
                 ZStack(alignment: .leading) {
                     // Background track
                     timelineTrack
 
                     // Anchors (photos/metrics)
                     anchorsView(
-                        width: geometry.size.width,
+                        width: trackWidth,
                         anchors: renderData.anchors,
                         zoomLevel: renderData.zoomLevel
                     )
+                    .offset(x: trackInset)
                     .accessibilityHidden(true)
 
                     // Scrubber handle
                     scrubberHandle
-                        .offset(x: handlePosition * geometry.size.width - scrubberHandleSize / 2)
+                        .offset(x: handlePosition * trackWidth)
                         .gesture(
                             DragGesture(minimumDistance: 0)
                                 .onChanged {
-                                    handleDrag($0, width: geometry.size.width, renderData: renderData)
+                                    handleDrag(
+                                        $0,
+                                        width: trackWidth,
+                                        trackInset: trackInset,
+                                        renderData: renderData
+                                    )
                                 }
                                 .onEnded { _ in handleDragEnd() }
                         )
@@ -115,34 +127,52 @@ struct ProgressTimelineView: View {
 
     // MARK: - Subviews
 
+    @ViewBuilder
     private var dateLabel: some View {
-        Text(currentDateLabel)
+        let label = Text(currentDateLabel)
             .font(.footnote.weight(.medium))
             .foregroundColor(Color.liquidTextPrimary)
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
-            .background(
-                Capsule()
-                    .fill(Color.white.opacity(0.15))
-                    .overlay(
-                        Capsule()
-                            .stroke(Color.white.opacity(0.3), lineWidth: 1)
-                    )
-            )
             .padding(.bottom, 4)
             .accessibilityHidden(true)
+
+        if #available(iOS 26.0, *) {
+            label
+                .glassEffect(
+                    .regular.tint(Color.liquidAccent.opacity(0.12)),
+                    in: Capsule(style: .continuous)
+                )
+        } else {
+            label
+                .background(.ultraThinMaterial, in: Capsule(style: .continuous))
+                .overlay {
+                    Capsule(style: .continuous)
+                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                }
+        }
     }
 
+    @ViewBuilder
     private var timelineTrack: some View {
-        RoundedRectangle(cornerRadius: 3)
-            .fill(Color.white.opacity(0.10))
-            .overlay(
-                RoundedRectangle(cornerRadius: 3)
-                    .stroke(Color.white.opacity(0.2), lineWidth: 1)
+        let track = Capsule(style: .continuous)
+            .fill(Color.white.opacity(0.08))
+            .overlay {
+                Capsule(style: .continuous)
+                    .stroke(Color.white.opacity(0.16), lineWidth: 1)
+            }
+            .frame(height: 12)
+            .padding(.horizontal, scrubberHandleSize / 2)
+            .padding(.vertical, (timelineHeight - 12) / 2)
+
+        if #available(iOS 26.0, *) {
+            track.glassEffect(
+                .regular.tint(Color.liquidAccent.opacity(0.08)).interactive(),
+                in: Capsule(style: .continuous)
             )
-            .frame(height: 6)
-            .padding(.vertical, (timelineHeight - 6) / 2)
-            .accessibilityHidden(true)
+        } else {
+            track.background(.ultraThinMaterial, in: Capsule(style: .continuous))
+        }
     }
 
     private func anchorsView(
@@ -170,42 +200,13 @@ struct ProgressTimelineView: View {
     }
 
     private func photoModeAnchor(for anchor: TimelineAnchor, zoomLevel: TimelineZoomLevel) -> some View {
-        Group {
-            if anchor.anchorType == .photo || anchor.anchorType == .photoWithMetrics {
-                if let photoUrl = anchor.bodyMetrics.photoUrl,
-                   !photoUrl.isEmpty,
-                   let _ = URL(string: photoUrl) {
-                    OptimizedProgressPhotoView(
-                        photoUrl: photoUrl,
-                        maxHeight: zoomLevel.thumbnailSize
-                    )
-                    .frame(width: zoomLevel.thumbnailSize, height: zoomLevel.thumbnailSize)
-                    .clipShape(Circle())
-                    .overlay(
-                        Circle()
-                            .stroke(Color.white.opacity(0.5), lineWidth: 2)
-                    )
-                } else {
-                    photoPlaceholder(zoomLevel: zoomLevel)
-                }
-            } else if zoomLevel.showMetricTicks {
-                Circle()
-                    .fill(Color.white.opacity(0.3))
-                    .frame(width: 4, height: 4)
-            } else {
-                EmptyView()
-            }
-        }
-    }
+        let isPhotoDetent = anchor.anchorType == .photo || anchor.anchorType == .photoWithMetrics
 
-    private func photoPlaceholder(zoomLevel: TimelineZoomLevel) -> some View {
-        Circle()
-            .fill(Color.white.opacity(0.2))
-            .frame(width: zoomLevel.thumbnailSize, height: zoomLevel.thumbnailSize)
-            .overlay(
-                Image(systemName: "photo")
-                    .font(.system(size: zoomLevel.thumbnailSize * 0.4))
-                    .foregroundColor(Color.white.opacity(0.5))
+        return Capsule(style: .continuous)
+            .fill(Color.white.opacity(isPhotoDetent ? 0.72 : 0.28))
+            .frame(
+                width: isPhotoDetent ? 3 : 2,
+                height: isPhotoDetent ? 18 : (zoomLevel.showMetricTicks ? 8 : 4)
             )
     }
 
@@ -222,12 +223,13 @@ struct ProgressTimelineView: View {
             }
     }
 
+    @ViewBuilder
     private var scrubberHandle: some View {
-        ZStack {
+        let handle = ZStack {
             Capsule()
                 .fill(Color.liquidAccent)
-                .frame(width: 4, height: 24)
-                .shadow(color: Color.liquidAccent.opacity(0.5), radius: 4, x: 0, y: 2)
+                .frame(width: 5, height: isDragging ? 30 : 25)
+                .shadow(color: Color.liquidAccent.opacity(0.45), radius: 5, x: 0, y: 2)
 
             Color.clear
         }
@@ -241,6 +243,15 @@ struct ProgressTimelineView: View {
             adjustSelection(for: direction)
         }
         .accessibilityIdentifier("dashboard_timeline_scrubber_handle")
+
+        if #available(iOS 26.0, *) {
+            handle.glassEffect(
+                .regular.tint(Color.liquidAccent.opacity(0.22)).interactive(),
+                in: Capsule(style: .continuous)
+            )
+        } else {
+            handle.background(.ultraThinMaterial, in: Capsule(style: .continuous))
+        }
     }
 
     // MARK: - Logic
@@ -254,11 +265,19 @@ struct ProgressTimelineView: View {
         return renderData.anchors.first(where: { $0.bodyMetrics.id == metric.id })?.position ?? dragPosition
     }
 
-    private func handleDrag(_ value: DragGesture.Value, width: CGFloat, renderData: TimelineRenderData) {
-        isDragging = true
+    private func handleDrag(
+        _ value: DragGesture.Value,
+        width: CGFloat,
+        trackInset: CGFloat,
+        renderData: TimelineRenderData
+    ) {
+        if !isDragging {
+            isDragging = true
+            selectionFeedbackGenerator.prepare()
+        }
 
         // Calculate position (0.0 to 1.0)
-        let position = max(0, min(1, value.location.x / width))
+        let position = max(0, min(1, (value.location.x - trackInset) / width))
         dragPosition = position
 
         // Convert position to date
@@ -317,12 +336,8 @@ struct ProgressTimelineView: View {
             withAnimation(.easeOut(duration: 0.2)) {
                 isDragging = false
             }
-        }
-
-        // Haptic feedback
-        let impact = UIImpactFeedbackGenerator(style: .light)
-        impact.impactOccurred()
     }
+}
 
     private var accessibilityTimelineValue: String {
         guard !bodyMetrics.isEmpty else {
@@ -362,6 +377,16 @@ struct ProgressTimelineView: View {
     private func updateSelectedIndex(_ index: Int) {
         guard bodyMetrics.indices.contains(index), selectedIndex != index else { return }
         selectedIndex = index
+
+        guard isDragging else { return }
+        let now = Date()
+        let isEdgeDetent = index == bodyMetrics.startIndex || index == bodyMetrics.index(before: bodyMetrics.endIndex)
+        let minimumInterval = isEdgeDetent ? 0 : 0.04
+        guard now.timeIntervalSince(lastHapticTime) >= minimumInterval else { return }
+
+        selectionFeedbackGenerator.selectionChanged()
+        selectionFeedbackGenerator.prepare()
+        lastHapticTime = now
     }
 
     private func refreshRenderDataIfNeeded(for signature: TimelineRenderSignature) {

--- a/apps/ios/LogYourBody/DesignSystem/Theme.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Theme.swift
@@ -61,6 +61,7 @@ enum WorldClassScreen: String, CaseIterable, Identifiable {
     case home
     case photoTimeline
     case stats
+    case chat
     case metricDetail
     case logWeight
     case logBodyFat
@@ -94,7 +95,7 @@ enum WorldClassScreen: String, CaseIterable, Identifiable {
              .bodyScoreReveal, .chooseHomeView, .email, .verifyAccount, .completeProfile,
              .firstProgressPhoto, .paywall:
             return .onboarding
-        case .home, .photoTimeline, .stats, .metricDetail, .logWeight, .logBodyFat,
+        case .home, .photoTimeline, .stats, .chat, .metricDetail, .logWeight, .logBodyFat,
              .addProgressPhoto, .glp1CheckIn, .shareBodyScore, .syncDetails:
             return .core
         case .dailyReminder, .planUnavailable, .restorePurchases:

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -767,8 +767,8 @@ struct LaunchTimelineSurface: View {
                         .padding(.top, 18)
                         .padding(.bottom, 8)
 
-                    timelineStrip
-                        .frame(height: 98)
+                    timelineScrubber
+                        .frame(height: 80)
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 4)
@@ -1005,93 +1005,19 @@ struct LaunchTimelineSurface: View {
 
             Spacer(minLength: 0)
 
-            Text("Swipe through entries")
+            Text("Scrub through time")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(theme.colors.textSecondary)
         }
         .accessibilityElement(children: .combine)
     }
 
-    private var timelineStrip: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(Array(bodyMetrics.enumerated()), id: \.element.id) { index, metric in
-                        Button {
-                            HapticManager.shared.selection()
-                            withAnimation(.easeOut(duration: 0.2)) {
-                                selectedIndex = index
-                            }
-                        } label: {
-                            timelineThumbnail(metric: metric, isSelected: index == selectedIndex)
-                        }
-                        .buttonStyle(.plain)
-                        .id(index)
-                        .accessibilityLabel(
-                            "Timeline entry \(metric.date.formatted(date: .abbreviated, time: .omitted))"
-                        )
-                        .accessibilityValue(index == selectedIndex ? "Selected" : "Not selected")
-                        .accessibilityIdentifier("launch_timeline_entry_\(index)")
-                    }
-                }
-                .padding(.horizontal, 1)
-            }
-            .accessibilityIdentifier("launch_timeline_photo_strip")
-            .onAppear {
-                proxy.scrollTo(selectedIndex, anchor: .center)
-            }
-            .onChange(of: selectedIndex) { _, newIndex in
-                withAnimation(.easeOut(duration: 0.2)) {
-                    proxy.scrollTo(newIndex, anchor: .center)
-                }
-            }
-        }
-    }
-
-    private func timelineThumbnail(metric: BodyMetrics, isSelected: Bool) -> some View {
-        ZStack(alignment: .bottomLeading) {
-            if let photoURL = metric.photoUrl, !photoURL.isEmpty {
-                CachedAsyncImage(urlString: photoURL) { image in
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                } placeholder: {
-                    thumbnailPlaceholder
-                }
-            } else {
-                thumbnailPlaceholder
-            }
-
-            LinearGradient(
-                colors: [.clear, .black.opacity(0.58)],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-
-            Text(metric.date.formatted(.dateTime.month(.abbreviated).day()))
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(.white)
-                .padding(6)
-        }
-        .frame(width: 76, height: 96)
-        .clipShape(RoundedRectangle(cornerRadius: 11))
-        .overlay {
-            RoundedRectangle(cornerRadius: 11)
-                .stroke(isSelected ? theme.colors.text : theme.colors.border, lineWidth: isSelected ? 2 : 1)
-        }
-        .scaleEffect(isSelected ? 1.02 : 1)
-    }
-
-    private var thumbnailPlaceholder: some View {
-        LinearGradient(
-            colors: [theme.colors.surface, theme.colors.backgroundSecondary],
-            startPoint: .topLeading,
-            endPoint: .bottomTrailing
+    private var timelineScrubber: some View {
+        DashboardTimelineScrubber(
+            bodyMetrics: bodyMetrics,
+            selectedIndex: $selectedIndex,
+            timelineMode: .constant(.photo)
         )
-        .overlay {
-            Image(systemName: "circle.dashed")
-                .font(.system(size: 17, weight: .medium))
-                .foregroundStyle(theme.colors.textTertiary)
-        }
+        .accessibilityIdentifier("launch_timeline_scrubber")
     }
 }

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineHUD.swift
@@ -80,12 +80,20 @@ extension DashboardViewLiquid {
                         )
                         photoTimelineAnalyticsPage
                     }
+                case .chat:
+                    ZStack {
+                        timelineAccessibilityMarker(
+                            id: "photo_timeline_root_page_chat",
+                            label: "Chat page"
+                        )
+                        ChatTabView()
+                    }
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .contentShape(Rectangle())
         }
-        .worldClassScreen(selectedPhotoTimelineRootPage == .timeline ? .photoTimeline : .stats)
+        .worldClassScreen(selectedPhotoTimelineRootPage.worldClassScreen)
     }
 
     private var photoTimelineRootNavigation: some View {
@@ -94,7 +102,22 @@ extension DashboardViewLiquid {
 
             photoTimelineRootNavigationButton(page: .analytics)
 
+            photoTimelineRootNavigationButton(page: .chat)
+
             Spacer(minLength: 0)
+
+            NavigationLink {
+                PreferencesView()
+                    .environmentObject(authManager)
+            } label: {
+                Image(systemName: "gearshape")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(theme.colors.textSecondary)
+                    .frame(width: 44, height: 44)
+            }
+            .accessibilityLabel("Settings")
+            .accessibilityHint("Opens account and app settings")
+            .accessibilityIdentifier("photo_timeline_root_settings")
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .overlay(alignment: .topLeading) {
@@ -115,6 +138,7 @@ extension DashboardViewLiquid {
         let isSelected = selectedPhotoTimelineRootPage == page
 
         return Button {
+            HapticManager.shared.selection()
             selectedPhotoTimelineRootPage = page
         } label: {
             VStack(spacing: 6) {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid.swift
@@ -125,6 +125,7 @@ struct DashboardViewLiquid: View {
     enum PhotoTimelineRootPage: Hashable {
         case timeline
         case analytics
+        case chat
 
         var navigationTitle: String {
             switch self {
@@ -132,6 +133,8 @@ struct DashboardViewLiquid: View {
                 "Timeline"
             case .analytics:
                 "Stats"
+            case .chat:
+                "Chat"
             }
         }
 
@@ -141,6 +144,19 @@ struct DashboardViewLiquid: View {
                 "photo_timeline_root_nav_timeline"
             case .analytics:
                 "photo_timeline_root_nav_stats"
+            case .chat:
+                "photo_timeline_root_nav_chat"
+            }
+        }
+
+        var worldClassScreen: WorldClassScreen {
+            switch self {
+            case .timeline:
+                .photoTimeline
+            case .analytics:
+                .stats
+            case .chat:
+                .chat
             }
         }
     }

--- a/apps/ios/LogYourBody/Views/MainTabView.swift
+++ b/apps/ios/LogYourBody/Views/MainTabView.swift
@@ -12,42 +12,19 @@ struct MainTabView: View {
     @State private var selectedSurface: PaidAppSurface = PaidAppSurfacePolicy.surface()
 
     var body: some View {
-        Group {
-            if shouldOpenChatFirst {
-                ChatFirstRootView()
-            } else {
-                NavigationStack {
-                    switch selectedSurface {
-                    case .chatFirst:
-                        ChatFirstRootView()
-                    case .photoTimelineHUD:
-                        DashboardViewLiquid(layoutMode: .photoTimelineHUD)
-                    case .legacyFullDashboardBeta:
-                        DashboardViewLiquid(layoutMode: .legacyTabbed)
-                    case .weightLoggerMVP:
-                        PaidWeightLoggerMVPView()
-                    }
-                }
+        NavigationStack {
+            switch selectedSurface {
+            case .photoTimelineHUD:
+                DashboardViewLiquid(layoutMode: .photoTimelineHUD)
+            case .legacyFullDashboardBeta:
+                DashboardViewLiquid(layoutMode: .legacyTabbed)
+            case .weightLoggerMVP:
+                PaidWeightLoggerMVPView()
             }
         }
         .onAppear {
             updateSelectedSurface()
         }
-    }
-
-    private var shouldOpenChatFirst: Bool {
-        #if DEBUG
-        let arguments = ProcessInfo.processInfo.arguments
-        if arguments.contains("-lybUITestChatFirstFixture") {
-            return true
-        }
-
-        if arguments.contains(where: { $0.hasPrefix("-lybUITest") }) {
-            return false
-        }
-        #endif
-
-        return true
     }
 
     private func updateSelectedSurface() {
@@ -711,17 +688,10 @@ private struct FailedChatTurn: Equatable {
     let clientMessageId: String
 }
 
-private enum ChatDestination: Hashable {
-    case timeline
-    case settings
-}
-
 @MainActor
-private struct ChatFirstRootView: View {
+struct ChatTabView: View {
     @EnvironmentObject private var authManager: AuthManager
     @Environment(\.theme) private var theme
-    @State private var path: [ChatDestination] = []
-    @State private var isSidebarPresented = false
     @State private var draft = ""
     @State private var isResponding = false
     @State private var isLoadingConversation = true
@@ -737,56 +707,25 @@ private struct ChatFirstRootView: View {
     @FocusState private var isComposerFocused: Bool
 
     var body: some View {
-        NavigationStack(path: $path) {
-            ZStack(alignment: .leading) {
-                accessibilityMarker(id: "chat_first_root", label: "Chat")
-                chatSurface
-
-                if isSidebarPresented {
-                    Color.black.opacity(0.42)
-                        .ignoresSafeArea()
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            withAnimation(.easeOut(duration: 0.22)) {
-                                isSidebarPresented = false
-                            }
-                        }
-
-                    chatSidebar
-                        .transition(.move(edge: .leading).combined(with: .opacity))
-                }
+        ZStack(alignment: .topLeading) {
+            accessibilityMarker(id: "chat_tab_root", label: "Chat")
+            chatSurface
+        }
+        .background(theme.colors.background.ignoresSafeArea())
+        .worldClassScreen(.chat)
+        .task(id: authManager.currentUser?.id) {
+            await loadLatestConversation()
+        }
+        .onDisappear {
+            currentRequestTask?.cancel()
+        }
+        .alert("Delete this chat?", isPresented: $isDeleteConfirmationPresented) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                deleteCurrentConversation()
             }
-            .background(theme.colors.background.ignoresSafeArea())
-            .toolbar(.hidden, for: .navigationBar)
-            .navigationDestination(for: ChatDestination.self) { destination in
-                switch destination {
-                case .timeline:
-                    DashboardViewLiquid(layoutMode: .photoTimelineHUD)
-                        .toolbar(.hidden, for: .tabBar)
-                case .settings:
-                    PreferencesView()
-                        .environmentObject(authManager)
-                        .toolbar(.hidden, for: .tabBar)
-                }
-            }
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 24, coordinateSpace: .local)
-                    .onEnded(handleSidebarGesture)
-            )
-            .task(id: authManager.currentUser?.id) {
-                await loadLatestConversation()
-            }
-            .onDisappear {
-                currentRequestTask?.cancel()
-            }
-            .alert("Delete this chat?", isPresented: $isDeleteConfirmationPresented) {
-                Button("Cancel", role: .cancel) {}
-                Button("Delete", role: .destructive) {
-                    deleteCurrentConversation()
-                }
-            } message: {
-                Text("This permanently removes the conversation from LogYourBody.")
-            }
+        } message: {
+            Text("This permanently removes the conversation from LogYourBody.")
         }
     }
 
@@ -805,33 +744,10 @@ private struct ChatFirstRootView: View {
     }
 
     private var chatHeader: some View {
-        HStack(spacing: 12) {
-            Button {
-                withAnimation(.easeOut(duration: 0.22)) {
-                    isSidebarPresented = true
-                }
-            } label: {
-                Image(systemName: "sidebar.leading")
-                    .font(.system(size: 17, weight: .semibold))
-                    .foregroundStyle(theme.colors.text)
-                    .frame(width: 44, height: 44)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Open sidebar")
-            .accessibilityHint("Shows Timeline, Settings, and profile controls")
-            .accessibilityIdentifier("chat_sidebar_button")
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text("LogYourBody")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(theme.colors.text)
-
-                Text("Private body chat")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(theme.colors.textSecondary)
-            }
-
-            Spacer(minLength: 0)
+        HStack(spacing: 8) {
+            Text("Private body chat")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(theme.colors.textSecondary)
 
             if isLoadingConversation {
                 ProgressView()
@@ -844,10 +760,26 @@ private struct ChatFirstRootView: View {
                     .frame(width: 8, height: 8)
                     .accessibilityHidden(true)
             }
+
+            Spacer(minLength: 0)
+
+            if messages.contains(where: { $0.role == .user }) {
+                Menu {
+                    Button("Delete Chat", systemImage: "trash", role: .destructive) {
+                        isDeleteConfirmationPresented = true
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(theme.colors.textSecondary)
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel("Chat options")
+                .accessibilityIdentifier("chat_options_menu")
+            }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 4)
-        .background(.ultraThinMaterial)
+        .padding(.horizontal, 16)
+        .frame(minHeight: 44)
         .overlay(alignment: .bottom) {
             Rectangle()
                 .fill(theme.colors.border.opacity(0.55))
@@ -1033,87 +965,6 @@ private struct ChatFirstRootView: View {
         .animation(.easeOut(duration: 0.18), value: canSend)
     }
 
-    private var chatSidebar: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 10) {
-                Text("LogYourBody")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(theme.colors.text)
-
-                Spacer(minLength: 0)
-
-                Button {
-                    withAnimation(.easeOut(duration: 0.22)) {
-                        isSidebarPresented = false
-                    }
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(theme.colors.textSecondary)
-                        .frame(width: 40, height: 40)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Close sidebar")
-            }
-            .padding(.horizontal, 18)
-            .padding(.top, 12)
-            .padding(.bottom, 18)
-
-            Text("Workspace")
-                .font(.system(size: 11, weight: .bold))
-                .foregroundStyle(theme.colors.textSecondary)
-                .textCase(.uppercase)
-                .padding(.horizontal, 20)
-                .padding(.bottom, 7)
-
-            sidebarButton(title: "Chat", icon: "bubble.left.and.bubble.right.fill") {
-                closeSidebar()
-            }
-
-            sidebarButton(title: "Timeline", icon: "photo.on.rectangle.angled") {
-                closeSidebar()
-                path.append(.timeline)
-            }
-            .accessibilityIdentifier("chat_timeline_link")
-
-            sidebarButton(title: "Settings", icon: "gearshape.fill") {
-                closeSidebar()
-                path.append(.settings)
-            }
-            .accessibilityIdentifier("chat_settings_link")
-
-            if messages.contains(where: { $0.role == .user }) {
-                sidebarButton(title: "Delete chat", icon: "trash") {
-                    closeSidebar()
-                    isDeleteConfirmationPresented = true
-                }
-                .accessibilityIdentifier("chat_delete_conversation_button")
-            }
-
-            Spacer(minLength: 0)
-
-            Text(
-                "Chats stay in LogYourBody for 30 days. A minimized body context is sent " +
-                    "to our model provider for each answer; it is never embedded or indexed."
-            )
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(theme.colors.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 20)
-                .padding(.bottom, 24)
-        }
-        .frame(maxWidth: 306, maxHeight: .infinity, alignment: .topLeading)
-        .background(.regularMaterial)
-        .overlay(alignment: .trailing) {
-            Rectangle()
-                .fill(theme.colors.border.opacity(0.7))
-                .frame(width: 1)
-        }
-        .overlay(alignment: .topLeading) {
-            accessibilityMarker(id: "chat_sidebar", label: "Chat sidebar")
-        }
-    }
-
     private func accessibilityMarker(id: String, label: String) -> some View {
         Color.clear
             .frame(width: 1, height: 1)
@@ -1121,26 +972,6 @@ private struct ChatFirstRootView: View {
             .accessibilityLabel(label)
             .accessibilityIdentifier(id)
             .allowsHitTesting(false)
-    }
-
-    private func sidebarButton(title: String, icon: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: 13) {
-                Image(systemName: icon)
-                    .font(.system(size: 16, weight: .semibold))
-                    .frame(width: 22)
-
-                Text(title)
-                    .font(.system(size: 15, weight: .semibold))
-
-                Spacer(minLength: 0)
-            }
-            .foregroundStyle(theme.colors.text)
-            .padding(.horizontal, 20)
-            .frame(minHeight: 48)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 
     private var canSend: Bool {
@@ -1151,29 +982,6 @@ private struct ChatFirstRootView: View {
 
     private var chatService: ChatServicing {
         AppServicePorts.chatService
-    }
-
-    private func closeSidebar() {
-        withAnimation(.easeOut(duration: 0.22)) {
-            isSidebarPresented = false
-        }
-    }
-
-    private func handleSidebarGesture(_ value: DragGesture.Value) {
-        let horizontalDistance = value.translation.width
-        guard abs(horizontalDistance) > 60 else { return }
-
-        if isSidebarPresented {
-            if horizontalDistance < 0 {
-                closeSidebar()
-            }
-        } else {
-            // Support the existing left-swipe muscle memory while also
-            // accepting the conventional leading-edge reveal gesture.
-            withAnimation(.easeOut(duration: 0.22)) {
-                isSidebarPresented = true
-            }
-        }
     }
 
     private func send(_ text: String) {
@@ -1401,7 +1209,6 @@ private struct ChatFirstRootView: View {
 
     private func deleteCurrentConversation() {
         guard !isResponding else { return }
-        closeSidebar()
 
         Task { @MainActor in
             guard let accessToken = await chatAccessToken() else {

--- a/apps/ios/LogYourBody/Views/MainTabViewPolicies.swift
+++ b/apps/ios/LogYourBody/Views/MainTabViewPolicies.swift
@@ -5,7 +5,6 @@
 import Foundation
 
 enum PaidAppSurface: Equatable {
-    case chatFirst
     case weightLoggerMVP
     case legacyFullDashboardBeta
     case photoTimelineHUD
@@ -13,7 +12,7 @@ enum PaidAppSurface: Equatable {
 
 enum PaidAppSurfacePolicy {
     static func surface() -> PaidAppSurface {
-        .chatFirst
+        .photoTimelineHUD
     }
 }
 

--- a/apps/ios/LogYourBodyTests/GoldenPathTests.swift
+++ b/apps/ios/LogYourBodyTests/GoldenPathTests.swift
@@ -26,11 +26,11 @@ final class GoldenPathTests: XCTestCase {
 
     // MARK: - Stage 1 · Launch: pinned surface, sign-in method, entitlement
 
-    func testGP1_PaidSurfaceIsChatFirst() {
+    func testGP1_PaidSurfaceIsPhotoTimelineHUD() {
         XCTAssertEqual(
             PaidAppSurfacePolicy.surface(),
-            .chatFirst,
-            "Paid home surface is pinned to authenticated chat; changing it must update docs/GOLDEN_PATH.md"
+            .photoTimelineHUD,
+            "Paid home surface is pinned to the photo timeline HUD; changing it must update docs/GOLDEN_PATH.md"
         )
     }
 
@@ -260,8 +260,8 @@ final class GoldenPathTests: XCTestCase {
     // MARK: - Stage 7 · The full journey, end to end
 
     func testGP7_FullGoldenPathEndToEnd() {
-        // 1. Launch: authenticated chat, with Timeline available from its sidebar.
-        XCTAssertEqual(PaidAppSurfacePolicy.surface(), .chatFirst)
+        // 1. Launch: the paid surface is the photo timeline HUD, with Chat as a peer tab.
+        XCTAssertEqual(PaidAppSurfacePolicy.surface(), .photoTimelineHUD)
 
         // 2-3. Sign in + subscribe: gates open only when every requirement is met.
         let user = makeCompleteUser()

--- a/apps/ios/LogYourBodyTests/LaunchSurfacePolicyTests.swift
+++ b/apps/ios/LogYourBodyTests/LaunchSurfacePolicyTests.swift
@@ -362,15 +362,15 @@ final class LaunchSurfacePolicyTests: XCTestCase {
         XCTAssertTrue(ProfileCompletionPolicy.isComplete(profile: blankNameProfile, fallbackName: "Fallback User"))
     }
 
-    func testWorldClassScreenCatalogCoversAllFortyFiveApprovedStates() {
-        XCTAssertEqual(WorldClassScreen.allCases.count, 45)
+    func testWorldClassScreenCatalogCoversAllFortySixApprovedStates() {
+        XCTAssertEqual(WorldClassScreen.allCases.count, 46)
 
         let counts = Dictionary(grouping: WorldClassScreen.allCases, by: \.flow)
             .mapValues(\.count)
 
         XCTAssertEqual(counts[.entry], 5)
         XCTAssertEqual(counts[.onboarding], 17)
-        XCTAssertEqual(counts[.core], 10)
+        XCTAssertEqual(counts[.core], 11)
         XCTAssertEqual(counts[.subscription], 3)
         XCTAssertEqual(counts[.account], 10)
     }

--- a/apps/ios/LogYourBodyTests/PhotoTimelineHUDPolicyTests.swift
+++ b/apps/ios/LogYourBodyTests/PhotoTimelineHUDPolicyTests.swift
@@ -13,10 +13,10 @@ import UIKit
 
 
 final class PhotoTimelineHUDPolicyTests: XCTestCase {
-    func testPhotoTimelineHUDRemainsAvailableWhileChatIsDefaultV1Surface() {
+    func testPhotoTimelineHUDIsDefaultV1Surface() {
         XCTAssertTrue(PhotoTimelineHUDPolicy.defaultShowsPhotoTimelineHUD)
         XCTAssertTrue(PhotoTimelineHUDPolicy.shouldShowPhotoTimelineHUD())
-        XCTAssertEqual(PaidAppSurfacePolicy.surface(), .chatFirst)
+        XCTAssertEqual(PaidAppSurfacePolicy.surface(), .photoTimelineHUD)
     }
 
     func testDefaultHomeModeDefaultsToAvatar() {

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -311,34 +311,35 @@ final class LogYourBodyUITests: XCTestCase {
 
         XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_surface"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["No progress photo"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_scrubber"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.descendants(matching: .any)["launch_timeline_photo_strip"].exists)
         XCTAssertFalse(app.descendants(matching: .any)["dashboard_home_timeline_avatar"].exists)
         XCTAssertFalse(app.tabBars.firstMatch.exists)
     }
 
-    func testChatFirstLaunchKeepsSidebarAndTimelineFocused() throws {
+    func testChatIsAPeerTabWithoutReplacingTimelineNavigation() throws {
         let app = XCUIApplication()
         launch(app, with: [
             "-lybUITestPhotoTimelineHUDFixture",
             "-lybUITestChatFirstFixture"
         ])
 
-        XCTAssertTrue(app.descendants(matching: .any)["chat_first_root"].waitForExistence(timeout: 12))
+        XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 12))
+        XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_surface"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.buttons["Timeline"].exists)
+        XCTAssertTrue(app.buttons["Stats"].exists)
+        XCTAssertTrue(app.buttons["Chat"].exists)
+        XCTAssertTrue(app.buttons["Settings"].exists)
+        XCTAssertFalse(app.buttons["Open sidebar"].exists)
+        XCTAssertFalse(app.descendants(matching: .any)["chat_sidebar"].exists)
         XCTAssertFalse(app.tabBars.firstMatch.exists)
 
-        let window = app.windows.firstMatch
-        let start = window.coordinate(withNormalizedOffset: CGVector(dx: 0.88, dy: 0.48))
-        let end = window.coordinate(withNormalizedOffset: CGVector(dx: 0.12, dy: 0.48))
-        start.press(forDuration: 0.05, thenDragTo: end)
+        try openChatTab(in: app)
+        attachScreenshot(named: "timeline-chat-peer-navigation", from: app)
 
-        XCTAssertTrue(app.descendants(matching: .any)["chat_sidebar"].waitForExistence(timeout: 5))
         app.buttons["Timeline"].tap()
-
-        let timeline = app.descendants(matching: .any)["launch_timeline_surface"]
-        XCTAssertTrue(timeline.waitForExistence(timeout: 12))
-        XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_photo_strip"].waitForExistence(timeout: 5))
-        XCTAssertFalse(app.tabBars.firstMatch.exists)
-        XCTAssertEqual(app.scrollViews.count, 1, "Timeline should expose only the horizontal photo strip scroll surface")
-        attachScreenshot(named: "chat-first-timeline-destination", from: app)
+        XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_surface"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_scrubber"].exists)
     }
 
     func testChatStreamsFixtureAnswer() throws {
@@ -348,7 +349,7 @@ final class LogYourBodyUITests: XCTestCase {
             "-lybUITestChatFirstFixture"
         ])
 
-        XCTAssertTrue(app.descendants(matching: .any)["chat_first_root"].waitForExistence(timeout: 12))
+        try openChatTab(in: app)
         XCTAssertFalse(app.tabBars.firstMatch.exists)
 
         let prompt = app.buttons["How am I doing?"]
@@ -374,6 +375,8 @@ final class LogYourBodyUITests: XCTestCase {
             "-lybUITestChatErrorFixture"
         ])
 
+        try openChatTab(in: app)
+
         let prompt = app.buttons["How am I doing?"]
         XCTAssertTrue(prompt.waitForExistence(timeout: 12))
         prompt.tap()
@@ -394,6 +397,8 @@ final class LogYourBodyUITests: XCTestCase {
             "-lybUITestChatFirstFixture",
             "-lybUITestChatOfflineFixture"
         ])
+
+        try openChatTab(in: app)
 
         let offlineCopy = app.staticTexts["You’re offline. Reconnect, then try again."]
         XCTAssertTrue(offlineCopy.waitForExistence(timeout: 12))
@@ -416,6 +421,8 @@ final class LogYourBodyUITests: XCTestCase {
             "-lybUITestChatFirstFixture",
             "-lybUITestChatSlowFixture"
         ])
+
+        try openChatTab(in: app)
 
         let prompt = app.buttons["How am I doing?"]
         XCTAssertTrue(prompt.waitForExistence(timeout: 12))
@@ -440,12 +447,8 @@ final class LogYourBodyUITests: XCTestCase {
 
     func testSettingsProfileFieldsOpenDirectEditors() throws {
         let app = XCUIApplication()
-        launch(app, with: [
-            "-lybUITestPhotoTimelineHUDFixture",
-            "-lybUITestChatFirstFixture"
-        ])
+        launch(app, with: ["-lybUITestPhotoTimelineHUDFixture"])
 
-        app.buttons["Open sidebar"].tap()
         app.buttons["Settings"].tap()
 
         let profileLink = app.buttons["settings_profile_link"]
@@ -538,7 +541,7 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertGreaterThanOrEqual(timeline.frame.minX, homeViewportFrame.minX - 1)
         XCTAssertLessThanOrEqual(timeline.frame.maxX, homeViewportFrame.maxX + 1)
 
-        let strip = app.descendants(matching: .any)["launch_timeline_photo_strip"]
+        let strip = app.descendants(matching: .any)["launch_timeline_scrubber"]
         XCTAssertTrue(strip.waitForExistence(timeout: 5))
         XCTAssertTrue(strip.isHittable)
         XCTAssertGreaterThanOrEqual(strip.frame.minX, homeViewportFrame.minX - 1)
@@ -607,7 +610,7 @@ final class LogYourBodyUITests: XCTestCase {
         let app = XCUIApplication()
         launch(app, with: ["-lybUITestPhotoTimelineHUDFixture"])
 
-        let strip = app.descendants(matching: .any)["launch_timeline_photo_strip"]
+        let strip = app.descendants(matching: .any)["launch_timeline_scrubber"]
         XCTAssertTrue(strip.waitForExistence(timeout: 12))
 
         // Regression guard for JovieInc/Jovie#11350: a horizontal swipe on the
@@ -709,16 +712,12 @@ final class LogYourBodyUITests: XCTestCase {
             "-lybUITestPhotoTimelineHUDFixture",
             "-lybUITestChatFirstFixture"
         ])
-        XCTAssertTrue(app.descendants(matching: .any)["chat_first_root"].waitForExistence(timeout: 12))
-        XCTAssertFalse(app.tabBars.firstMatch.exists)
-        app.swipeLeft()
-        XCTAssertTrue(app.descendants(matching: .any)["chat_sidebar"].waitForExistence(timeout: 5))
-        let timelineLink = app.buttons["chat_timeline_link"]
-        XCTAssertTrue(timelineLink.waitForExistence(timeout: 5))
-        XCTAssertTrue(timelineLink.isHittable)
-        timelineLink.tap()
+        XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 12))
+        XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_scrubber"].waitForExistence(timeout: 8))
+        try openChatTab(in: app)
+        attachScreenshot(named: "launch-quality-chat-tab", from: app)
+        app.buttons["Timeline"].tap()
         XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_surface"].waitForExistence(timeout: 12))
-        attachScreenshot(named: "launch-quality-chat-sidebar-timeline", from: app)
 
         launch(app, with: ["-lybUITestBodyScoreOnboardingFixture"])
         try assertAndCaptureOnboardingFixedCTA(in: app)
@@ -925,7 +924,7 @@ final class LogYourBodyUITests: XCTestCase {
 
         XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 12))
 
-        XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_photo_strip"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_scrubber"].waitForExistence(timeout: 10))
 
         try exerciseTimelineRootNavigation(in: app)
     }
@@ -980,6 +979,20 @@ final class LogYourBodyUITests: XCTestCase {
             ],
             timeout: timeout
         )
+    }
+
+    private func openChatTab(in app: XCUIApplication) throws {
+        XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 12))
+
+        let chatButton = app.buttons["Chat"]
+        XCTAssertTrue(chatButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(chatButton.isHittable)
+        chatButton.tap()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["chat_tab_root"].waitForExistence(timeout: 10)
+        )
+        XCTAssertFalse(app.descendants(matching: .any)["chat_sidebar"].exists)
     }
 
     private func waitForOneOf(_ elements: [XCUIElement], timeout: TimeInterval) -> Bool {

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -713,7 +713,12 @@ final class LogYourBodyUITests: XCTestCase {
             "-lybUITestChatFirstFixture"
         ])
         XCTAssertTrue(waitForTimelineRoot(in: app, timeout: 12))
-        XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_scrubber"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.descendants(matching: .any)["launch_timeline_surface"].waitForExistence(timeout: 12))
+        let scrubber = app.descendants(matching: .any)["launch_timeline_scrubber"]
+        if !scrubber.waitForExistence(timeout: 3) {
+            app.swipeUp()
+        }
+        XCTAssertTrue(scrubber.waitForExistence(timeout: 5))
         try openChatTab(in: app)
         attachScreenshot(named: "launch-quality-chat-tab", from: app)
         app.buttons["Timeline"].tap()

--- a/docs/GOLDEN_PATH.md
+++ b/docs/GOLDEN_PATH.md
@@ -1,8 +1,8 @@
 # The LogYourBody Golden Path
 
-**One sentence:** A paying user can launch into authenticated chat, continue with Apple,
-subscribe, log today's weight, immediately see it on their body timeline, ask about the
-authorized trend, and trust that the data survives — offline, across launches, and through sync.
+**One sentence:** A paying user can launch the app, continue with Apple, subscribe,
+log today's weight, immediately see it on their body timeline, and trust that it survives —
+offline, across launches, and through sync.
 
 This is the entire value loop of the product. LogYourBody is a paid iOS app with a single
 promise: _log your body, see your progress_. If any stage below breaks, a paying user gets
@@ -25,7 +25,7 @@ Golden Path gate (`GoldenPathTests`) must stay green on every commit to `main`.
 
 | #   | Stage           | Contract                                                                                                                                                                                                                                                    | Enforced by                                                                                |
 | --- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| 1   | **Launch**      | The app boots to authenticated chat with the Timeline available from its sidebar; Apple is the only primary sign-in method; the RevenueCat entitlement is `Premium`.                                                                                        | `GoldenPathTests` GP1; launch-quality chat/sidebar XCUITests                               |
+| 1   | **Launch**      | The app boots to the pinned paid surface (photo timeline HUD) with Chat available as a peer navigation tab; Apple is the only primary sign-in method; the RevenueCat entitlement is `Premium`.                                                              | `GoldenPathTests` GP1; launch-quality navigation XCUITests                                |
 | 2   | **Sign in**     | An unauthenticated user can never reach the paid surface; a profile is "complete" only with name + DOB + height + gender.                                                                                                                                   | `GoldenPathTests` GP2                                                                      |
 | 3   | **Subscribe**   | An unsubscribed user is gated; a fully qualified user (authed + onboarded + complete profile + subscribed) passes every gate; trial→paid emits the conversion event.                                                                                        | `GoldenPathTests` GP3                                                                      |
 | 4   | **Log weight**  | Valid weights (70–660 lbs / 32–300 kg) save; garbage and out-of-range input is rejected with a plain-language message; no double-submit while saving.                                                                                                       | `GoldenPathTests` GP4                                                                      |

--- a/scripts/ios/launch-quality-audit.sh
+++ b/scripts/ios/launch-quality-audit.sh
@@ -282,8 +282,8 @@ fi
   printf '# iOS Launch Quality Audit\n\n'
   printf -- '- Destination: `%s`\n' "$DESTINATION"
   printf -- '- Static UI regression audit: `launch-ui-regression-audit.md`\n'
-  printf -- '- Unit coverage: chat-first launch policy, photo timeline HUD availability, Body Score share card layout\n'
-  printf -- '- UI coverage: chat launch/sidebar/Timeline routing, no bottom stats switch card, home/analytics/onboarding/share screenshot attachments\n'
+  printf -- '- Unit coverage: photo timeline HUD launch policy, Body Score share card layout\n'
+  printf -- '- UI coverage: Timeline/Stats/Chat peer navigation, one timeline scrubber, home/analytics/onboarding/share screenshot attachments\n'
   printf -- '- Runtime warning audit: `runtime-warnings.log`, fail-on-warning=`%s`\n' "$FAIL_ON_RUNTIME_WARNINGS"
   printf -- '- Build strategy: one `build-for-testing`, unit selectors in one `test-without-building` run, and one composite launch-quality UI selector that captures all required screenshot surfaces with simulator parallelism disabled\n'
   printf -- '- Build timeout: `%ss`; test command timeout: `%ss` per xcodebuild invocation\n' "$BUILD_FOR_TESTING_TIMEOUT_SECONDS" "$XCODEBUILD_COMMAND_TIMEOUT_SECONDS"

--- a/scripts/ios/launch-ui-regression-audit.py
+++ b/scripts/ios/launch-ui-regression-audit.py
@@ -132,8 +132,8 @@ def write_outputs(artifact_dir: Path, violations: list[AuditViolation]) -> None:
                 "- The dashboard avatar visual fills a full-width black stage while preserving each transparent asset's native aspect ratio.",
                 "- Dashboard/HUD launch surfaces stay on theme-backed glass or flat surface treatments.",
                 "- Timeline/Stats swipe navigation changes page on release, not during drag updates.",
-                "- Paid users default directly into authenticated chat without a Statsig or legacy fallback gate.",
-                "- The Timeline HUD remains available from the chat sidebar as the critical body-history surface.",
+                "- Paid users default directly into the timeline HUD without a Statsig or legacy fallback gate.",
+                "- Chat remains a peer navigation tab and never replaces the body-history shell.",
             ]
         )
 
@@ -262,9 +262,9 @@ def main() -> int:
     require_token(
         root=root,
         path=main_tab_view_policies,
-        token="static func surface() -> PaidAppSurface {\n        .chatFirst",
-        check="routing.chat_first_default",
-        detail="Paid app default surface must route straight to authenticated chat for v1.",
+        token="static func surface() -> PaidAppSurface {\n        .photoTimelineHUD",
+        check="routing.timeline_hud_default",
+        detail="Paid app default surface must route straight to the timeline HUD for v1.",
         violations=violations,
     )
 


### PR DESCRIPTION
## Summary
- restore the body timeline as the default paid surface
- keep Timeline, Stats, and Chat as peer navigation; remove the chat-first sidebar shell
- replace the horizontal photo strip with one time-weighted Liquid Glass scrubber
- add photo/metric detents with throttled selection haptics while scrubbing
- keep Settings directly reachable from the root navigation

## Evidence
- Debug simulator build succeeded on iOS 26.5
- SwiftLint strict: 0 violations across 377 files
- focused unit tests passed: paid launch policy, timeline mapping/anchors/performance, and Chat service protocol
- focused UI tests passed: Timeline remains root, Chat peer-tab navigation, streamed fixture answer, no-photo timeline state
- launch UI regression audit passed
- fresh simulator screenshots inspected for Timeline and Chat

## Proof boundary
This PR proves source, local build/tests, and simulator behavior only. It does not prove TestFlight, physical-device acceptance, App Store availability, or live backend Chat. Production backend deployment remains separately gated by a valid Supabase PAT and deployment receipts.
