### PR TITLE
fix(ios): tighten onboarding copy hierarchy

### DIFF
--- a/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingAtoms.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingAtoms.swift
@@ -156,38 +156,6 @@ struct OnboardingDisclosureLink: View {
 
 // MARK: - Supporting Atoms
 
-struct OnboardingBulletItem: Identifiable, Hashable {
-    let id = UUID()
-    let iconName: String
-    let text: String
-}
-
-struct OnboardingIconBullet: View {
-    @Environment(\.theme)
-    private var theme
-
-    let item: OnboardingBulletItem
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: item.iconName)
-                .font(.system(.body, design: .rounded).weight(.semibold))
-                .foregroundStyle(theme.colors.primary)
-                .frame(width: 24, height: 24)
-                .background(
-                    Circle()
-                        .fill(theme.colors.primary.opacity(0.15))
-                )
-
-            Text(item.text)
-                .font(theme.typography.bodyMedium)
-                .foregroundStyle(theme.colors.text)
-                .multilineTextAlignment(.leading)
-        }
-        .padding(.vertical, 4)
-    }
-}
-
 struct OnboardingBadge: View {
     @Environment(\.theme)
     private var theme

--- a/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingMolecules.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Components/OnboardingMolecules.swift
@@ -1,19 +1,5 @@
 import SwiftUI
 
-// MARK: - Bullet Lists
-
-struct OnboardingBulletList: View {
-    let items: [OnboardingBulletItem]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            ForEach(items) { item in
-                OnboardingIconBullet(item: item)
-            }
-        }
-    }
-}
-
 // MARK: - Option Buttons
 
 struct OnboardingOptionButton: View {

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreFirstProgressPhotoView.swift
@@ -37,12 +37,12 @@ struct BodyScoreFirstProgressPhotoView: View {
     var body: some View {
         OnboardingPageTemplate(
             title: "Start a visual timeline?",
-            subtitle: "One private photo makes future change easier to see. Add one now or skip.",
+            subtitle: "Add one private, unaltered photo now or skip. Analysis always requires consent.",
             onBack: { viewModel.goBack() },
             progress: viewModel.progress(for: .firstPhoto),
             screen: .firstProgressPhoto,
             content: {
-                previewCard
+                EmptyView()
             },
             footer: {
                 actionStack
@@ -61,52 +61,6 @@ struct BodyScoreFirstProgressPhotoView: View {
             )
             .environmentObject(authManager)
         }
-    }
-
-    private var previewCard: some View {
-        VStack(alignment: .leading, spacing: theme.spacing.md) {
-            Image(systemName: "camera.metering.center.weighted")
-                .font(theme.typography.headlineMedium)
-                .foregroundStyle(theme.colors.text.opacity(0.82))
-
-            VStack(alignment: .leading, spacing: theme.spacing.xxs) {
-                Text("A private baseline, on your terms.")
-                    .font(theme.typography.headlineSmall)
-                    .foregroundStyle(theme.colors.text)
-
-                Text(
-                    "Consistent framing helps you compare honestly. " +
-                        "We never alter your body or analyze a photo without consent."
-                )
-                    .font(OnboardingTypography.body)
-                    .foregroundStyle(theme.colors.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            HStack(alignment: .top, spacing: theme.spacing.sm) {
-                Image(systemName: "lock.shield")
-                    .font(.system(.footnote, design: .default).weight(.semibold))
-                    .foregroundStyle(theme.colors.text)
-
-                Text("Camera and photo library access are optional.")
-                    .font(OnboardingTypography.caption)
-                    .foregroundStyle(theme.colors.textTertiary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .padding(theme.spacing.md)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .systemBGlassSurface(
-            cornerRadius: theme.radius.card,
-            tint: theme.colors.text,
-            tintOpacity: 0.04,
-            borderColor: theme.colors.border,
-            borderOpacity: 0.65,
-            shadowOpacity: 0.12,
-            shadowRadius: 12,
-            shadowY: 6
-        )
-        .accessibilityIdentifier("onboarding_first_photo_card")
     }
 
     private var actionStack: some View {

--- a/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHookView.swift
+++ b/apps/ios/LogYourBody/Features/Onboarding/Views/BodyScoreHookView.swift
@@ -4,26 +4,16 @@ struct BodyScoreHookView: View {
     @ObservedObject var viewModel: OnboardingFlowViewModel
     @Environment(\.dismiss) private var dismiss
 
-    private let bulletItems: [OnboardingBulletItem] = [
-        .init(iconName: "scalemass", text: "Your latest weight"),
-        .init(iconName: "percent", text: "A measured or estimated body-fat value"),
-        .init(iconName: "ruler", text: "Your height for a frame-adjusted comparison")
-    ]
-
     var body: some View {
         OnboardingPageTemplate(
             title: "See what’s changing.",
-            subtitle: "Use weight, body fat, and height to build your first Body Score in about 60 seconds.",
+            subtitle: "Weight, body fat, and height build your first Body Score in about a minute.",
             showsBackButton: false,
             progress: viewModel.progress(for: .hook),
             screen: .bodyScoreIntro
         ) {
-            VStack(spacing: JovieTokens.sectionGap) {
-                BodyScoreContourField()
-                    .frame(height: 190)
-
-                OnboardingBulletList(items: bulletItems)
-            }
+            BodyScoreContourField()
+                .frame(height: 190)
         } footer: {
             VStack(spacing: 12) {
                 Button {

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -773,6 +773,26 @@ final class LogYourBodyUITests: XCTestCase {
         try assertAndCaptureOnboardingFirstPhotoCTA(in: app)
     }
 
+    func testOnboardingConcisionSurvivesAccessibilityDynamicType() throws {
+        let app = XCUIApplication()
+        let accessibilityArguments = [
+            "-UIPreferredContentSizeCategoryName",
+            "UICTContentSizeCategoryAccessibilityXXL"
+        ]
+
+        launch(
+            app,
+            with: ["-lybUITestBodyScoreOnboardingFixture"] + accessibilityArguments
+        )
+        try assertAndCaptureOnboardingFixedCTA(in: app)
+
+        launch(
+            app,
+            with: ["-lybUITestBodyScoreFirstPhotoFixture"] + accessibilityArguments
+        )
+        try assertAndCaptureOnboardingFirstPhotoCTA(in: app)
+    }
+
     func testPhaseInsightFixtureShowsDeterministicCuttingInsight() throws {
         let app = XCUIApplication()
         launch(app, with: [
@@ -1063,6 +1083,9 @@ final class LogYourBodyUITests: XCTestCase {
         let windowFrame = app.windows.firstMatch.frame
         XCTAssertGreaterThan(startButton.frame.minY, windowFrame.height * 0.72)
         XCTAssertLessThanOrEqual(startButton.frame.maxY, windowFrame.maxY + 1)
+        XCTAssertFalse(app.staticTexts["Your latest weight"].exists)
+        XCTAssertFalse(app.staticTexts["A measured or estimated body-fat value"].exists)
+        XCTAssertFalse(app.staticTexts["Your height for a frame-adjusted comparison"].exists)
         attachScreenshot(named: "launch-quality-onboarding-fixed-cta", from: app)
     }
 
@@ -1076,6 +1099,9 @@ final class LogYourBodyUITests: XCTestCase {
         XCTAssertTrue(addPhotoButton.isHittable)
         XCTAssertTrue(skipButton.isHittable)
         XCTAssertFalse(app.buttons["Continue"].exists)
+        XCTAssertFalse(app.descendants(matching: .any)["onboarding_first_photo_card"].exists)
+        XCTAssertFalse(app.staticTexts["A private baseline, on your terms."].exists)
+        XCTAssertFalse(app.staticTexts["Camera and photo library access are optional."].exists)
 
         attachScreenshot(named: "launch-quality-onboarding-first-photo", from: app)
     }


### PR DESCRIPTION
## Summary

- reduce the Body Score intro to one support message plus the existing contour visual
- reduce the first-photo step to one privacy/consent message plus its two existing actions
- remove the now-unused onboarding bullet primitives instead of leaving a parallel composition path
- add 390 pt, 320 pt, and Accessibility XXL UI regression coverage for the concise states

Linear: LYB-4

## Proof

- `swiftlint lint --strict`: 0 violations across 377 files
- 53 focused onboarding/launch policy unit tests: passed
- 390 pt UI tests: onboarding intro and first-photo passed
- 320 pt UI tests: onboarding intro and first-photo passed
- Accessibility XXL UI test: both screens passed with essential content and fixed actions visible
- full app `build-for-testing`: passed from the exact base before the focused change; post-change UI test build and codesign passed
- `git diff --check`: clean

## Review note

The local structured autoreview helper failed closed before model review because TruffleHog is not installed on the host. The final diff was inspected directly; deleted primitives have no remaining production references, and CI remains authoritative.
