### PR TITLE
fix: use timeline track width for scrub position

### DIFF
--- a/apps/ios/LogYourBody/Components/PhotoAnchoredTimelineSlider.swift
+++ b/apps/ios/LogYourBody/Components/PhotoAnchoredTimelineSlider.swift
@@ -36,6 +36,11 @@ struct TimelineDataPoint: Identifiable {
 
 /// Calculates smart time-weighted positions for timeline entries
 class TimelineCalculator {
+    static func position(forLocationX locationX: CGFloat, trackWidth: CGFloat) -> Double {
+        guard trackWidth > 0 else { return 0 }
+        return min(max(Double(locationX / trackWidth), 0), 1)
+    }
+
     /// Calculate weighted timeline positions for body metrics
     static func calculateTimelinePoints(from metrics: [BodyMetrics]) -> [TimelineDataPoint] {
         guard !metrics.isEmpty else { return [] }
@@ -525,11 +530,10 @@ struct PhotoAnchoredTimelineSlider: View {
                         isDragging = true
                         thumbScale = 1.2
 
-                        let geometry = value.translation.width
-                        guard geometry > 0 else { return }
-
-                        let position = value.location.x / geometry
-                        let clampedPosition = min(max(0, position), 1)
+                        let clampedPosition = TimelineCalculator.position(
+                            forLocationX: value.location.x,
+                            trackWidth: geometry.size.width
+                        )
 
                         // Find nearest timeline point to this position
                         if let nearestPoint = TimelineCalculator.findNearestPoint(to: clampedPosition, in: timelinePoints) {

--- a/apps/ios/LogYourBody/Helpers/TimelineCalculator.swift
+++ b/apps/ios/LogYourBody/Helpers/TimelineCalculator.swift
@@ -28,6 +28,11 @@ struct TimelineDataPoint: Identifiable {
 class TimelineCalculator {
     private static let timelineCache = LRUCache<TimelineCacheKey, [TimelineDataPoint]>(capacity: 50)
 
+    static func position(forLocationX locationX: CGFloat, trackWidth: CGFloat) -> Double {
+        guard trackWidth > 0 else { return 0 }
+        return min(max(Double(locationX / trackWidth), 0), 1)
+    }
+
     /// Calculate weighted timeline positions for body metrics
     /// - Parameter metrics: Array of BodyMetrics sorted by date (newest first)
     /// - Returns: Array of TimelineDataPoint with weighted positions

--- a/apps/ios/LogYourBodyTests/TimelineDataProviderScrubTests.swift
+++ b/apps/ios/LogYourBodyTests/TimelineDataProviderScrubTests.swift
@@ -13,6 +13,20 @@ import XCTest
 final class TimelineDataProviderScrubTests: XCTestCase {
     private let calendar = Calendar.current
 
+    // MARK: - Timeline drag position (track geometry -> normalized position)
+
+    func testDragPositionMapsLocationToTrackFraction() {
+        XCTAssertEqual(TimelineCalculator.position(forLocationX: 25, trackWidth: 200), 0.125)
+        XCTAssertEqual(TimelineCalculator.position(forLocationX: 100, trackWidth: 200), 0.5)
+        XCTAssertEqual(TimelineCalculator.position(forLocationX: 200, trackWidth: 200), 1)
+    }
+
+    func testDragPositionClampsOutsideTrackAndHandlesInvalidWidth() {
+        XCTAssertEqual(TimelineCalculator.position(forLocationX: -10, trackWidth: 200), 0)
+        XCTAssertEqual(TimelineCalculator.position(forLocationX: 250, trackWidth: 200), 1)
+        XCTAssertEqual(TimelineCalculator.position(forLocationX: 100, trackWidth: 0), 0)
+    }
+
     // MARK: - dateFromPosition (position -> date, three-zone time weighting)
 
     func testDateFromPositionMapsZoneBoundaries() throws {


### PR DESCRIPTION
## Summary
- Normalize timeline drag locations against the track geometry width.
- Add clamping and focused mapping tests for the scrub-position helper.

## Test plan
- `git diff --check` ✅
- `xcodebuild ... test` ⚠️ unavailable in this Linux environment (`xcodebuild: command not found`).
- GitHub Actions will run the required iOS/JS checks.

## Screenshots
Not captured: this is a math-only interaction fix and the iOS simulator is unavailable in this environment.

Fixes LYB-1
https://linear.app/jovie/issue/LYB-1/lyb-bug-timeline-slider-drag-divides-by-translationwidth-instead-of