### PR TITLE
fix(ios): keep timeline scrubber visible for first entry

### DIFF
--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -9,7 +9,7 @@ struct DashboardTimelineScrubber: View {
 
     var body: some View {
         Group {
-            if bodyMetrics.count > 1 {
+            if !bodyMetrics.isEmpty {
                 ProgressTimelineView(
                     bodyMetrics: bodyMetrics,
                     selectedIndex: $selectedIndex,


### PR DESCRIPTION
## Summary
- render the single Timeline scrubber for users with one body-metric entry
- preserve the empty-state behavior when there are no entries
- unblock the exact-main launch-quality gate discovered after PR #688 merged

## Evidence
- exact failing CI UI gate reproduced from run 30777781442
- focused `testLaunchQualityGateCapturesCriticalSurfaces` passes locally after the fix
- no backend, deployment, TestFlight, or physical-device proof claimed