### PR TITLE
fix(ios): stabilize chat composer geometry

### DIFF
--- a/apps/ios/LogYourBody/DesignSystem/Theme.swift
+++ b/apps/ios/LogYourBody/DesignSystem/Theme.swift
@@ -11,6 +11,7 @@ import UIKit
 enum JovieTokens {
     static let screenInset: CGFloat = 20
     static let compactInset: CGFloat = 16
+    static let tightGap: CGFloat = 8
     static let sectionGap: CGFloat = 28
     static let itemGap: CGFloat = 12
     static let minimumHitTarget: CGFloat = 44
@@ -22,6 +23,22 @@ enum JovieTokens {
     static let ambientAccentOpacity: Double = 0.08
     static let subtleDuration: Double = 0.15
     static let cinematicDuration: Double = 0.42
+}
+
+enum ChatComposerGeometry {
+    static let multilineTextHeightThreshold = JovieTokens.sectionGap
+
+    static func isMultiline(textHeight: CGFloat) -> Bool {
+        textHeight > multilineTextHeightThreshold
+    }
+
+    static func cornerRadius(isMultiline: Bool) -> CGFloat {
+        isMultiline ? JovieTokens.controlRadius : JovieTokens.controlHeight
+    }
+
+    static func transitionAnimation(reduceMotion: Bool) -> Animation? {
+        reduceMotion ? nil : .easeInOut(duration: JovieTokens.subtleDuration)
+    }
 }
 
 enum WorldClassScreenFlow: String, CaseIterable {

--- a/apps/ios/LogYourBody/Views/MainTabView.swift
+++ b/apps/ios/LogYourBody/Views/MainTabView.swift
@@ -692,7 +692,9 @@ private struct FailedChatTurn: Equatable {
 struct ChatTabView: View {
     @EnvironmentObject private var authManager: AuthManager
     @Environment(\.theme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var draft = ""
+    @State private var composerTextHeight: CGFloat = 0
     @State private var isResponding = false
     @State private var isLoadingConversation = true
     @State private var messages: [ChatMessage] = [.welcome]
@@ -918,7 +920,10 @@ struct ChatTabView: View {
     }
 
     private var composer: some View {
-        HStack(spacing: 10) {
+        let isMultiline = ChatComposerGeometry.isMultiline(textHeight: composerTextHeight)
+        let cornerRadius = ChatComposerGeometry.cornerRadius(isMultiline: isMultiline)
+
+        return HStack(alignment: .bottom, spacing: JovieTokens.itemGap) {
             TextField("Message LogYourBody", text: $draft, axis: .vertical)
                 .lineLimit(1...4)
                 .focused($isComposerFocused)
@@ -930,6 +935,14 @@ struct ChatTabView: View {
                     send(draft)
                 }
                 .accessibilityIdentifier("chat_composer")
+                .background {
+                    GeometryReader { geometry in
+                        Color.clear.preference(
+                            key: ChatComposerTextHeightPreferenceKey.self,
+                            value: geometry.size.height
+                        )
+                    }
+                }
 
             Button {
                 if isResponding {
@@ -943,7 +956,10 @@ struct ChatTabView: View {
                     .foregroundStyle(
                         (canSend || isResponding) ? theme.colors.background : theme.colors.textTertiary
                     )
-                    .frame(width: 34, height: 34)
+                    .frame(
+                        width: JovieTokens.minimumHitTarget,
+                        height: JovieTokens.minimumHitTarget
+                    )
                     .background(
                         (canSend || isResponding) ? theme.colors.text : theme.colors.surface,
                         in: Circle()
@@ -954,15 +970,45 @@ struct ChatTabView: View {
             .accessibilityLabel(isResponding ? "Stop answer" : "Send message")
             .accessibilityIdentifier("chat_send_button")
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        .padding(.leading, JovieTokens.compactInset)
+        .padding(.trailing, JovieTokens.tightGap)
+        .padding(.vertical, JovieTokens.tightGap)
+        .background {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(theme.colors.surface.opacity(JovieTokens.hairlineOpacity))
+
+            Color.clear
+                .accessibilityElement()
+                .accessibilityLabel("Chat composer container")
+                .accessibilityIdentifier("chat_composer_shell")
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .stroke(
+                    (isComposerFocused ? theme.colors.primary : theme.colors.border)
+                        .opacity(JovieTokens.hairlineOpacity),
+                    lineWidth: 1
+                )
+        }
+        .padding(.horizontal, JovieTokens.screenInset)
+        .padding(.vertical, JovieTokens.itemGap)
         .background(.ultraThinMaterial)
         .overlay(alignment: .top) {
             Rectangle()
-                .fill(theme.colors.border.opacity(0.55))
+                .fill(theme.colors.border.opacity(JovieTokens.hairlineOpacity))
                 .frame(height: 1)
         }
-        .animation(.easeOut(duration: 0.18), value: canSend)
+        .onPreferenceChange(ChatComposerTextHeightPreferenceKey.self) { height in
+            composerTextHeight = height
+        }
+        .animation(
+            ChatComposerGeometry.transitionAnimation(reduceMotion: reduceMotion),
+            value: isMultiline
+        )
+        .animation(
+            ChatComposerGeometry.transitionAnimation(reduceMotion: reduceMotion),
+            value: canSend
+        )
     }
 
     private func accessibilityMarker(id: String, label: String) -> some View {
@@ -1242,6 +1288,14 @@ struct ChatTabView: View {
         }
         #endif
         return await authManager.getAccessToken()
+    }
+}
+
+private struct ChatComposerTextHeightPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }
 

--- a/apps/ios/LogYourBodyTests/LaunchSurfacePolicyTests.swift
+++ b/apps/ios/LogYourBodyTests/LaunchSurfacePolicyTests.swift
@@ -13,6 +13,32 @@ import UIKit
 
 
 final class LaunchSurfacePolicyTests: XCTestCase {
+    func testChatComposerGeometryUsesOnlyCanonicalPillAndMultilineRadii() {
+        XCTAssertFalse(
+            ChatComposerGeometry.isMultiline(
+                textHeight: ChatComposerGeometry.multilineTextHeightThreshold
+            )
+        )
+        XCTAssertTrue(
+            ChatComposerGeometry.isMultiline(
+                textHeight: ChatComposerGeometry.multilineTextHeightThreshold + 1
+            )
+        )
+        XCTAssertEqual(
+            ChatComposerGeometry.cornerRadius(isMultiline: false),
+            JovieTokens.controlHeight
+        )
+        XCTAssertEqual(
+            ChatComposerGeometry.cornerRadius(isMultiline: true),
+            JovieTokens.controlRadius
+        )
+    }
+
+    func testChatComposerGeometryDisablesTransitionAnimationForReducedMotion() {
+        XCTAssertNil(ChatComposerGeometry.transitionAnimation(reduceMotion: true))
+        XCTAssertNotNil(ChatComposerGeometry.transitionAnimation(reduceMotion: false))
+    }
+
     func testIncompleteOnboardingRequiresBodyCompositionOnboarding() {
         XCTAssertTrue(
             LaunchSurfacePolicy.requiresBodyCompositionOnboarding(

--- a/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
+++ b/apps/ios/LogYourBodyUITests/LogYourBodyUITests.swift
@@ -445,6 +445,45 @@ final class LogYourBodyUITests: XCTestCase {
         attachScreenshot(named: "chat-stream-cancelled", from: app)
     }
 
+    func testChatComposerKeepsOneGridFromPillToMultiline() throws {
+        let app = XCUIApplication()
+        launch(app, with: [
+            "-lybUITestPhotoTimelineHUDFixture",
+            "-lybUITestChatFirstFixture"
+        ])
+
+        try openChatTab(in: app)
+
+        let composer = app.textFields["chat_composer"]
+        let shell = app.descendants(matching: .any)["chat_composer_shell"]
+        let sendButton = app.buttons["chat_send_button"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 8))
+        XCTAssertTrue(shell.waitForExistence(timeout: 5))
+        XCTAssertTrue(sendButton.waitForExistence(timeout: 5))
+
+        let singleLineFrame = shell.frame
+        XCTAssertGreaterThanOrEqual(sendButton.frame.width, 44)
+        XCTAssertGreaterThanOrEqual(sendButton.frame.height, 44)
+        attachScreenshot(named: "chat-composer-single-line", from: app)
+
+        composer.tap()
+        composer.typeText(
+            "Compare my latest weight, body-fat trend, and progress photos with the previous month " +
+                "and explain the most important change in plain language."
+        )
+
+        let multiline = NSPredicate { _, _ in
+            shell.frame.height > singleLineFrame.height
+        }
+        expectation(for: multiline, evaluatedWith: shell)
+        waitForExpectations(timeout: 5)
+
+        XCTAssertEqual(shell.frame.minX, singleLineFrame.minX, accuracy: 1)
+        XCTAssertEqual(shell.frame.width, singleLineFrame.width, accuracy: 1)
+        XCTAssertLessThanOrEqual(sendButton.frame.maxY, shell.frame.maxY)
+        attachScreenshot(named: "chat-composer-multiline", from: app)
+    }
+
     func testSettingsProfileFieldsOpenDirectEditors() throws {
         let app = XCUIApplication()
         launch(app, with: ["-lybUITestPhotoTimelineHUDFixture"])


### PR DESCRIPTION
## Summary

- keep the native chat composer on one canonical inset and token grid as it grows from pill to multiline
- reserve a 44pt send/stop hit target and bottom-align it through multiline growth
- use canonical radii, focus borders, and reduced-motion-aware transitions
- add focused policy and UI coverage at regular and compact widths

## Verification

- `swiftlint lint --strict --quiet --config .swiftlint.yml`
- `LogYourBodyTests/LaunchSurfacePolicyTests/testChatComposerGeometryUsesOnlyCanonicalPillAndMultilineRadii`
- `LogYourBodyTests/LaunchSurfacePolicyTests/testChatComposerGeometryDisablesTransitionAnimationForReducedMotion`
- `LogYourBodyUITests/testChatCanCancelStreamingAnswer` on iPhone 16 Pro (390pt)
- `LogYourBodyUITests/testChatComposerKeepsOneGridFromPillToMultiline` on iPhone 16 Pro (390pt)
- `LogYourBodyUITests/testChatComposerKeepsOneGridFromPillToMultiline` on iPhone SE (3rd generation) (320pt)
- visually reviewed single-line, multiline, and stopped-state screenshots at 390pt and single-line/multiline screenshots at 320pt

## Scope note

LYB-17 also describes desktop, attachment, and microphone states that do not exist in the current native iOS product. This PR does not invent inactive controls. It covers every currently supported native composer state: single-line, multiline, focused, send, and stop.
