### PR TITLE
fix(ios): close visual parity loop for Home and Stats vs JOV-2866/JOV-2872 references (JOV-4778)

### DIFF
--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+Components.swift
@@ -721,13 +721,18 @@ struct DashboardStepsCard<ProgressView: View>: View {
 
 /// The focused timeline surface used by the launch experience.
 ///
+/// Composition follows the locked JOV-2866 photo-first hierarchy: the photo
+/// stage is the visual anchor, the timeline scrubber sits immediately below
+/// it, three compact metric facts follow, and Body Score stays available as a
+/// secondary row rather than the first visual object.
+///
 /// This intentionally has no vertical scroll container. The only scrolling
 /// gesture on the page is the photo strip, so a user can move through time
-/// directly without losing the score and essential metrics above it.
+/// directly without losing the essential metrics below it.
 struct LaunchTimelineSurface: View {
     @Environment(\.theme) private var theme
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @ScaledMetric(relativeTo: .largeTitle) private var scoreFontSize: CGFloat = 58
+    @ScaledMetric(relativeTo: .largeTitle) private var scoreFontSize: CGFloat = 34
 
     let metric: BodyMetrics
     let bodyMetrics: [BodyMetrics]
@@ -750,7 +755,7 @@ struct LaunchTimelineSurface: View {
 
     var body: some View {
         GeometryReader { geometry in
-            let stageHeight = min(248, max(160, geometry.size.height * 0.35))
+            let stageHeight = min(336, max(216, geometry.size.height * 0.44))
 
             ZStack(alignment: .topLeading) {
                 launchAccessibilityMarker(id: "launch_timeline_surface", label: "Timeline")
@@ -760,15 +765,15 @@ struct LaunchTimelineSurface: View {
                         .frame(height: stageHeight)
                         .clipShape(RoundedRectangle(cornerRadius: theme.radius.card))
 
-                    scoreAndMetrics
-                        .padding(.top, 14)
-
-                    stripHeader
-                        .padding(.top, 18)
-                        .padding(.bottom, 8)
-
                     timelineScrubber
                         .frame(height: 80)
+                        .padding(.top, 12)
+
+                    metricStrip
+                        .padding(.top, 12)
+
+                    scoreRow
+                        .padding(.top, 12)
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 4)
@@ -876,46 +881,46 @@ struct LaunchTimelineSurface: View {
         }
     }
 
-    private var scoreAndMetrics: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Group {
-                if let onTapBodyScore {
-                    Button(action: onTapBodyScore) {
-                        scoreContent
-                    }
-                    .buttonStyle(.plain)
-                } else {
+    private var metricStrip: some View {
+        HStack(spacing: 8) {
+            launchMetricCell(
+                title: "Weight",
+                value: weightValue,
+                caption: weightCaption,
+                accent: theme.colors.accentViolet,
+                action: onTapWeight
+            )
+
+            launchMetricCell(
+                title: "Body Fat",
+                value: bodyFatValue,
+                caption: bodyFatCaption,
+                accent: theme.colors.accentPink,
+                action: onTapBodyFat
+            )
+
+            launchMetricCell(
+                title: "FFMI",
+                value: ffmiValue,
+                caption: ffmiCaption,
+                accent: theme.colors.accentTeal,
+                action: onTapFFMI
+            )
+        }
+    }
+
+    private var scoreRow: some View {
+        Group {
+            if let onTapBodyScore {
+                Button(action: onTapBodyScore) {
                     scoreContent
                 }
-            }
-            .accessibilityIdentifier("launch_timeline_body_score")
-
-            HStack(spacing: 8) {
-                launchMetricCell(
-                    title: "Weight",
-                    value: weightValue,
-                    caption: weightCaption,
-                    accent: theme.colors.accentViolet,
-                    action: onTapWeight
-                )
-
-                launchMetricCell(
-                    title: "Body Fat",
-                    value: bodyFatValue,
-                    caption: bodyFatCaption,
-                    accent: theme.colors.accentPink,
-                    action: onTapBodyFat
-                )
-
-                launchMetricCell(
-                    title: "FFMI",
-                    value: ffmiValue,
-                    caption: ffmiCaption,
-                    accent: theme.colors.accentTeal,
-                    action: onTapFFMI
-                )
+                .buttonStyle(.plain)
+            } else {
+                scoreContent
             }
         }
+        .accessibilityIdentifier("launch_timeline_body_score")
     }
 
     private var scoreContent: some View {
@@ -968,23 +973,23 @@ struct LaunchTimelineSurface: View {
                     .frame(width: 22, height: 2)
 
                 Text(title)
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 11, weight: .bold))
                     .foregroundStyle(theme.colors.textSecondary)
                     .lineLimit(1)
 
                 Text(value)
-                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .font(.system(size: 20, weight: .semibold, design: .rounded))
                     .foregroundStyle(theme.colors.text)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.72)
+                    .minimumScaleFactor(0.6)
 
                 Text(caption)
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(theme.colors.textSecondary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.72)
             }
-            .frame(maxWidth: .infinity, minHeight: 62, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 68, alignment: .leading)
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
             .background(theme.colors.surface.opacity(0.72), in: RoundedRectangle(cornerRadius: 12))
@@ -995,21 +1000,6 @@ struct LaunchTimelineSurface: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel("\(title) \(value), \(caption)")
-    }
-
-    private var stripHeader: some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text("Timeline")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(theme.colors.text)
-
-            Spacer(minLength: 0)
-
-            Text("Scrub through time")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(theme.colors.textSecondary)
-        }
-        .accessibilityElement(children: .combine)
     }
 
     private var timelineScrubber: some View {

--- a/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewLiquid+PhotoTimelineAnalytics.swift
@@ -56,7 +56,7 @@ extension DashboardViewLiquid {
     }
 
     var photoTimelinePresenceSummary: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: JovieTokens.itemGap) {
             ViewThatFits(in: .horizontal) {
                 HStack {
                     timelineDataTitle
@@ -70,11 +70,7 @@ extension DashboardViewLiquid {
                 }
             }
 
-            Text(photoTimelinePresenceLegendText)
-                .font(.footnote.weight(.medium))
-                .foregroundColor(theme.colors.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .accessibilityIdentifier("photo_timeline_stats_presence_legend")
+            photoTimelinePresenceChipGrid
         }
         .padding(JovieTokens.compactInset)
         .background(theme.colors.surface, in: RoundedRectangle(cornerRadius: theme.radius.card, style: .continuous))
@@ -85,6 +81,58 @@ extension DashboardViewLiquid {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Timeline data. \(photoTimelinePresenceLegendText). \(timelinePresenceValueCount) values.")
         .accessibilityIdentifier("photo_timeline_stats_presence_summary")
+    }
+
+    private var photoTimelinePresenceChipGrid: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.flexible(), spacing: 8),
+                GridItem(.flexible(), spacing: 8)
+            ],
+            spacing: 8
+        ) {
+            ForEach(MetricPresence.allCases, id: \.self) { presence in
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(photoTimelinePresenceColor(for: presence))
+                        .frame(width: 8, height: 8)
+
+                    Text(photoTimelinePresenceLabel(for: presence))
+                        .font(.footnote.weight(.medium))
+                        .foregroundColor(theme.colors.text)
+                        .lineLimit(1)
+
+                    Spacer(minLength: 4)
+
+                    Text("\(timelinePresenceCounts[presence] ?? 0)")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundColor(theme.colors.textSecondary)
+                        .monospacedDigit()
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(
+                    theme.colors.backgroundSecondary,
+                    in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+                )
+            }
+        }
+        .accessibilityIdentifier("photo_timeline_stats_presence_legend")
+    }
+
+    func photoTimelinePresenceColor(for presence: MetricPresence) -> Color {
+        switch presence {
+        case .present:
+            return theme.colors.primary
+        case .estimated:
+            return theme.colors.accentOrange
+        case .interpolated:
+            return theme.colors.accentPink
+        case .lastKnown:
+            return theme.colors.accentViolet
+        case .missing:
+            return theme.colors.textTertiary
+        }
     }
 
     private var timelineDataTitle: some View {


### PR DESCRIPTION
## Summary

Closes the screenshot-backed parity loop for the native iOS Home (photo timeline HUD) and Stats surfaces against the approved LYB references. No new visual direction invented — every change maps to a checked-in reference or a test-pinned contract.

Refs JOV-4778 (https://linear.app/jovie/issue/JOV-4778) / LogYourBody#693.

## Recorded deltas (reference → before this PR)

**Home — `LaunchTimelineSurface` (via `-lybUITestPhotoTimelineHUDFixture`):**
1. **Composition order** — annotated target locks photo → scrubber (immediately below) → metric strip → stats secondary; before: photo stage → 58pt Body Score hero + metric cells → "Timeline / Scrub through time" header → scrubber at the bottom.
2. **Photo viewport** — target: 4:5-style photo as the visual anchor; before: stage capped at 248pt / 35% of height.
3. **Metric hierarchy** — references (`full-dashboard-home.jpg`, `stats-destination.jpg`) use large rounded hero numerals (181.7 / 15.8); before: 16pt values with 10pt labels/captions.
4. **Body Score** — design target: "Do not make Body Score the first visual object"; before: 58pt hero was the first object under the photo.

**Stats — `photoTimelineAnalyticsPage`:**
5. **Timeline-state summary** — `stats-destination.jpg` shows dot + label + count chips in a 2-up grid; before: single footnote text line with "•" separators (the off-system typography the founder flagged).
6. Metric cards and "Body trends" header already match the reference (big value + sparkline + delta pill) — unchanged.

## Changes

- `DashboardViewLiquid+Components.swift` (`LaunchTimelineSurface`):
  - Reordered to photo stage → timeline scrubber → metric strip → Body Score row.
  - Photo stage enlarged: height cap 248→336pt, fraction 0.35→0.44 (min 160→216).
  - Metric strip typography to reference numeral scale: value 16→20pt rounded semibold, labels/captions 10→11pt, cell min height 62→68.
  - Body Score demoted to a compact secondary row (58→34pt), tap target, share action, and `launch_timeline_body_score` id preserved.
  - Removed the redundant "Timeline / Scrub through time" strip header (scrubber now sits directly under the photo per the locked hierarchy).
- `DashboardViewLiquid+PhotoTimelineAnalytics.swift`:
  - Presence summary now renders the reference chip grid: colored presence dot, label, monospaced count, 2-up `LazyVGrid`, inset chip background. Colors use existing theme accents (Measured = primary, Estimated = accentOrange, Interpolated = accentPink, Last known = accentViolet, Missing = textTertiary).

## Intentional reference deviations

- The summary title stays "Timeline data" (not "Timeline states") and the populated HUD keeps the top Timeline/Stats/Chat navigation with no avatar header and no `photo_timeline_hud_stats_button` — all pinned by existing UI tests (`LogYourBodyUITests`: `XCTAssertFalse(app.staticTexts["Timeline states"].exists)`, `XCTAssertFalse(...["dashboard_home_timeline_avatar"].exists)`, Stats button midY < 18% of window). These reflect later approved navigation direction; the tests are the contract.
- Accessibility identifiers, data semantics, presence states, and navigation are unchanged.

## Test plan

- Host is Linux (no Xcode/simulator) — implementation validated by diff review; simulator proof runs in the repo's existing macOS CI lane.
- [ ] CI `iOS Launch Quality Gate` (macos-15): strict SwiftLint, `PhotoTimelineHUDPolicyTests`, timeline UI routing tests, screenshot-attached Home/analytics UI tests — covers both touched surfaces with the HUD fixture.
- [ ] CI uploads `ios-launch-quality-gate-<run_id>` artifacts with before/after Home + Stats screenshots for the parity receipt.
- Focused UI tests exercised by the gate: HUD fixture routing, no-photo timeline state, Stats navigation + presence summary + metric cards, chat peer tab.

## Screenshots

Screenshot capture is CI-lane only on this host; the gate attaches `launch-quality-analytics` and home timeline screenshots per run — see the `ios-launch-quality-gate-<run_id>` artifact on this PR's checks for current-vs-reference comparison. References for reviewers: `docs/audits/jov-2866/photo-first-hud-annotated-target.jpg`, `docs/audits/jov-2872/stats-destination.jpg`, `docs/audits/jov-2872/hud-stats-entry.jpg`.